### PR TITLE
fix: connect to the correct Next.js dev HMR endpoint per version

### DIFF
--- a/docs/troubleshooting/troubleshooting.mdx
+++ b/docs/troubleshooting/troubleshooting.mdx
@@ -157,8 +157,10 @@ This will ensure that the WebSocket connection uses the correct protocol (`wss:/
 Alternatively if more of your URL is dynamic, you can set the full URL for the WebSocket connection using the `PAYLOAD_HMR_URL_OVERRIDE` environment variable:
 
 ```
-PAYLOAD_HMR_URL_OVERRIDE=wss://localhost:3000/_next/webpack-hmr
+PAYLOAD_HMR_URL_OVERRIDE=wss://localhost:3000/_next/hmr
 ```
+
+You do not need to set this to match your Next.js version. Next.js serves HMR on `/_next/hmr` from version 16.3 onwards, and on `/_next/webpack-hmr` before that. Payload reads the installed Next.js version and connects to the correct path on its own.
 
 ## Database password encoding issues
 

--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -8,7 +8,6 @@ import { spawn } from 'child_process'
 import crypto from 'crypto'
 import { fileURLToPath } from 'node:url'
 import path from 'path'
-import WebSocket from 'ws'
 
 import type { DevReloadStrategy } from './admin/adapters/devReload.js'
 import type { AuthArgs } from './auth/operations/auth.js'
@@ -154,6 +153,7 @@ import { _internal_jobSystemGlobals } from './queues/utilities/getCurrentDate.js
 import { formatAdminURL } from './utilities/formatAdminURL.js'
 import { isNextBuild } from './utilities/isNextBuild.js'
 import { getLogger } from './utilities/logger.js'
+import { defaultNextJsDevReloadStrategy } from './utilities/nextJsDevReloadStrategy.js'
 import { serverInit as serverInitTelemetry } from './utilities/telemetry/events/serverInit.js'
 import { traverseFields } from './utilities/traverseFields.js'
 
@@ -1205,53 +1205,6 @@ if (!_cached) {
  * when calling getPayload multiple times or from multiple locations.
  * - adds HMR support and reloads the payload instance when the config changes.
  */
-/**
- * Default HMR reload strategy using Next.js webpack-hmr WebSocket.
- * Used as fallback when no custom devReloadStrategy is provided.
- */
-function defaultNextJsDevReloadStrategy(): DevReloadStrategy | null {
-  try {
-    const port = process.env.PORT || '3000'
-    const hasHTTPS =
-      process.env.USE_HTTPS === 'true' || process.argv.includes('--experimental-https')
-    const protocol = hasHTTPS ? 'wss' : 'ws'
-
-    const hmrPath = '/_next/webpack-hmr'
-    const prefix = process.env.__NEXT_ASSET_PREFIX ?? ''
-
-    const url =
-      process.env.PAYLOAD_HMR_URL_OVERRIDE ?? `${protocol}://localhost:${port}${prefix}${hmrPath}`
-
-    return {
-      connect(onReload) {
-        const ws = new WebSocket(url)
-
-        ws.onmessage = (event) => {
-          if (typeof event.data === 'string') {
-            const data = JSON.parse(event.data)
-            if (
-              data.type === 'serverComponentChanges' ||
-              data.action === 'serverComponentChanges'
-            ) {
-              onReload()
-            }
-          }
-        }
-
-        ws.onerror = () => {
-          // swallow any websocket connection error
-        }
-
-        return () => {
-          ws.close()
-        }
-      },
-    }
-  } catch (_) {
-    return null
-  }
-}
-
 export const getPayload = async (
   options: {
     /**

--- a/packages/payload/src/utilities/getNextVersion.spec.ts
+++ b/packages/payload/src/utilities/getNextVersion.spec.ts
@@ -1,0 +1,19 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { getNextVersion } from './getNextVersion.js'
+
+describe('getNextVersion', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('should read the version of the installed Next.js', () => {
+    expect(getNextVersion()).toMatch(/^\d+\.\d+\.\d+/)
+  })
+
+  it('should return undefined when Next.js cannot be resolved', () => {
+    vi.spyOn(process, 'cwd').mockReturnValue('/')
+
+    expect(getNextVersion()).toBeUndefined()
+  })
+})

--- a/packages/payload/src/utilities/getNextVersion.ts
+++ b/packages/payload/src/utilities/getNextVersion.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from 'fs'
+
+import { resolveFrom } from './dependencies/resolveFrom.js'
+
+/**
+ * Reads the version of the Next.js installed alongside the running app.
+ * Returns undefined if Next.js cannot be resolved, e.g. because Payload runs
+ * outside of Next.js or from a directory the app's dependencies are not visible from.
+ */
+export const getNextVersion = (): string | undefined => {
+  try {
+    const packageJSONPath = resolveFrom(process.cwd(), 'next/package.json', true)
+
+    if (!packageJSONPath) {
+      return undefined
+    }
+
+    const { version } = JSON.parse(readFileSync(packageJSONPath, 'utf-8'))
+
+    return typeof version === 'string' ? version : undefined
+  } catch (_) {
+    return undefined
+  }
+}

--- a/packages/payload/src/utilities/nextJsDevReloadStrategy.spec.ts
+++ b/packages/payload/src/utilities/nextJsDevReloadStrategy.spec.ts
@@ -1,0 +1,225 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { MockWebSocket } = vi.hoisted(() => {
+  class MockWebSocket {
+    static instances: MockWebSocket[] = []
+
+    isClosed = false
+
+    onclose: (() => void) | null = null
+
+    onerror: (() => void) | null = null
+
+    onmessage: ((event: { data: unknown }) => void) | null = null
+
+    onopen: (() => void) | null = null
+
+    url: string
+
+    constructor(url: string) {
+      this.url = url
+      MockWebSocket.instances.push(this)
+    }
+
+    close() {
+      this.isClosed = true
+    }
+
+    /** Simulate a refused upgrade: the socket errors, then closes without ever opening. */
+    failToConnect() {
+      this.onerror?.()
+      this.onclose?.()
+    }
+
+    /** Simulate Next.js announcing a server component change. */
+    sendServerComponentChanges() {
+      this.onmessage?.({ data: JSON.stringify({ type: 'serverComponentChanges' }) })
+    }
+
+    /** Simulate a successful upgrade. */
+    succeedToConnect() {
+      this.onopen?.()
+    }
+  }
+
+  return { MockWebSocket }
+})
+
+vi.mock('ws', () => ({ default: MockWebSocket }))
+vi.mock('./getNextVersion.js', () => ({ getNextVersion: vi.fn() }))
+
+const { getNextVersion } = await import('./getNextVersion.js')
+const { defaultNextJsDevReloadStrategy } = await import('./nextJsDevReloadStrategy.js')
+
+const modernURL = 'ws://localhost:3000/_next/hmr'
+const legacyURL = 'ws://localhost:3000/_next/webpack-hmr'
+
+describe('defaultNextJsDevReloadStrategy', () => {
+  const cleanups: (() => void)[] = []
+
+  beforeEach(() => {
+    MockWebSocket.instances.length = 0
+    vi.mocked(getNextVersion).mockReturnValue('16.3.0')
+    vi.stubEnv('PAYLOAD_HMR_URL_OVERRIDE', undefined)
+    vi.stubEnv('PORT', '3000')
+  })
+
+  afterEach(() => {
+    for (const cleanup of cleanups) {
+      cleanup()
+    }
+
+    cleanups.length = 0
+    vi.unstubAllEnvs()
+  })
+
+  const connect = (onReload: () => void = () => {}) => {
+    const strategy = defaultNextJsDevReloadStrategy()
+
+    expect(strategy).not.toBeNull()
+
+    cleanups.push(strategy!.connect(onReload))
+  }
+
+  const urls = () => MockWebSocket.instances.map((instance) => instance.url)
+
+  it('should connect only to the current HMR path on Next.js 16.3', () => {
+    connect()
+
+    expect(urls()).toStrictEqual([modernURL])
+  })
+
+  it('should connect only to the current HMR path on Next.js versions above 16.3', () => {
+    vi.mocked(getNextVersion).mockReturnValue('17.0.1')
+
+    connect()
+
+    expect(urls()).toStrictEqual([modernURL])
+  })
+
+  it('should connect only to the legacy HMR path on Next.js below 16.3', () => {
+    vi.mocked(getNextVersion).mockReturnValue('16.2.7')
+
+    connect()
+
+    expect(urls()).toStrictEqual([legacyURL])
+  })
+
+  it('should connect only to the legacy HMR path on a Next.js 15 install', () => {
+    vi.mocked(getNextVersion).mockReturnValue('15.5.0')
+
+    connect()
+
+    expect(urls()).toStrictEqual([legacyURL])
+  })
+
+  // The rename landed partway through the 16.3.0 canary series, so no cutoff is correct
+  // for every canary of that release. Race both rather than guess.
+  it('should try both HMR paths on a canary of the version that renamed the path', () => {
+    vi.mocked(getNextVersion).mockReturnValue('16.3.0-canary.12')
+
+    connect()
+
+    expect(urls()).toStrictEqual([modernURL, legacyURL])
+  })
+
+  it('should connect only to the current HMR path on a canary above 16.3', () => {
+    vi.mocked(getNextVersion).mockReturnValue('17.0.0-canary.1')
+
+    connect()
+
+    expect(urls()).toStrictEqual([modernURL])
+  })
+
+  it('should connect only to the legacy HMR path on a canary below 16.3', () => {
+    vi.mocked(getNextVersion).mockReturnValue('16.2.0-canary.5')
+
+    connect()
+
+    expect(urls()).toStrictEqual([legacyURL])
+  })
+
+  it('should try both HMR paths when the Next.js version is unknown', () => {
+    vi.mocked(getNextVersion).mockReturnValue(undefined)
+
+    connect()
+
+    expect(urls()).toStrictEqual([modernURL, legacyURL])
+  })
+
+  it('should close the losing socket once one of the raced paths opens', () => {
+    vi.mocked(getNextVersion).mockReturnValue(undefined)
+
+    connect()
+
+    MockWebSocket.instances[1]!.succeedToConnect()
+
+    expect(MockWebSocket.instances[0]!.isClosed).toBe(true)
+    expect(MockWebSocket.instances[1]!.isClosed).toBe(false)
+  })
+
+  it('should call onReload for server component changes', () => {
+    const onReload = vi.fn()
+
+    connect(onReload)
+
+    MockWebSocket.instances[0]!.succeedToConnect()
+    MockWebSocket.instances[0]!.sendServerComponentChanges()
+
+    expect(onReload).toHaveBeenCalledTimes(1)
+  })
+
+  it('should ignore messages from a socket that lost the race', () => {
+    const onReload = vi.fn()
+
+    vi.mocked(getNextVersion).mockReturnValue(undefined)
+
+    connect(onReload)
+
+    MockWebSocket.instances[1]!.succeedToConnect()
+    MockWebSocket.instances[0]!.sendServerComponentChanges()
+
+    expect(onReload).not.toHaveBeenCalled()
+  })
+
+  it('should keep listening after a reconnect-worthy close of the open socket', () => {
+    const onReload = vi.fn()
+
+    connect(onReload)
+
+    const socket = MockWebSocket.instances[0]!
+
+    socket.succeedToConnect()
+    socket.onclose?.()
+
+    expect(urls()).toStrictEqual([modernURL])
+  })
+
+  it('should close every socket on cleanup', () => {
+    vi.mocked(getNextVersion).mockReturnValue(undefined)
+
+    const strategy = defaultNextJsDevReloadStrategy()
+    const cleanup = strategy!.connect(() => {})
+
+    cleanup()
+
+    expect(MockWebSocket.instances.map((instance) => instance.isClosed)).toStrictEqual([true, true])
+  })
+
+  it('should use PAYLOAD_HMR_URL_OVERRIDE on its own, whatever the version', () => {
+    vi.mocked(getNextVersion).mockReturnValue(undefined)
+    vi.stubEnv('PAYLOAD_HMR_URL_OVERRIDE', 'ws://localhost:4000/custom-hmr')
+
+    connect()
+
+    expect(urls()).toStrictEqual(['ws://localhost:4000/custom-hmr'])
+  })
+
+  it('should use the wss protocol when HTTPS is enabled', () => {
+    vi.stubEnv('USE_HTTPS', 'true')
+
+    connect()
+
+    expect(urls()).toStrictEqual(['wss://localhost:3000/_next/hmr'])
+  })
+})

--- a/packages/payload/src/utilities/nextJsDevReloadStrategy.spec.ts
+++ b/packages/payload/src/utilities/nextJsDevReloadStrategy.spec.ts
@@ -25,20 +25,9 @@ const { MockWebSocket } = vi.hoisted(() => {
       this.isClosed = true
     }
 
-    /** Simulate a refused upgrade: the socket errors, then closes without ever opening. */
-    failToConnect() {
-      this.onerror?.()
-      this.onclose?.()
-    }
-
     /** Simulate Next.js announcing a server component change. */
     sendServerComponentChanges() {
       this.onmessage?.({ data: JSON.stringify({ type: 'serverComponentChanges' }) })
-    }
-
-    /** Simulate a successful upgrade. */
-    succeedToConnect() {
-      this.onopen?.()
     }
   }
 
@@ -81,81 +70,64 @@ describe('defaultNextJsDevReloadStrategy', () => {
     cleanups.push(strategy!.connect(onReload))
   }
 
-  const urls = () => MockWebSocket.instances.map((instance) => instance.url)
+  const connectedURL = () => {
+    expect(MockWebSocket.instances).toHaveLength(1)
 
-  it('should connect only to the current HMR path on Next.js 16.3', () => {
+    return MockWebSocket.instances[0]!.url
+  }
+
+  it('should connect to the current HMR path on Next.js 16.3', () => {
     connect()
 
-    expect(urls()).toStrictEqual([modernURL])
+    expect(connectedURL()).toBe(modernURL)
   })
 
-  it('should connect only to the current HMR path on Next.js versions above 16.3', () => {
+  it('should connect to the current HMR path on Next.js versions above 16.3', () => {
     vi.mocked(getNextVersion).mockReturnValue('17.0.1')
 
     connect()
 
-    expect(urls()).toStrictEqual([modernURL])
+    expect(connectedURL()).toBe(modernURL)
   })
 
-  it('should connect only to the legacy HMR path on Next.js below 16.3', () => {
+  it('should connect to the legacy HMR path on Next.js below 16.3', () => {
     vi.mocked(getNextVersion).mockReturnValue('16.2.7')
 
     connect()
 
-    expect(urls()).toStrictEqual([legacyURL])
+    expect(connectedURL()).toBe(legacyURL)
   })
 
-  it('should connect only to the legacy HMR path on a Next.js 15 install', () => {
+  it('should connect to the legacy HMR path on a Next.js 15 install', () => {
     vi.mocked(getNextVersion).mockReturnValue('15.5.0')
 
     connect()
 
-    expect(urls()).toStrictEqual([legacyURL])
+    expect(connectedURL()).toBe(legacyURL)
   })
 
-  // The rename landed partway through the 16.3.0 canary series, so no cutoff is correct
-  // for every canary of that release. Race both rather than guess.
-  it('should try both HMR paths on a canary of the version that renamed the path', () => {
+  it('should ignore pre-release identifiers when choosing the path', () => {
     vi.mocked(getNextVersion).mockReturnValue('16.3.0-canary.12')
 
     connect()
 
-    expect(urls()).toStrictEqual([modernURL, legacyURL])
+    expect(connectedURL()).toBe(modernURL)
   })
 
-  it('should connect only to the current HMR path on a canary above 16.3', () => {
-    vi.mocked(getNextVersion).mockReturnValue('17.0.0-canary.1')
-
-    connect()
-
-    expect(urls()).toStrictEqual([modernURL])
-  })
-
-  it('should connect only to the legacy HMR path on a canary below 16.3', () => {
+  it('should connect to the legacy HMR path on a pre-release below 16.3', () => {
     vi.mocked(getNextVersion).mockReturnValue('16.2.0-canary.5')
 
     connect()
 
-    expect(urls()).toStrictEqual([legacyURL])
+    expect(connectedURL()).toBe(legacyURL)
   })
 
-  it('should try both HMR paths when the Next.js version is unknown', () => {
+  it('should connect to the current HMR path when the Next.js version is unknown', () => {
     vi.mocked(getNextVersion).mockReturnValue(undefined)
 
     connect()
 
-    expect(urls()).toStrictEqual([modernURL, legacyURL])
-  })
-
-  it('should close the losing socket once one of the raced paths opens', () => {
-    vi.mocked(getNextVersion).mockReturnValue(undefined)
-
-    connect()
-
-    MockWebSocket.instances[1]!.succeedToConnect()
-
-    expect(MockWebSocket.instances[0]!.isClosed).toBe(true)
-    expect(MockWebSocket.instances[1]!.isClosed).toBe(false)
+    expect(connectedURL()).toBe(modernURL)
   })
 
   it('should call onReload for server component changes', () => {
@@ -163,56 +135,27 @@ describe('defaultNextJsDevReloadStrategy', () => {
 
     connect(onReload)
 
-    MockWebSocket.instances[0]!.succeedToConnect()
     MockWebSocket.instances[0]!.sendServerComponentChanges()
 
     expect(onReload).toHaveBeenCalledTimes(1)
   })
 
-  it('should ignore messages from a socket that lost the race', () => {
-    const onReload = vi.fn()
-
-    vi.mocked(getNextVersion).mockReturnValue(undefined)
-
-    connect(onReload)
-
-    MockWebSocket.instances[1]!.succeedToConnect()
-    MockWebSocket.instances[0]!.sendServerComponentChanges()
-
-    expect(onReload).not.toHaveBeenCalled()
-  })
-
-  it('should keep listening after a reconnect-worthy close of the open socket', () => {
-    const onReload = vi.fn()
-
-    connect(onReload)
-
-    const socket = MockWebSocket.instances[0]!
-
-    socket.succeedToConnect()
-    socket.onclose?.()
-
-    expect(urls()).toStrictEqual([modernURL])
-  })
-
-  it('should close every socket on cleanup', () => {
-    vi.mocked(getNextVersion).mockReturnValue(undefined)
-
+  it('should close the socket on cleanup', () => {
     const strategy = defaultNextJsDevReloadStrategy()
     const cleanup = strategy!.connect(() => {})
 
     cleanup()
 
-    expect(MockWebSocket.instances.map((instance) => instance.isClosed)).toStrictEqual([true, true])
+    expect(MockWebSocket.instances[0]!.isClosed).toBe(true)
   })
 
-  it('should use PAYLOAD_HMR_URL_OVERRIDE on its own, whatever the version', () => {
+  it('should use PAYLOAD_HMR_URL_OVERRIDE whatever the version', () => {
     vi.mocked(getNextVersion).mockReturnValue(undefined)
     vi.stubEnv('PAYLOAD_HMR_URL_OVERRIDE', 'ws://localhost:4000/custom-hmr')
 
     connect()
 
-    expect(urls()).toStrictEqual(['ws://localhost:4000/custom-hmr'])
+    expect(connectedURL()).toBe('ws://localhost:4000/custom-hmr')
   })
 
   it('should use the wss protocol when HTTPS is enabled', () => {
@@ -220,6 +163,6 @@ describe('defaultNextJsDevReloadStrategy', () => {
 
     connect()
 
-    expect(urls()).toStrictEqual(['wss://localhost:3000/_next/hmr'])
+    expect(connectedURL()).toBe('wss://localhost:3000/_next/hmr')
   })
 })

--- a/packages/payload/src/utilities/nextJsDevReloadStrategy.ts
+++ b/packages/payload/src/utilities/nextJsDevReloadStrategy.ts
@@ -1,0 +1,117 @@
+import WebSocket from 'ws'
+
+import type { DevReloadStrategy } from '../admin/adapters/devReload.js'
+
+import { compareVersions, parseVersion } from './dependencies/versionUtils.js'
+import { getNextVersion } from './getNextVersion.js'
+
+/** Next.js serves the dev HMR WebSocket on this path from 16.3 onwards. */
+const modernHMRPath = '/_next/hmr'
+
+/** Next.js served the dev HMR WebSocket on this path before 16.3. */
+const legacyHMRPath = '/_next/webpack-hmr'
+
+const firstModernHMRPathVersion = '16.3.0'
+
+/**
+ * Default HMR reload strategy using the Next.js dev HMR WebSocket.
+ * Used as fallback when no custom devReloadStrategy is provided.
+ */
+export const defaultNextJsDevReloadStrategy = (): DevReloadStrategy | null => {
+  try {
+    const urls = getHMRURLs()
+
+    return {
+      connect(onReload) {
+        const sockets = urls.map((url) => new WebSocket(url))
+
+        let openSocket: null | WebSocket = null
+
+        for (const socket of sockets) {
+          // Next.js answers only on the path its own version serves, and leaves an
+          // upgrade request to any other path open and unanswered, so that a custom
+          // WebSocket server can claim it. That means a wrong path never errors and
+          // never closes - the only reliable signal is which socket opens.
+          socket.onopen = () => {
+            openSocket = socket
+
+            for (const otherSocket of sockets) {
+              if (otherSocket !== socket) {
+                otherSocket.close()
+              }
+            }
+          }
+
+          socket.onmessage = (event) => {
+            if (socket !== openSocket || typeof event.data !== 'string') {
+              return
+            }
+
+            const data = JSON.parse(event.data)
+
+            if (
+              data.type === 'serverComponentChanges' ||
+              data.action === 'serverComponentChanges'
+            ) {
+              onReload()
+            }
+          }
+
+          socket.onerror = () => {
+            // swallow any websocket connection error
+          }
+        }
+
+        return () => {
+          for (const socket of sockets) {
+            socket.close()
+          }
+        }
+      },
+    }
+  } catch (_) {
+    return null
+  }
+}
+
+/**
+ * Returns every HMR URL to connect to. Normally this is the single URL that the installed
+ * Next.js version serves. If that version cannot be read, both known paths are returned and
+ * raced instead, so that HMR still works rather than depending on a correct guess.
+ *
+ * A `PAYLOAD_HMR_URL_OVERRIDE` is used verbatim and on its own, as it states exactly
+ * which endpoint to connect to.
+ */
+const getHMRURLs = (): string[] => {
+  if (process.env.PAYLOAD_HMR_URL_OVERRIDE) {
+    return [process.env.PAYLOAD_HMR_URL_OVERRIDE]
+  }
+
+  const port = process.env.PORT || '3000'
+  const hasHTTPS = process.env.USE_HTTPS === 'true' || process.argv.includes('--experimental-https')
+  const protocol = hasHTTPS ? 'wss' : 'ws'
+  const prefix = process.env.__NEXT_ASSET_PREFIX ?? ''
+
+  return getHMRPaths().map((hmrPath) => `${protocol}://localhost:${port}${prefix}${hmrPath}`)
+}
+
+const getHMRPaths = (): string[] => {
+  const nextVersion = getNextVersion()
+
+  if (!nextVersion) {
+    return [modernHMRPath, legacyHMRPath]
+  }
+
+  const { parts, preReleases } = parseVersion(nextVersion)
+  const mainVersion = parts.join('.')
+
+  // The rename landed partway through the pre-releases of `firstModernHMRPathVersion`, so
+  // its pre-releases serve either path. Race both rather than guess which one.
+  if (preReleases.length && mainVersion === firstModernHMRPathVersion) {
+    return [modernHMRPath, legacyHMRPath]
+  }
+
+  return compareVersions(mainVersion, firstModernHMRPathVersion) === 'lower'
+    ? [legacyHMRPath]
+    : [modernHMRPath]
+}

--- a/packages/payload/src/utilities/nextJsDevReloadStrategy.ts
+++ b/packages/payload/src/utilities/nextJsDevReloadStrategy.ts
@@ -19,36 +19,15 @@ const firstModernHMRPathVersion = '16.3.0'
  */
 export const defaultNextJsDevReloadStrategy = (): DevReloadStrategy | null => {
   try {
-    const urls = getHMRURLs()
+    const url = getHMRURL()
 
     return {
       connect(onReload) {
-        const sockets = urls.map((url) => new WebSocket(url))
+        const ws = new WebSocket(url)
 
-        let openSocket: null | WebSocket = null
-
-        for (const socket of sockets) {
-          // Next.js answers only on the path its own version serves, and leaves an
-          // upgrade request to any other path open and unanswered, so that a custom
-          // WebSocket server can claim it. That means a wrong path never errors and
-          // never closes - the only reliable signal is which socket opens.
-          socket.onopen = () => {
-            openSocket = socket
-
-            for (const otherSocket of sockets) {
-              if (otherSocket !== socket) {
-                otherSocket.close()
-              }
-            }
-          }
-
-          socket.onmessage = (event) => {
-            if (socket !== openSocket || typeof event.data !== 'string') {
-              return
-            }
-
+        ws.onmessage = (event) => {
+          if (typeof event.data === 'string') {
             const data = JSON.parse(event.data)
-
             if (
               data.type === 'serverComponentChanges' ||
               data.action === 'serverComponentChanges'
@@ -56,16 +35,14 @@ export const defaultNextJsDevReloadStrategy = (): DevReloadStrategy | null => {
               onReload()
             }
           }
+        }
 
-          socket.onerror = () => {
-            // swallow any websocket connection error
-          }
+        ws.onerror = () => {
+          // swallow any websocket connection error
         }
 
         return () => {
-          for (const socket of sockets) {
-            socket.close()
-          }
+          ws.close()
         }
       },
     }
@@ -74,17 +51,9 @@ export const defaultNextJsDevReloadStrategy = (): DevReloadStrategy | null => {
   }
 }
 
-/**
- * Returns every HMR URL to connect to. Normally this is the single URL that the installed
- * Next.js version serves. If that version cannot be read, both known paths are returned and
- * raced instead, so that HMR still works rather than depending on a correct guess.
- *
- * A `PAYLOAD_HMR_URL_OVERRIDE` is used verbatim and on its own, as it states exactly
- * which endpoint to connect to.
- */
-const getHMRURLs = (): string[] => {
+const getHMRURL = (): string => {
   if (process.env.PAYLOAD_HMR_URL_OVERRIDE) {
-    return [process.env.PAYLOAD_HMR_URL_OVERRIDE]
+    return process.env.PAYLOAD_HMR_URL_OVERRIDE
   }
 
   const port = process.env.PORT || '3000'
@@ -92,26 +61,24 @@ const getHMRURLs = (): string[] => {
   const protocol = hasHTTPS ? 'wss' : 'ws'
   const prefix = process.env.__NEXT_ASSET_PREFIX ?? ''
 
-  return getHMRPaths().map((hmrPath) => `${protocol}://localhost:${port}${prefix}${hmrPath}`)
+  return `${protocol}://localhost:${port}${prefix}${getHMRPath()}`
 }
 
-const getHMRPaths = (): string[] => {
+/**
+ * Pre-release identifiers are ignored, so that a `16.3.0-canary` build maps to the 16.3 path.
+ * An unreadable version uses the current path, as Payload being unable to resolve Next.js
+ * normally means it is not running under Next.js, where this strategy does not apply.
+ */
+const getHMRPath = (): string => {
   const nextVersion = getNextVersion()
 
   if (!nextVersion) {
-    return [modernHMRPath, legacyHMRPath]
+    return modernHMRPath
   }
 
-  const { parts, preReleases } = parseVersion(nextVersion)
-  const mainVersion = parts.join('.')
-
-  // The rename landed partway through the pre-releases of `firstModernHMRPathVersion`, so
-  // its pre-releases serve either path. Race both rather than guess which one.
-  if (preReleases.length && mainVersion === firstModernHMRPathVersion) {
-    return [modernHMRPath, legacyHMRPath]
-  }
+  const mainVersion = parseVersion(nextVersion).parts.join('.')
 
   return compareVersions(mainVersion, firstModernHMRPathVersion) === 'lower'
-    ? [legacyHMRPath]
-    : [modernHMRPath]
+    ? legacyHMRPath
+    : modernHMRPath
 }


### PR DESCRIPTION
### What?

Payload's config hot reload in development stopped working on Next.js 16.3. Adding a collection or a field had no effect until the dev server was restarted.

Next.js 16.3 renamed the dev HMR WebSocket endpoint:

- Old: `/_next/webpack-hmr` — [`router-server.ts#L859-L860` on `v16.2.7`](https://github.com/vercel/next.js/blob/v16.2.7/packages/next/src/server/lib/router-server.ts#L859-L860)
- New: `/_next/hmr` — [`router-server.ts#L946-L947` on `v16.3.0`](https://github.com/vercel/next.js/blob/v16.3.0/packages/next/src/server/lib/router-server.ts#L946-L947)

The client moved with it, in [`client/dev/hot-reloader/app/web-socket.ts`](https://github.com/vercel/next.js/blob/v16.3.0/packages/next/src/client/dev/hot-reloader/app/web-socket.ts). There is no alias in either direction: `/_next/webpack-hmr` does not appear anywhere in the 16.3.0 build, and `/_next/hmr` does not appear anywhere in 16.2.7.

### Why?

Payload hardcoded `/_next/webpack-hmr`. On 16.3 the upgrade request no longer matched, so the socket never opened. The failure was invisible because the `onerror` handler and the surrounding `connect` call both swallow errors, so `onReload` never fired, `cached.reload` stayed `false`, and `reload()` never ran. No type regeneration, no import map regeneration, and no client config cache clear. Just an incorrect endpoint.

[Related Vercel PR ](https://github.com/vercel/next.js/pull/91415)which went into canary several months ago

### How?

Read the installed Next.js version and connect to the path that version serves: `/_next/hmr` at 16.3 and above, `/_next/webpack-hmr` below it. One socket, no configuration, correct across supported Next.js versions.

Version detection reads `next/package.json` resolved from `process.cwd()`, reusing the existing `resolveFrom` and `compareVersions` helpers. `resolveFrom` goes through `Module._resolveFilename`, so Next's `exports` map cannot block it. Since resolution starts at the app root, an app on 16.3 is detected as 16.3 regardless of what this repo pins for its own tests.

Two deliberate calls in that decision:

- Pre-release identifiers are ignored, so `16.3.0-canary.12` maps to `/_next/hmr`. Strict semver would rank it below `16.3.0` and pick the legacy path.
- An unreadable version uses `/_next/hmr`. Payload being unable to resolve Next.js usually means it is not running under Next.js, where this strategy does not apply.

Trying the new path first and falling back when it fails is **not** viable, which is worth recording for future reference. Next.js answers only on the path its own version serves, and leaves any other upgrade request open and unanswered so that a custom WebSocket server can claim it. Probing a real 16.2.7 dev server:

```
/_next/hmr             => no response after 8s
/_next/webpack-hmr     => open
/_next/not-a-real-path => no response after 8s
```

A wrong path never errors and never closes, so a fallback triggered by failure would hang forever on Next 16.2 and below and break HMR for every older version.

`PAYLOAD_HMR_URL_OVERRIDE` keeps working and is still used verbatim, skipping version detection.

The strategy also moved out of `packages/payload/src/index.ts` into `packages/payload/src/utilities/nextJsDevReloadStrategy.ts` so it can be tested directly.

### Testing

Unit tests cover path selection per version, pre-release handling, the unknown-version default, message handling, cleanup, and the override. Written first and confirmed failing against the old behaviour before the fix.

Verified end-to-end against a running dev server on 16.2.7 to confirm no regression on the older endpoint: editing a collection regenerated the import map and the new field appeared in the admin UI without a restart. The 16.3 path is covered by the endpoint rename in Next's source plus unit tests, not by a live reload — booting this repo's dev server on 16.3.0 is blocked by an unrelated problem in Next 16.3's rewritten TypeScript verification, which reports `typescript` as missing and tries to install it at the workspace root. That is a separate piece of work, and this fix is version-independent, so the repo's Next pin stays at 16.2.7 here.