### PR TITLE
fix(drizzle): warn on truncated identifiers, throw on collisions

### DIFF
--- a/packages/drizzle/src/postgres/init.ts
+++ b/packages/drizzle/src/postgres/init.ts
@@ -4,6 +4,7 @@ import type { BasePostgresAdapter } from './types.js'
 
 import { buildDrizzleRelations } from '../schema/buildDrizzleRelations.js'
 import { buildRawSchema } from '../schema/buildRawSchema.js'
+import { checkTruncatedIdentifiers } from '../utilities/checkTruncatedIdentifiers.js'
 import { executeSchemaHooks } from '../utilities/executeSchemaHooks.js'
 import { buildDrizzleTable } from './schema/buildDrizzleTable.js'
 import { setColumnID } from './schema/setColumnID.js'
@@ -18,6 +19,9 @@ export const init: Init = async function init(this: BasePostgresAdapter) {
   })
 
   await executeSchemaHooks({ type: 'beforeSchemaInit', adapter: this })
+
+  // Warn on identifiers Postgres will truncate past 63 chars; throw only when two collide.
+  checkTruncatedIdentifiers({ adapter: this, logWarnings: process.env.NODE_ENV !== 'production' })
 
   if (this.payload.config.localization) {
     this.enums.enum__locales = this.pgSchema.enum(

--- a/packages/drizzle/src/schema/build.ts
+++ b/packages/drizzle/src/schema/build.ts
@@ -19,7 +19,6 @@ import { createTableName } from '../createTableName.js'
 import { buildForeignKeyName } from '../utilities/buildForeignKeyName.js'
 import { buildIndexName } from '../utilities/buildIndexName.js'
 import { isUUIDType } from '../utilities/isUUIDType.js'
-import { validateIdentifierLength } from '../utilities/validateIdentifierLength.js'
 import { traverseFields } from './traverseFields.js'
 
 type Args = {
@@ -189,7 +188,7 @@ export const buildTable = ({
   adapter.rawTables[tableName] = table
 
   if (hasLocalizedField || localizedRelations.size) {
-    const localeTableName = validateIdentifierLength(`${tableName}${adapter.localesSuffix}`)
+    const localeTableName = `${tableName}${adapter.localesSuffix}`
     adapter.rawTables[localeTableName] = localesTable
 
     localesColumns.id = {
@@ -340,7 +339,7 @@ export const buildTable = ({
 
   if (isRoot) {
     if (hasManyTextField) {
-      const textsTableName = validateIdentifierLength(`${rootTableName}_texts`)
+      const textsTableName = `${rootTableName}_texts`
       adapter.rawTables[textsTableName] = textsTable
 
       const columns: Record<string, RawColumn> = {
@@ -446,7 +445,7 @@ export const buildTable = ({
     }
 
     if (hasManyNumberField) {
-      const numbersTableName = validateIdentifierLength(`${rootTableName}_numbers`)
+      const numbersTableName = `${rootTableName}_numbers`
       adapter.rawTables[numbersTableName] = numbersTable
       const columns: Record<string, RawColumn> = {
         id: {
@@ -576,9 +575,7 @@ export const buildTable = ({
         }
       }
 
-      const relationshipsTableName = validateIdentifierLength(
-        `${tableName}${adapter.relationshipsSuffix}`,
-      )
+      const relationshipsTableName = `${tableName}${adapter.relationshipsSuffix}`
 
       const relationshipIndexes: Record<string, RawIndex> = {
         order: {

--- a/packages/drizzle/src/schema/buildRawSchema.spec.ts
+++ b/packages/drizzle/src/schema/buildRawSchema.spec.ts
@@ -240,4 +240,44 @@ describe('buildRawSchema', () => {
 
     expect(warn).not.toHaveBeenCalled()
   })
+
+  it('should warn about raw inline sub-table index and foreign key names that exceed 63 chars', async () => {
+    // Array sub-tables assign structural index/FK names inline (not via buildIndexName/
+    // buildForeignKeyName), so a long-but-valid array table name still overflows them.
+    const arrayFieldName = 'a'.repeat(58)
+
+    const config = sanitizeConfig({
+      collections: [
+        {
+          slug: 'p',
+          fields: [
+            {
+              name: arrayFieldName,
+              type: 'array',
+              fields: [{ name: 'title', type: 'text' }],
+            },
+          ],
+          timestamps: false,
+          versions: false,
+        },
+      ],
+    } as Config)
+
+    const warn = vi.fn()
+    const adapter = createAdapter(config, warn)
+
+    buildRawSchema({ adapter, setColumnID })
+
+    const arrayTable = `p_${arrayFieldName}`
+
+    checkTruncatedIdentifiers({ adapter, logWarnings: true })
+
+    expect(arrayTable.length).toBeLessThanOrEqual(63)
+    expect(warn).toHaveBeenCalledTimes(1)
+
+    const message: string = warn.mock.calls[0][0]
+
+    expect(message).toContain(`${arrayTable}_order_idx`)
+    expect(message).toContain(`${arrayTable}_parent_id_fk`)
+  })
 })

--- a/packages/drizzle/src/schema/buildRawSchema.spec.ts
+++ b/packages/drizzle/src/schema/buildRawSchema.spec.ts
@@ -1,9 +1,10 @@
 import type { Block, Config, SanitizedConfig } from 'payload'
 import { sanitizeConfig } from 'payload'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { setColumnID } from '../postgres/schema/setColumnID.js'
 import type { DrizzleAdapter } from '../types.js'
+import { checkTruncatedIdentifiers } from '../utilities/checkTruncatedIdentifiers.js'
 import { buildRawSchema } from './buildRawSchema.js'
 
 const headlineBlock: Block = {
@@ -27,7 +28,10 @@ const createContainerBlock = (slug: string): Block => ({
   ],
 })
 
-const createAdapter = (config: SanitizedConfig): DrizzleAdapter =>
+const createAdapter = (
+  config: SanitizedConfig,
+  warn: (...args: any[]) => void = () => {},
+): DrizzleAdapter =>
   ({
     blocksAsJSON: false,
     fieldConstraints: {},
@@ -45,6 +49,7 @@ const createAdapter = (config: SanitizedConfig): DrizzleAdapter =>
         ]),
       ),
       config,
+      logger: { warn },
     },
     rawRelations: {},
     rawTables: {},
@@ -165,7 +170,7 @@ describe('buildRawSchema', () => {
     expect(adapter.rawTables.posts_blocks_headline_2_locales).toBeUndefined()
   })
 
-  it('should throw when a localized field pushes the _locales companion table past 63 chars', async () => {
+  it('should warn when a localized field pushes the _locales companion table past 63 chars', async () => {
     // Base table name (61 chars) is under the limit, but `${base}_locales` (69) overflows it.
     const longSlug = `localized_collection_${'x'.repeat(40)}`
 
@@ -190,17 +195,19 @@ describe('buildRawSchema', () => {
       },
     } as Config)
 
-    const adapter = createAdapter(config)
+    const warn = vi.fn()
+    const adapter = createAdapter(config, warn)
 
-    expect(() =>
-      buildRawSchema({
-        adapter,
-        setColumnID,
-      }),
-    ).toThrow('Exceeded max identifier length')
+    buildRawSchema({ adapter, setColumnID })
+
+    expect(adapter.rawTables[`${longSlug}_locales`]).toBeDefined()
+
+    expect(() => checkTruncatedIdentifiers({ adapter, logWarnings: true })).not.toThrow()
+    expect(warn).toHaveBeenCalledTimes(1)
+    expect(warn.mock.calls[0][0]).toContain(`${longSlug}_locales`)
   })
 
-  it('should not throw for a localized field whose _locales companion table fits within 63 chars', async () => {
+  it('should not warn when the _locales companion table fits within 63 chars', async () => {
     const config = sanitizeConfig({
       collections: [
         {
@@ -222,13 +229,15 @@ describe('buildRawSchema', () => {
       },
     } as Config)
 
-    const adapter = createAdapter(config)
+    const warn = vi.fn()
+    const adapter = createAdapter(config, warn)
 
-    buildRawSchema({
-      adapter,
-      setColumnID,
-    })
+    buildRawSchema({ adapter, setColumnID })
 
     expect(adapter.rawTables.short_localized_locales).toBeDefined()
+
+    checkTruncatedIdentifiers({ adapter, logWarnings: true })
+
+    expect(warn).not.toHaveBeenCalled()
   })
 })

--- a/packages/drizzle/src/utilities/buildForeignKeyName.ts
+++ b/packages/drizzle/src/utilities/buildForeignKeyName.ts
@@ -1,5 +1,7 @@
 import type { DrizzleAdapter } from '../types.js'
 
+import { maxGeneratedIdentifierLength } from './validateIdentifierLength.js'
+
 export const buildForeignKeyName = ({
   name,
   adapter,
@@ -11,9 +13,9 @@ export const buildForeignKeyName = ({
 }): string => {
   let foreignKeyName = `${name}${number ? `_${number}` : ''}_fk`
 
-  if (foreignKeyName.length > 60) {
+  if (foreignKeyName.length > maxGeneratedIdentifierLength) {
     const suffix = `${number ? `_${number}` : ''}_fk`
-    foreignKeyName = `${name.slice(0, 60 - suffix.length)}${suffix}`
+    foreignKeyName = `${name.slice(0, maxGeneratedIdentifierLength - suffix.length)}${suffix}`
   }
 
   if (!adapter.foreignKeys.has(foreignKeyName)) {

--- a/packages/drizzle/src/utilities/buildIndexName.ts
+++ b/packages/drizzle/src/utilities/buildIndexName.ts
@@ -1,5 +1,7 @@
 import type { DrizzleAdapter } from '../types.js'
 
+import { maxGeneratedIdentifierLength } from './validateIdentifierLength.js'
+
 export const buildIndexName = ({
   name,
   adapter,
@@ -13,9 +15,9 @@ export const buildIndexName = ({
 }): string => {
   let indexName = `${name}${number ? `_${number}` : ''}${appendSuffix ? '_idx' : ''}`
 
-  if (indexName.length > 60) {
+  if (indexName.length > maxGeneratedIdentifierLength) {
     const suffix = `${number ? `_${number}` : ''}${appendSuffix ? '_idx' : ''}`
-    indexName = `${name.slice(0, 60 - suffix.length)}${suffix}`
+    indexName = `${name.slice(0, maxGeneratedIdentifierLength - suffix.length)}${suffix}`
   }
 
   if (!adapter.indexes.has(indexName) && !(indexName in adapter.rawTables)) {

--- a/packages/drizzle/src/utilities/checkTruncatedIdentifiers.spec.ts
+++ b/packages/drizzle/src/utilities/checkTruncatedIdentifiers.spec.ts
@@ -156,4 +156,79 @@ describe('checkTruncatedIdentifiers', () => {
       'truncate to the same name',
     )
   })
+
+  it('should warn about a single over-long inline index name', () => {
+    const indexName = `${'a'.repeat(maxIdentifierLength)}_idx`
+    const warn = vi.fn()
+
+    const adapter = buildAdapter(
+      {
+        posts: {
+          name: 'posts',
+          columns: { id: { name: 'id', type: 'serial' } },
+          indexes: { a: { name: indexName, on: 'id' } },
+        },
+      },
+      warn,
+    )
+
+    checkTruncatedIdentifiers({ adapter, logWarnings: true })
+
+    expect(warn).toHaveBeenCalledTimes(1)
+    expect(warn.mock.calls[0][0]).toContain(indexName)
+  })
+
+  it('should throw when two inline index names truncate to the same name', () => {
+    const shared = 'a'.repeat(maxIdentifierLength)
+
+    const adapter = buildAdapter({
+      posts: {
+        name: 'posts',
+        columns: { id: { name: 'id', type: 'serial' } },
+        indexes: { a: { name: `${shared}_one`, on: 'id' } },
+      },
+      pages: {
+        name: 'pages',
+        columns: { id: { name: 'id', type: 'serial' } },
+        indexes: { b: { name: `${shared}_two`, on: 'id' } },
+      },
+    })
+
+    expect(() => checkTruncatedIdentifiers({ adapter, logWarnings: true })).toThrow(
+      'truncate to the same name',
+    )
+  })
+
+  it('should throw when two inline foreign key names truncate to the same name', () => {
+    const shared = 'a'.repeat(maxIdentifierLength)
+
+    const adapter = buildAdapter({
+      posts: {
+        name: 'posts',
+        columns: { author_id: { name: 'author_id', type: 'integer' } },
+        foreignKeys: {
+          a: {
+            name: `${shared}_one`,
+            columns: ['author_id'],
+            foreignColumns: [{ name: 'id', table: 'authors' }],
+          },
+        },
+      },
+      pages: {
+        name: 'pages',
+        columns: { author_id: { name: 'author_id', type: 'integer' } },
+        foreignKeys: {
+          b: {
+            name: `${shared}_two`,
+            columns: ['author_id'],
+            foreignColumns: [{ name: 'id', table: 'authors' }],
+          },
+        },
+      },
+    })
+
+    expect(() => checkTruncatedIdentifiers({ adapter, logWarnings: true })).toThrow(
+      'truncate to the same name',
+    )
+  })
 })

--- a/packages/drizzle/src/utilities/checkTruncatedIdentifiers.spec.ts
+++ b/packages/drizzle/src/utilities/checkTruncatedIdentifiers.spec.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { DrizzleAdapter } from '../types.js'
+
+import { checkTruncatedIdentifiers } from './checkTruncatedIdentifiers.js'
+import { maxIdentifierLength } from './validateIdentifierLength.js'
+
+const buildAdapter = (
+  rawTables: DrizzleAdapter['rawTables'],
+  warn: (...args: any[]) => void = () => {},
+): Pick<DrizzleAdapter, 'payload' | 'rawTables'> =>
+  ({
+    payload: { logger: { warn } },
+    rawTables,
+  }) as unknown as Pick<DrizzleAdapter, 'payload' | 'rawTables'>
+
+const longName = (char: string) => char.repeat(maxIdentifierLength + 1)
+
+describe('checkTruncatedIdentifiers', () => {
+  it('should neither warn nor throw when all identifiers fit within the limit', () => {
+    const warn = vi.fn()
+
+    const adapter = buildAdapter(
+      {
+        posts: {
+          name: 'posts',
+          columns: {
+            id: { name: 'id', type: 'serial' },
+            title: { name: 'title', type: 'text' },
+          },
+        },
+      },
+      warn,
+    )
+
+    expect(() => checkTruncatedIdentifiers({ adapter, logWarnings: true })).not.toThrow()
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('should warn (not throw) for a single over-long column name', () => {
+    const columnName = longName('a')
+    const warn = vi.fn()
+
+    const adapter = buildAdapter(
+      {
+        posts: {
+          name: 'posts',
+          columns: {
+            overflow: { name: columnName, type: 'text' },
+          },
+        },
+      },
+      warn,
+    )
+
+    expect(() => checkTruncatedIdentifiers({ adapter, logWarnings: true })).not.toThrow()
+    expect(warn).toHaveBeenCalledTimes(1)
+    expect(warn.mock.calls[0][0]).toContain(columnName)
+  })
+
+  it('should not warn when logWarnings is false', () => {
+    const warn = vi.fn()
+
+    const adapter = buildAdapter(
+      {
+        posts: {
+          name: 'posts',
+          columns: {
+            overflow: { name: longName('a'), type: 'text' },
+          },
+        },
+      },
+      warn,
+    )
+
+    expect(() => checkTruncatedIdentifiers({ adapter, logWarnings: false })).not.toThrow()
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('should throw when two columns in the same table truncate to the same name', () => {
+    // Differ only past the 63rd character, so both truncate to the same identifier.
+    const shared = 'a'.repeat(maxIdentifierLength)
+
+    const adapter = buildAdapter({
+      posts: {
+        name: 'posts',
+        columns: {
+          first: { name: `${shared}_one`, type: 'text' },
+          second: { name: `${shared}_two`, type: 'text' },
+        },
+      },
+    })
+
+    expect(() => checkTruncatedIdentifiers({ adapter, logWarnings: true })).toThrow(
+      'truncate to the same name',
+    )
+  })
+
+  it('should throw on a collision even when logWarnings is false', () => {
+    const shared = 'a'.repeat(maxIdentifierLength)
+
+    const adapter = buildAdapter({
+      posts: {
+        name: 'posts',
+        columns: {
+          first: { name: `${shared}_one`, type: 'text' },
+          second: { name: `${shared}_two`, type: 'text' },
+        },
+      },
+    })
+
+    expect(() => checkTruncatedIdentifiers({ adapter, logWarnings: false })).toThrow()
+  })
+
+  it('should not treat same-named columns in different tables as a collision', () => {
+    const shared = 'a'.repeat(maxIdentifierLength)
+    const warn = vi.fn()
+
+    const adapter = buildAdapter(
+      {
+        posts: {
+          name: 'posts',
+          columns: {
+            overflow: { name: `${shared}_one`, type: 'text' },
+          },
+        },
+        pages: {
+          name: 'pages',
+          columns: {
+            overflow: { name: `${shared}_two`, type: 'text' },
+          },
+        },
+      },
+      warn,
+    )
+
+    expect(() => checkTruncatedIdentifiers({ adapter, logWarnings: true })).not.toThrow()
+    expect(warn).toHaveBeenCalledTimes(1)
+  })
+
+  it('should throw when two table names truncate to the same name', () => {
+    const shared = 'a'.repeat(maxIdentifierLength)
+
+    const adapter = buildAdapter({
+      [`${shared}_one`]: {
+        name: `${shared}_one`,
+        columns: { id: { name: 'id', type: 'serial' } },
+      },
+      [`${shared}_two`]: {
+        name: `${shared}_two`,
+        columns: { id: { name: 'id', type: 'serial' } },
+      },
+    })
+
+    expect(() => checkTruncatedIdentifiers({ adapter, logWarnings: true })).toThrow(
+      'truncate to the same name',
+    )
+  })
+})

--- a/packages/drizzle/src/utilities/checkTruncatedIdentifiers.ts
+++ b/packages/drizzle/src/utilities/checkTruncatedIdentifiers.ts
@@ -1,0 +1,87 @@
+import { APIError } from 'payload'
+
+import type { DrizzleAdapter } from '../types.js'
+
+import { maxIdentifierLength } from './validateIdentifierLength.js'
+
+const truncate = (name: string): string =>
+  name.length > maxIdentifierLength ? name.slice(0, maxIdentifierLength) : name
+
+/**
+ * Warns about identifiers Postgres will silently truncate past 63 chars, and throws
+ * when two of them truncate to the same name (a schema Postgres can't create anyway).
+ *
+ * Base table/enum names throw during construction, so this only covers concatenated
+ * identifiers: companion tables, columns, and inline index/foreign key names.
+ */
+export const checkTruncatedIdentifiers = ({
+  adapter,
+  logWarnings,
+}: {
+  adapter: Pick<DrizzleAdapter, 'payload' | 'rawTables'>
+  logWarnings: boolean
+}): void => {
+  const truncatedNames = new Set<string>()
+  const collisions = new Set<string>()
+
+  // finalName -> originalName, per namespace, to detect post-truncation collisions
+  const tableNames = new Map<string, string>()
+  const indexNames = new Map<string, string>()
+  const foreignKeyNames = new Map<string, string>()
+
+  const check = (original: string, seen: Map<string, string>) => {
+    const final = truncate(original)
+
+    const existing = seen.get(final)
+    if (existing !== undefined && existing !== original) {
+      collisions.add(`"${existing}" and "${original}" both become "${final}"`)
+      return
+    }
+
+    seen.set(final, original)
+
+    if (final !== original) {
+      truncatedNames.add(original)
+    }
+  }
+
+  for (const tableName in adapter.rawTables) {
+    const table = adapter.rawTables[tableName]
+
+    check(table.name, tableNames)
+
+    // Columns only collide with other columns in the same table.
+    const columnNames = new Map<string, string>()
+    for (const columnKey in table.columns) {
+      check(table.columns[columnKey].name, columnNames)
+    }
+
+    if (table.indexes) {
+      for (const indexKey in table.indexes) {
+        check(table.indexes[indexKey].name, indexNames)
+      }
+    }
+
+    if (table.foreignKeys) {
+      for (const foreignKeyKey in table.foreignKeys) {
+        check(table.foreignKeys[foreignKeyKey].name, foreignKeyNames)
+      }
+    }
+  }
+
+  if (collisions.size > 0) {
+    throw new APIError(
+      `Multiple identifiers exceed Postgres's ${maxIdentifierLength}-character limit and truncate to the same name, which Postgres cannot create: ${Array.from(
+        collisions,
+      ).join('; ')}. Use the dbName property to give them shorter, distinct names.`,
+    )
+  }
+
+  if (logWarnings && truncatedNames.size > 0) {
+    adapter.payload.logger.warn(
+      `The following identifiers exceed Postgres's ${maxIdentifierLength}-character limit and will be silently truncated, which can leave the database out of sync with your Payload schema: ${Array.from(
+        truncatedNames,
+      ).join(', ')}. Use the dbName property to shorten them.`,
+    )
+  }
+}

--- a/packages/drizzle/src/utilities/validateIdentifierLength.ts
+++ b/packages/drizzle/src/utilities/validateIdentifierLength.ts
@@ -4,6 +4,12 @@ import { APIError } from 'payload'
 export const maxIdentifierLength = 63
 
 /**
+ * Cap for builder-generated identifiers (`buildIndexName`/`buildForeignKeyName`). Sits
+ * below `maxIdentifierLength` to leave headroom for the appended `_idx`/`_fk`/`_N` suffixes.
+ */
+export const maxGeneratedIdentifierLength = maxIdentifierLength - 3
+
+/**
  * Throws if a table or enum identifier exceeds the Postgres 63-char limit.
  */
 export const validateIdentifierLength = (name: string): string => {


### PR DESCRIPTION
Surfaces Postgres identifier truncation instead of letting it silently desync the schema.

Postgres truncates any identifier over 63 characters. Payload builds column and inline index/foreign-key names by concatenating nested field paths, so deeply nested fields can exceed the limit. Postgres then stores a shorter name than Payload's schema and migration snapshot expect, and dev `push` hangs on a repeated `is <column> created or renamed?` prompt on every boot.

#17567 addressed this for table names by throwing, but that only reached base and companion tables. Columns and inline index/foreign-key names were still truncated silently, and throwing outright blocks existing installs that already carry a truncated name from upgrading.

Adds `checkTruncatedIdentifiers`, run during postgres `init` after `beforeSchemaInit`:

- Warns (dev only) when a single identifier exceeds 63 characters, so existing installs keep booting.
- Throws when two identifiers truncate to the same name, since Postgres cannot create that schema anyway.

Base table and enum names still throw during construction via `validateIdentifierLength`, unchanged.

Related: softens the companion-table checks from #17567 (`_locales`, `_rels`, `_texts`, `_numbers`) from a hard throw to the same warn-or-collision handling.
