### PR TITLE
fix(ui): translate the collection label in the create new card button

### DIFF
--- a/packages/ui/src/elements/DocumentDrawer/index.tsx
+++ b/packages/ui/src/elements/DocumentDrawer/index.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { useModal } from '@faceless-ui/modal'
+import { getTranslation } from '@payloadcms/translations'
 import React, { useCallback, useId, useMemo, useRef } from 'react'
 
 import type {
@@ -40,13 +41,13 @@ export const DocumentDrawerToggler: React.FC<DocumentTogglerProps> = ({
   operation,
   ...rest
 }) => {
-  const { t } = useTranslation()
+  const { i18n, t } = useTranslation()
   const [collectionConfig] = useRelatedCollections(collectionSlug)
 
   return (
     <DrawerToggler
       aria-label={t(operation === 'create' ? 'fields:addNewLabel' : 'general:editLabel', {
-        label: collectionConfig?.labels.singular,
+        label: getTranslation(collectionConfig?.labels?.singular, i18n),
       })}
       buttonStyle={buttonStyle}
       className={[className, `${documentDrawerBaseClass}__toggler`].filter(Boolean).join(' ')}

--- a/packages/ui/src/widgets/CollectionCards/index.tsx
+++ b/packages/ui/src/widgets/CollectionCards/index.tsx
@@ -103,7 +103,7 @@ export async function CollectionCards(props: WidgetServerProps) {
                             ) : hasCreatePermission && type === EntityType.collection ? (
                               <Button
                                 aria-label={t('general:createNewLabel', {
-                                  label,
+                                  label: title,
                                 })}
                                 buttonStyle="ghost"
                                 el="link"


### PR DESCRIPTION
The create button on collection cards passes the raw entity label into general:createNewLabel. When a collection has localized labels that label is an object, so the aria-label comes out as "[object Object] neu erstellen", and Button copies aria-label into title so both attributes get it.

Fixed by passing the title that's already translated a few lines up, which is what the showAllLabel call does too. One word change, no new imports.

Closes #17069
