### PR TITLE
fix: correct cron jsdoc examples to fire once instead of every second

### DIFF
--- a/packages/payload/src/queues/config/types/index.ts
+++ b/packages/payload/src/queues/config/types/index.ts
@@ -27,11 +27,11 @@ export type AutorunCronConfig = {
    *     │ │ │ │ │ ┌───────────── day of the week (0 - 6) (Sunday to Saturday)
    *     │ │ │ │ │ │
    *     │ │ │ │ │ │
-   *  - '* 0 * * * *' every hour at minute 0
-   *  - '* 0 0 * * *' daily at midnight
-   *  - '* 0 0 * * 0' weekly at midnight on Sundays
-   *  - '* 0 0 1 * *' monthly at midnight on the 1st day of the month
-   *  - '* 0/5 * * * *' every 5 minutes
+   *  - '0 0 * * * *' every hour at minute 0
+   *  - '0 0 0 * * *' daily at midnight
+   *  - '0 0 0 * * 0' weekly at midnight on Sundays
+   *  - '0 0 0 1 * *' monthly at midnight on the 1st day of the month
+   *  - '0 0/5 * * * *' every 5 minutes
    *  - '* * * * * *' every second
    */
   cron?: string
@@ -258,11 +258,11 @@ export type ScheduleConfig = {
    *     │ │ │ │ │ ┌───────────── day of the week (0 - 6) (Sunday to Saturday)
    *     │ │ │ │ │ │
    *     │ │ │ │ │ │
-   *  - '* 0 * * * *' every hour at minute 0
-   *  - '* 0 0 * * *' daily at midnight
-   *  - '* 0 0 * * 0' weekly at midnight on Sundays
-   *  - '* 0 0 1 * *' monthly at midnight on the 1st day of the month
-   *  - '* 0/5 * * * *' every 5 minutes
+   *  - '0 0 * * * *' every hour at minute 0
+   *  - '0 0 0 * * *' daily at midnight
+   *  - '0 0 0 * * 0' weekly at midnight on Sundays
+   *  - '0 0 0 1 * *' monthly at midnight on the 1st day of the month
+   *  - '0 0/5 * * * *' every 5 minutes
    *  - '* * * * * *' every second
    */
   cron: string


### PR DESCRIPTION
Fixes #17589 

**What this PR does:**
It actually fixes a small but confusing documentation error in the JSDoc comments for the `AutorunCronConfig` and `ScheduleConfig` types. 

Previously, almost all of the cron examples had a wildcard `*` in the seconds position. This meant that a schedule meant to run "daily at midnight" (`* 0 0 * * *`) would actually fire every single second for the entire minute of midnight. 

I've updated the examples to correctly use `0` in the seconds position so they fire exactly once at the start of the intended interval. The "every second" example was left as-is since it was already correct.

**Changes:**
- Updated examples in `AutorunCronConfig`
- Updated examples in `ScheduleConfig`
