### PR TITLE
fix(db-mongodb): stop unique localized fields from claiming defaultValue in untouched locales

### DIFF
--- a/packages/db-mongodb/src/models/buildSchema.spec.ts
+++ b/packages/db-mongodb/src/models/buildSchema.spec.ts
@@ -106,6 +106,42 @@ describe('buildSchema unique + localized defaultValue', () => {
     expect(schema.path('uniqueLocalizedHasManySelect.es').options.type[0].default).toBeUndefined()
   })
 
+  it('does not carry the static defaultValue on a unique localized point field', () => {
+    const schema = buildSchema({
+      buildSchemaOptions: {},
+      configFields: [
+        {
+          name: 'uniqueLocalizedPoint',
+          type: 'point',
+          defaultValue: [0, 0],
+          localized: true,
+          unique: true,
+        },
+      ],
+      payload,
+    })
+
+    expect(schema.path('uniqueLocalizedPoint.en.coordinates').options.default).toBeUndefined()
+    expect(schema.path('uniqueLocalizedPoint.es.coordinates').options.default).toBeUndefined()
+  })
+
+  it('still applies the static defaultValue on a non-unique localized point field', () => {
+    const schema = buildSchema({
+      buildSchemaOptions: {},
+      configFields: [
+        {
+          name: 'localizedPoint',
+          type: 'point',
+          defaultValue: [0, 0],
+          localized: true,
+        },
+      ],
+      payload,
+    })
+
+    expect(schema.path('localizedPoint.en.coordinates').options.default).toEqual([0, 0])
+  })
+
   it('still applies the static defaultValue on a non-unique localized relationship field', () => {
     const schema = buildSchema({
       buildSchemaOptions: {},

--- a/packages/db-mongodb/src/models/buildSchema.spec.ts
+++ b/packages/db-mongodb/src/models/buildSchema.spec.ts
@@ -1,0 +1,126 @@
+import type { Config, SanitizedConfig } from 'payload'
+
+import { sanitizeConfig } from 'payload'
+import { beforeAll, describe, expect, it } from 'vitest'
+
+import { buildSchema } from './buildSchema.js'
+
+let payload: any
+
+describe('buildSchema unique + localized defaultValue', () => {
+  beforeAll(() => {
+    const config: SanitizedConfig = sanitizeConfig({
+      localization: {
+        defaultLocale: 'en',
+        fallback: true,
+        locales: ['en', 'es'],
+      },
+    } as Config)
+
+    payload = {
+      collections: {},
+      config,
+      db: {},
+    }
+  })
+
+  it('does not carry the static defaultValue on a unique localized relationship field', () => {
+    const schema = buildSchema({
+      buildSchemaOptions: {},
+      configFields: [
+        {
+          name: 'uniqueLocalizedRelationship',
+          type: 'relationship',
+          defaultValue: '000000000000000000000001',
+          localized: true,
+          relationTo: 'some-collection',
+          unique: true,
+        },
+      ],
+      payload,
+    })
+
+    expect(schema.path('uniqueLocalizedRelationship.en').options.default).toBeUndefined()
+    expect(schema.path('uniqueLocalizedRelationship.es').options.default).toBeUndefined()
+  })
+
+  it('does not carry the static defaultValue on a unique localized hasMany relationship field', () => {
+    const schema = buildSchema({
+      buildSchemaOptions: {},
+      configFields: [
+        {
+          name: 'uniqueLocalizedHasManyRelationship',
+          type: 'relationship',
+          defaultValue: ['000000000000000000000001'],
+          hasMany: true,
+          localized: true,
+          relationTo: 'some-collection',
+          unique: true,
+        },
+      ],
+      payload,
+    })
+
+    expect(schema.path('uniqueLocalizedHasManyRelationship.en').options.default).toBeUndefined()
+    expect(schema.path('uniqueLocalizedHasManyRelationship.es').options.default).toBeUndefined()
+  })
+
+  it('does not carry the static defaultValue on a unique localized upload field', () => {
+    const schema = buildSchema({
+      buildSchemaOptions: {},
+      configFields: [
+        {
+          name: 'uniqueLocalizedUpload',
+          type: 'upload',
+          defaultValue: '000000000000000000000001',
+          localized: true,
+          relationTo: 'some-upload-collection',
+          unique: true,
+        },
+      ],
+      payload,
+    })
+
+    expect(schema.path('uniqueLocalizedUpload.en').options.default).toBeUndefined()
+    expect(schema.path('uniqueLocalizedUpload.es').options.default).toBeUndefined()
+  })
+
+  it('does not carry the static defaultValue on a unique localized hasMany select field', () => {
+    const schema = buildSchema({
+      buildSchemaOptions: {},
+      configFields: [
+        {
+          name: 'uniqueLocalizedHasManySelect',
+          type: 'select',
+          defaultValue: ['a'],
+          hasMany: true,
+          localized: true,
+          options: ['a', 'b'],
+          unique: true,
+        },
+      ],
+      payload,
+    })
+
+    expect(schema.path('uniqueLocalizedHasManySelect.en').options.type[0].default).toBeUndefined()
+    expect(schema.path('uniqueLocalizedHasManySelect.es').options.type[0].default).toBeUndefined()
+  })
+
+  it('still applies the static defaultValue on a non-unique localized relationship field', () => {
+    const schema = buildSchema({
+      buildSchemaOptions: {},
+      configFields: [
+        {
+          name: 'localizedRelationship',
+          type: 'relationship',
+          defaultValue: '000000000000000000000001',
+          localized: true,
+          relationTo: 'some-collection',
+        },
+      ],
+      payload,
+    })
+
+    expect(schema.path('localizedRelationship.en').options.default).toBe('000000000000000000000001')
+  })
+})

--- a/packages/db-mongodb/src/models/buildSchema.ts
+++ b/packages/db-mongodb/src/models/buildSchema.ts
@@ -508,6 +508,14 @@ const point: FieldSchemaGenerator<PointField> = (
   buildSchemaOptions,
   parentIsLocalized,
 ): void => {
+  // Point fields build their per-locale schema by hand instead of going through
+  // `formatBaseSchema`/`localizeSchema`'s shared suppression, so `unique` localized
+  // fields need the same default suppression applied here directly.
+  const suppressDefault =
+    !buildSchemaOptions.disableUnique &&
+    field.unique &&
+    fieldShouldBeLocalized({ field, parentIsLocalized })
+
   const baseSchema: SchemaTypeOptions<unknown> = {
     type: {
       type: String,
@@ -518,7 +526,7 @@ const point: FieldSchemaGenerator<PointField> = (
     },
     coordinates: {
       type: [Number],
-      default: formatDefaultValue(field),
+      default: suppressDefault ? undefined : formatDefaultValue(field),
       required: false,
     },
   }

--- a/packages/db-mongodb/src/models/buildSchema.ts
+++ b/packages/db-mongodb/src/models/buildSchema.ts
@@ -112,11 +112,26 @@ const localizeSchema = (
     localization &&
     Array.isArray(localization.locales)
   ) {
+    // Non-unique fields intentionally rely on the field-level `default` being applied
+    // independently to every locale (e.g. draft/publish status defaulting each untouched
+    // locale to 'draft'), so only suppress it for `unique` fields: reusing a static default
+    // across every locale there would make Mongoose silently write the same value into
+    // locales Payload left untouched, which then collides with any other document that also
+    // left that locale at its default.
+    // `hasMany` fields pass `schema` as a one-element array (e.g. `[baseSchema]`), so the
+    // suppression has to happen on the wrapped element to preserve the array type.
+    const suppressUniqueDefault = (schemaOptions: SchemaTypeOptions<any>) =>
+      schemaOptions.unique ? { ...schemaOptions, default: undefined } : schemaOptions
+
+    const localeSchema = Array.isArray(schema)
+      ? [suppressUniqueDefault(schema[0])]
+      : suppressUniqueDefault(schema)
+
     return {
       type: localization.localeCodes.reduce(
-        (localeSchema, locale) => ({
-          ...localeSchema,
-          [locale]: schema,
+        (localesType, locale) => ({
+          ...localesType,
+          [locale]: localeSchema,
         }),
         {
           _id: false,

--- a/packages/db-mongodb/src/models/buildSchema.ts
+++ b/packages/db-mongodb/src/models/buildSchema.ts
@@ -101,6 +101,17 @@ const formatBaseSchema = ({
   return schema
 }
 
+/**
+ * Non-unique fields intentionally rely on the field-level `default` being applied
+ * independently to every locale (e.g. draft/publish status defaulting each untouched
+ * locale to 'draft'), so only suppress it for `unique` fields: reusing a static default
+ * across every locale there would make Mongoose silently write the same value into
+ * locales Payload left untouched, which then collides with any other document that also
+ * left that locale at its default.
+ */
+const suppressUniqueDefault = (schemaOptions: SchemaTypeOptions<any>) =>
+  schemaOptions.unique ? { ...schemaOptions, default: undefined } : schemaOptions
+
 const localizeSchema = (
   entity: NonPresentationalField | Tab,
   schema: SchemaTypeOptions<any>,
@@ -112,17 +123,8 @@ const localizeSchema = (
     localization &&
     Array.isArray(localization.locales)
   ) {
-    // Non-unique fields intentionally rely on the field-level `default` being applied
-    // independently to every locale (e.g. draft/publish status defaulting each untouched
-    // locale to 'draft'), so only suppress it for `unique` fields: reusing a static default
-    // across every locale there would make Mongoose silently write the same value into
-    // locales Payload left untouched, which then collides with any other document that also
-    // left that locale at its default.
     // `hasMany` fields pass `schema` as a one-element array (e.g. `[baseSchema]`), so the
     // suppression has to happen on the wrapped element to preserve the array type.
-    const suppressUniqueDefault = (schemaOptions: SchemaTypeOptions<any>) =>
-      schemaOptions.unique ? { ...schemaOptions, default: undefined } : schemaOptions
-
     const localeSchema = Array.isArray(schema)
       ? [suppressUniqueDefault(schema[0])]
       : suppressUniqueDefault(schema)
@@ -609,10 +611,15 @@ const relationship: FieldSchemaGenerator<RelationshipField> = (
           }
         }
 
+        localeSchema = suppressUniqueDefault(localeSchema)
+
         return {
           ...locales,
           [locale]: field.hasMany
-            ? { type: [localeSchema], default: formatDefaultValue(field) }
+            ? {
+                type: [localeSchema],
+                default: localeSchema.unique ? undefined : formatDefaultValue(field),
+              }
             : localeSchema,
         }
       }, {}),
@@ -866,10 +873,15 @@ const upload: FieldSchemaGenerator<UploadField> = (
           }
         }
 
+        localeSchema = suppressUniqueDefault(localeSchema)
+
         return {
           ...locales,
           [locale]: field.hasMany
-            ? { type: [localeSchema], default: formatDefaultValue(field) }
+            ? {
+                type: [localeSchema],
+                default: localeSchema.unique ? undefined : formatDefaultValue(field),
+              }
             : localeSchema,
         }
       }, {}),

--- a/test/fields/int.spec.ts
+++ b/test/fields/int.spec.ts
@@ -2601,6 +2601,70 @@ describe('Fields', () => {
       }).toBeDefined()
     })
 
+    it('should allow creating a second document when a localized unique required field falls back to its static defaultValue in an untouched locale', async () => {
+      const firstDoc = await payload.create({
+        collection: 'indexed-fields',
+        data: {
+          text: 'first-' + Date.now(),
+          localizedUniqueRequiredText: 'first-en-' + Date.now(),
+          uniqueRequiredText: 'uniqueRequired-first-' + Date.now(),
+        },
+      })
+
+      const firstDocAllLocales = await payload.findByID({
+        id: firstDoc.id,
+        collection: 'indexed-fields',
+        locale: 'all',
+      })
+
+      // The es locale was never submitted, so it should remain unset rather than being
+      // silently filled with the field's static defaultValue.
+      expect(firstDocAllLocales.localizedUniqueRequiredText.es).toBeUndefined()
+
+      await expect(
+        payload.create({
+          collection: 'indexed-fields',
+          data: {
+            text: 'second-' + Date.now(),
+            localizedUniqueRequiredText: 'second-en-' + Date.now(),
+            uniqueRequiredText: 'uniqueRequired-second-' + Date.now(),
+          },
+        }),
+      ).resolves.toBeDefined()
+    })
+
+    it('should still enforce uniqueness when a localized unique field explicitly keeps the same defaultValue in a locale', async () => {
+      await payload.create({
+        collection: 'indexed-fields',
+        locale: 'all',
+        data: {
+          text: 'first-' + Date.now(),
+          localizedUniqueRequiredText: {
+            en: 'first-en-' + Date.now(),
+            // explicitly kept as the field's defaultValue, rather than left untouched
+            es: 'localizedUniqueRequired',
+          },
+          uniqueRequiredText: 'uniqueRequired-first-' + Date.now(),
+        },
+      })
+
+      await expect(
+        payload.create({
+          collection: 'indexed-fields',
+          locale: 'all',
+          data: {
+            text: 'second-' + Date.now(),
+            localizedUniqueRequiredText: {
+              en: 'second-en-' + Date.now(),
+              // also explicitly kept as the same defaultValue -> should still collide
+              es: 'localizedUniqueRequired',
+            },
+            uniqueRequiredText: 'uniqueRequired-second-' + Date.now(),
+          },
+        }),
+      ).rejects.toThrow(/unique/i)
+    })
+
     it('should throw validation error saving on unique relationship fields hasMany: false non polymorphic', async () => {
       const textDoc = await payload.create({
         collection: 'text-fields',


### PR DESCRIPTION
## Summary

A `unique` + `localized` field with a static `defaultValue` could permanently block document creation. Mongoose reused the same schema options object (carrying the field's `default`) across every locale's sub-path, so a locale a document never touched silently got the literal `defaultValue` written into it. Once one document claimed that value in a given locale, no other document could ever save that same locale again.

## Why

Payload's own field-level fallback logic already applies `defaultValue` per locale, scoped to the locale actually being processed. The Mongo adapter duplicated this at the Mongoose schema level in a way that wasn't locale-scoped, so it silently overrode the correct, intentional decision to leave other locales unset. Postgres and SQLite don't have this problem: they never set a DB-level default, and never insert a row for a locale that wasn't submitted.

## How

- Suppress the schema-level `default` only for fields with `unique: true`. Non-unique fields keep the existing per-locale default behavior (e.g. draft/publish status defaulting each untouched locale to `draft`), since that's intentional and unrelated to this bug.
- `hasMany` fields pass their schema wrapped in an array, so the suppression is applied to the wrapped element to preserve the array type.
- `relationship`, `upload`, and `point` fields build their per-locale schema by hand instead of going through the shared locale-schema helper, so they each had the same bug independently of the fix above. Applied the same suppression there, for both the single-value and `hasMany` shapes.