### PR TITLE
fix: add generated-file header to importMap.js output

### DIFF
--- a/packages/payload/src/bin/generateImportMap/index.ts
+++ b/packages/payload/src/bin/generateImportMap/index.ts
@@ -155,7 +155,9 @@ export async function writeImportMap({
     mapKeys.push(`  "${userPath}": ${identifier}`)
   }
 
-  const importMapOutputFile = `${imports.join('\n')}
+  const importMapOutputFile = `/* THIS FILE WAS GENERATED AUTOMATICALLY BY PAYLOAD. */
+/* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
+${imports.join('\n')}
 
 /** @type import('payload').ImportMap */
 export const importMap = {


### PR DESCRIPTION
Adds the same "DO NOT MODIFY" header used by Payload's other generated files
(`layout.tsx`, `route.ts`, `not-found.tsx`, `page.tsx`, `api/graphql/route.ts`,
`api/graphql-playground/route.ts`) to the `importMap.js` output produced by
`generate:importmap`.

Previously `importMap.js` was written without any header, so a developer opening it
had no indication it's regenerated automatically and that manual edits get silently
overwritten.

Before:

```js
export const importMap = {
  ...
}
```

After:

```js
/* THIS FILE WAS GENERATED AUTOMATICALLY BY PAYLOAD. */
/* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
import ...

export const importMap = {
  ...
}
```
