### PR TITLE
fix(ui): reset view actions on route changes

### DIFF
--- a/packages/ui/src/providers/Actions/index.tsx
+++ b/packages/ui/src/providers/Actions/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { createContext, use, useState } from 'react'
+import React, { createContext, use, useEffect, useRef, useState } from 'react'
 
 type ActionsContextType = {
   Actions: {
@@ -21,8 +21,15 @@ export const ActionsProvider: React.FC<{
     [key: string]: React.ReactNode
   }
   readonly children: React.ReactNode
-}> = ({ Actions, children }) => {
+  readonly viewKey?: string
+}> = ({ Actions, children, viewKey }) => {
   const [viewActions, setViewActions] = useState(Actions)
+  const actionsRef = useRef(Actions)
+  actionsRef.current = Actions
+
+  useEffect(() => {
+    setViewActions(actionsRef.current)
+  }, [viewKey])
 
   return (
     <ActionsContext

--- a/packages/ui/src/providers/Actions/index.tsx
+++ b/packages/ui/src/providers/Actions/index.tsx
@@ -1,6 +1,8 @@
 'use client'
 
-import React, { createContext, use, useEffect, useRef, useState } from 'react'
+import React, { createContext, use, useEffect, useState } from 'react'
+
+import { useEffectEvent } from '../../hooks/useEffectEvent.js'
 
 type ActionsContextType = {
   Actions: {
@@ -24,11 +26,12 @@ export const ActionsProvider: React.FC<{
   readonly viewKey?: string
 }> = ({ Actions, children, viewKey }) => {
   const [viewActions, setViewActions] = useState(Actions)
-  const actionsRef = useRef(Actions)
-  actionsRef.current = Actions
+  const resetViewActions = useEffectEvent(() => {
+    setViewActions(Actions)
+  })
 
   useEffect(() => {
-    setViewActions(actionsRef.current)
+    resetViewActions()
   }, [viewKey])
 
   return (

--- a/packages/ui/src/templates/Default/index.tsx
+++ b/packages/ui/src/templates/Default/index.tsx
@@ -40,6 +40,7 @@ export type DefaultTemplateProps = {
   globalSlug?: string
   req?: PayloadRequest
   viewActions?: CustomComponent[]
+  viewKey?: string
   viewType?: ViewTypes
   visibleEntities: VisibleEntities
 } & Omit<ServerProps, 'server'>
@@ -60,6 +61,7 @@ export const DefaultTemplate: React.FC<DefaultTemplateProps> = ({
   searchParams,
   user,
   viewActions,
+  viewKey,
   viewType,
   visibleEntities,
 }) => {
@@ -185,7 +187,7 @@ export const DefaultTemplate: React.FC<DefaultTemplateProps> = ({
     <EntityVisibilityProvider visibleEntities={visibleEntities}>
       <CommandPalette />
       <BulkUploadProvider modalSlugPrefix={collectionSlug}>
-        <ActionsProvider Actions={Actions}>
+        <ActionsProvider Actions={Actions} viewKey={viewKey}>
           {RenderServerComponent({
             clientProps,
             Component: CustomHeader,

--- a/packages/ui/src/views/Root/index.tsx
+++ b/packages/ui/src/views/Root/index.tsx
@@ -374,6 +374,7 @@ export const renderRoot = async ({
           searchParams={searchParams}
           user={req.user}
           viewActions={viewActions}
+          viewKey={key}
           viewType={viewType}
           visibleEntities={{
             // The reason we are not passing in initPageResult.visibleEntities directly is due to a "Cannot assign to read only property of object '#<Object>" error introduced in React 19


### PR DESCRIPTION
Resets client-managed `viewActions` when the active admin route changes. These are actions that are registered client-side via the `useActions` hook.

The problem is that TanStack Start preserves the `ActionsProvider` and only replaces the view-keyed subtree. So stale actions registered by the previous view could remain in the header after navigation. The fix is to pass the current view key to the `ActionsProvider`. When that key changes, the provider can reset its state and clear out any stale actions that were registered client-side.

The existing E2E tests cover this behavior when run against the TanStack Start framework.