### PR TITLE
fix(ui): preserve list preferences when switching tabs

### DIFF
--- a/packages/ui/src/elements/DefaultListViewTabs/index.tsx
+++ b/packages/ui/src/elements/DefaultListViewTabs/index.tsx
@@ -44,9 +44,13 @@ export const DefaultListViewTabs: React.FC<DefaultListViewTabsProps> = ({
 
     // Save preference for list vs hierarchy (not trash)
     if (newViewType === 'list' || newViewType === 'hierarchy') {
-      await setPreference(`collection-${collectionConfig.slug}`, {
-        listViewType: newViewType,
-      })
+      await setPreference(
+        `collection-${collectionConfig.slug}`,
+        {
+          listViewType: newViewType,
+        },
+        true,
+      )
     }
 
     let path: `/${string}` = `/collections/${collectionConfig.slug}`


### PR DESCRIPTION
Fixes #17666

**What this PR does:**

This fixes a bug where switching between list-view tabs (like "All" and "By Folder") would completely wipe a user's saved preferences for that collection (such as custom columns, sorting, and limits). 

Previously, `DefaultListViewTabs` was calling `setPreference` without the merge flag. Because `setPreference` defaults to `merge = false`, the entire preference record was being overwritten with just `{ listViewType: newViewType }`. 

By passing `true` as the third parameter to `setPreference`, the list view type is now correctly merged into the existing preferences, ensuring users don't randomly lose their column setups!

**Changes:**
- Added the `merge: true` flag to the `setPreference` call in `DefaultListViewTabs/index.tsx`.