### PR TITLE
chore(ui): remove deprecated props from ListHeader component

### DIFF
--- a/packages/ui/src/elements/ListHeader/TitleActions/ListBulkUploadButton.tsx
+++ b/packages/ui/src/elements/ListHeader/TitleActions/ListBulkUploadButton.tsx
@@ -15,18 +15,11 @@ export function ListBulkUploadButton({
   hasCreatePermission,
   isBulkUploadEnabled,
   onBulkUploadSuccess,
-  openBulkUpload: openBulkUploadFromProps,
 }: {
   collectionSlug: CollectionSlug
   hasCreatePermission: boolean
   isBulkUploadEnabled: boolean
   onBulkUploadSuccess?: () => void
-  /**
-   * @deprecated This prop will be removed in the next major version.
-   *
-   * Prefer using `onBulkUploadSuccess`
-   */
-  openBulkUpload?: () => void
 }) {
   const {
     modalSlug: bulkUploadModalSlug,
@@ -40,20 +33,16 @@ export function ListBulkUploadButton({
   const router = useRouter()
 
   const openBulkUpload = React.useCallback(() => {
-    if (typeof openBulkUploadFromProps === 'function') {
-      openBulkUploadFromProps()
-    } else {
-      setCollectionSlug(collectionSlug)
-      setParentID(parent?.id)
-      openModal(bulkUploadModalSlug)
-      setOnSuccess(() => {
-        if (typeof onBulkUploadSuccess === 'function') {
-          onBulkUploadSuccess()
-        } else {
-          router.refresh()
-        }
-      })
-    }
+    setCollectionSlug(collectionSlug)
+    setParentID(parent?.id)
+    openModal(bulkUploadModalSlug)
+    setOnSuccess(() => {
+      if (typeof onBulkUploadSuccess === 'function') {
+        onBulkUploadSuccess()
+      } else {
+        router.refresh()
+      }
+    })
   }, [
     router,
     collectionSlug,
@@ -64,7 +53,6 @@ export function ListBulkUploadButton({
     setParentID,
     setOnSuccess,
     onBulkUploadSuccess,
-    openBulkUploadFromProps,
   ])
 
   if (!hasCreatePermission || !isBulkUploadEnabled) {

--- a/packages/ui/src/views/List/ListHeader/index.tsx
+++ b/packages/ui/src/views/List/ListHeader/index.tsx
@@ -1,4 +1,4 @@
-import type { I18nClient, TFunction } from '@payloadcms/translations'
+import type { I18nClient } from '@payloadcms/translations'
 import type { ClientCollectionConfig, ViewTypes } from 'payload'
 
 import { getTranslation } from '@payloadcms/translations'
@@ -36,16 +36,7 @@ export type ListHeaderProps = {
   isTrashEnabled?: boolean
   newDocumentURL: string
   onBulkUploadSuccess?: () => void
-  /** @deprecated This prop will be removed in the next major version.
-   *
-   * Opening of the bulk upload modal is handled internally.
-   *
-   * Prefer `onBulkUploadSuccess` usage to handle the success of the bulk upload.
-   */
-  openBulkUpload: () => void
   smallBreak: boolean
-  /** @deprecated This prop will be removed in the next major version. */
-  t?: TFunction
   TitleActions?: React.ReactNode[]
   viewType?: ViewTypes
 }
@@ -63,7 +54,6 @@ export const CollectionListHeader: React.FC<ListHeaderProps> = ({
   isBulkUploadEnabled,
   isTrashEnabled,
   onBulkUploadSuccess,
-  openBulkUpload,
   smallBreak,
   viewType,
 }) => {
@@ -134,7 +124,6 @@ export const CollectionListHeader: React.FC<ListHeaderProps> = ({
             isBulkUploadEnabled={isBulkUploadEnabled}
             key="list-header-bulk-upload"
             onBulkUploadSuccess={onBulkUploadSuccess}
-            openBulkUpload={openBulkUpload}
           />
         ),
         hasDeletePermission && isTrashEnabled && viewType === 'trash' && (

--- a/packages/ui/src/views/List/index.client.tsx
+++ b/packages/ui/src/views/List/index.client.tsx
@@ -6,7 +6,6 @@ import { getTranslation } from '@payloadcms/translations'
 import { formatAdminURL, formatFilesize } from 'payload/shared'
 import React, { Fragment, useEffect, useRef, useState } from 'react'
 
-import { useBulkUpload } from '../../elements/BulkUpload/index.js'
 import { Button } from '../../elements/Button/index.js'
 import { ListControls } from '../../elements/ListControls/index.js'
 import { useListDrawerContext } from '../../elements/ListDrawer/Provider.js'
@@ -23,7 +22,6 @@ import { useControllableState } from '../../hooks/useControllableState.js'
 import { useConfig } from '../../providers/Config/index.js'
 import { DocumentSelectionProvider } from '../../providers/DocumentSelection/index.js'
 import { useListQuery } from '../../providers/ListQuery/index.js'
-import { useRouter } from '../../providers/RouterAdapter/index.js'
 import { SelectionProvider } from '../../providers/Selection/index.js'
 import { TableColumnsProvider } from '../../providers/TableColumns/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
@@ -81,7 +79,6 @@ export function DefaultListView(props: ListViewClientProps) {
     },
     getEntityConfig,
   } = useConfig()
-  const router = useRouter()
 
   const { data, hasActiveFilters, isGroupingBy, query } = useListQuery()
 
@@ -98,7 +95,6 @@ export function DefaultListView(props: ListViewClientProps) {
   }, [query?.where])
 
   const { openModal } = useModal()
-  const { modalSlug: bulkUploadModalSlug, setCollectionSlug, setOnSuccess } = useBulkUpload()
 
   const collectionConfig = getEntityConfig({ collectionSlug })
 
@@ -132,12 +128,6 @@ export function DefaultListView(props: ListViewClientProps) {
       return data?.docs
     }
   }, [data?.docs, isUploadCollection])
-
-  const openBulkUpload = React.useCallback(() => {
-    setCollectionSlug(collectionSlug)
-    openModal(bulkUploadModalSlug)
-    setOnSuccess(() => router.refresh())
-  }, [router, collectionSlug, bulkUploadModalSlug, openModal, setCollectionSlug, setOnSuccess])
 
   useEffect(() => {
     if (!isInDrawer) {
@@ -224,7 +214,6 @@ export function DefaultListView(props: ListViewClientProps) {
               isBulkUploadEnabled={isBulkUploadEnabled && !upload.hideFileInputOnCreate}
               isTrashEnabled={isTrashEnabled}
               newDocumentURL={newDocumentURL}
-              openBulkUpload={openBulkUpload}
               smallBreak={smallBreak}
               viewType={viewType}
             />


### PR DESCRIPTION
## Summary

`ListHeader` and `ListBulkUploadButton` carried two deprecated props, `openBulkUpload` and `t`, marked for removal in the next major version. This PR removes both props and the code paths that supported them. `ListBulkUploadButton` now always opens the bulk upload modal through its own internal state, instead of an optional caller-supplied callback.

## How

- Removed `openBulkUpload` from `ListBulkUploadButton`, `CollectionListHeader`, and the list view that called it. The button now always uses its internal `useBulkUpload` handling.
- The internal handling also sets `parentID` before opening the modal. The removed caller callback did not do this, so bulk uploads opened from the list header in a hierarchy collection were not linked to the current parent document. This is now fixed as a side effect of removing the deprecated path.
- Removed the unused `t` prop from `ListHeaderProps`.
- Removed hooks and imports that only existed to support the deleted callback (`useRouter`, `useBulkUpload` in the list view).

## Breaking changes

`ListHeader` (exported from `@payloadcms/ui`) no longer accepts `openBulkUpload` or `t` props. Consumers who pass `openBulkUpload` to control the bulk upload flow should use `onBulkUploadSuccess` instead, which runs after a successful upload. The modal open behavior is now always handled internally.

## Related work

[PYLD-2691](https://linear.app/figma/issue/PYLD-2691/ui-element-deprecations)
