### PR TITLE
fix(ui): prevent blank admin screen on unauthenticated routes in Next.js 16 (#17545)

### DIFF
--- a/packages/payload/src/config/client.spec.ts
+++ b/packages/payload/src/config/client.spec.ts
@@ -4,7 +4,8 @@ import type { SanitizedConfig } from './types.js'
 
 import { describe, expect, it } from 'vitest'
 
-import { createClientConfig } from './client.js'
+import type { ClientConfig } from './client.js'
+import { createClientConfig, createUnauthenticatedClientConfig } from './client.js'
 
 describe('createClientConfig', () => {
   it('should omit baseAccess from the client config', () => {
@@ -21,5 +22,82 @@ describe('createClientConfig', () => {
     })
 
     expect(clientConfig).not.toHaveProperty('baseAccess')
+  })
+})
+
+describe('createUnauthenticatedClientConfig', () => {
+  const mockClientConfig = {
+    admin: {
+      autoLogin: { email: 'test@example.com' },
+      autoRefresh: true,
+      avatar: 'gravatar',
+      dateFormat: 'yyyy-MM-dd',
+      meta: { titleSuffix: '- Admin' },
+      routes: {
+        account: '/account',
+        createFirstUser: '/create-first-user',
+        forgot: '/forgot',
+        inactivity: '/inactivity',
+        login: '/login',
+        logout: '/logout',
+        reset: '/reset',
+        unauthorized: '/unauthorized',
+      },
+      theme: 'dark',
+      user: 'users',
+    },
+    collections: [
+      {
+        slug: 'users',
+        auth: {
+          disableLocalStrategy: false,
+          loginWithUsername: false,
+        },
+        fields: [
+          {
+            name: 'email',
+            type: 'email',
+          },
+        ],
+      },
+    ],
+    globals: [],
+    routes: {
+      admin: '/admin',
+      api: '/api',
+    },
+    serverURL: 'http://localhost:3000',
+  } as unknown as ClientConfig
+
+  it('preserves admin config properties such as theme, routes, and autoLogin', () => {
+    const unauthConfig = createUnauthenticatedClientConfig({
+      clientConfig: mockClientConfig,
+    })
+
+    expect(unauthConfig.unauthenticated).toBe(true)
+    expect(unauthConfig.admin.theme).toBe('dark')
+    expect(unauthConfig.admin.user).toBe('users')
+    expect(unauthConfig.admin.routes.login).toBe('/login')
+    expect(unauthConfig.admin.autoLogin).toEqual({ email: 'test@example.com' })
+  })
+
+  it('includes the admin user collection config and handles missing collection gracefully', () => {
+    const unauthConfig = createUnauthenticatedClientConfig({
+      clientConfig: mockClientConfig,
+    })
+
+    expect(unauthConfig.collections).toHaveLength(1)
+    expect(unauthConfig.collections[0].slug).toBe('users')
+
+    const configWithoutUserCollection = {
+      ...mockClientConfig,
+      collections: [],
+    } as unknown as ClientConfig
+
+    const unauthConfigEmpty = createUnauthenticatedClientConfig({
+      clientConfig: configWithoutUserCollection,
+    })
+
+    expect(unauthConfigEmpty.collections).toHaveLength(0)
   })
 })

--- a/packages/payload/src/config/client.ts
+++ b/packages/payload/src/config/client.ts
@@ -62,16 +62,9 @@ export type ClientConfig = {
 } & Omit<SanitizedConfig, 'admin' | 'collections' | 'globals' | 'i18n' | ServerOnlyRootProperties>
 
 export type UnauthenticatedClientConfig = {
-  admin: {
-    routes: ClientConfig['admin']['routes']
-    user: ClientConfig['admin']['user']
-  }
-  collections: [
-    {
-      auth: ClientCollectionConfig['auth']
-      slug: string
-    },
-  ]
+  admin: ClientConfig['admin']
+  collections: ClientCollectionConfig[]
+  custom?: Record<string, any>
   globals: []
   routes: ClientConfig['routes']
   serverURL: ClientConfig['serverURL']
@@ -135,19 +128,12 @@ export const createUnauthenticatedClientConfig = ({
    */
   const adminUserCollection = clientConfig.collections.find(
     ({ slug }) => slug === clientConfig.admin.user,
-  )!
+  )
 
   return {
-    admin: {
-      routes: clientConfig.admin.routes,
-      user: clientConfig.admin.user,
-    },
-    collections: [
-      {
-        slug: adminUserCollection.slug,
-        auth: adminUserCollection.auth,
-      },
-    ],
+    admin: clientConfig.admin,
+    collections: adminUserCollection ? [adminUserCollection] : [],
+    custom: clientConfig.custom,
     globals: [],
     routes: clientConfig.routes,
     serverURL: clientConfig.serverURL,

--- a/packages/ui/src/views/CreateFirstUser/index.client.tsx
+++ b/packages/ui/src/views/CreateFirstUser/index.client.tsx
@@ -124,7 +124,7 @@ export const CreateFirstUserClient: React.FC<{
         />
         <ConfirmPasswordField />
         <RenderFields
-          fields={collectionConfig.fields}
+          fields={collectionConfig?.fields || []}
           forceRender
           parentIndexPath=""
           parentPath=""

--- a/packages/ui/src/views/Login/LoginForm/index.tsx
+++ b/packages/ui/src/views/Login/LoginForm/index.tsx
@@ -37,8 +37,7 @@ export const LoginForm: React.FC<{
   } = config
 
   const collectionConfig = getEntityConfig({ collectionSlug: userSlug })
-  const { auth: authOptions } = collectionConfig
-  const loginWithUsername = authOptions.loginWithUsername
+  const loginWithUsername = collectionConfig?.auth?.loginWithUsername
   const { canLoginWithEmail, canLoginWithUsername } = getLoginOptions(loginWithUsername)
 
   const [loginType] = React.useState<LoginFieldProps['type']>(() => {

--- a/packages/ui/src/views/Root/index.tsx
+++ b/packages/ui/src/views/Root/index.tsx
@@ -183,7 +183,7 @@ export const renderRoot = async ({
 
   let collectionPreferences: CollectionPreferences = undefined
 
-  if (collectionConfig && segments.length === 2) {
+  if (req?.user?.id && collectionConfig && segments.length === 2) {
     await getPreferences<CollectionPreferences>(
       `collection-${collectionConfig.slug}`,
       req.payload,


### PR DESCRIPTION
Fixes #17545.

### Summary of Changes

- **Unauthenticated Client Config**: Preserve `admin` UI settings (`theme`, `autoLogin`, `autoRefresh`, `dateFormat`, `meta`, `avatar`, `custom`, `toast`) in `createUnauthenticatedClientConfig` so layouts and providers (`ThemeProvider`, `AuthProvider`) have necessary configuration on unauthenticated routes (`/login`, `/forgot`, `/create-first-user`, `/logout`).
- **LoginForm**: Added safe navigation for `collectionConfig?.auth?.loginWithUsername` to avoid unhandled TypeErrors.
- **CreateFirstUserClient**: Added fallback `collectionConfig?.fields || []` when rendering fields on unauthenticated state.
- **Root View**: Added nullish check for `req?.user?.id` before querying collection preferences in `renderRoot`.
- **Tests**: Added unit tests for `createUnauthenticatedClientConfig`.