### PR TITLE
fix(ui): add accessible names to pagination arrow buttons

### DIFF
--- a/packages/ui/src/elements/Pagination/ClickableArrow/index.tsx
+++ b/packages/ui/src/elements/Pagination/ClickableArrow/index.tsx
@@ -2,6 +2,7 @@
 import React from 'react'
 
 import { ChevronIcon } from '../../../icons/Chevron/index.js'
+import { useTranslation } from '../../../providers/Translation/index.js'
 import './index.css'
 
 const baseClass = 'clickable-arrow'
@@ -14,6 +15,7 @@ export type ClickableArrowProps = {
 
 export const ClickableArrow: React.FC<ClickableArrowProps> = (props) => {
   const { direction = 'right', isDisabled = false, updatePage } = props
+  const { i18n } = useTranslation()
 
   const classes = [
     baseClass,
@@ -25,6 +27,7 @@ export const ClickableArrow: React.FC<ClickableArrowProps> = (props) => {
 
   return (
     <button
+      aria-label={direction === 'left' ? i18n.t('general:previous') : i18n.t('general:next')}
       className={classes}
       disabled={isDisabled}
       onClick={!isDisabled ? updatePage : undefined}


### PR DESCRIPTION
The previous and next pagination arrows in the admin list view are icon only buttons. Their only child is the chevron icon, so there is no text and no aria label, which means no accessible name at all. Screen readers just say "button", and axe flags it as a critical button-name violation.

Fixed by setting aria-label from the direction prop, using the general:previous and general:next keys that already exist, so no translation files change. Both Pagination and SimplePagination get it from this one change.

Closes #17377
