### PR TITLE
fix(tanstack-start): bundle storage adapter leaf deps in production build

### DIFF
--- a/packages/tanstack-start/src/withPayload/config/external.ts
+++ b/packages/tanstack-start/src/withPayload/config/external.ts
@@ -9,8 +9,9 @@
  * fragile UMD wrappers (e.g. `pluralize`, whose `this`-based global assignment
  * throws when transformed rather than required).
  *
- * Note `pluralize` is deliberately excluded from {@link buildExternalPackages}:
- * for the production build it must bundle (see there).
+ * Safe here whoever declared the entry: Node resolves from the importing package,
+ * so pnpm's isolated layout never applies. The build is stricter — see
+ * {@link buildBundledPackages}.
  */
 export const ssrExternalPackages: string[] = [
   'ajv',
@@ -46,23 +47,38 @@ export const ssrExternalPackages: string[] = [
 ]
 
 /**
+ * Entries of {@link ssrExternalPackages} that must bundle in the production build.
+ *
+ * Externalizing only works for specifiers resolvable from the project root. These
+ * are leaf deps of Payload packages, so under pnpm they live in `.pnpm/…` and a bare
+ * specifier in a root-resolved chunk is invisible — `ERR_MODULE_NOT_FOUND` at
+ * runtime, or a build-time resolve failure under Nitro's re-bundle pass.
+ *
+ * `pluralize` also needs forcing back via `noExternal` (see `withPayload`); the
+ * storage leaves don't, since their adapters are already `noExternal`.
+ */
+export const buildBundledPackages: string[] = [
+  'pluralize',
+  // Leaf deps of the `@payloadcms/storage-*` adapters.
+  '@aws-sdk/client-s3',
+  '@aws-sdk/s3-request-presigner',
+  '@azure/storage-blob',
+  '@google-cloud/storage',
+]
+
+/**
  * External packages for the production `vite build` only (not dev serve).
  *
  * Externalizes the `@payloadcms/*` package boundaries — plus `payload` — so each
  * resolves its own transitive Node deps (`pino`, `drizzle-orm`, `libsql`, …) from
  * its own `node_modules` at runtime. Externalizing only the leaf deps breaks under
  * pnpm: a leaf imported by bundled code becomes an unresolvable bare specifier from
- * `dist/`, since pnpm does not hoist it.
+ * `dist/`, since pnpm does not hoist it; see {@link buildBundledPackages}.
  *
  * Kept out of dev's `ssr.external` on purpose: the monorepo resolves these to
  * TypeScript source (`.ts` imported via `.js` specifiers), which only Vite's
  * transform can resolve — an externalized copy would hit Node's raw resolver and
  * fail on the `.js`→`.ts` mismatch.
- *
- * `pluralize` is excluded: it is reached from client-safe code (`payload`'s
- * `formatLabels`, shipped in the `/shared` export), so externalizing it would
- * leave a bare specifier in a bundled client chunk that pnpm can't resolve from
- * `dist/` at runtime. It must bundle for the build.
  */
 export const buildExternalPackages: string[] = [
   'payload',
@@ -73,7 +89,7 @@ export const buildExternalPackages: string[] = [
   '@payloadcms/db-vercel-postgres',
   '@payloadcms/db-sqlite',
   '@payloadcms/db-d1-sqlite',
-  ...ssrExternalPackages.filter((pkg) => pkg !== 'pluralize'),
+  ...ssrExternalPackages.filter((pkg) => !buildBundledPackages.includes(pkg)),
 ]
 
 export const payloadNoExternalPatterns: Array<RegExp | string> = [


### PR DESCRIPTION
`buildExternalPackages` splices in `ssrExternalPackages`, a dev-serve list of leaf deps belonging to Payload packages, alongside entries that are package boundaries the consuming app declares itself. Externalizing a leaf emits a bare specifier into a chunk that resolves from the project root, where pnpm's isolated layout makes it invisible.

Registering `s3Storage()` on a bundled build under pnpm therefore failed:

  Rolldown failed to resolve import "@aws-sdk/client-s3" from
  node_modules/.nitro/vite/services/rsc/assets/payload.config-<hash>.js

Move the storage adapter leaf deps into a new `buildBundledPackages` list so they bundle instead, alongside `pluralize`, which already needed the same treatment. Dev serve is unchanged: Node resolves these from the importing package, so the isolated layout never applies there.

`@vercel/blob` already takes this path by virtue of never having been listed in `ssrExternalPackages`, which is why storage-vercel-blob was unaffected.

Confirmed against the TanStack demo (pnpm 10 `--ignore-workspace`, Nitro node-server preset) with `s3Storage()` on the top-level `storage:` field:

- before: `vite build` fails with the error above, exit 1
- after: build succeeds; AWS SDK bundled into the config chunk, no bare `@aws-sdk` specifiers in `.output/server`, and the built server boots with no `ERR_MODULE_NOT_FOUND`

Cost is ~18-30 kB gzipped across the two payload.config chunks.

`@azure/storage-blob` and `@google-cloud/storage` are included as the same latent failure for storage-azure and storage-gcs, but only the S3 case was reproduced.

<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

## Which branch should this PR target?

- **`main`** — Payload v4 development. New features, enhancements, and v4 bug fixes go here.
- **`3.x`** — Payload v3 maintenance. Bug fixes only. **New features are not accepted against v3.** If this PR adds a feature to v3, please retarget it at `main` (v4) instead.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
