### PR TITLE
ci: allow changes job to check out repository

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,7 @@ jobs:
   changes:
     runs-on: ubuntu-24.04
     permissions:
+      contents: read
       pull-requests: read
     outputs:
       needs_build: ${{ steps.filter.outputs.needs_build }}


### PR DESCRIPTION
Grants the `changes` job `contents: read` so `actions/checkout` can use the automatically provided `GITHUB_TOKEN`.