### PR TITLE
fix(tanstack-start): full-trace tslib in nitro server build

### DIFF
--- a/packages/tanstack-start/src/withPayload/index.ts
+++ b/packages/tanstack-start/src/withPayload/index.ts
@@ -96,8 +96,14 @@ export type WithPayloadOptions = {
   vite?: UserConfig
 }
 
+/** The `nitro()` options Payload's server build requires. Typed structurally — `nitro` is the host's dependency, not Payload's. */
+export type PayloadNitroOptions = {
+  traceDeps: string[]
+}
+
 /** The options Payload's admin requires for each third-party plugin. */
 export type PayloadPluginOptions = {
+  nitro: PayloadNitroOptions
   react: NonNullable<Parameters<typeof viteReact>[0]>
   rsc: NonNullable<Parameters<typeof rsc>[0]>
   tanstackStart: NonNullable<Parameters<typeof tanstackStart>[0]>
@@ -137,6 +143,7 @@ export type WithPayloadBuilder = (context: WithPayloadBuilderContext) => UserCon
  *       rsc(pluginOptions.rsc),
  *       tanstackStart(pluginOptions.tanstackStart),
  *       viteReact(pluginOptions.react),
+ *       nitro(pluginOptions.nitro), // only if the app deploys through Nitro
  *     ],
  *     // ...other config options
  *   }),
@@ -239,6 +246,7 @@ export function withPayload(
     }
 
     const pluginOptions: PayloadPluginOptions = {
+      nitro: payloadNitroOptions(),
       react: payloadReactOptions(),
       rsc: payloadRscOptions(),
       tanstackStart: payloadTanstackStartOptions({
@@ -273,6 +281,16 @@ export function withPayload(
 /** `@vitejs/plugin-rsc` options for Payload: `serverHandler: false` (TanStack owns the handler). */
 export function payloadRscOptions(): NonNullable<Parameters<typeof rsc>[0]> {
   return { serverHandler: false }
+}
+
+/**
+ * `nitro/vite` options for Payload's server build. `tslib*` full-traces `tslib`
+ * so an externalized dep's `tslib/modules/index.js` import (its `import.node`
+ * export condition) ships — otherwise the build is green and the server 500s
+ * with `ERR_MODULE_NOT_FOUND` on the first request.
+ */
+export function payloadNitroOptions(): PayloadNitroOptions {
+  return { traceDeps: ['tslib*'] }
 }
 
 /** `@vitejs/plugin-react` options for Payload: transform every `.[jt]sx?` file. */


### PR DESCRIPTION
Exposes `pluginOptions.nitro` (`traceDeps: ['tslib*']`) so hosts pass it to `nitro()` like the other plugins. Without it, an externalized dep's `tslib/modules/index.js` import isn't copied into the output and the server 500s with ERR_MODULE_NOT_FOUND on the first request.


The demo needs to be changed after we merge this / release a canary version by adding ` nitro(pluginOptions.nitro)` there.

<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

## Which branch should this PR target?

- **`main`** — Payload v4 development. New features, enhancements, and v4 bug fixes go here.
- **`3.x`** — Payload v3 maintenance. Bug fixes only. **New features are not accepted against v3.** If this PR adds a feature to v3, please retarget it at `main` (v4) instead.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
