### PR TITLE
fix(plugin-cloud-storage): rewrite thumbnailURL for cloud-stored uploads

### DIFF
--- a/packages/payload/src/uploads/generateFilePathOrURL.spec.ts
+++ b/packages/payload/src/uploads/generateFilePathOrURL.spec.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+
+import type { Config } from '../config/types.js'
+
+import { generateFilePathOrURL } from './generateFilePathOrURL.js'
+
+describe('generateFilePathOrURL', () => {
+  const config = { routes: { api: '/api' } } as Config
+
+  it('should return an external url as is when serverURL is not configured', () => {
+    const url = generateFilePathOrURL({
+      collectionSlug: 'media',
+      config,
+      filename: 'image-300x225.png',
+      relative: false,
+      serverURL: undefined,
+      urlOrPath: 'https://cdn.example.com/image-300x225.png',
+    })
+
+    expect(url).toBe('https://cdn.example.com/image-300x225.png')
+  })
+
+  it('should return an external url as is when it does not match serverURL', () => {
+    const url = generateFilePathOrURL({
+      collectionSlug: 'media',
+      config: { ...config, serverURL: 'http://localhost:3000' },
+      filename: 'image-300x225.png',
+      relative: false,
+      serverURL: 'http://localhost:3000',
+      urlOrPath: 'https://cdn.example.com/image-300x225.png',
+    })
+
+    expect(url).toBe('https://cdn.example.com/image-300x225.png')
+  })
+
+  it('should regenerate the file route for urls pointing at serverURL', () => {
+    const url = generateFilePathOrURL({
+      collectionSlug: 'media',
+      config: { ...config, serverURL: 'http://localhost:3000' },
+      filename: 'image.png',
+      relative: false,
+      serverURL: 'http://localhost:3000',
+      urlOrPath: 'http://localhost:3000/api/media/file/stale.png',
+    })
+
+    expect(url).toBe('http://localhost:3000/api/media/file/image.png')
+  })
+
+  it('should regenerate the file route for relative paths', () => {
+    const url = generateFilePathOrURL({
+      collectionSlug: 'media',
+      config,
+      filename: 'image.png',
+      relative: true,
+      urlOrPath: '/api/media/file/stale.png',
+    })
+
+    expect(url).toBe('/api/media/file/image.png')
+  })
+})

