### PR TITLE
ci: use client-id and partial clone in release workflows

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -29,13 +29,16 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
+          client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
       - name: Checkout tag
         uses: actions/checkout@v5
         with:
           ref: ${{ github.ref }}
+          # Full history and tags are required to resolve the changelog base tag;
+          # blob:none keeps that graph without historical file contents.
           fetch-depth: 0
+          filter: blob:none
           token: ${{ steps.app-token.outputs.token }}
       - name: Setup
         uses: ./.github/actions/setup

--- a/.github/workflows/release-bump.yml
+++ b/.github/workflows/release-bump.yml
@@ -58,13 +58,16 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
+          client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
       - name: Checkout
         uses: actions/checkout@v5
         with:
           ref: main
+          # Full history is required so the rebase-retry loop can rebase onto a
+          # moved main; blob:none keeps that graph without historical file contents.
           fetch-depth: 0
+          filter: blob:none
           token: ${{ steps.app-token.outputs.token }}
       - name: Setup
         uses: ./.github/actions/setup


### PR DESCRIPTION
## What

Two small fixes to the release workflows, surfaced by the first `release-bump` dry-run.

### `app-id` → `client-id`

`actions/create-github-app-token` now logs `Input 'app-id' has been deprecated with message: Use 'client-id' instead.` The legacy input still works, so this is a warning-only fix.

`RELEASE_APP_CLIENT_ID` is already set as an environment secret on both `bump` and `release`. `RELEASE_APP_ID` becomes unused and can be deleted after this merges.

### `filter: blob:none` on both checkouts

`fetch-depth: 0` means all history for all branches **and** all tags, which on this repo is the entire object database — the dry-run spent a large share of its wall clock in `Fetching the repository`.

A partial clone keeps the full commit and tree graph while downloading file contents lazily. Both jobs genuinely need depth 0 — the bump job rebases onto a moved `main`, and the publish job needs every `v4.*` tag plus the full `lastTag..HEAD` range — so `filter` is the lever that does not cost correctness.

Tradeoff: operations touching absent blobs trigger an on-demand fetch. Here that is a version-field-only rebase and one tree checkout. Nothing in either job runs `git log -p` across history.

## Testing

`release-bump` dry-run went green prior to these changes; re-running it after merge exercises both edits (token mint via `client-id`, partial clone).
