### PR TITLE
chore: remove stray console.log from localization int test

### DIFF
--- a/test/localization/int.spec.ts
+++ b/test/localization/int.spec.ts
@@ -3222,7 +3222,6 @@ describe('Localization', () => {
             toLocale: 'es',
           })) as ArrayField
 
-          console.log('res', res)
           expect(res.items?.[0]?.nestedItems?.[0]?.text).toBe('nested text')
         } finally {
           await payload.delete({


### PR DESCRIPTION
Removes a leftover `console.log('res', res)` from the "should copy nested arrays through tabs within localized arrays" test in `test/localization/int.spec.ts`. 