--- a/packages/payload/src/uploads/generateFilePathOrURL.ts
+++ b/packages/payload/src/uploads/generateFilePathOrURL.ts
@@ -27,7 +27,9 @@ export function generateFilePathOrURL({
   urlOrPath: string | undefined
 }): null | string {
   if (urlOrPath) {
-    if (!urlOrPath.startsWith('/') && !urlOrPath.startsWith(serverURL || '')) {
+    const isOwnServerURL = Boolean(serverURL) && urlOrPath.startsWith(serverURL!)
+
+    if (!urlOrPath.startsWith('/') && !isOwnServerURL) {
       // external url
       return urlOrPath
     }

--- a/packages/payload/src/utilities/appendUploadSelectFields.ts
+++ b/packages/payload/src/utilities/appendUploadSelectFields.ts
@@ -32,6 +32,7 @@ export const appendUploadSelectFields = ({
       select.sizes = {
         [collectionConfig.upload.adminThumbnail]: {
           filename: true,
+          url: true,
         },
       }
     } else {

--- a/packages/plugin-cloud-storage/src/fields/getFields.ts
+++ b/packages/plugin-cloud-storage/src/fields/getFields.ts
@@ -179,6 +179,37 @@ export const getFields = ({
     }
 
     fields.push(sizesField)
+
+    /**
+     * `thumbnailURL` is derived from the `adminThumbnail` image size by Payload core, which falls
+     * back to the `/api/<collection>/file/<filename>` route. Point it at the adapter instead so a
+     * cloud-stored upload never references Payload's own file route.
+     */
+    const { adminThumbnail } = collection.upload
+
+    if (adapter && typeof adminThumbnail === 'string') {
+      const adminThumbnailSize = collection.upload.imageSizes.find(
+        (size) => size.name === adminThumbnail,
+      )
+
+      if (adminThumbnailSize) {
+        fields.push({
+          name: 'thumbnailURL',
+          type: 'text',
+          hooks: {
+            afterRead: [
+              getAfterReadHook({
+                adapter,
+                collection,
+                disablePayloadAccessControl,
+                generateFileURL,
+                size: adminThumbnailSize,
+              }),
+            ],
+          },
+        } as TextField)
+      }
+    }
   }
 
   // If prefix is enabled or alwaysInsertFields is true, save it to db

--- a/test/plugin-cloud-storage/collections/MediaWithCustomURL.ts
+++ b/test/plugin-cloud-storage/collections/MediaWithCustomURL.ts
@@ -2,9 +2,17 @@ import type { CollectionConfig } from 'payload'
 
 export const MediaWithCustomURL: CollectionConfig = {
   slug: 'media-with-custom-url',
-  upload: {
-    disableLocalStorage: true,
-  },
   fields: [],
+  upload: {
+    adminThumbnail: 'thumbnail',
+    disableLocalStorage: true,
+    imageSizes: [
+      {
+        name: 'thumbnail',
+        height: 225,
+        width: 300,
+      },
+    ],
+  },
   versions: false,
 }

--- a/test/plugin-cloud-storage/int.spec.ts
+++ b/test/plugin-cloud-storage/int.spec.ts
@@ -1,4 +1,4 @@
-import type { Payload, UploadInstructions } from 'payload'
+import type { Payload, SelectType, UploadInstructions } from 'payload'
 import type { SuiteAPI } from 'vitest'
 
 import * as AWS from '@aws-sdk/client-s3'
@@ -6,7 +6,7 @@ import { getFilePrefix } from '@payloadcms/plugin-cloud-storage/utilities'
 import fs from 'fs'
 import path from 'path'
 import { APIError } from 'payload'
-import { sanitizeFilename } from 'payload/shared'
+import { appendUploadSelectFields, sanitizeFilename } from 'payload/shared'
 import shelljs from 'shelljs'
 import { fileURLToPath } from 'url'
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
@@ -508,6 +508,53 @@ describe('@payloadcms/plugin-cloud-storage', () => {
 
           expect(apiResponse.url).toContain('test-cdn.example.com')
           expect(apiResponse.url).toContain(prefix)
+
+          await payload.delete({ id: upload.id, collection: mediaWithCustomURLSlug })
+        })
+
+        it('should generate thumbnailURL from the adapter instead of the payload file route', async () => {
+          const upload = await payload.create({
+            collection: mediaWithCustomURLSlug,
+            data: {},
+            filePath: path.resolve(dirname, '../uploads/image.png'),
+          })
+
+          expect(upload.thumbnailURL).toContain('test-cdn.example.com')
+
+          const apiResponse = await payload.findByID({
+            id: upload.id,
+            collection: mediaWithCustomURLSlug,
+          })
+
+          expect(apiResponse.thumbnailURL).toContain('test-cdn.example.com')
+
+          await payload.delete({ id: upload.id, collection: mediaWithCustomURLSlug })
+        })
+
+        it('should generate thumbnailURL from the adapter when read with the admin thumbnail select', async () => {
+          const upload = await payload.create({
+            collection: mediaWithCustomURLSlug,
+            data: {},
+            filePath: path.resolve(dirname, '../uploads/image.png'),
+          })
+
+          /** The list view only selects the fields required to render admin thumbnails */
+          const select: SelectType = { id: true }
+
+          appendUploadSelectFields({
+            collectionConfig: payload.collections[mediaWithCustomURLSlug].config,
+            select,
+          })
+
+          const apiResponse = await payload.findByID({
+            id: upload.id,
+            collection: mediaWithCustomURLSlug,
+            select,
+          })
+
+          expect(apiResponse.thumbnailURL).toContain('test-cdn.example.com')
+
+          await payload.delete({ id: upload.id, collection: mediaWithCustomURLSlug })
         })
 
         it('should use custom generateFileURL even without disablePayloadAccessControl', async () => {

--- a/test/plugin-cloud-storage/payload-types.ts
+++ b/test/plugin-cloud-storage/payload-types.ts
@@ -108,6 +108,8 @@ export interface Config {
   locale: null;
   widgets: {
     collections: CollectionsWidget;
+    'collection-query': CollectionQueryWidget;
+    activity: ActivityWidget;
   };
   user: User;
   jobs: {
@@ -207,6 +209,16 @@ export interface MediaWithCustomUrl {
   height?: number | null;
   focalX?: number | null;
   focalY?: number | null;
+  sizes?: {
+    thumbnail?: {
+      url?: string | null;
+      width?: number | null;
+      height?: number | null;
+      mimeType?: string | null;
+      filesize?: number | null;
+      filename?: string | null;
+    };
+  };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -565,6 +577,20 @@ export interface MediaWithCustomUrlSelect<T extends boolean = true> {
   height?: T;
   focalX?: T;
   focalY?: T;
+  sizes?:
+    | T
+    | {
+        thumbnail?:
+          | T
+          | {
+              url?: T;
+              width?: T;
+              height?: T;
+              mimeType?: T;
+              filesize?: T;
+              filename?: T;
+            };
+      };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -784,6 +810,62 @@ export interface CollectionsWidget {
     [k: string]: unknown;
   };
   width: 'full';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "collection-query_widget".
+ */
+export interface CollectionQueryWidget {
+  data?: {
+    title?: string | null;
+    relatedCollection:
+      | 'media'
+      | 'media-with-composite-prefixes'
+      | 'media-with-custom-url'
+      | 'media-with-generate-file-url'
+      | 'media-with-overwrite'
+      | 'media-with-prefix'
+      | 'media-with-throwing-hook'
+      | 'restricted-media'
+      | 'test-metadata'
+      | 'users';
+    where?:
+      | {
+          [k: string]: unknown;
+        }
+      | unknown[]
+      | string
+      | number
+      | boolean
+      | null;
+    sortField?: string | null;
+    sortDirection?: ('asc' | 'desc') | null;
+    limit?: number | null;
+  };
+  width: 'x-small' | 'small' | 'medium' | 'large' | 'x-large' | 'full';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "activity_widget".
+ */
+export interface ActivityWidget {
+  data?: {
+    excludedCollections?:
+      | (
+          | 'media'
+          | 'media-with-composite-prefixes'
+          | 'media-with-custom-url'
+          | 'media-with-generate-file-url'
+          | 'media-with-overwrite'
+          | 'media-with-prefix'
+          | 'media-with-throwing-hook'
+          | 'restricted-media'
+          | 'test-metadata'
+          | 'users'
+        )[]
+      | null;
+  };
+  width: 'x-small' | 'small' | 'medium' | 'large' | 'x-large' | 'full';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema


### PR DESCRIPTION
`thumbnailURL` was left pointing at `/api/<collection>/file/<filename>` while `url` and `sizes[].url` were rewritten to the storage adapter's URL, breaking admin thumbnails wherever Payload's file route is not served.

Derive `thumbnailURL` from the adapter when `adminThumbnail` names an image size. Also fix two core defects the same read path exposed: an absolute URL was treated as internal when `serverURL` was unset, and the admin list select omitted the thumbnail size's `url`.

<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

## Which branch should this PR target?

- **`main`** — Payload v4 development. New features, enhancements, and v4 bug fixes go here.
- **`3.x`** — Payload v3 maintenance. Bug fixes only. **New features are not accepted against v3.** If this PR adds a feature to v3, please retarget it at `main` (v4) instead.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
