### PR TITLE
fix(ui): keep polymorphic join drawer closed after delete

### DIFF
--- a/packages/ui/src/elements/RelationshipTable/index.tsx
+++ b/packages/ui/src/elements/RelationshipTable/index.tsx
@@ -319,11 +319,15 @@ export const RelationshipTable: React.FC<RelationshipTableComponentProps> = (pro
     allowCreate !== false &&
     permissions?.collections?.[isPolymorphic ? relationTo[0] : relationTo]?.create
 
-  useEffect(() => {
+  const openSelectedCollectionDrawer = useEffectEvent(() => {
     if (isPolymorphic && selectedCollection) {
       openDrawer()
     }
-  }, [selectedCollection, openDrawer, isPolymorphic])
+  })
+
+  useEffect(() => {
+    openSelectedCollectionDrawer()
+  }, [selectedCollection, isPolymorphic])
 
   useEffect(() => {
     if (isPolymorphic && !isDrawerOpen && selectedCollection) {

--- a/test/joins/e2e.spec.ts
+++ b/test/joins/e2e.spec.ts
@@ -574,6 +574,37 @@ describe('Join Field', () => {
     await expect(siblingField.locator('tbody tr td', { hasText: exactText(title) })).toBeHidden()
   })
 
+  test('should keep the drawer closed after deleting through a polymorphic join table', async () => {
+    const title = 'Polymorphic Drawer Delete Post'
+
+    await payload.create({
+      collection: postsSlug,
+      data: {
+        title,
+        category: categoryID as string,
+      },
+    })
+
+    await page.goto(categoriesURL.edit(categoryID))
+
+    const joinField = page.locator('#field-polymorphicJoin.field-type.join')
+    const editRow = joinField.locator('tbody tr', { hasText: title })
+    await expect(editRow).toBeVisible()
+    await editRow.locator('button.drawer-link__doc-drawer-toggler').first().click()
+
+    const editDrawer = page.locator('[id^=doc-drawer_posts_1_]')
+    await expect(editDrawer).toBeVisible()
+    await editDrawer.locator('.doc-controls__popup .popup__trigger-wrap button').click()
+    await page.locator('.popup__content #action-delete').click()
+
+    const deleteConfirmModal = page.locator('dialog[id^="delete-"][open]')
+    await expect(deleteConfirmModal).toBeVisible()
+    await deleteConfirmModal.locator('button[data-dialog-action="confirm"]').click()
+
+    await expect(joinField.locator('tbody tr', { hasText: title })).toBeHidden()
+    await expect(page.locator('.drawer--is-open')).toHaveCount(0)
+  })
+
   test('should edit joined document and update relationship table', async () => {
     await page.goto(categoriesURL.edit(categoryID))
 


### PR DESCRIPTION
Deleting a document through a polymorphic join table could reopen its drawer after the deletion completed.

1. The selected collection remained set while the drawer state settled.
2. The drawer-opening effect depended on `openDrawer`, whose identity changed when the drawer closed and reran the effect.

The fix reads `openDrawer` through `useEffectEvent` so the effect only responds to polymorphic collection selection changes. Adds an end-to-end regression test that deletes the joined document and verifies the drawer remains closed.

<!-- e2e-pr-media:start -->
### Before
https://github.com/user-attachments/assets/c1cd7a5c-6df0-44c0-a697-6eff13dda185

### After
https://github.com/user-attachments/assets/343d5b58-b889-4fb9-b699-0e47f492a0aa
<!-- e2e-pr-media:end -->
