### PR TITLE
fix: prevent multipart content-type backtracking

### DIFF
--- a/examples/auth/src/app/(app)/create-account/CreateAccountForm/index.tsx
+++ b/examples/auth/src/app/(app)/create-account/CreateAccountForm/index.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
+import { getSafeRedirect } from 'payload/shared'
 import React, { useCallback, useRef, useState } from 'react'
 import { useForm } from 'react-hook-form'
 
@@ -51,7 +52,10 @@ export const CreateAccountForm: React.FC = () => {
         return
       }
 
-      const redirect = searchParams.get('redirect')
+      const redirect = getSafeRedirect({
+        fallbackTo: `/account?success=${encodeURIComponent('Account created successfully')}`,
+        redirectTo: searchParams.get('redirect') ?? '',
+      })
 
       const timer = setTimeout(() => {
         setLoading(true)
@@ -60,8 +64,7 @@ export const CreateAccountForm: React.FC = () => {
       try {
         await login(data)
         clearTimeout(timer)
-        if (redirect) {router.push(redirect)}
-        else {router.push(`/account?success=${encodeURIComponent('Account created successfully')}`)}
+        router.push(redirect)
       } catch (_) {
         clearTimeout(timer)
         setError('There was an error with the credentials provided. Please try again.')

--- a/examples/auth/src/app/(app)/login/LoginForm/index.tsx
+++ b/examples/auth/src/app/(app)/login/LoginForm/index.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
+import { getSafeRedirect } from 'payload/shared'
 import React, { useCallback, useRef } from 'react'
 import { useForm } from 'react-hook-form'
 
@@ -19,7 +20,12 @@ type FormData = {
 export const LoginForm: React.FC = () => {
   const searchParams = useSearchParams()
   const allParams = searchParams.toString() ? `?${searchParams.toString()}` : ''
-  const redirect = useRef(searchParams.get('redirect'))
+  const redirect = useRef(
+    getSafeRedirect({
+      fallbackTo: '/account',
+      redirectTo: searchParams.get('redirect') ?? '',
+    }),
+  )
   const { login } = useAuth()
   const router = useRouter()
   const [error, setError] = React.useState<null | string>(null)
@@ -39,8 +45,7 @@ export const LoginForm: React.FC = () => {
     async (data: FormData) => {
       try {
         await login(data)
-        if (redirect?.current) {router.push(redirect.current)}
-        else {router.push('/account')}
+        router.push(redirect.current)
       } catch (_) {
         setError('There was an error with the credentials provided. Please try again.')
       }

--- a/packages/payload/src/collections/operations/find.ts
+++ b/packages/payload/src/collections/operations/find.ts
@@ -18,6 +18,7 @@ import type {
 import { executeAccess } from '../../auth/executeAccess.js'
 import { combineQueries } from '../../database/combineQueries.js'
 import { validateQueryPaths } from '../../database/queryValidation/validateQueryPaths.js'
+import { validateSortQuery } from '../../database/queryValidation/validateSortQuery.js'
 import { sanitizeJoinQuery } from '../../database/sanitizeJoinQuery.js'
 import { sanitizeWhereQuery } from '../../database/sanitizeWhereQuery.js'
 import { afterRead } from '../../fields/hooks/afterRead/index.js'
@@ -158,7 +159,14 @@ export const findOperation = async <
 
     const sort = sanitizeSortQuery({
       fields: collection.config.flattenedFields,
-      sort: incomingSort,
+      sort: incomingSort || collectionConfig.defaultSort,
+    })
+
+    await validateSortQuery({
+      collectionConfig,
+      overrideAccess: overrideAccess!,
+      req,
+      sort,
     })
 
     const sanitizedJoins = await sanitizeJoinQuery({

--- a/packages/payload/src/collections/operations/findDistinct.ts
+++ b/packages/payload/src/collections/operations/findDistinct.ts
@@ -9,6 +9,7 @@ import type { Collection } from '../config/types.js'
 import { executeAccess } from '../../auth/executeAccess.js'
 import { combineQueries } from '../../database/combineQueries.js'
 import { validateQueryPaths } from '../../database/queryValidation/validateQueryPaths.js'
+import { validateSortQuery } from '../../database/queryValidation/validateSortQuery.js'
 import { sanitizeWhereQuery } from '../../database/sanitizeWhereQuery.js'
 import { APIError } from '../../errors/APIError.js'
 import { Forbidden } from '../../errors/Forbidden.js'
@@ -136,6 +137,13 @@ export const findDistinctOperation = async (
         throw new Forbidden(req.t)
       }
     }
+
+    await validateSortQuery({
+      collectionConfig,
+      overrideAccess: overrideAccess!,
+      req,
+      sort: args.sort,
+    })
 
     if ('virtual' in fieldResult.field && fieldResult.field.virtual) {
       if (typeof fieldResult.field.virtual !== 'string') {

--- a/packages/payload/src/collections/operations/findVersions.ts
+++ b/packages/payload/src/collections/operations/findVersions.ts
@@ -8,6 +8,7 @@ import type { FindOptions } from './local/find.js'
 import { executeAccess } from '../../auth/executeAccess.js'
 import { combineQueries } from '../../database/combineQueries.js'
 import { validateQueryPaths } from '../../database/queryValidation/validateQueryPaths.js'
+import { validateSortQuery } from '../../database/queryValidation/validateSortQuery.js'
 import { sanitizeWhereQuery } from '../../database/sanitizeWhereQuery.js'
 import { afterRead } from '../../fields/hooks/afterRead/index.js'
 import { appendNonTrashedFilter } from '../../utilities/appendNonTrashedFilter.js'
@@ -85,6 +86,14 @@ export const findVersionsOperation = async <TData extends TypeWithVersion<TData>
       req,
       versionFields,
       where: where!,
+    })
+
+    await validateSortQuery({
+      collectionConfig,
+      overrideAccess: overrideAccess!,
+      req,
+      sort,
+      versionFields,
     })
 
     let fullWhere = combineQueries(where!, accessResults)

--- a/packages/payload/src/collections/operations/update.ts
+++ b/packages/payload/src/collections/operations/update.ts
@@ -15,6 +15,7 @@ import type {
 import { executeAccess } from '../../auth/executeAccess.js'
 import { combineQueries } from '../../database/combineQueries.js'
 import { validateQueryPaths } from '../../database/queryValidation/validateQueryPaths.js'
+import { validateSortQuery } from '../../database/queryValidation/validateSortQuery.js'
 import { sanitizeWhereQuery } from '../../database/sanitizeWhereQuery.js'
 import { APIError } from '../../errors/index.js'
 import { type CollectionSlug, type FindOptions } from '../../index.js'
@@ -175,7 +176,14 @@ export const updateOperation = async <
 
     const sort = sanitizeSortQuery({
       fields: collection.config.flattenedFields,
-      sort: incomingSort,
+      sort: incomingSort || collectionConfig.defaultSort,
+    })
+
+    await validateSortQuery({
+      collectionConfig,
+      overrideAccess: overrideAccess!,
+      req,
+      sort,
     })
 
     let docs

--- a/packages/payload/src/database/queryValidation/validateQueryPaths.ts
+++ b/packages/payload/src/database/queryValidation/validateQueryPaths.ts
@@ -50,7 +50,7 @@ export async function validateQueryPaths({
     for (const path in where) {
       const constraint = where[path]
 
-      if ((path === 'and' || path === 'or') && Array.isArray(constraint)) {
+      if (['and', 'or'].includes(path.toLowerCase()) && Array.isArray(constraint)) {
         for (const item of constraint) {
           if (collectionConfig) {
             promises.push(
@@ -80,6 +80,8 @@ export async function validateQueryPaths({
             )
           }
         }
+      } else if (Array.isArray(constraint)) {
+        errors.push({ path })
       } else if (!Array.isArray(constraint)) {
         for (const operator in constraint) {
           const val = constraint[operator as keyof typeof constraint]

--- a/packages/payload/src/database/queryValidation/validateSortQuery.ts
+++ b/packages/payload/src/database/queryValidation/validateSortQuery.ts
@@ -1,0 +1,83 @@
+import type { SanitizedCollectionConfig } from '../../collections/config/types.js'
+import type { FlattenedField } from '../../fields/config/types.js'
+import type { SanitizedGlobalConfig } from '../../globals/config/types.js'
+import type { PayloadRequest, Sort, Where } from '../../types/index.js'
+
+import { getLocalizedPaths } from '../getLocalizedPaths.js'
+import { validateQueryPaths } from './validateQueryPaths.js'
+
+type Args = {
+  overrideAccess: boolean
+  req: PayloadRequest
+  sort?: Sort
+  versionFields?: FlattenedField[]
+} & (
+  | {
+      collectionConfig: SanitizedCollectionConfig
+      globalConfig?: undefined
+    }
+  | {
+      collectionConfig?: undefined
+      globalConfig: SanitizedGlobalConfig
+    }
+)
+
+/**
+ * Ensures sort paths are subject to the same field-read access checks as query `where` paths,
+ * since database sorting happens before response-time field redaction.
+ */
+export const validateSortQuery = async ({
+  collectionConfig,
+  globalConfig,
+  overrideAccess,
+  req,
+  sort,
+  versionFields,
+}: Args): Promise<void> => {
+  if (overrideAccess || !sort) {
+    return
+  }
+
+  const fields = versionFields || (globalConfig || collectionConfig).flattenedFields
+  const sortFields = Array.isArray(sort) ? sort : [sort]
+  const where: Where = {}
+
+  for (const sortField of sortFields) {
+    const path = sortField.replace(/^-/, '').replace(/__/g, '.')
+    const paths = getLocalizedPaths({
+      collectionSlug: collectionConfig?.slug,
+      fields,
+      globalSlug: globalConfig?.slug,
+      incomingPath: path,
+      locale: req.locale!,
+      overrideAccess: true,
+      payload: req.payload,
+    })
+
+    if (path !== 'id' && path !== '_id' && paths.every(({ invalid }) => !invalid)) {
+      where[path] = { exists: true }
+    }
+  }
+
+  if (Object.keys(where).length === 0) {
+    return
+  }
+
+  if (collectionConfig) {
+    await validateQueryPaths({
+      collectionConfig,
+      overrideAccess,
+      req,
+      versionFields,
+      where,
+    })
+  } else {
+    await validateQueryPaths({
+      globalConfig,
+      overrideAccess,
+      req,
+      versionFields,
+      where,
+    })
+  }
+}

--- a/packages/payload/src/database/sanitizeJoinQuery.ts
+++ b/packages/payload/src/database/sanitizeJoinQuery.ts
@@ -5,6 +5,7 @@ import { executeAccess } from '../auth/executeAccess.js'
 import { QueryError } from '../errors/QueryError.js'
 import { combineQueries } from './combineQueries.js'
 import { validateQueryPaths } from './queryValidation/validateQueryPaths.js'
+import { validateSortQuery } from './queryValidation/validateSortQuery.js'
 import { sanitizeWhereQuery } from './sanitizeWhereQuery.js'
 
 type Args = {
@@ -73,6 +74,12 @@ const sanitizeJoinFieldQuery = async ({
       req,
       // incoming where input, but we shouldn't validate generated from the access control.
       where: joinQuery.where,
+    }),
+    validateSortQuery({
+      collectionConfig: joinCollectionConfig,
+      overrideAccess,
+      req,
+      sort: joinQuery.sort || join.field.defaultSort || joinCollectionConfig.defaultSort,
     }),
   )
 

--- a/packages/payload/src/globals/operations/findVersions.ts
+++ b/packages/payload/src/globals/operations/findVersions.ts
@@ -7,6 +7,7 @@ import type { SanitizedGlobalConfig } from '../config/types.js'
 import { executeAccess } from '../../auth/executeAccess.js'
 import { combineQueries } from '../../database/combineQueries.js'
 import { validateQueryPaths } from '../../database/queryValidation/validateQueryPaths.js'
+import { validateSortQuery } from '../../database/queryValidation/validateSortQuery.js'
 import { afterRead } from '../../fields/hooks/afterRead/index.js'
 import { killTransaction } from '../../utilities/killTransaction.js'
 import { sanitizeInternalFields } from '../../utilities/sanitizeInternalFields.js'
@@ -64,6 +65,14 @@ export const findVersionsOperation = async <T extends TypeWithVersion<T>>(
       req,
       versionFields,
       where: where!,
+    })
+
+    await validateSortQuery({
+      globalConfig,
+      overrideAccess: overrideAccess!,
+      req,
+      sort,
+      versionFields,
     })
 
     const fullWhere = combineQueries(where!, accessResults)

--- a/packages/payload/src/uploads/fetchAPI-multipart/isEligibleRequest.spec.ts
+++ b/packages/payload/src/uploads/fetchAPI-multipart/isEligibleRequest.spec.ts
@@ -26,4 +26,35 @@ describe('isEligibleRequest', () => {
 
     expect(isEligibleRequest(request)).toBe(false)
   })
+
+  it.each([
+    'multipart/form-data; boundary=----test-boundary',
+    'multipart/form-data;boundary=----test-boundary',
+    'multipart/form-data; boundary="quoted-boundary"',
+    'multipart/mixed; charset=utf-8; boundary=example',
+    'multipart/x^foo; boundary=abc',
+    'multipart/form-data; note="[a\\b]@c<>"; boundary=abc',
+  ])('should accept valid multipart content type %s', (contentType) => {
+    const request = new Request('http://localhost/api/upload', {
+      body: 'test',
+      headers: { 'content-type': contentType },
+      method: 'POST',
+    })
+
+    expect(isEligibleRequest(request)).toBe(true)
+  })
+
+  it('should reject invalid multipart content types promptly', () => {
+    const request = new Request('http://localhost/api/upload', {
+      body: 'test',
+      headers: {
+        'content-type': `multipart/form-data; boundary=${';'.repeat(23)}!`,
+      },
+      method: 'POST',
+    })
+    const start = performance.now()
+
+    expect(isEligibleRequest(request)).toBe(false)
+    expect(performance.now() - start).toBeLessThan(25)
+  }, 100)
 })

--- a/packages/payload/src/uploads/fetchAPI-multipart/isEligibleRequest.spec.ts
+++ b/packages/payload/src/uploads/fetchAPI-multipart/isEligibleRequest.spec.ts
@@ -44,17 +44,15 @@ describe('isEligibleRequest', () => {
     expect(isEligibleRequest(request)).toBe(true)
   })
 
-  it('should reject invalid multipart content types promptly', () => {
+  it('should reject invalid multipart content types without catastrophic backtracking', () => {
     const request = new Request('http://localhost/api/upload', {
       body: 'test',
       headers: {
-        'content-type': `multipart/form-data; boundary=${';'.repeat(23)}!`,
+        'content-type': `multipart/form-data; boundary=${';'.repeat(50)}!`,
       },
       method: 'POST',
     })
-    const start = performance.now()
 
     expect(isEligibleRequest(request)).toBe(false)
-    expect(performance.now() - start).toBeLessThan(25)
-  }, 100)
+  }, 1000)
 })

--- a/packages/payload/src/uploads/fetchAPI-multipart/isEligibleRequest.ts
+++ b/packages/payload/src/uploads/fetchAPI-multipart/isEligibleRequest.ts
@@ -1,5 +1,5 @@
-// eslint-disable-next-line regexp/no-super-linear-backtracking, regexp/no-obscure-range
-const ACCEPTABLE_CONTENT_TYPE = /multipart\/['"()+-_]+(?:; ?['"()+-_]*)+$/i
+const ACCEPTABLE_CONTENT_TYPE =
+  /multipart\/[\w'"()+,./:<=>?@[\\\]^-]+(?:; ?[\w'"()+,./:<=>?@[\\\]^-]*)+$/i
 const UNACCEPTABLE_METHODS = new Set(['CONNECT', 'DELETE', 'GET', 'HEAD', 'OPTIONS', 'TRACE'])
 
 const hasBody = (req: Request): boolean => {

--- a/packages/payload/src/utilities/getSafeRedirect.spec.ts
+++ b/packages/payload/src/utilities/getSafeRedirect.spec.ts
@@ -22,6 +22,27 @@ describe('getSafeRedirect', () => {
     },
   )
 
+  it.each([
+    'redirect=%2F%09%2Fexample.invalid',
+    'redirect=%2F%0D%2Fexample.invalid',
+    'redirect=%2F%0A%2Fexample.invalid',
+  ])('should use the fallback when a path resolves outside the current origin: %s', (query) => {
+    const redirectTo = new URLSearchParams(query).get('redirect')
+
+    expect(redirectTo).not.toBeNull()
+    expect(getSafeRedirect({ redirectTo: redirectTo!, fallbackTo: fallback })).toBe(fallback)
+  })
+
+  it.each([
+    '/%2509/example.invalid',
+    '/%250D/example.invalid',
+    '/%250A/example.invalid',
+    '/%255Cexample.invalid',
+    '/%252fexample.invalid',
+  ])('should use the fallback for ambiguous encoded path prefixes: %s', (input) => {
+    expect(getSafeRedirect({ redirectTo: input, fallbackTo: fallback })).toBe(fallback)
+  })
+
   // Unsafe redirect patterns
   it.each([
     '//example.com', // protocol-relative URL
@@ -53,8 +74,53 @@ describe('getSafeRedirect', () => {
     )
   })
 
-  // If decoding the input fails (e.g., invalid percent encoding), it should not crash
-  it('should return fallback on invalid encoding', () => {
+  it('should return fallback when the input is not a path or URL', () => {
     expect(getSafeRedirect({ redirectTo: '%E0%A4%A', fallbackTo: fallback })).toBe(fallback)
   })
+
+  it('should preserve an accepted local redirect', () => {
+    const redirectTo = '/dashboard?tab=overview#details'
+
+    expect(getSafeRedirect({ redirectTo, fallbackTo: fallback })).toBe(redirectTo)
+  })
+
+  it('should preserve a parsed navigation target byte-for-byte', () => {
+    const redirectTo = new URLSearchParams(
+      'redirect=%2Foauth%2Fcallback%3Fcode%3DA%252FB%26state%3Dopaque%253D%23done',
+    ).get('redirect')
+
+    expect(redirectTo).toBe('/oauth/callback?code=A%2FB&state=opaque%3D#done')
+    expect(getSafeRedirect({ redirectTo: redirectTo!, fallbackTo: fallback })).toBe(
+      '/oauth/callback?code=A%2FB&state=opaque%3D#done',
+    )
+  })
+
+  it.each([
+    [
+      'https://example.invalid/path?code=A%252FB#done',
+      'https://example.invalid/path?code=A%252FB#done',
+    ],
+    ['http://example.invalid/dashboard', 'http://example.invalid/dashboard'],
+  ])('should preserve an HTTP absolute redirect when enabled: %s', (input, expected) => {
+    expect(
+      getSafeRedirect({
+        allowAbsoluteUrls: true,
+        redirectTo: input,
+        fallbackTo: fallback,
+      }),
+    ).toBe(expected)
+  })
+
+  it.each([
+    ['https://example.invalid/path', false],
+    ['mailto:user@example.invalid', true],
+    ['//example.invalid/path', true],
+  ])(
+    'should use the fallback without an explicitly enabled HTTP(S) URL: %s',
+    (input, allowAbsoluteUrls) => {
+      expect(getSafeRedirect({ allowAbsoluteUrls, redirectTo: input, fallbackTo: fallback })).toBe(
+        fallback,
+      )
+    },
+  )
 })

--- a/packages/payload/src/utilities/getSafeRedirect.ts
+++ b/packages/payload/src/utilities/getSafeRedirect.ts
@@ -11,17 +11,28 @@ export const getSafeRedirect = ({
     return fallbackTo
   }
 
-  // Normalize and decode the path
-  let redirectPath: string
+  const redirectPath = redirectTo.trim()
+
+  const hasControlCharacters = [...redirectPath].some((character) => {
+    const code = character.charCodeAt(0)
+    return code <= 31 || code === 127
+  })
+  const hasAmbiguousPathPrefix = /^\/%(?:25)*(?:09|0a|0d|2f|5c)/i.test(redirectPath)
+
+  let parsedRedirect: URL
   try {
-    redirectPath = decodeURIComponent(redirectTo.trim())
+    parsedRedirect = new URL(redirectPath, 'http://localhost')
   } catch {
-    return fallbackTo // invalid encoding
+    return fallbackTo
   }
 
   const isSafeRedirect =
+    !hasControlCharacters &&
+    !hasAmbiguousPathPrefix &&
     // Must start with a single forward slash (e.g., "/admin")
     redirectPath.startsWith('/') &&
+    // Must resolve to the same origin after URL parser normalization
+    parsedRedirect.origin === 'http://localhost' &&
     // Prevent protocol-relative URLs (e.g., "//example.com")
     !redirectPath.startsWith('//') &&
     // Prevent encoded slashes that could resolve to protocol-relative
@@ -37,8 +48,10 @@ export const getSafeRedirect = ({
 
   const isAbsoluteSafeRedirect =
     allowAbsoluteUrls &&
+    !hasControlCharacters &&
     // Must be a valid absolute URL with http or https
-    /^https?:\/\/\S+$/i.test(redirectPath)
+    /^https?:\/\/\S+$/i.test(redirectPath) &&
+    (parsedRedirect.protocol === 'http:' || parsedRedirect.protocol === 'https:')
 
   return isSafeRedirect || isAbsoluteSafeRedirect ? redirectPath : fallbackTo
 }

--- a/packages/payload/src/versions/drafts/appendVersionToQueryKey.spec.ts
+++ b/packages/payload/src/versions/drafts/appendVersionToQueryKey.spec.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+
+import { appendVersionToQueryKey } from './appendVersionToQueryKey.js'
+
+describe('appendVersionToQueryKey', () => {
+  it.each(['aNd', 'oR'])(
+    'should preserve case-insensitive %s conditions when prefixing version fields',
+    (logicalOperator) => {
+      expect(
+        appendVersionToQueryKey({
+          [logicalOperator]: [
+            {
+              title: {
+                equals: 'example',
+              },
+            },
+          ],
+        }),
+      ).toStrictEqual({
+        [logicalOperator.toLowerCase()]: [
+          {
+            'version.title': {
+              equals: 'example',
+            },
+          },
+        ],
+      })
+    },
+  )
+})

--- a/packages/payload/src/versions/drafts/appendVersionToQueryKey.ts
+++ b/packages/payload/src/versions/drafts/appendVersionToQueryKey.ts
@@ -2,7 +2,7 @@ import type { Where } from '../../types/index.js'
 
 export const appendVersionToQueryKey = (query: Where = {}): Where => {
   return Object.entries(query).reduce((res, [key, val]) => {
-    if (['AND', 'and', 'OR', 'or'].includes(key) && Array.isArray(val)) {
+    if (['and', 'or'].includes(key.toLowerCase()) && Array.isArray(val)) {
       return {
         ...res,
         [key.toLowerCase()]: val.map((subQuery) => appendVersionToQueryKey(subQuery)),

--- a/packages/plugin-import-export/src/export/handlePreview.ts
+++ b/packages/plugin-import-export/src/export/handlePreview.ts
@@ -275,7 +275,7 @@ export const handlePreview = async (req: PayloadRequest): Promise<Response> => {
 
         for (const key of fields) {
           const value = getObjectDotNotation(output, key)
-          setNestedValue(trimmed, key, value ?? null)
+          setNestedValue(trimmed, key, value ?? null, output)
         }
 
         output = trimmed

--- a/packages/plugin-import-export/src/utilities/fieldPath.ts
+++ b/packages/plugin-import-export/src/utilities/fieldPath.ts
@@ -1,0 +1,4 @@
+const unsupportedFieldPathSegments = new Set(['__proto__', 'constructor', 'prototype'])
+
+export const hasUnsupportedFieldPathSegment = (segments: string[]): boolean =>
+  segments.some((segment) => unsupportedFieldPathSegments.has(segment))

--- a/packages/plugin-import-export/src/utilities/getSelect.spec.ts
+++ b/packages/plugin-import-export/src/utilities/getSelect.spec.ts
@@ -1,0 +1,52 @@
+import { APIError } from 'payload'
+import { describe, expect, it } from 'vitest'
+
+import { getSelect } from './getSelect.js'
+
+const unsupportedSegments = ['__proto__', 'constructor', 'prototype']
+
+describe('getSelect', () => {
+  it.each(
+    unsupportedSegments.flatMap((segment) => [
+      [`${segment}.field`, segment, 'root'],
+      [`group.${segment}.field`, segment, 'middle'],
+      [`group.${segment}`, segment, 'leaf'],
+    ]),
+  )('rejects invalid field path %s', (path) => {
+    try {
+      getSelect([path])
+      expect.fail('Expected getSelect to reject the invalid field path')
+    } catch (error) {
+      expect(error).toBeInstanceOf(APIError)
+
+      if (error instanceof APIError) {
+        expect(error.status).toBe(400)
+        expect(error.isPublic).toBe(true)
+      }
+    }
+  })
+
+  it('leaves global object state unchanged when rejecting invalid paths', () => {
+    expect(Object.prototype).not.toHaveProperty('syntheticMarker')
+
+    for (const path of ['__proto__.syntheticMarker', 'constructor.prototype.syntheticMarker']) {
+      expect(() => getSelect([path])).toThrow(APIError)
+    }
+
+    expect(Object.prototype).not.toHaveProperty('syntheticMarker')
+  })
+
+  it('builds select objects and merges nested siblings', () => {
+    const select = getSelect(['id', 'group.title', 'group.description'])
+
+    expect(select).toEqual({
+      group: {
+        description: true,
+        title: true,
+      },
+      id: true,
+    })
+    expect(Object.getPrototypeOf(select)).toBeNull()
+    expect(Object.getPrototypeOf(select.group)).toBeNull()
+  })
+})

--- a/packages/plugin-import-export/src/utilities/getSelect.ts
+++ b/packages/plugin-import-export/src/utilities/getSelect.ts
@@ -1,5 +1,11 @@
 import type { SelectIncludeType } from 'payload'
 
+import { APIError } from 'payload'
+
+import { hasUnsupportedFieldPathSegment } from './fieldPath.js'
+
+const createSelect = (): SelectIncludeType => Object.create(null) as SelectIncludeType
+
 /**
  * Takes an input of array of string paths in dot notation and returns a select object.
  * Used for both export and import to build Payload's select query format.
@@ -9,18 +15,23 @@ import type { SelectIncludeType } from 'payload'
  * // Returns: { id: true, title: true, group: { value: true }, createdAt: true, updatedAt: true }
  */
 export const getSelect = (fields: string[]): SelectIncludeType => {
-  const select: SelectIncludeType = {}
+  const select = createSelect()
 
   fields.forEach((field) => {
     const segments = field.split('.')
+
+    if (hasUnsupportedFieldPathSegment(segments)) {
+      throw new APIError('Invalid field path.', 400, null, true)
+    }
+
     let selectRef = select
 
     segments.forEach((segment, i) => {
       if (i === segments.length - 1) {
         selectRef[segment] = true
       } else {
-        if (!selectRef[segment]) {
-          selectRef[segment] = {}
+        if (!Object.prototype.hasOwnProperty.call(selectRef, segment)) {
+          selectRef[segment] = createSelect()
         }
         selectRef = selectRef[segment] as SelectIncludeType
       }

--- a/packages/plugin-import-export/src/utilities/setNestedValue.spec.ts
+++ b/packages/plugin-import-export/src/utilities/setNestedValue.spec.ts
@@ -1,0 +1,111 @@
+import { APIError } from 'payload'
+import { describe, expect, it } from 'vitest'
+
+import { setNestedValue } from './setNestedValue.js'
+
+const unsupportedSegments = ['__proto__', 'constructor', 'prototype']
+const unsupportedPaths = unsupportedSegments.flatMap((segment) => [
+  `${segment}.value`,
+  `group.${segment}.value`,
+  `group.${segment}`,
+  `items.${segment}.0.value`,
+  `items.0.${segment}.value`,
+  `items.0.${segment}`,
+])
+
+describe('setNestedValue', () => {
+  it.each(unsupportedPaths)('rejects invalid field path %s without changing the target', (path) => {
+    const target = { stable: { value: true } }
+    const objectPrototypeBefore = Object.getOwnPropertyDescriptors(Object.prototype)
+    const targetPrototypeBefore = Object.getPrototypeOf(target)
+
+    try {
+      setNestedValue(target, path, true)
+      expect.fail('Expected setNestedValue to reject the invalid field path')
+    } catch (error) {
+      expect(error).toBeInstanceOf(APIError)
+
+      if (error instanceof APIError) {
+        expect(error.status).toBe(400)
+        expect(error.isPublic).toBe(true)
+      }
+    }
+
+    expect(target).toEqual({ stable: { value: true } })
+    expect(Object.getPrototypeOf(target)).toBe(targetPrototypeBefore)
+    expect(Object.getOwnPropertyDescriptors(Object.prototype)).toEqual(objectPrototypeBefore)
+  })
+
+  it('rejects field paths with out-of-range array indexes', () => {
+    const source = { items: [{ value: true }] }
+    const target: Record<string, unknown> = {}
+
+    expect(() => setNestedValue(target, 'items.4294967294.value', true, source)).toThrow(APIError)
+    expect(target).toEqual({ items: [] })
+  })
+
+  it('supports out-of-order array indexes that exist in the source document', () => {
+    const source = { items: [{ value: 'first' }, { value: 'second' }, { value: 'third' }] }
+    const target: Record<string, unknown> = {}
+
+    setNestedValue(target, 'items.2.value', 'third', source)
+
+    expect(target).toEqual({ items: [undefined, undefined, { value: 'third' }] })
+  })
+
+  it.each(['-1', '+1', '01', ' 1', '1 ', '1e2', '0x10', 'Infinity', '9007199254740992'])(
+    'treats noncanonical numeric segment %s as an object key',
+    (segment) => {
+      const target: Record<string, unknown> = {}
+
+      setNestedValue(target, `items.${segment}.value`, 'example')
+
+      expect(Array.isArray(target.items)).toBe(false)
+      expect(target).toEqual({ items: { [segment]: { value: 'example' } } })
+    },
+  )
+
+  it('builds nested objects and arrays', () => {
+    const target: Record<string, unknown> = {}
+
+    setNestedValue(target, 'group.items.0.title', 'first')
+    setNestedValue(target, 'group.items.0.description', 'description')
+    setNestedValue(target, 'group.items.1.title', 'second')
+
+    expect(target).toEqual({
+      group: {
+        items: [{ description: 'description', title: 'first' }, { title: 'second' }],
+      },
+    })
+
+    const group = target.group as Record<string, unknown>
+    const items = group.items as Record<string, unknown>[]
+
+    expect(Object.getPrototypeOf(group)).toBeNull()
+    expect(Array.isArray(items)).toBe(true)
+    expect(Object.getPrototypeOf(items[0])).toBeNull()
+    expect(Object.getPrototypeOf(items[1])).toBeNull()
+  })
+
+  it('supports nested arrays using numeric lookahead', () => {
+    const target: Record<string, unknown> = {}
+
+    setNestedValue(target, 'matrix.0.1.value', 'nested')
+
+    expect(target).toEqual({
+      matrix: [[undefined, { value: 'nested' }]],
+    })
+  })
+
+  it('creates own containers instead of traversing inherited properties', () => {
+    const inheritedGroup = { inherited: true }
+    const target = Object.create({ group: inheritedGroup }) as Record<string, unknown>
+
+    setNestedValue(target, 'group.value', 'own')
+
+    expect(Object.prototype.hasOwnProperty.call(target, 'group')).toBe(true)
+    expect(target.group).toEqual({ value: 'own' })
+    expect(Object.getPrototypeOf(target.group)).toBeNull()
+    expect(inheritedGroup).toEqual({ inherited: true })
+  })
+})

--- a/packages/plugin-import-export/src/utilities/setNestedValue.ts
+++ b/packages/plugin-import-export/src/utilities/setNestedValue.ts
@@ -1,3 +1,52 @@
+import { APIError } from 'payload'
+
+import { hasUnsupportedFieldPathSegment } from './fieldPath.js'
+
+const MAX_UNVERIFIED_SPARSE_ARRAY_GAP = 1
+
+const createObject = (): Record<string, unknown> => Object.create(null) as Record<string, unknown>
+
+const isArrayIndex = (part: string): boolean => {
+  if (!/^(?:0|[1-9]\d*)$/.test(part)) {
+    return false
+  }
+
+  const index = Number(part)
+
+  return Number.isSafeInteger(index) && index >= 0
+}
+
+const getPathKey = (
+  target: Record<string, unknown> | unknown[],
+  part: string,
+  source: unknown,
+): number | string => {
+  if (!Array.isArray(target) || !isArrayIndex(part)) {
+    return part
+  }
+
+  const index = Number(part)
+
+  if (
+    (Array.isArray(source) && index >= source.length) ||
+    (!Array.isArray(source) && index > target.length + MAX_UNVERIFIED_SPARSE_ARRAY_GAP)
+  ) {
+    throw new APIError('Invalid field path.', 400, null, true)
+  }
+
+  return index
+}
+
+const getSourceValue = (source: unknown, part: string): unknown => {
+  if (source === null || typeof source !== 'object') {
+    return undefined
+  }
+
+  const key = Array.isArray(source) && isArrayIndex(part) ? Number(part) : part
+
+  return (source as Record<number | string, unknown>)[key]
+}
+
 /**
  * Sets a value deeply into a nested object or array, based on a dot-notation path.
  *
@@ -14,56 +63,52 @@
  * @param obj - The target object to mutate.
  * @param path - A dot-separated string path indicating where to assign the value.
  * @param value - The value to set at the specified path.
+ * @param source - The source object used to validate array boundaries.
  */
 
 export const setNestedValue = (
   obj: Record<string, unknown>,
   path: string,
   value: unknown,
+  source?: Record<string, unknown>,
 ): void => {
   const parts = path.split('.')
-  let current: unknown = obj
 
-  for (let i = 0; i < parts.length; i++) {
-    const part = parts[i]
-    const isLast = i === parts.length - 1
-    const isIndex = !Number.isNaN(Number(part))
-
-    if (isIndex) {
-      const index = Number(part)
-
-      // Ensure the current target is an array
-      if (!Array.isArray(current)) {
-        current = []
-      }
-
-      const currentArray = current as unknown[]
-
-      // Ensure the array slot is initialized
-      if (!currentArray[index]) {
-        currentArray[index] = {}
-      }
-
-      if (isLast) {
-        currentArray[index] = value
-      } else {
-        current = currentArray[index]
-      }
-    } else {
-      const currentObj = current as Record<string, unknown>
-
-      // Ensure the object key exists
-      if (isLast) {
-        if (typeof part === 'string') {
-          currentObj[part] = value
-        }
-      } else {
-        if (typeof currentObj[part as string] !== 'object' || currentObj[part as string] === null) {
-          currentObj[part as string] = {}
-        }
-
-        current = currentObj[part as string]
-      }
-    }
+  if (hasUnsupportedFieldPathSegment(parts)) {
+    throw new APIError('Invalid field path.', 400, null, true)
   }
+
+  const lastPart = parts.pop()
+
+  if (lastPart === undefined) {
+    return
+  }
+
+  let current: Record<string, unknown> | unknown[] = obj
+  let sourceCurrent: unknown = source
+
+  for (const [i, part] of parts.entries()) {
+    const key = getPathKey(current, part, sourceCurrent)
+    const currentRecord = current as Record<number | string, unknown>
+    const nextPart = parts[i + 1] ?? lastPart
+    const nextSource = getSourceValue(sourceCurrent, part)
+
+    const nextValue = currentRecord[key]
+
+    if (
+      !Object.prototype.hasOwnProperty.call(currentRecord, key) ||
+      typeof nextValue !== 'object' ||
+      nextValue === null
+    ) {
+      currentRecord[key] = isArrayIndex(nextPart) ? [] : createObject()
+    }
+
+    current = currentRecord[key] as Record<string, unknown> | unknown[]
+    sourceCurrent = nextSource
+  }
+
+  const lastKey = getPathKey(current, lastPart, sourceCurrent)
+  const finalRecord = current as Record<number | string, unknown>
+
+  finalRecord[lastKey] = value
 }

--- a/packages/plugin-multi-tenant/src/index.ts
+++ b/packages/plugin-multi-tenant/src/index.ts
@@ -1,5 +1,5 @@
 import type { AcceptedLanguages } from '@payloadcms/translations'
-import type { CollectionConfig, Config } from 'payload'
+import type { CollectionConfig, Config, TypedUser } from 'payload'
 
 import chalk from 'chalk'
 import { hasAutosaveEnabled } from 'payload/shared'
@@ -91,6 +91,27 @@ export const multiTenantPlugin =
       adminUsersCollection.fields.push(
         tenantsArrayField({
           ...(pluginConfig?.tenantsArrayField || {}),
+          arrayFieldAccess: {
+            create: ({ req }) =>
+              Boolean(
+                req.user &&
+                  userHasAccessToAllTenants(
+                    req.user as ConfigType extends { user: unknown }
+                      ? ConfigType['user']
+                      : TypedUser,
+                  ),
+              ),
+            update: ({ req }) =>
+              Boolean(
+                req.user &&
+                  userHasAccessToAllTenants(
+                    req.user as ConfigType extends { user: unknown }
+                      ? ConfigType['user']
+                      : TypedUser,
+                  ),
+              ),
+            ...(pluginConfig?.tenantsArrayField?.arrayFieldAccess || {}),
+          },
           tenantsArrayFieldName,
           tenantsArrayTenantFieldName,
           tenantsCollectionSlug,

--- a/test/access-control/getConfig.ts
+++ b/test/access-control/getConfig.ts
@@ -173,6 +173,7 @@ export const getConfig: () => Partial<Config> = () => ({
             read: () => false,
             update: () => false,
           },
+          localized: true,
         },
         {
           name: 'group',
@@ -218,6 +219,13 @@ export const getConfig: () => Partial<Config> = () => ({
           ],
           label: 'Access',
         },
+        {
+          name: 'relatedItems',
+          type: 'join',
+          collection: 'relation-restricted',
+          defaultSort: 'createdAt',
+          on: 'post',
+        },
       ],
     },
     {
@@ -259,16 +267,30 @@ export const getConfig: () => Partial<Config> = () => ({
       slug: 'relation-restricted',
       access: {
         read: () => true,
+        update: () => true,
       },
+      defaultSort: 'post.restrictedField',
       fields: [
         {
           name: 'name',
           type: 'text',
         },
         {
+          name: 'rank',
+          type: 'number',
+          access: {
+            read: () => false,
+          },
+        },
+        {
           name: 'post',
           type: 'relationship',
           relationTo: slug,
+        },
+        {
+          name: 'postLabel',
+          type: 'text',
+          virtual: 'post.restrictedField',
         },
       ],
     },
@@ -871,6 +893,10 @@ export const getConfig: () => Partial<Config> = () => ({
       ],
     },
   ],
+  localization: {
+    defaultLocale: 'en',
+    locales: ['en', 'es'],
+  },
   onInit: async (payload) => {
     await payload.create({
       collection: 'users',

--- a/test/access-control/int.spec.ts
+++ b/test/access-control/int.spec.ts
@@ -320,6 +320,71 @@ describe('Access Control', () => {
         ).rejects.toThrow('The following path cannot be queried: restrictedField')
       })
 
+      it('should reject constrained sort paths', async () => {
+        const requests = [
+          payload.find({
+            collection: slug,
+            overrideAccess: false,
+            sort: 'restrictedField',
+          }),
+          payload.find({
+            collection: 'relation-restricted',
+            overrideAccess: false,
+            sort: 'post.restrictedField',
+          }),
+          payload.find({
+            collection: 'relation-restricted',
+            overrideAccess: false,
+            sort: 'postLabel',
+          }),
+          payload.find({
+            collection: slug,
+            overrideAccess: false,
+            sort: 'restrictedField.en',
+          }),
+          payload.find({
+            collection: 'relation-restricted',
+            overrideAccess: false,
+          }),
+          payload.find({
+            collection: slug,
+            joins: {
+              relatedItems: {
+                sort: 'rank',
+              },
+            },
+            overrideAccess: false,
+          }),
+          payload.update({
+            collection: 'relation-restricted',
+            data: {
+              name: 'updated',
+            },
+            limit: 1,
+            overrideAccess: false,
+            sort: 'rank',
+            where: {},
+          }),
+          payload.find({
+            collection: 'fields-and-top-access',
+            draft: true,
+            overrideAccess: false,
+            sort: 'secret',
+          }),
+          payload.findVersions({
+            collection: 'fields-and-top-access',
+            overrideAccess: false,
+            sort: 'version.secret',
+          }),
+        ]
+
+        await Promise.all(
+          requests.map((request) =>
+            expect(request).rejects.toThrow('The following path cannot be queried'),
+          ),
+        )
+      })
+
       it('field without read access should not show when overrideAccess: true', async () => {
         const { id, restrictedField } = await createDoc({ restrictedField: 'restricted' })
 

--- a/test/access-control/int.spec.ts
+++ b/test/access-control/int.spec.ts
@@ -266,25 +266,40 @@ describe('Access Control', () => {
         expect(retrievedDoc.restrictedField).toBeUndefined()
       })
 
-      it('should error when querying field without read access', async () => {
-        const { id } = await createDoc({ restrictedField: 'restricted' })
+      it.each(['AND', 'OR', 'AnD', 'oR'])(
+        'should validate field read access inside case-insensitive %s conditions',
+        async (logicalOperator) => {
+          const { id } = await createDoc({ restrictedField: 'restricted' })
 
+          await expect(
+            payload.find({
+              collection: slug,
+              overrideAccess: false,
+              where: {
+                [logicalOperator]: [
+                  {
+                    id: { equals: id },
+                  },
+                  {
+                    restrictedField: {
+                      equals: 'restricted',
+                    },
+                  },
+                ],
+              },
+            }),
+          ).rejects.toThrow('The following path cannot be queried: restrictedField')
+        },
+      )
+
+      it('should reject array-valued field conditions', async () => {
         await expect(
           payload.find({
             collection: slug,
             overrideAccess: false,
             where: {
-              and: [
-                {
-                  id: { equals: id },
-                },
-                {
-                  restrictedField: {
-                    equals: 'restricted',
-                  },
-                },
-              ],
-            },
+              restrictedField: [{ equals: 'restricted' }],
+            } as any,
           }),
         ).rejects.toThrow('The following path cannot be queried: restrictedField')
       })

--- a/test/database/int.spec.ts
+++ b/test/database/int.spec.ts
@@ -3813,6 +3813,19 @@ describe('database', () => {
     })
 
     it('should allow to sort by a virtual field with a refence, Local / GraphQL', async () => {
+      // The `migrate:fresh` test earlier in this file drops the entire database, which removes
+      // the admin user backing the REST client's session. Re-authenticate so the GraphQL request
+      // below has a logged-in user for the field-level access checks the sort validation performs.
+      const { docs: existingUsers } = await payload.find({
+        collection: 'users',
+        limit: 1,
+        where: { email: { equals: devUser.email } },
+      })
+      if (existingUsers.length === 0) {
+        await payload.create({ collection: 'users', data: devUser })
+      }
+      await restClient.login({ slug: 'users', credentials: devUser })
+
       const post_1 = await payload.create({ collection: 'posts', data: { title: 'A' } })
       const post_2 = await payload.create({ collection: 'posts', data: { title: 'B' } })
       const doc_1 = await payload.create({

--- a/test/plugin-import-export/int.spec.ts
+++ b/test/plugin-import-export/int.spec.ts
@@ -6419,6 +6419,48 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(data.error).toContain('not found')
     })
 
+    it('rejects an invalid preview field path and keeps collection access unchanged', async () => {
+      const post = await payload.create({
+        collection: 'posts-imports-only',
+        data: {
+          title: 'Preview field validation',
+        },
+      })
+      const objectPrototypeBefore = Object.getOwnPropertyDescriptors(Object.prototype)
+
+      try {
+        const previewResponse = await restClient.POST('/exports/export-preview', {
+          auth: false,
+          body: JSON.stringify({
+            collectionSlug: 'posts-imports-only',
+            fields: ['__proto__.overrideAccess'],
+            format: 'json',
+          }),
+        })
+        const objectPrototypeAfterPreview = Object.getOwnPropertyDescriptors(Object.prototype)
+
+        const updateResponse = await restClient.PATCH(`/posts-imports-only/${post.id}`, {
+          auth: false,
+          body: JSON.stringify({ title: 'Updated preview field validation' }),
+        })
+        const unchangedPost = await payload.findByID({
+          collection: 'posts-imports-only',
+          id: post.id,
+        })
+
+        expect(previewResponse.status).toBe(400)
+        expect(objectPrototypeAfterPreview).toEqual(objectPrototypeBefore)
+        expect(updateResponse.status).toBe(403)
+        expect(unchangedPost.title).toBe('Preview field validation')
+      } finally {
+        delete (Object.prototype as Record<string, unknown>).overrideAccess
+        await payload.delete({
+          collection: 'posts-imports-only',
+          id: post.id,
+        })
+      }
+    })
+
     it('should apply toCSV customizations in export preview and remove replaced columns', async () => {
       const page = await payload.create({
         collection: 'pages',

--- a/test/plugin-multi-tenant/int.spec.ts
+++ b/test/plugin-multi-tenant/int.spec.ts
@@ -246,6 +246,178 @@ describe('@payloadcms/plugin-multi-tenant', () => {
     })
   })
 
+  describe('tenant membership updates', () => {
+    it('should only allow global users to update tenant memberships', async () => {
+      const tenantA = await payload.create({
+        collection: tenantsSlug,
+        data: { name: 'Membership Tenant A', domain: 'membership-a.test' },
+      })
+      const tenantB = await payload.create({
+        collection: tenantsSlug,
+        data: { name: 'Membership Tenant B', domain: 'membership-b.test' },
+      })
+      const user = await payload.create({
+        collection: usersSlug,
+        data: {
+          email: 'membership-user@test.com',
+          password: 'test',
+          roles: ['user'],
+          tenants: [{ tenant: tenantA.id }],
+        },
+      })
+      const admin = await payload.create({
+        collection: usersSlug,
+        data: {
+          email: 'membership-admin@test.com',
+          password: 'test',
+          roles: ['admin'],
+        },
+      })
+      const tenantBDoc = await payload.create({
+        collection: relationshipsSlug,
+        data: { tenant: tenantB.id, title: 'Tenant B membership document' },
+      })
+
+      const selfUpdatedUser = await payload.update({
+        id: user.id,
+        collection: usersSlug,
+        data: {
+          tenants: [{ tenant: tenantA.id }, { tenant: tenantB.id }],
+        },
+        overrideAccess: false,
+        user,
+      })
+
+      expect(selfUpdatedUser.tenants).toHaveLength(1)
+      const unauthorizedResult = await payload.find({
+        collection: relationshipsSlug,
+        overrideAccess: false,
+        user: selfUpdatedUser,
+        where: { id: { equals: tenantBDoc.id } },
+      })
+      expect(unauthorizedResult.docs).toHaveLength(0)
+
+      const adminUpdatedUser = await payload.update({
+        id: user.id,
+        collection: usersSlug,
+        data: {
+          tenants: [{ tenant: tenantA.id }, { tenant: tenantB.id }],
+        },
+        overrideAccess: false,
+        user: admin,
+      })
+
+      expect(adminUpdatedUser.tenants).toHaveLength(2)
+
+      // Cleanup
+      await payload.delete({ id: tenantBDoc.id, collection: relationshipsSlug })
+      await payload.delete({ id: user.id, collection: usersSlug })
+      await payload.delete({ id: admin.id, collection: usersSlug })
+      await payload.delete({ id: tenantA.id, collection: tenantsSlug })
+      await payload.delete({ id: tenantB.id, collection: tenantsSlug })
+    })
+
+    it('should only allow global users to set tenant memberships when creating users', async () => {
+      const tenantA = await payload.create({
+        collection: tenantsSlug,
+        data: { name: 'Create Membership Tenant A', domain: 'create-membership-a.test' },
+      })
+      const tenantB = await payload.create({
+        collection: tenantsSlug,
+        data: { name: 'Create Membership Tenant B', domain: 'create-membership-b.test' },
+      })
+      const tenantAUser = await payload.create({
+        collection: usersSlug,
+        data: {
+          email: 'create-membership-user@test.com',
+          password: 'test',
+          roles: ['user'],
+          tenants: [{ tenant: tenantA.id }],
+        },
+      })
+      const admin = await payload.create({
+        collection: usersSlug,
+        data: {
+          email: 'create-membership-admin@test.com',
+          password: 'test',
+          roles: ['admin'],
+        },
+      })
+      const tenantBDoc = await payload.create({
+        collection: relationshipsSlug,
+        data: { tenant: tenantB.id, title: 'Tenant B create membership document' },
+      })
+
+      const userCreatedByTenantMember = await payload.create({
+        collection: usersSlug,
+        data: {
+          email: 'created-by-tenant-member@test.com',
+          password: 'test',
+          roles: ['user'],
+          tenants: [{ tenant: tenantB.id }],
+        },
+        overrideAccess: false,
+        user: tenantAUser,
+      })
+      const tenantMemberLogin = await payload.login({
+        collection: usersSlug,
+        data: {
+          email: 'created-by-tenant-member@test.com',
+          password: 'test',
+        },
+      })
+
+      expect(tenantMemberLogin.user).toBeDefined()
+      await expect(
+        payload.find({
+          collection: relationshipsSlug,
+          overrideAccess: false,
+          user: tenantMemberLogin.user!,
+          where: { id: { equals: tenantBDoc.id } },
+        }),
+      ).rejects.toThrow('You are not allowed to perform this action.')
+      expect(userCreatedByTenantMember.tenants ?? []).toHaveLength(0)
+
+      const userCreatedByAdmin = await payload.create({
+        collection: usersSlug,
+        data: {
+          email: 'created-by-membership-admin@test.com',
+          password: 'test',
+          roles: ['user'],
+          tenants: [{ tenant: tenantB.id }],
+        },
+        overrideAccess: false,
+        user: admin,
+      })
+      const adminCreatedLogin = await payload.login({
+        collection: usersSlug,
+        data: {
+          email: 'created-by-membership-admin@test.com',
+          password: 'test',
+        },
+      })
+
+      expect(userCreatedByAdmin.tenants).toHaveLength(1)
+      expect(adminCreatedLogin.user).toBeDefined()
+      const authorizedResult = await payload.find({
+        collection: relationshipsSlug,
+        overrideAccess: false,
+        user: adminCreatedLogin.user!,
+        where: { id: { equals: tenantBDoc.id } },
+      })
+      expect(authorizedResult.docs).toHaveLength(1)
+
+      // Cleanup
+      await payload.delete({ id: tenantBDoc.id, collection: relationshipsSlug })
+      await payload.delete({ id: tenantAUser.id, collection: usersSlug })
+      await payload.delete({ id: admin.id, collection: usersSlug })
+      await payload.delete({ id: userCreatedByTenantMember.id, collection: usersSlug })
+      await payload.delete({ id: userCreatedByAdmin.id, collection: usersSlug })
+      await payload.delete({ id: tenantA.id, collection: tenantsSlug })
+      await payload.delete({ id: tenantB.id, collection: tenantsSlug })
+    })
+  })
+
   describe('access control with user object passed directly', () => {
     it('should enforce tenant access when user object is fetched from database', async () => {
       // Create two tenants


### PR DESCRIPTION
Updates multipart `Content-Type` validation so parameter separators cannot also be consumed as parameter content. This allows malformed values to be rejected promptly while preserving the multipart subtype and parameter formats Payload already supports.
