### PR TITLE
fix(ui): stale hierarchy sidebar tree after list view mutations

### DIFF
--- a/packages/ui/src/elements/DeleteDocument/index.tsx
+++ b/packages/ui/src/elements/DeleteDocument/index.tsx
@@ -15,6 +15,7 @@ import { useConfig } from '../../providers/Config/index.js'
 import { useDocumentEvents } from '../../providers/DocumentEvents/index.js'
 import { useDocumentInfo } from '../../providers/DocumentInfo/index.js'
 import { useDocumentTitle } from '../../providers/DocumentTitle/index.js'
+import { useHierarchy } from '../../providers/Hierarchy/index.js'
 import { useRouter } from '../../providers/RouterAdapter/index.js'
 import { useRouteTransition } from '../../providers/RouteTransition/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
@@ -65,6 +66,7 @@ export const DeleteDocument: React.FC<Props> = (props) => {
   const { startRouteTransition } = useRouteTransition()
   const { openModal } = useModal()
   const { reportUpdate } = useDocumentEvents()
+  const { refreshTree } = useHierarchy()
 
   const modalSlug = `delete-${id}`
 
@@ -124,6 +126,12 @@ export const DeleteDocument: React.FC<Props> = (props) => {
           updatedAt: new Date().toISOString(),
         }
 
+        // Hierarchy sidebar tabs render their tree from a server snapshot taken when they
+        // mounted, so a route refresh alone leaves the deleted node on screen.
+        if (collectionConfig.hierarchy) {
+          refreshTree(collectionSlug)
+        }
+
         if (redirectAfterDelete) {
           // Navigating away tears this surface down, so just notify other surfaces.
           reportUpdate(deleteEvent)
@@ -172,6 +180,7 @@ export const DeleteDocument: React.FC<Props> = (props) => {
     collectionConfig,
     startRouteTransition,
     reportUpdate,
+    refreshTree,
   ])
 
   if (id) {

--- a/packages/ui/src/elements/DeleteMany/index.tsx
+++ b/packages/ui/src/elements/DeleteMany/index.tsx
@@ -10,6 +10,7 @@ import { toast } from 'sonner'
 
 import { CheckboxInput } from '../../fields/Checkbox/Input.js'
 import { useConfig } from '../../providers/Config/index.js'
+import { useHierarchy } from '../../providers/Hierarchy/index.js'
 import { useLocale } from '../../providers/Locale/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
 import { requests } from '../../utilities/api.js'
@@ -105,6 +106,7 @@ export function DeleteMany({
   const { code: locale } = useLocale()
   const { i18n } = useTranslation()
   const { openModal } = useModal()
+  const { refreshTree } = useHierarchy()
 
   const [deletePermanently, setDeletePermanently] = React.useState(false)
   const confirmManyDeleteDrawerSlug = `${modalPrefix ? `${modalPrefix}-` : ''}confirm-delete-many-docs`
@@ -235,6 +237,12 @@ export function DeleteMany({
             totalCount: json.totalDocs,
           }
 
+          // Hierarchy sidebar tabs render their tree from a server snapshot taken when they
+          // mounted, so a route refresh alone leaves the deleted nodes on screen.
+          if (collectionConfig.hierarchy && deletedDocs > 0) {
+            refreshTree(relationTo)
+          }
+
           if (deleteManyResponse.status > 400 && json?.errors.length === 0) {
             toast.error(t('error:unknown'))
             result[relationTo].errors = [t('error:unknown')]
@@ -268,6 +276,7 @@ export function DeleteMany({
     search,
     api,
     i18n,
+    refreshTree,
     viewType,
     where,
     t,

--- a/packages/ui/src/views/Edit/index.tsx
+++ b/packages/ui/src/views/Edit/index.tsx
@@ -26,6 +26,7 @@ import { useConfig } from '../../providers/Config/index.js'
 import { useDocumentEvents } from '../../providers/DocumentEvents/index.js'
 import { useDocumentInfo } from '../../providers/DocumentInfo/index.js'
 import { useEditDepth } from '../../providers/EditDepth/index.js'
+import { useHierarchy } from '../../providers/Hierarchy/index.js'
 import { useLivePreviewContext, usePreviewURL } from '../../providers/LivePreview/context.js'
 import { OperationProvider } from '../../providers/Operation/index.js'
 import { useRouteCache } from '../../providers/RouteCache/index.js'
@@ -141,6 +142,7 @@ export function DefaultEditView({
   const router = useRouter()
   const params = useSearchParams()
   const { reportUpdate } = useDocumentEvents()
+  const { refreshTree } = useHierarchy()
   const { resetUploadEdits } = useUploadEdits()
   const { getFormState } = useServerFunctions()
   const { startRouteTransition } = useRouteTransition()
@@ -297,6 +299,31 @@ export function DefaultEditView({
     user?.id,
   ])
 
+  /**
+   * Hierarchy sidebar tabs render their tree from a server snapshot taken when they mounted, so
+   * a route refresh alone leaves the tree showing pre-save data — a missing node after a create,
+   * a stale label after a rename.
+   *
+   * Drawer saves are excluded because whatever opened the drawer owns refreshing the tree (e.g.
+   * the sidebar tree's own create drawer), and reloading the tab from here would unmount a
+   * drawer that is still open. Autosaved updates are excluded because they fire on an interval
+   * while the user types, which would remount the tree on every tick.
+   */
+  const refreshHierarchyTree = useCallback(
+    ({ operation }: { operation: 'create' | 'update' }) => {
+      if (!collectionSlug || !collectionConfig?.hierarchy || isInDrawer) {
+        return
+      }
+
+      if (operation === 'update' && autosaveEnabled) {
+        return
+      }
+
+      refreshTree(collectionSlug)
+    },
+    [autosaveEnabled, collectionConfig?.hierarchy, collectionSlug, isInDrawer, refreshTree],
+  )
+
   const onSave: FormOnSuccess<any, OnSaveContext> = useCallback(
     async (json, ctx) => {
       const { context, formState } = ctx || {}
@@ -414,6 +441,8 @@ export function DefaultEditView({
           updatedAt,
         })
 
+        refreshHierarchyTree({ operation: 'update' })
+
         abortOnSaveRef.current = null
 
         return state
@@ -426,6 +455,8 @@ export function DefaultEditView({
           operation: 'create',
           updatedAt,
         })
+
+        refreshHierarchyTree({ operation: 'create' })
       }
     },
     [
@@ -459,6 +490,7 @@ export function DefaultEditView({
       upload,
       isLockingEnabled,
       reportUpdate,
+      refreshHierarchyTree,
       drawerSlug,
       entitySlug,
       setDocumentIsLocked,

--- a/test/hierarchy/e2e.spec.ts
+++ b/test/hierarchy/e2e.spec.ts
@@ -1,4 +1,4 @@
-import type { Page } from '@playwright/test'
+import type { Locator, Page } from '@playwright/test'
 
 import { expect, test } from '@playwright/test'
 import path from 'path'
@@ -7,7 +7,12 @@ import { fileURLToPath } from 'url'
 import type { PayloadTestSDK } from '../__helpers/shared/sdk/index.js'
 import type { Config, Organization } from './payload-types.js'
 
-import { ensureCompilationIsDone, initPageConsoleErrorCatch } from '../__helpers/e2e/helpers.js'
+import {
+  ensureCompilationIsDone,
+  initPageConsoleErrorCatch,
+  saveDocAndAssert,
+  selectTableRow,
+} from '../__helpers/e2e/helpers.js'
 import { openNav } from '../__helpers/e2e/toggleNav.js'
 import { AdminUrlUtil } from '../__helpers/shared/adminUrlUtil.js'
 import { initPayloadE2ENoConfig } from '../__helpers/shared/initPayloadE2ENoConfig.js'
@@ -297,6 +302,81 @@ test.describe('Hierarchy Sidebar', () => {
       // Switch back to Organizations - should still be expanded (independent state)
       await page.getByRole('tab', { name: 'Organizations' }).click()
       await expect(page.getByRole('tree').getByText('Engineering Division')).toBeVisible()
+    })
+  })
+
+  test.describe('List View Mutations', () => {
+    let departmentsURL: AdminUrlUtil
+
+    test.beforeAll(() => {
+      departmentsURL = new AdminUrlUtil(serverURL, 'departments')
+    })
+
+    /** Navigate to the departments list view and return its sidebar tree. */
+    const openDepartmentsTree = async (url: string): Promise<Locator> => {
+      await page.goto(url)
+      await openNav(page)
+      await page.getByRole('tab', { name: 'Departments' }).click()
+
+      const tree = page.getByRole('tree')
+      await expect(tree).toBeVisible()
+      return tree
+    }
+
+    test('should remove a document deleted from the list view from the sidebar tree', async () => {
+      const deptName = `Delete From List ${Date.now()}`
+
+      const dept = await payload.create({ collection: 'departments', data: { deptName } })
+      createdDeptIds.push(dept.id)
+
+      const tree = await openDepartmentsTree(departmentsURL.list)
+      await expect(tree.getByText(deptName)).toBeVisible()
+
+      await selectTableRow(page, deptName)
+      await page.locator('.delete-documents__toggle').click()
+      await page.locator('#confirm-delete-many-docs [data-dialog-action="confirm"]').click()
+
+      await expect(page.locator(`tbody tr:has-text("${deptName}")`)).toBeHidden()
+      await expect(tree.getByText(deptName)).toBeHidden()
+    })
+
+    test('should add a document created from the create view to the sidebar tree', async () => {
+      const deptName = `Create From List ${Date.now()}`
+
+      const tree = await openDepartmentsTree(departmentsURL.list)
+      await expect(tree.getByText(deptName)).toBeHidden()
+
+      await page.locator('.list-controls').getByRole('link', { name: 'Create New' }).click()
+      await page.locator('#field-deptName').fill(deptName)
+      await saveDocAndAssert(page)
+
+      await expect(tree.getByText(deptName)).toBeVisible()
+
+      const { docs } = await payload.find({
+        collection: 'departments',
+        where: { deptName: { equals: deptName } },
+      })
+      createdDeptIds.push(...docs.map(({ id }) => id))
+    })
+
+    test('should reflect a title renamed from the edit view in the sidebar tree', async () => {
+      const originalName = `Rename Me ${Date.now()}`
+      const renamedName = `${originalName} Renamed`
+
+      const dept = await payload.create({
+        collection: 'departments',
+        data: { deptName: originalName },
+      })
+      createdDeptIds.push(dept.id)
+
+      const tree = await openDepartmentsTree(departmentsURL.edit(dept.id))
+      await expect(tree.getByText(originalName, { exact: true })).toBeVisible()
+
+      await page.locator('#field-deptName').fill(renamedName)
+      await saveDocAndAssert(page)
+
+      await expect(tree.getByText(renamedName)).toBeVisible()
+      await expect(tree.getByText(originalName, { exact: true })).toBeHidden()
     })
   })
 

--- a/test/tags/e2e.spec.ts
+++ b/test/tags/e2e.spec.ts
@@ -7,7 +7,11 @@ import { fileURLToPath } from 'url'
 import type { PayloadTestSDK } from '../__helpers/shared/sdk/index.js'
 import type { Config, Tag } from './payload-types.js'
 
-import { ensureCompilationIsDone, initPageConsoleErrorCatch } from '../__helpers/e2e/helpers.js'
+import {
+  ensureCompilationIsDone,
+  initPageConsoleErrorCatch,
+  selectTableRow,
+} from '../__helpers/e2e/helpers.js'
 import { openNav } from '../__helpers/e2e/toggleNav.js'
 import { AdminUrlUtil } from '../__helpers/shared/adminUrlUtil.js'
 import { initPayloadE2ENoConfig } from '../__helpers/shared/initPayloadE2ENoConfig.js'
@@ -118,7 +122,8 @@ test.describe('Tags', () => {
 
   test.afterAll(async () => {
     for (const id of createdTagIds) {
-      await payload.delete({ id, collection: tagsSlug })
+      // Tags deleted through the UI during a test are already gone
+      await payload.delete({ id, collection: tagsSlug }).catch(() => {})
     }
   })
 
@@ -161,6 +166,23 @@ test.describe('Tags', () => {
       await createChildTag(childName)
 
       await expect(tree.getByText(childName)).toBeVisible()
+    })
+
+    test('should remove a tag deleted from the list view from the sidebar tree', async () => {
+      const tagName = `Delete From List ${Date.now()}`
+
+      const tag = await payload.create({ collection: tagsSlug, data: { name: tagName } })
+      createdTagIds.push(tag.id)
+
+      const tree = await openTagsTree()
+      await expect(tree.getByText(tagName)).toBeVisible()
+
+      await selectTableRow(page, tagName)
+      await page.locator('.delete-documents__toggle').click()
+      await page.locator('#confirm-delete-many-docs [data-dialog-action="confirm"]').click()
+
+      await expect(page.locator(`tbody tr:has-text("${tagName}")`)).toBeHidden()
+      await expect(tree.getByText(tagName)).toBeHidden()
     })
   })
 })


### PR DESCRIPTION
Deleting or creating folders/tags outside the hierarchy view left the sidebar tree showing pre-mutation data. Only the hierarchy view called refreshTree, and a route refresh cannot fix it on its own because a mounted tree seeds its children from initialData once and never re-syncs.

Bulk deletes, single document deletes, and document saves now refresh the tree for hierarchy-enabled collections. Drawer saves and autosaved updates are excluded so an open drawer is not unmounted mid-edit.

<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

## Which branch should this PR target?

- **`main`** — Payload v4 development. New features, enhancements, and v4 bug fixes go here.
- **`3.x`** — Payload v3 maintenance. Bug fixes only. **New features are not accepted against v3.** If this PR adds a feature to v3, please retarget it at `main` (v4) instead.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
