### PR TITLE
ci: allow changes job to check out repository

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,7 @@ jobs:
   changes:
     runs-on: ubuntu-24.04
     permissions:
+      contents: read
       pull-requests: read
     outputs:
       needs_build: ${{ steps.filter.outputs.needs_build }}


### PR DESCRIPTION
Adds `contents: read` to the `changes` job permissions so `actions/checkout` can authenticate with the automatically provided `GITHUB_TOKEN`.