### PR TITLE
feat: preserve Unicode in default slugify

### DIFF
--- a/docs/fields/slug.mdx
+++ b/docs/fields/slug.mdx
@@ -48,6 +48,7 @@ The slug is static: it fills once while empty and is preserved thereafter, so ed
 
 - On create, an empty slug is derived from the `useAsSlug` source field, if any. With no source value (or no `useAsSlug` configured), it falls back to `<singular>-<N>`, where `N` is the first available integer (e.g. `posts-1`). The slug is therefore always present the moment the document is created.
 - An explicit value always wins and is normalized through [`slugify`](#custom-slugify-function) (e.g. `Hello World` → `hello-world`). It must be unique — a collision is rejected rather than silently changed.
+- The default slugify is Unicode-preserving: letters and numbers from any script are kept (`正念餅乾` stays `正念餅乾`, `Café Pläne` becomes `café-pläne`) rather than transliterated. Input is NFKC-normalized, so full-width characters fold to their ASCII forms (`ＡＢＣ` → `abc`). Whitespace and dashes become hyphens, and invisible characters — zero-width joiners, bidi controls, variation selectors — are removed, so two slugs never differ by a character a reader cannot see. Lowercasing is not locale-aware — Turkish `I` folds to `i`, never dotless `ı`.
 - Once set, the slug is never regenerated automatically. Editors can unlock the field to edit it directly, or re-generate it on-demand from the Admin Panel.
 - Generated values are deduped against existing documents so two never claim the same slug.
 
@@ -59,7 +60,7 @@ A localized slug is unique per locale: the same value can be reused across a doc
 
 ## Custom Slugify Function
 
-You can override the default slugify function of the Slug Field. This is necessary if the slug requires special treatment, such as character encoding, additional language support, etc.
+You can override the default slugify function of the Slug Field. The default preserves Unicode letters as-is, so an override is only necessary for special treatment such as transliteration (e.g. `正念餅乾` → `zheng-nian-bing-gan`), locale-aware casing, or custom character encoding.
 
 This function receives the value of the `useAsSlug` field as `valueToSlugify` and must return a string.
 

--- a/docs/migration-guide/v4.mdx
+++ b/docs/migration-guide/v4.mdx
@@ -45,6 +45,36 @@ export default buildConfig({
 
 One place inherits `defaultDepth` without naming it: when localization is enabled, `@payloadcms/plugin-search` refetches the document without an explicit depth before handing `originalDoc` to your `beforeSync` hook. Read only first-level relationships there, or refetch yourself with the depth you need.
 
+### Default `slugify` is now Unicode-preserving
+
+The default slug transform (used by the `slug` field, hierarchy path computation, and exported from `payload/shared`) previously deleted every non-ASCII character, so non-Latin titles produced empty slugs and fell back to `posts-1`-style values, and accented titles were mangled (`Café Pläne` → `caf-plne`). It now preserves Unicode letters and numbers from any script:
+
+| title        | 3.x slug             | 4.0 slug     |
+| ------------ | -------------------- | ------------ |
+| `你好世界`   | `posts-1` (fallback) | `你好世界`   |
+| `Привет мир` | `-`                  | `привет-мир` |
+| `Café Pläne` | `caf-plne`           | `café-pläne` |
+
+Input is NFKC-normalized (full-width `ＡＢＣ１２３` folds to `abc123`, with some lossy folds such as `½` → `12`, `⅒` → `110`, and `№` → `no`). Every character Unicode classifies as a dash — including the minus sign `−`, which was previously deleted and silently joined the words on either side — becomes a hyphen, as does all whitespace. Invisible characters are removed: zero-width joiners, bidi controls, and variation selectors. Removing variation selectors means glyph variants of the same character share one slug (`辻` with and without `U+E0100`); use the `slugify` override if you need that distinction. Lowercasing is invariant, not locale-aware, so Turkish `I` becomes `i` rather than `ı`. To keep ASCII-only slugs via transliteration, use the [`slugify` field option](../fields/slug#custom-slugify-function).
+
+Most ASCII titles are unaffected — `Hello World` is still `hello-world`, and underscores are still kept, so `foo_bar` is still `foo_bar`. These cases change:
+
+| input     | 3.x     | 4.0             |
+| --------- | ------- | --------------- |
+| `a  b`    | `a--b`  | `a-b`           |
+| `a--b`    | `a--b`  | `a-b`           |
+| `-abc-`   | `-abc-` | `abc`           |
+| `a-`      | `a-`    | `a`             |
+| `a<tab>b` | `ab`    | `a-b`           |
+| `___`     | `___`   | `''` (fallback) |
+| `-`       | `-`     | `''` (fallback) |
+
+Consecutive hyphens collapse, leading and trailing hyphens are trimmed, and whitespace that used to be deleted — tabs, non-breaking spaces — now separates words. A slug containing no letter or number at all is treated as empty, and the numeric fallback applies instead.
+
+Existing stored slugs are not rewritten by upgrading. They are re-normalized the next time a document is saved with its slug in the payload, which autosave does on every tick. A stored `a--b` therefore becomes `a-b`. If the re-normalized value collides with another document's slug, the save fails with a validation error rather than deduplicating — only slugs Payload generates from the source field get a numeric suffix, and a value submitted in the slug field must be unique as-is. With autosave enabled this repeats on every tick until an editor sets a new slug by hand.
+
+Legacy slugs with no letter or number, such as `-` or `___`, are preserved rather than emptied: a submitted value that normalizes to nothing is ignored and the stored slug wins. Clearing the field does not regenerate it either — an empty submission is ignored the same way. To replace one of these, click Generate to derive a slug from the source field, or type a replacement directly.
+
 ### Versions are now enabled by default for all collections and globals
 
 Collections and globals now have `versions: true` by default (`maxPerDoc`/`max: 100`, drafts disabled). In previous versions you had to opt in; you now opt out.

--- a/packages/payload/src/utilities/slugify.spec.ts
+++ b/packages/payload/src/utilities/slugify.spec.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it } from 'vitest'
+
+import { slugify } from './slugify.js'
+
+/**
+ * Inputs for the invariant suite at the bottom: every literal asserted in this
+ * file, plus a few extra adversarial inputs. When you add a case to any block
+ * above, add its input here too.
+ */
+const allInputs: string[] = [
+  '',
+  '   ',
+  'Hello World!',
+  '  Trimmed  ',
+  'snake_case stays',
+  '你好世界',
+  '正念餅乾',
+  '안녕하세요',
+  'Привет мир',
+  'Γειά σου Κόσμε',
+  'مرحبا بالعالم',
+  'שלום עולם',
+  'สวัสดีชาวโลก',
+  'नमस्ते दुनिया',
+  'Café Pläne',
+  'Fahrplan Zukunft Pläne',
+  'Điện Biên Phủ',
+  'ＡＢＣ１２３',
+  '½',
+  'Ⅻ',
+  '㍿',
+  'a  b',
+  'a—b',
+  'a–b',
+  'a--b',
+  '-abc-',
+  'a---b',
+  'a\tb',
+  'a-',
+  'a\u2011b',
+  'a\u2212b',
+  'a\u2053b',
+  'a\u2043b',
+  'a\u00ADb',
+  'a\u207Bb',
+  'a\u301Cb',
+  'a\u00A0b',
+  '!!!',
+  '-',
+  '___',
+  '-_-',
+  '\u0301',
+  '👍',
+  '❤️',
+  '👨‍👩‍👧',
+  'a❤️b',
+  'a!\u0301b',
+  '1️⃣',
+  '\u0301abc',
+  'İstanbul',
+  'อุ',
+  'a\u200cb',
+  'a\u200db',
+  'אבג\u202etxt',
+  'a\uFE0Fb',
+  'a\u034Fb',
+  '\u3164',
+  '\uFFA0',
+  'a\u3164b',
+  'H\u0331',
+  '\u1E96',
+  'J\u030C',
+  '\u01F0',
+  'T\u0308',
+  '\u1E97',
+  '\u1100!\u1161',
+  'a\u202e\u0301b',
+  'a\u200c\u0301b',
+  'a\ufe0f\u0301b',
+  'a\u034f\u0301b',
+  'a\u3164\u0301b',
+  '\u00e1b',
+  '¼',
+  '⅒',
+  '↉',
+  '⑿',
+  '㊿',
+  '№',
+  '༳',
+  '௰',
+]
+
+describe('slugify', () => {
+  it('should handle empty input', () => {
+    expect(slugify(undefined)).toBeUndefined()
+    expect(slugify('')).toBe('')
+    expect(slugify('   ')).toBe('')
+  })
+
+  it('should slugify ASCII text', () => {
+    expect(slugify('Hello World!')).toBe('hello-world')
+    expect(slugify('  Trimmed  ')).toBe('trimmed')
+    expect(slugify('snake_case stays')).toBe('snake_case-stays')
+  })
+
+  it('should preserve non-Latin scripts', () => {
+    expect(slugify('你好世界')).toBe('你好世界')
+    expect(slugify('正念餅乾')).toBe('正念餅乾')
+    expect(slugify('안녕하세요')).toBe('안녕하세요')
+    expect(slugify('Привет мир')).toBe('привет-мир')
+    expect(slugify('Γειά σου Κόσμε')).toBe('γειά-σου-κόσμε')
+    expect(slugify('مرحبا بالعالم')).toBe('مرحبا-بالعالم')
+    expect(slugify('שלום עולם')).toBe('שלום-עולם')
+    expect(slugify('สวัสดีชาวโลก')).toBe('สวัสดีชาวโลก')
+    expect(slugify('नमस्ते दुनिया')).toBe('नमस्ते-दुनिया')
+  })
+
+  it('should preserve accented Latin', () => {
+    expect(slugify('Café Pläne')).toBe('café-pläne')
+    expect(slugify('Fahrplan Zukunft Pläne')).toBe('fahrplan-zukunft-pläne')
+    expect(slugify('Điện Biên Phủ')).toBe('điện-biên-phủ')
+  })
+
+  it('should fold compatibility forms via NFKC', () => {
+    expect(slugify('ＡＢＣ１２３')).toBe('abc123')
+    expect(slugify('½')).toBe('12')
+    expect(slugify('Ⅻ')).toBe('xii')
+    expect(slugify('㍿')).toBe('株式会社')
+  })
+
+  it('should collapse whitespace and dash punctuation to single hyphens', () => {
+    expect(slugify('a  b')).toBe('a-b')
+    expect(slugify('a—b')).toBe('a-b') // em dash
+    expect(slugify('a–b')).toBe('a-b') // en dash
+    expect(slugify('a--b')).toBe('a-b')
+    expect(slugify('-abc-')).toBe('abc')
+    expect(slugify('a---b')).toBe('a-b')
+  })
+
+  it('should treat the full Unicode Dash set, plus the hyphen bullet, as separators', () => {
+    expect(slugify('a\u2011b')).toBe('a-b') // non-breaking hyphen
+    expect(slugify('a\u2212b')).toBe('a-b') // minus sign — Dash but not Dash_Punctuation
+    expect(slugify('a\u2053b')).toBe('a-b') // swung dash — Dash but not Dash_Punctuation
+    expect(slugify('a\u2043b')).toBe('a-b') // hyphen bullet — explicit addition, in neither set
+    expect(slugify('a\u207Bb')).toBe('a-b') // superscript minus, folds to U+2212 under NFKC
+    expect(slugify('a\u301Cb')).toBe('a-b') // wave dash
+    expect(slugify('a\u00A0b')).toBe('a-b') // NBSP is \s — separated, no longer joined
+  })
+
+  it('should delete the soft hyphen rather than turn it into a separator', () => {
+    // U+00AD marks a permitted line-break point inside a word; the word is one word.
+    expect(slugify('a\u00ADb')).toBe('ab')
+  })
+
+  it('should return the empty string when no letter or number remains', () => {
+    expect(slugify('!!!')).toBe('')
+    expect(slugify('-')).toBe('')
+    expect(slugify('___')).toBe('')
+    expect(slugify('-_-')).toBe('')
+    expect(slugify('\u0301')).toBe('') // lone combining acute
+    expect(slugify('👍')).toBe('')
+    expect(slugify('❤️')).toBe('') // heart + variation selector
+    expect(slugify('👨‍👩‍👧')).toBe('') // ZWJ family sequence
+    expect(slugify('\u3164')).toBe('') // Hangul filler — an invisible \p{L}, must not satisfy the guard
+    expect(slugify('\uFFA0')).toBe('') // halfwidth Hangul filler, same
+  })
+
+  it('should not let removed characters re-attach their combining marks', () => {
+    expect(slugify('a❤️b')).toBe('ab')
+    expect(slugify('a!\u0301b')).toBe('ab')
+  })
+
+  it('should strip marks that do not follow a letter', () => {
+    expect(slugify('1️⃣')).toBe('1') // keycap: digit + VS16 + combining enclosing keycap
+    expect(slugify('\u0301abc')).toBe('abc')
+  })
+
+  it('should keep marks that follow a letter', () => {
+    expect(slugify('İstanbul')).toBe('i\u0307stanbul')
+    expect(slugify('อุ')).toBe('อุ') // Thai letter + vowel mark below
+  })
+
+  it('should strip ZWJ, ZWNJ, and bidi controls', () => {
+    expect(slugify('a\u200cb')).toBe('ab') // ZWNJ
+    expect(slugify('a\u200db')).toBe('ab') // ZWJ
+    expect(slugify('אבג\u202etxt')).toBe('אבגtxt') // RLO
+  })
+
+  it('should strip default-ignorable code points that hide between visible characters', () => {
+    expect(slugify('a\uFE0Fb')).toBe('ab') // variation selector 16
+    expect(slugify('a\u034Fb')).toBe('ab') // combining grapheme joiner
+    expect(slugify('a\u3164b')).toBe('ab') // Hangul filler mid-word
+  })
+
+  it('should not let a deleted invisible character re-attach its combining marks', () => {
+    // The default-ignorable strip has to run after the disallowed-character pass
+    // and carry the same trailing \p{M}*. Otherwise deleting the invisible exposes
+    // its marks to the preceding letter, and NFKC composes them: every case here
+    // would become 'áb' and collide with a genuine 'áb'.
+    expect(slugify('a‮́b')).toBe('ab') // RLO — grapheme-breaking, mark was never on the 'a'
+    expect(slugify('a‌́b')).toBe('ab') // ZWNJ
+    expect(slugify('a️́b')).toBe('ab') // variation selector 16
+    expect(slugify('a͏́b')).toBe('ab') // combining grapheme joiner
+    expect(slugify('aㅤ́b')).toBe('ab') // Hangul filler
+    expect(slugify('áb')).toBe('áb') // the genuine title the above must not collide with
+  })
+
+  it('should produce byte-identical, NFKC-normalized output for canonically equivalent inputs', () => {
+    // Lowercasing a composed capital can only be expressed decomposed; without a
+    // trailing normalize these pairs would be canonically equal but byte-distinct,
+    // and exact-string uniqueness checks would treat them as different slugs.
+    expect(slugify('H\u0331')).toBe('\u1E96') // ẖ, single code point
+    expect(slugify('H\u0331')).toBe(slugify('\u1E96'))
+    expect(slugify('J\u030C')).toBe('\u01F0') // ǰ
+    expect(slugify('J\u030C')).toBe(slugify('\u01F0'))
+    expect(slugify('T\u0308')).toBe('\u1E97') // ẗ
+    expect(slugify('T\u0308')).toBe(slugify('\u1E97'))
+  })
+
+  it('should renormalize after deletions expose composable sequences', () => {
+    // Deleting the '!' makes the two jamo adjacent; NFKC composes them into a
+    // syllable. If normalization ran before the deletions instead of after,
+    // the output would not be a fixed point and autosave would rewrite it.
+    expect(slugify('\u1100!\u1161')).toBe('\uAC00')
+  })
+
+  it('should be a fixed point: slugify(slugify(x)) === slugify(x)', () => {
+    // Autosave resends the stored slug on every tick and it is re-slugified.
+    // Any input whose slug is not a fixed point gets silently rewritten.
+    for (const input of allInputs) {
+      const once = slugify(input)
+      expect(slugify(once)).toBe(once)
+    }
+  })
+
+  it('should be invariant under the normalization form of the input', () => {
+    // The same visible title typed on macOS (NFD-ish) and Windows (NFC-ish)
+    // must produce the same slug.
+    for (const input of allInputs) {
+      const out = slugify(input)
+      expect(slugify(input.normalize('NFD'))).toBe(out)
+      expect(slugify(input.normalize('NFC'))).toBe(out)
+    }
+  })
+})

--- a/packages/payload/src/utilities/slugify.ts
+++ b/packages/payload/src/utilities/slugify.ts
@@ -1,6 +1,80 @@
-export const slugify = (val?: string): string | undefined =>
-  val
-    ?.trim()
-    .replace(/ /g, '-')
-    .replace(/[^\w-]+/g, '')
+/**
+ * Converts a string into a URL-safe slug, preserving non-Latin scripts.
+ *
+ * Contract, which `generateSlug` and `computePaths` depend on:
+ * - `null`/`undefined` in → `undefined` out.
+ * - Anything that cannot yield a usable slug → `''` (never a string with no
+ *   visible letter or number), so the caller's `hasValue` check works.
+ * - The output is a fixed point: `slugify(slugify(x)) === slugify(x)`.
+ *   Autosave re-slugifies the stored slug on every tick; a non-fixed-point
+ *   would rewrite slugs behind the editor's back.
+ * - Canonically equivalent inputs produce byte-identical output, and the
+ *   output is itself NFKC-normalized, so exact-string uniqueness checks and
+ *   normalizing downstream layers (databases, routers, CDNs) agree on
+ *   which slugs are the same.
+ *
+ * Scripts are preserved, never transliterated (`正念餅乾` stays `正念餅乾`).
+ * Use the field-level `slugify` override or `hierarchy.slugify` for
+ * transliteration. Lowercasing is locale-independent by design: the same
+ * title must produce the same slug on every machine.
+ *
+ * Only ES2018 regex features are used. No lookbehind — Safari < 16.4 fails
+ * at parse time on lookbehind, and this ships in the browser admin bundle
+ * (see the same decision in `wordBoundariesRegex.ts`).
+ */
+export const slugify = (val?: string): string | undefined => {
+  if (val == null) {
+    return undefined
+  }
+
+  const result = val
+    // Fold compatibility forms first (full-width ＡＢＣ → abc, ㍿ → 株式会社),
+    // and equalize NFC/NFD input so the same visible title always slugifies
+    // identically regardless of the platform that typed it.
+    .normalize('NFKC')
     .toLowerCase()
+    // Whitespace and anything Unicode classifies as a dash become hyphens.
+    // \p{Dash}, not \p{Dash_Punctuation}: the minus sign U+2212 and swung dash
+    // U+2053 are dashes but not Pd, and deleting them would join the two sides
+    // (`a−b` → `ab`) — a silent collision with a real `ab`. U+2043 (hyphen
+    // bullet) is dash-shaped but in neither set, so it is added explicitly.
+    .replace(/[\s\p{Dash}\u2043]+/gu, '-')
+    // Drop everything that isn't a letter, combining mark, number, underscore,
+    // or hyphen. The trailing \p{M}* is load-bearing: it deletes combining marks
+    // together with the character they were attached to, so `a!́b` → `ab`
+    // rather than the orphaned mark re-attaching to the `a`.
+    .replace(/[^\p{L}\p{M}\p{N}_-]+\p{M}*/gu, '')
+    // Then the invisible characters the pass above keeps because they are marks
+    // (VS16, CGJ, the Mongolian and ideographic variation selectors) or even
+    // letters (the Hangul fillers U+115F/U+1160/U+3164/U+FFA0). Left in, they
+    // produce slugs that compare unequal without reliably looking different, and
+    // a filler alone would satisfy the letter-or-number guard below as an
+    // invisible slug. The variation selectors are the deliberate trade-off here:
+    // they do change rendering, so stripping them merges glyph variants of the
+    // same character (辻 U+8FBB with and without U+E0100) into one slug. A URL
+    // is the wrong place to carry a distinction a reader cannot see or type.
+    // This must run AFTER the pass above, and needs the same trailing \p{M}*:
+    // deleting an invisible would otherwise expose its combining marks to the
+    // preceding character, so `a<RLO>́b` would compose to `áb` and collide with
+    // a genuine `áb`. Removing the marks along with what they followed gives `ab`.
+    .replace(/\p{Default_Ignorable_Code_Point}+\p{M}*/gu, '')
+    // Strip any remaining mark run that doesn't follow a letter or another mark
+    // (i.e. at the start, or after a digit/underscore/hyphen). Written as a
+    // capture instead of a lookbehind for Safari < 16.4, matching the approach
+    // in wordBoundariesRegex.ts.
+    .replace(/(^|[^\p{L}\p{M}])\p{M}+/gu, '$1')
+    // Re-normalize, and only here. Two things de-normalize the string above:
+    // lowercasing (NFKC has no composed form for H̱, so lowercase leaves
+    // `h + U+0331` instead of the canonical single code point ẖ), and the
+    // deletions themselves (removing the `!` from `ᄀ!ᅡ` leaves adjacent jamo
+    // that NFKC composes into 가). Normalizing any earlier misses the second
+    // case and the output stops being a fixed point.
+    .normalize('NFKC')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '')
+
+  // A slug must contain at least one visible letter or number. Without this,
+  // input like `-_-` would survive as a non-empty string, pass the caller's
+  // hasValue check, and suppress the numeric fallback.
+  return /[\p{L}\p{N}]/u.test(result) ? result : ''
+}

--- a/test/fields/int.spec.ts
+++ b/test/fields/int.spec.ts
@@ -113,6 +113,135 @@ describe('Fields', () => {
       expect(doc.slug).toBe('hello-world')
     })
 
+    it('should generate a non-ASCII slug from a non-Latin source', async () => {
+      const doc = await payload.create({
+        collection: 'slug-fields',
+        data: { title: '正念餅乾' },
+      })
+      created.push(doc.id)
+      expect(doc.slug).toBe('正念餅乾')
+
+      const accented = await payload.create({
+        collection: 'slug-fields',
+        data: { title: 'Café Pläne' },
+      })
+      created.push(accented.id)
+      expect(accented.slug).toBe('café-pläne')
+    })
+
+    it('should dedupe generated non-ASCII slugs with a numeric suffix', async () => {
+      const first = await payload.create({
+        collection: 'slug-fields',
+        data: { title: '你好世界' },
+      })
+      created.push(first.id)
+      expect(first.slug).toBe('你好世界')
+
+      const second = await payload.create({
+        collection: 'slug-fields',
+        data: { title: '你好世界' },
+      })
+      created.push(second.id)
+      expect(second.slug).toBe('你好世界-1')
+    })
+
+    it('should reject an explicit non-ASCII slug that collides', async () => {
+      const first = await payload.create({
+        collection: 'slug-fields',
+        data: { title: 'First', slug: '你好世界' },
+      })
+      created.push(first.id)
+      expect(first.slug).toBe('你好世界')
+
+      await expect(
+        payload.create({
+          collection: 'slug-fields',
+          data: { title: 'Second', slug: '你好世界' },
+        }),
+      ).rejects.toThrow()
+    })
+
+    it('should preserve a stored slug when an update sends a value that slugifies to nothing', async () => {
+      // A stored legacy slug like `-` re-sent by autosave slugifies to `''` under the new
+      // transform; the hook must fall through to preserving the stored value, not empty it.
+      const doc = await payload.create({
+        collection: 'slug-fields',
+        data: { title: 'Stable Title' },
+      })
+      created.push(doc.id)
+      expect(doc.slug).toBe('stable-title')
+
+      const updated = await payload.update({
+        collection: 'slug-fields',
+        id: doc.id,
+        data: { slug: '!!!' },
+      })
+      expect(updated.slug).toBe('stable-title')
+    })
+
+    it('should preserve a legacy slug that the new transform empties, and not regenerate it on clear', async () => {
+      // Pre-4.0, a pure-Cyrillic title stored `-`. That value has no letter or number,
+      // so it now slugifies to `''`. Seed it through the db to bypass the hook, since
+      // the hook itself can no longer produce it.
+      const doc = await payload.create({
+        collection: 'slug-fields',
+        data: { title: 'Legacy' },
+      })
+      created.push(doc.id)
+      await payload.db.updateOne({
+        id: doc.id,
+        collection: 'slug-fields',
+        data: { slug: '-' },
+      })
+
+      // Autosave resends the stored slug on every tick; it must survive.
+      const resent = await payload.update({
+        collection: 'slug-fields',
+        id: doc.id,
+        data: { slug: '-' },
+      })
+      expect(resent.slug).toBe('-')
+
+      // Clearing the field does not regenerate it — an empty submission is ignored
+      // and the stored value wins. Documented in the v4 migration guide.
+      const cleared = await payload.update({
+        collection: 'slug-fields',
+        id: doc.id,
+        data: { slug: '' },
+      })
+      expect(cleared.slug).toBe('-')
+    })
+
+    it('should reject rather than dedupe when a re-normalized slug collides', async () => {
+      // `a--b` re-normalizes to `a-b` on the next save. Only generated values are
+      // deduped, so an explicit value that lands on an existing slug must throw.
+      const target = await payload.create({
+        collection: 'slug-fields',
+        data: { title: 'Target', slug: 'a-b' },
+      })
+      created.push(target.id)
+      expect(target.slug).toBe('a-b')
+
+      const legacy = await payload.create({
+        collection: 'slug-fields',
+        data: { title: 'Legacy Dashes' },
+      })
+      created.push(legacy.id)
+      await payload.db.updateOne({
+        id: legacy.id,
+        collection: 'slug-fields',
+        data: { slug: 'a--b' },
+      })
+
+      await expect(
+        payload.update({
+          collection: 'slug-fields',
+          id: legacy.id,
+          data: { slug: 'a--b' },
+        }),
+      ).rejects.toThrow()
+    })
+
     it('should freeze a diverged slug on update', async () => {
       const doc = await payload.create({
         collection: 'slug-fields',

--- a/test/hierarchy/int.spec.ts
+++ b/test/hierarchy/int.spec.ts
@@ -1137,7 +1137,7 @@ describe('Hierarchy', () => {
       })
 
       expect(draftChild._h_slugPath).toEqual({
-        de: 'fahrplan/zukunft/plne', // Note: Default slugify removes umlauts
+        de: 'fahrplan/zukunft/pläne', // Default slugify preserves Unicode letters
         en: 'roadmap/future/plans',
         es: 'hoja-de-ruta/futuro/planes',
       })


### PR DESCRIPTION
## Summary

The default slug transform filtered with `[^\w-]+`, and `\w` in JavaScript is `[A-Za-z0-9_]`. Every non-ASCII character was deleted, so non-Latin titles slugified to an empty string, `getSlugFallbackValue` took over, and documents ended up as `posts-1`, `posts-2`, `posts-3`. Accented Latin was mangled rather than emptied, so this is not only a CJK problem — French, Spanish, German, Polish and Vietnamese are all affected.

| title         | before               | after         |
| ------------- | -------------------- | ------------- |
| `你好世界`    | `posts-1` (fallback) | `你好世界`    |
| `안녕하세요`  | `posts-2` (fallback) | `안녕하세요`  |
| `Привет мир`  | `-`                  | `привет-мир`  |
| `Café Pläne`  | `caf-plne`           | `café-pläne`  |
| `ＡＢＣ 123`  | `-123`               | `abc-123`     |
| `hello world` | `hello-world`        | `hello-world` |
| `foo_bar`     | `foo_bar`            | `foo_bar`     |

The same function backs hierarchy path computation through `computePaths.ts`, so non-Latin paths were broken identically — the existing `de: 'fahrplan/zukunft/plne'` assertion in `test/hierarchy/int.spec.ts` is updated here.

Follows the discussion in #17532, and the follow-up noted in #14117 that the default should handle special characters on its own.

## How

Same shape as before — whitespace to hyphens, strip the rest, lowercase — with Unicode-aware character classes. No new dependencies, same signature, same `''`-for-unusable-input contract, no lookbehind (`slugify` ships in `payload/shared` and runs in the admin bundle; this matches the Safari note already in `wordBoundariesRegex.ts`).

Three decisions worth stating, since they are policy rather than mechanics:

**Preserve, don't transliterate.** `正念餅乾` stays `正念餅乾`. Transliteration is per-script policy and lossy — for Chinese it is ambiguous, since homophones collapse — and `slugify` and `hierarchy.slugify` already exist as escape hatches.

**NFKC, not NFC.** NFKC folds lossily (`½` → `12`, `№` → `no`), which argues for NFC. But CJK input methods routinely emit full-width Latin, and under NFC `ＡＢＣ` stays `ａｂｃ` in the URL: visually identical to `abc`, a different string, so you get confusable URLs for exactly the users this helps. This matches Django's `slugify(allow_unicode=True)`.

**Nothing invisible survives, and the output is normalization-stable.** Zero-width joiners, bidi controls and variation selectors are stripped, and the result is re-normalized after the deletions. Both matter for uniqueness: slugs that differ only by an invisible character, or only by normalization form, compare unequal while looking identical. Two consequences are deliberate — stripping variation selectors merges glyph variants of one character into a single slug, and stripping ZWNJ changes Persian spelling (`می‌روم` → `میروم`). A URL is the wrong place to carry a distinction a reader cannot see or type; the `slugify` override covers anyone who disagrees.

Two invariants are asserted in the spec because they are what make the function safe to run repeatedly:

- `slugify(slugify(x)) === slugify(x)`. Autosave resends the stored slug every tick and it is re-slugified, so a non-fixed-point rewrites slugs behind the editor's back.
- `slugify(x) === slugify(NFD(x)) === slugify(NFC(x))`. The same visible title typed on two platforms must produce one slug.

Both hold across an exhaustive sweep of every Unicode scalar value and a fuzz corpus of mixed-script strings.

## Compatibility

Stored slugs are not rewritten by upgrading; they are re-normalized on the next save that includes the slug, which autosave does on every tick. Two categories change, both covered in the v4 migration guide:

- **Dash runs, edge dashes, and previously-deleted whitespace**: `a--b` → `a-b`, `-abc-` → `abc`, and a tab now separates rather than vanishes. If a re-normalized value collides with another document's slug the save throws a `ValidationError` rather than deduping, since only generated values are deduped.
- **Slugs with no letter or number** (`-`, `___`) now normalize to nothing, so they are preserved rather than rewritten. Clearing the field does not regenerate them; the editor has to click Generate or type a replacement.

Documented rather than fixed: NFKC's own oddities (`⅒` → `110`, `İ` → `i̇`), and invariant lowercasing, which is wrong for Turkish (`IĞDIR` → `iğdir`, not `ığdır`) because the API has no locale to thread through.

## Test coverage

Unit coverage for the scripts above, NFKC folds, mark and invisible-character handling, and both invariants. Integration coverage in `test/fields/int.spec.ts` for the localized fill path, dedupe on non-ASCII values, preservation of a legacy `-` slug, and the collision-throws-rather-than-dedupes path. `test/hierarchy/int.spec.ts` is updated for the umlaut assertion. Run against sqlite; CI covers mongodb and postgres.

The four `examples/*/formatSlug.ts` copies of the old algorithm are left for a follow-up to keep this diff reviewable.
