### PR TITLE
fix(plugins): preserve trusted Local API access

### DIFF
--- a/packages/payload-cloud/src/plugin.ts
+++ b/packages/payload-cloud/src/plugin.ts
@@ -137,6 +137,7 @@ export const payloadCloudPlugin =
       if (process.env.PAYLOAD_CLOUD_JOBS_INSTANCE) {
         const retrievedGlobal = await payload.findGlobal({
           slug: 'payload-cloud-instance',
+          overrideAccess: true,
         })
 
         if (retrievedGlobal.instance === process.env.PAYLOAD_CLOUD_JOBS_INSTANCE) {
@@ -163,6 +164,7 @@ export const payloadCloudPlugin =
         data: {
           instance,
         },
+        overrideAccess: true,
       })
 
       if (!hasExistingAutorun) {

--- a/packages/plugin-cloud-storage/src/hooks/afterChange.ts
+++ b/packages/plugin-cloud-storage/src/hooks/afterChange.ts
@@ -67,6 +67,7 @@ export const getAfterChangeHook =
               data: uploadMetadata,
               depth: 0,
               draft: isDraftSave,
+              overrideAccess: true,
               req,
             })
           } finally {

--- a/packages/plugin-cloud-storage/src/utilities/getFilePrefix.ts
+++ b/packages/plugin-cloud-storage/src/utilities/getFilePrefix.ts
@@ -47,6 +47,7 @@ export async function getFilePrefix({
     depth: 0,
     draft: true,
     limit: 1,
+    overrideAccess: true,
     pagination: false,
     where: {
       or: [

--- a/packages/plugin-ecommerce/src/collections/carts/beforeChange.ts
+++ b/packages/plugin-ecommerce/src/collections/carts/beforeChange.ts
@@ -37,6 +37,7 @@ export const beforeChangeCart: (args: Props) => CollectionBeforeChangeHook =
             id,
             collection: variantsSlug,
             depth: 0,
+            overrideAccess: true,
             select: {
               [priceField]: true,
             },
@@ -50,6 +51,7 @@ export const beforeChangeCart: (args: Props) => CollectionBeforeChangeHook =
             id,
             collection: productsSlug,
             depth: 0,
+            overrideAccess: true,
             select: {
               [priceField]: true,
             },

--- a/packages/plugin-ecommerce/src/collections/variants/createVariantsCollection/hooks/beforeChange.ts
+++ b/packages/plugin-ecommerce/src/collections/variants/createVariantsCollection/hooks/beforeChange.ts
@@ -15,6 +15,7 @@ export const variantsCollectionBeforeChange: (args: Props) => CollectionBeforeCh
         id: productID,
         collection: productsSlug,
         depth: 0,
+        overrideAccess: true,
         select: {
           title: true,
           variantTypes: true,
@@ -30,6 +31,7 @@ export const variantsCollectionBeforeChange: (args: Props) => CollectionBeforeCh
           id: option,
           collection: variantOptionsSlug,
           depth: 0,
+          overrideAccess: true,
           select: {
             label: true,
           },

--- a/packages/plugin-ecommerce/src/collections/variants/createVariantsCollection/hooks/validateOptions.ts
+++ b/packages/plugin-ecommerce/src/collections/variants/createVariantsCollection/hooks/validateOptions.ts
@@ -38,6 +38,7 @@ export const validateOptions: (props?: Props) => Validate =
           },
         },
       },
+      overrideAccess: true,
       select: {
         variants: true,
         variantTypes: true,

--- a/packages/plugin-ecommerce/src/endpoints/confirmOrder.ts
+++ b/packages/plugin-ecommerce/src/endpoints/confirmOrder.ts
@@ -178,6 +178,7 @@ export const confirmOrderHandler: ConfirmOrderHandler =
           id: paymentResponse.transactionID,
           collection: transactionsSlug,
           depth: 0,
+          overrideAccess: true,
           select: {
             id: true,
             items: true,

--- a/packages/plugin-ecommerce/src/endpoints/initiatePayment.ts
+++ b/packages/plugin-ecommerce/src/endpoints/initiatePayment.ts
@@ -206,6 +206,7 @@ export const initiatePaymentHandler: InitiatePayment =
           id,
           collection: productsSlug,
           depth: 0,
+          overrideAccess: true,
           select: {
             inventory: true,
             [priceField]: true,
@@ -258,6 +259,7 @@ export const initiatePaymentHandler: InitiatePayment =
             id,
             collection: variantsSlug,
             depth: 0,
+            overrideAccess: true,
             select: {
               inventory: true,
               [priceField]: true,

--- a/packages/plugin-ecommerce/src/payments/adapters/stripe/confirmOrder.ts
+++ b/packages/plugin-ecommerce/src/payments/adapters/stripe/confirmOrder.ts
@@ -60,6 +60,7 @@ export const confirmOrder: (props: Props) => NonNullable<PaymentAdapter>['confir
       // Find our existing transaction by the payment intent ID
       const transactionsResults = await payload.find({
         collection: transactionsSlug,
+        overrideAccess: true,
         req,
         where: {
           'stripe.paymentIntentID': {
@@ -108,6 +109,7 @@ export const confirmOrder: (props: Props) => NonNullable<PaymentAdapter>['confir
           status: 'processing',
           transactions: [transaction.id],
         },
+        overrideAccess: true,
         req,
       })
 
@@ -119,6 +121,7 @@ export const confirmOrder: (props: Props) => NonNullable<PaymentAdapter>['confir
         data: {
           purchasedAt: timestamp,
         },
+        overrideAccess: true,
         req,
       })
 
@@ -129,6 +132,7 @@ export const confirmOrder: (props: Props) => NonNullable<PaymentAdapter>['confir
           order: order.id,
           status: 'succeeded',
         },
+        overrideAccess: true,
         req,
       })
 

--- a/packages/plugin-ecommerce/src/payments/adapters/stripe/initiatePayment.ts
+++ b/packages/plugin-ecommerce/src/payments/adapters/stripe/initiatePayment.ts
@@ -119,6 +119,7 @@ export const initiatePayment: (props: Props) => NonNullable<PaymentAdapter>['ini
             paymentIntentID: paymentIntent.id,
           },
         },
+        overrideAccess: true,
         req,
       })
 

--- a/packages/plugin-ecommerce/src/ui/VariantOptionsSelector/index.tsx
+++ b/packages/plugin-ecommerce/src/ui/VariantOptionsSelector/index.tsx
@@ -21,6 +21,7 @@ export const VariantOptionsSelector: React.FC<Props> = async (props) => {
     collection: productsSlug,
     depth: 0,
     draft: true,
+    overrideAccess: true,
     select: {
       variants: true,
       variantTypes: true,
@@ -49,6 +50,7 @@ export const VariantOptionsSelector: React.FC<Props> = async (props) => {
             sort: 'value',
           },
         },
+        overrideAccess: true,
       })
 
       if (variantType) {

--- a/packages/plugin-form-builder/src/collections/FormSubmissions/hooks/handleUploads.ts
+++ b/packages/plugin-form-builder/src/collections/FormSubmissions/hooks/handleUploads.ts
@@ -60,6 +60,7 @@ export const handleUploads = async (
     form = await payload.findByID({
       id: formID,
       collection: formSlug,
+      overrideAccess: true,
       req,
     })
   } catch {
@@ -170,6 +171,7 @@ export const handleUploads = async (
               mimetype: requestFile.mimetype,
               size: requestFile.size,
             },
+            overrideAccess: true,
             req,
           })
 
@@ -226,6 +228,7 @@ export const handleUploads = async (
           fileDoc = (await payload.findByID({
             id: fileId,
             collection: uploadCollection,
+            overrideAccess: true,
             req,
           })) as FileData & TypeWithID
         } catch {
@@ -294,7 +297,7 @@ export const handleUploads = async (
     // Best-effort cleanup of any docs created before the error was detected
     for (const doc of createdDocs) {
       try {
-        await payload.delete({ id: doc.id, collection: doc.collection, req })
+        await payload.delete({ id: doc.id, collection: doc.collection, overrideAccess: true, req })
       } catch {
         // best-effort — don't mask the original validation error
       }

--- a/packages/plugin-form-builder/src/collections/FormSubmissions/hooks/sendEmail.ts
+++ b/packages/plugin-form-builder/src/collections/FormSubmissions/hooks/sendEmail.ts
@@ -27,6 +27,7 @@ export const sendEmail = async (
         id: formID,
         collection: formOverrides?.slug || 'forms',
         locale,
+        overrideAccess: true,
         req,
       })
 

--- a/packages/plugin-form-builder/src/collections/FormSubmissions/index.ts
+++ b/packages/plugin-form-builder/src/collections/FormSubmissions/index.ts
@@ -37,6 +37,7 @@ export const generateSubmissionCollection = (
             _existingForm = await payload.findByID({
               id: value,
               collection: formSlug,
+              overrideAccess: true,
               req,
             })
 

--- a/packages/plugin-import-export/src/export/batchProcessor.ts
+++ b/packages/plugin-import-export/src/export/batchProcessor.ts
@@ -161,6 +161,7 @@ export function createExportBatchProcessor(options: ExportBatchProcessorOptions 
       }
 
       const result = await req.payload.find({
+        ...{ overrideAccess: true },
         ...findArgs,
         limit: Math.min(batchSize, remaining),
         page: currentPage,
@@ -268,6 +269,7 @@ export function createExportBatchProcessor(options: ExportBatchProcessorOptions 
       }
 
       const result = await req.payload.find({
+        ...{ overrideAccess: true },
         ...findArgs,
         limit: Math.min(batchSize, remaining),
         page: currentPage,
@@ -352,6 +354,7 @@ export function createExportBatchProcessor(options: ExportBatchProcessorOptions 
       }
 
       const result = await req.payload.find({
+        ...{ overrideAccess: true },
         ...findArgs,
         limit: Math.min(batchSize, remaining),
         page: currentPage,

--- a/packages/plugin-import-export/src/export/createExport.ts
+++ b/packages/plugin-import-export/src/export/createExport.ts
@@ -308,6 +308,7 @@ export const createExport = async (args: CreateExportArgs) => {
         }
 
         const result = await payload.find({
+          ...{ overrideAccess: true },
           ...findArgs,
           page: currentBatchPage,
           limit: Math.min(batchSize, remaining),

--- a/packages/plugin-import-export/src/export/getExportCollection.ts
+++ b/packages/plugin-import-export/src/export/getExportCollection.ts
@@ -182,6 +182,7 @@ export const getExportCollection = ({
 
     await req.payload.jobs.queue({
       input,
+      overrideAccess: true,
       task: 'createCollectionExport',
     })
   })

--- a/packages/plugin-import-export/src/import/createImport.ts
+++ b/packages/plugin-import-export/src/import/createImport.ts
@@ -72,6 +72,7 @@ export const createImport = async ({
     user = (await req.payload.findByID({
       id: userID,
       collection: userCollection,
+      overrideAccess: true,
       req,
     })) as User
   }

--- a/packages/plugin-import-export/src/import/getCreateImportCollectionTask.ts
+++ b/packages/plugin-import-export/src/import/getCreateImportCollectionTask.ts
@@ -40,6 +40,7 @@ export const getCreateCollectionImportTask = (
       const importDoc = await req.payload.findByID({
         id: importId,
         collection: importCollection,
+        overrideAccess: true,
       })
 
       if (!importDoc) {
@@ -121,6 +122,7 @@ export const getCreateCollectionImportTask = (
             updated: result.updated,
           },
         },
+        overrideAccess: true,
       })
 
       return {

--- a/packages/plugin-import-export/src/import/getImportCollection.ts
+++ b/packages/plugin-import-export/src/import/getImportCollection.ts
@@ -354,6 +354,7 @@ export const getImportCollection = ({
 
       await req.payload.jobs.queue({
         input,
+        overrideAccess: true,
         task: 'createCollectionImport',
       })
     } catch (err) {

--- a/packages/plugin-mcp/src/mcp/builtin/collections/authTools.spec.ts
+++ b/packages/plugin-mcp/src/mcp/builtin/collections/authTools.spec.ts
@@ -1,0 +1,63 @@
+import type { CollectionToolHandlerArgs } from '../../../types.js'
+
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../../utils/getLogger.js', () => ({
+  getLogger: () => ({ error: vi.fn() }),
+}))
+
+import {
+  forgotPasswordCollectionTool,
+  loginCollectionTool,
+  resetPasswordCollectionTool,
+  unlockCollectionTool,
+} from './authTools.js'
+
+const cases = [
+  {
+    input: { disableEmail: true, email: 'test@example.com' },
+    method: 'forgotPassword',
+    tool: forgotPasswordCollectionTool,
+  },
+  {
+    input: { depth: 0, email: 'test@example.com', password: 'password', showHiddenFields: false },
+    method: 'login',
+    tool: loginCollectionTool,
+  },
+  {
+    input: { password: 'password', token: 'token' },
+    method: 'resetPassword',
+    tool: resetPasswordCollectionTool,
+  },
+  {
+    input: { email: 'test@example.com' },
+    method: 'unlock',
+    tool: unlockCollectionTool,
+  },
+] as const
+
+describe('auth collection tools', () => {
+  it.each([false, true])(
+    'passes authorizedMCP.overrideAccess=%s to Local API calls',
+    async (overrideAccess) => {
+      for (const { input, method, tool } of cases) {
+        const localAPICall = vi.fn().mockResolvedValue({})
+        const args = {
+          authorizedMCP: { items: [], overrideAccess },
+          collectionSlug: 'users',
+          input,
+          req: {
+            payload: {
+              [method]: localAPICall,
+            },
+          },
+          serverContext: {},
+        } as unknown as CollectionToolHandlerArgs
+
+        await tool.handler(args)
+
+        expect(localAPICall).toHaveBeenCalledWith(expect.objectContaining({ overrideAccess }))
+      }
+    },
+  )
+})

--- a/packages/plugin-mcp/src/mcp/builtin/collections/authTools.ts
+++ b/packages/plugin-mcp/src/mcp/builtin/collections/authTools.ts
@@ -87,13 +87,14 @@ export const forgotPasswordCollectionTool = defineCollectionTool({
       .default(false),
     email: emailSchema,
   }),
-}).handler(async ({ collectionSlug, input, req }) => {
+}).handler(async ({ authorizedMCP, collectionSlug, input, req }) => {
   const logger = getLogger({ payload: req.payload })
   try {
     const result = await req.payload.forgotPassword({
       collection: collectionSlug,
       data: { email: input.email },
       disableEmail: input.disableEmail,
+      overrideAccess: authorizedMCP.overrideAccess,
     })
     return {
       content: [
@@ -137,13 +138,14 @@ export const loginCollectionTool = defineCollectionTool({
       .optional()
       .default(false),
   }),
-}).handler(async ({ collectionSlug, input, req }) => {
+}).handler(async ({ authorizedMCP, collectionSlug, input, req }) => {
   const logger = getLogger({ payload: req.payload })
   try {
     const result = await req.payload.login({
       collection: collectionSlug,
       data: { email: input.email, password: input.password },
       depth: input.depth,
+      overrideAccess: authorizedMCP.overrideAccess,
       showHiddenFields: input.showHiddenFields,
     })
     return {
@@ -175,13 +177,13 @@ export const resetPasswordCollectionTool = defineCollectionTool({
     password: z.string().describe('The new password for the user'),
     token: z.string().describe('The password reset token sent to the user email'),
   }),
-}).handler(async ({ collectionSlug, input, req }) => {
+}).handler(async ({ authorizedMCP, collectionSlug, input, req }) => {
   const logger = getLogger({ payload: req.payload })
   try {
     const result = await req.payload.resetPassword({
       collection: collectionSlug,
       data: { password: input.password, token: input.token },
-      overrideAccess: true,
+      overrideAccess: authorizedMCP.overrideAccess,
     })
     return {
       content: [
@@ -209,13 +211,13 @@ export const unlockCollectionTool = defineCollectionTool({
   },
   description: 'Unlocks a user account that has been locked due to failed login attempts.',
   input: z.object({ email: emailSchema }),
-}).handler(async ({ collectionSlug, input, req }) => {
+}).handler(async ({ authorizedMCP, collectionSlug, input, req }) => {
   const logger = getLogger({ payload: req.payload })
   try {
     const result = await req.payload.unlock({
       collection: collectionSlug,
       data: { email: input.email },
-      overrideAccess: true,
+      overrideAccess: authorizedMCP.overrideAccess,
     })
     return {
       content: [

--- a/packages/plugin-mcp/src/mcp/builtin/collections/deleteTool.ts
+++ b/packages/plugin-mcp/src/mcp/builtin/collections/deleteTool.ts
@@ -80,7 +80,10 @@ export const deleteDocumentsTool = defineCollectionTool({
       deleteOptions.where = where
     }
 
-    const result = await payload.delete(deleteOptions as Parameters<typeof payload.delete>[0])
+    const result = await payload.delete({
+      ...{ overrideAccess: true },
+      ...(deleteOptions as Parameters<typeof payload.delete>[0]),
+    })
 
     if (id) {
       return {

--- a/packages/plugin-mcp/src/mcp/builtin/collections/findTool.ts
+++ b/packages/plugin-mcp/src/mcp/builtin/collections/findTool.ts
@@ -190,7 +190,7 @@ export const findDocumentsTool = defineCollectionTool({
       findOptions.where = where
     }
 
-    const result = await payload.find(findOptions)
+    const result = await payload.find({ ...{ overrideAccess: true }, ...findOptions })
 
     let responseText = `Collection: "${collectionSlug}"\nTotal: ${result.totalDocs} documents\nPage: ${result.page} of ${result.totalPages}\n`
     for (const doc of result.docs) {

--- a/packages/plugin-mcp/src/mcp/builtin/globals/findTool.ts
+++ b/packages/plugin-mcp/src/mcp/builtin/globals/findTool.ts
@@ -82,7 +82,7 @@ export const findGlobalTool = defineGlobalTool({
       findOptions.populate = populate as PopulateType
     }
 
-    const result = await payload.findGlobal(findOptions)
+    const result = await payload.findGlobal({ ...{ overrideAccess: true }, ...findOptions })
 
     return {
       content: [

--- a/packages/plugin-mcp/src/mcp/builtin/globals/updateTool.ts
+++ b/packages/plugin-mcp/src/mcp/builtin/globals/updateTool.ts
@@ -94,7 +94,7 @@ export const updateGlobalTool = defineGlobalTool({
       updateOptions.select = select as SelectType
     }
 
-    const result = await payload.updateGlobal(updateOptions)
+    const result = await payload.updateGlobal({ ...{ overrideAccess: true }, ...updateOptions })
 
     return {
       content: [

--- a/packages/plugin-multi-tenant/src/hooks/afterTenantDelete.ts
+++ b/packages/plugin-multi-tenant/src/hooks/afterTenantDelete.ts
@@ -88,6 +88,7 @@ export const afterTenantDelete =
       cleanupPromises.push(
         req.payload.delete({
           collection: slug,
+          overrideAccess: true,
           req,
           where: {
             [tenantFieldName]: {
@@ -103,6 +104,7 @@ export const afterTenantDelete =
         collection: usersSlug,
         depth: 0,
         limit: 0,
+        overrideAccess: true,
         req,
         where: {
           [`${usersTenantsArrayFieldName}.${usersTenantsArrayTenantFieldName}`]: {
@@ -128,6 +130,7 @@ export const afterTenantDelete =
                 }
               }),
             },
+            overrideAccess: true,
             req,
           }),
         )

--- a/packages/plugin-multi-tenant/src/utilities/getGlobalViewRedirect.ts
+++ b/packages/plugin-multi-tenant/src/utilities/getGlobalViewRedirect.ts
@@ -75,6 +75,7 @@ export async function getGlobalViewRedirect({
         collection: collectionSlug,
         depth: 0,
         limit: 1,
+        overrideAccess: true,
         pagination: false,
         select: {
           id: true,
@@ -171,6 +172,7 @@ async function generateCreateRedirect({
         },
         depth: 0,
         draft: true,
+        overrideAccess: true,
         select: {
           id: true,
         },

--- a/packages/plugin-nested-docs/src/hooks/resaveChildren.ts
+++ b/packages/plugin-nested-docs/src/hooks/resaveChildren.ts
@@ -22,6 +22,7 @@ export const resaveChildren =
       draft: true,
       limit: 0,
       locale: req.locale,
+      overrideAccess: true,
       req,
       where: {
         [parentSlug]: {
@@ -38,6 +39,7 @@ export const resaveChildren =
       draft: false,
       limit: 0,
       locale: req.locale,
+      overrideAccess: true,
       req,
       where: {
         [parentSlug]: {
@@ -82,6 +84,7 @@ export const resaveChildren =
             depth: 0,
             draft: isDraft,
             locale: req.locale,
+            overrideAccess: true,
             req,
           })
         }

--- a/packages/plugin-nested-docs/src/hooks/resaveSelfAfterCreate.ts
+++ b/packages/plugin-nested-docs/src/hooks/resaveSelfAfterCreate.ts
@@ -30,6 +30,7 @@ export const resaveSelfAfterCreate =
         depth: 0,
         draft: collection?.versions?.drafts && doc._status !== 'published',
         locale,
+        overrideAccess: true,
         req,
       })
     } catch (err: unknown) {

--- a/packages/plugin-nested-docs/src/utilities/getParents.ts
+++ b/packages/plugin-nested-docs/src/utilities/getParents.ts
@@ -21,6 +21,7 @@ export const getParents = async (
         collection: collection.slug,
         depth: 0,
         disableErrors: true,
+        overrideAccess: true,
         req,
       })
     }

--- a/packages/plugin-search/src/Search/hooks/deleteFromSearch.ts
+++ b/packages/plugin-search/src/Search/hooks/deleteFromSearch.ts
@@ -9,6 +9,7 @@ export const deleteFromSearch: DeleteFromSearch =
       await payload.delete({
         collection: searchSlug,
         depth: 0,
+        overrideAccess: true,
         req,
         where: {
           'doc.relationTo': {

--- a/packages/plugin-search/src/utilities/syncDocAsSearchIndex.ts
+++ b/packages/plugin-search/src/utilities/syncDocAsSearchIndex.ts
@@ -73,6 +73,7 @@ export const syncDocAsSearchIndex = async ({
         id,
         collection,
         locale: syncLocale,
+        overrideAccess: true,
         req,
         // Include trashed documents when the document being synced is trashed
         trash: isTrashDocument,
@@ -117,6 +118,7 @@ export const syncDocAsSearchIndex = async ({
         },
         depth: 0,
         locale: syncLocale,
+        overrideAccess: true,
         req,
       })
     }
@@ -128,6 +130,7 @@ export const syncDocAsSearchIndex = async ({
           collection: searchSlug,
           depth: 0,
           locale: syncLocale,
+          overrideAccess: true,
           req,
           where: {
             'doc.relationTo': {
@@ -154,6 +157,7 @@ export const syncDocAsSearchIndex = async ({
             await payload.delete({
               collection: searchSlug,
               depth: 0,
+              overrideAccess: true,
               req,
               where: { id: { in: duplicativeDocIDs } },
             })
@@ -177,6 +181,7 @@ export const syncDocAsSearchIndex = async ({
                 id: searchDocID,
                 collection: searchSlug,
                 depth: 0,
+                overrideAccess: true,
                 req,
               })
             } catch (err: unknown) {
@@ -198,6 +203,7 @@ export const syncDocAsSearchIndex = async ({
                   },
                   depth: 0,
                   locale: syncLocale,
+                  overrideAccess: true,
                   req,
                 })
               } catch (err: unknown) {
@@ -216,6 +222,7 @@ export const syncDocAsSearchIndex = async ({
                 draft: false,
                 limit: 1,
                 locale: syncLocale,
+                overrideAccess: true,
                 pagination: false,
                 req,
                 where: {
@@ -241,6 +248,7 @@ export const syncDocAsSearchIndex = async ({
                     id: searchDocID,
                     collection: searchSlug,
                     depth: 0,
+                    overrideAccess: true,
                     req,
                   })
                 } catch (err: unknown) {
@@ -259,6 +267,7 @@ export const syncDocAsSearchIndex = async ({
               },
               depth: 0,
               locale: syncLocale,
+              overrideAccess: true,
               req,
             })
           } catch (err: unknown) {

--- a/packages/plugin-stripe/src/webhooks/handleCreatedOrUpdated.ts
+++ b/packages/plugin-stripe/src/webhooks/handleCreatedOrUpdated.ts
@@ -55,6 +55,7 @@ export const handleCreatedOrUpdated: HandleCreatedOrUpdated = async (args) => {
     const payloadQuery = await payload.find({
       collection: collectionSlug,
       limit: 1,
+      overrideAccess: true,
       pagination: false,
       where: {
         stripeID: {
@@ -98,6 +99,7 @@ export const handleCreatedOrUpdated: HandleCreatedOrUpdated = async (args) => {
             const authQuery = await payload.find({
               collection: collectionSlug,
               limit: 1,
+              overrideAccess: true,
               pagination: false,
               where: {
                 email: {
@@ -121,6 +123,7 @@ export const handleCreatedOrUpdated: HandleCreatedOrUpdated = async (args) => {
                   id: authDoc.id,
                   collection: collectionSlug,
                   data: syncedData,
+                  overrideAccess: true,
                 })
 
                 if (logs) {
@@ -171,6 +174,7 @@ export const handleCreatedOrUpdated: HandleCreatedOrUpdated = async (args) => {
               passwordConfirm: password,
             },
             disableVerificationEmail: isAuthCollection ? true : undefined,
+            overrideAccess: true,
           })
 
           if (logs) {
@@ -197,6 +201,7 @@ export const handleCreatedOrUpdated: HandleCreatedOrUpdated = async (args) => {
           id: foundDoc.id,
           collection: collectionSlug,
           data: syncedData,
+          overrideAccess: true,
         })
 
         if (logs) {

--- a/packages/plugin-stripe/src/webhooks/handleDeleted.ts
+++ b/packages/plugin-stripe/src/webhooks/handleDeleted.ts
@@ -41,6 +41,7 @@ export const handleDeleted: HandleDeleted = async (args) => {
       const payloadQuery = await payload.find({
         collection: collectionSlug,
         limit: 1,
+        overrideAccess: true,
         pagination: false,
         where: {
           stripeID: {
@@ -69,6 +70,7 @@ export const handleDeleted: HandleDeleted = async (args) => {
           payload.delete({
             id: foundDoc.id,
             collection: collectionSlug,
+            overrideAccess: true,
           })
 
           // NOTE: the `afterDelete` hook will trigger, which will attempt to delete the document from Stripe and safely error out

--- a/packages/richtext-lexical/src/utilities/upgradeLexicalData/index.ts
+++ b/packages/richtext-lexical/src/utilities/upgradeLexicalData/index.ts
@@ -66,6 +66,7 @@ async function upgradeGlobal({
       data: document,
       depth: 0,
       locale: locale || undefined,
+      overrideAccess: true,
     })
   }
 }
@@ -93,6 +94,7 @@ async function upgradeCollection({
     await payload.count({
       collection: collection.slug,
       locale: locale || undefined,
+      overrideAccess: true,
     })
   ).totalDocs
 
@@ -139,6 +141,7 @@ async function upgradeCollection({
           data: document,
           depth: 0,
           locale: locale || undefined,
+          overrideAccess: true,
         })
       }
     }

--- a/test/evals/config.ts
+++ b/test/evals/config.ts
@@ -35,6 +35,7 @@ export default buildConfigWithDefaults({
   },
   onInit: async (payload) => {
     await payload.create({
+      overrideAccess: true,
       collection: 'users',
       data: {
         email: devUser.email,

--- a/test/evals/datasets/mcp.ts
+++ b/test/evals/datasets/mcp.ts
@@ -39,6 +39,7 @@ export const mcpDataset: EvalCase[] = [
       'Upload the local file "checklist.jpg" to the media library and use "Local checklist icon" as its alt text.',
     verify: async ({ audit, expect, payload, transcript }) => {
       const { docs } = await payload.find({
+        overrideAccess: true,
         collection: 'media',
         where: { alt: { equals: 'Local checklist icon' } },
       })
@@ -99,6 +100,7 @@ export const mcpDataset: EvalCase[] = [
       'Add this checklist icon to the media library and use "Checklist icon" as its alt text: https://raw.githubusercontent.com/payloadcms/payload/main/test/uploads/image.jpg',
     verify: async ({ audit, expect, payload, transcript }) => {
       const { docs } = await payload.find({
+        overrideAccess: true,
         collection: 'media',
         where: { alt: { equals: 'Checklist icon' } },
       })
@@ -133,6 +135,7 @@ export const mcpDataset: EvalCase[] = [
       const originalFile = await readFile(path.join(uploadsFixtureDirectory, 'image.png'))
 
       await payload.create({
+        overrideAccess: true,
         collection: 'media',
         data: { alt: 'Outdated checklist icon' },
         file: {
@@ -144,7 +147,7 @@ export const mcpDataset: EvalCase[] = [
       })
     },
     verify: async ({ audit, expect, payload, transcript }) => {
-      const { docs } = await payload.find({ collection: 'media' })
+      const { docs } = await payload.find({ overrideAccess: true, collection: 'media' })
       const media = docs[0]
 
       expect(docs).toHaveLength(1)
@@ -174,6 +177,7 @@ export const mcpDataset: EvalCase[] = [
     input: 'Create a post titled "Created by Payload MCP eval".',
     verify: async ({ audit, expect, payload, transcript }) => {
       const { docs } = await payload.find({
+        overrideAccess: true,
         collection: 'posts',
         where: { title: { equals: 'Created by Payload MCP eval' } },
       })
@@ -197,6 +201,7 @@ export const mcpDataset: EvalCase[] = [
       'Create two posts in one request: one titled "First bulk MCP post" and one titled "Second bulk MCP post".',
     verify: async ({ audit, expect, payload, transcript }) => {
       const { docs } = await payload.find({
+        overrideAccess: true,
         collection: 'posts',
         sort: 'title',
         where: {
@@ -236,12 +241,14 @@ export const mcpDataset: EvalCase[] = [
     input: 'Rename the post "MCP Update Target" to "Updated by Payload MCP eval".',
     setup: async ({ payload }) => {
       await payload.create({
+        overrideAccess: true,
         collection: 'posts',
         data: { title: 'MCP Update Target' },
       })
     },
     verify: async ({ audit, expect, payload, transcript }) => {
       const { docs } = await payload.find({
+        overrideAccess: true,
         collection: 'posts',
       })
 
@@ -264,15 +271,17 @@ export const mcpDataset: EvalCase[] = [
     input: 'Delete the post titled "MCP Delete Target".',
     setup: async ({ payload }) => {
       for (const title of ['MCP Delete Target', 'MCP Keep', 'MCP Update Target']) {
-        await payload.create({ collection: 'posts', data: { title } })
+        await payload.create({ overrideAccess: true, collection: 'posts', data: { title } })
       }
     },
     verify: async ({ audit, expect, payload, transcript }) => {
       const deletedPosts = await payload.find({
+        overrideAccess: true,
         collection: 'posts',
         where: { title: { equals: 'MCP Delete Target' } },
       })
       const remainingPosts = await payload.find({
+        overrideAccess: true,
         collection: 'posts',
       })
 
@@ -297,7 +306,10 @@ export const mcpDataset: EvalCase[] = [
     configPath: 'mcp/shared',
     input: 'Change the site tagline to "Updated through Payload MCP".',
     verify: async ({ audit, expect, payload, transcript }) => {
-      const settings = (await payload.findGlobal({ slug: 'site-settings' })) as {
+      const settings = (await payload.findGlobal({
+        overrideAccess: true,
+        slug: 'site-settings',
+      })) as {
         tagline?: unknown
       }
 
@@ -323,16 +335,19 @@ export const mcpDataset: EvalCase[] = [
     input: 'Create a post titled "Relationship created by Payload MCP eval" by Ada Lovelace.',
     setup: async ({ payload }) => {
       await payload.create({
+        overrideAccess: true,
         collection: 'authors',
         data: { name: 'Ada Lovelace' },
       })
     },
     verify: async ({ audit, expect, payload, transcript }) => {
       const { docs: authors } = await payload.find({
+        overrideAccess: true,
         collection: 'authors',
         where: { name: { equals: 'Ada Lovelace' } },
       })
       const { docs: posts } = await payload.find({
+        overrideAccess: true,
         collection: 'posts',
         depth: 0,
         where: { title: { equals: 'Relationship created by Payload MCP eval' } },
@@ -365,6 +380,7 @@ export const mcpDataset: EvalCase[] = [
       'Create a post titled "Lexical content created by Payload MCP eval" with an H2 heading "Release notes", a paragraph saying "Payload MCP is ready." with only "Payload MCP" in bold, and a bulleted list containing "Create content" and "Manage schemas".',
     verify: async ({ audit, expect, payload, transcript }) => {
       const { docs } = await payload.find({
+        overrideAccess: true,
         collection: 'posts',
         where: { title: { equals: 'Lexical content created by Payload MCP eval' } },
       })
@@ -414,6 +430,7 @@ export const mcpDataset: EvalCase[] = [
       'The published article "MCP Draft Update Target" needs a correction, but it is not ready to go live. Change its title to "MCP Draft Update Saved" and save it as a draft without changing the published article.',
     setup: async ({ payload }) => {
       await payload.create({
+        overrideAccess: true,
         collection: 'articles',
         data: { _status: 'published', title: 'MCP Draft Update Target' },
         locale: 'en',
@@ -421,6 +438,7 @@ export const mcpDataset: EvalCase[] = [
     },
     verify: async ({ audit, expect, payload, transcript }) => {
       const { docs: draftArticles } = await payload.find({
+        overrideAccess: true,
         collection: 'articles',
         draft: true,
         locale: 'en',
@@ -430,6 +448,7 @@ export const mcpDataset: EvalCase[] = [
 
       const draftArticle = draftArticles[0]
       const publishedArticle = await payload.findByID({
+        overrideAccess: true,
         id: draftArticle!.id,
         collection: 'articles',
         draft: false,
@@ -458,6 +477,7 @@ export const mcpDataset: EvalCase[] = [
       'Fix the title of the article "MCP Published Update Target" to "MCP Published Update Saved" and publish the corrected version now.',
     setup: async ({ payload }) => {
       await payload.create({
+        overrideAccess: true,
         collection: 'articles',
         data: { _status: 'published', title: 'MCP Published Update Target' },
         locale: 'en',
@@ -465,6 +485,7 @@ export const mcpDataset: EvalCase[] = [
     },
     verify: async ({ audit, expect, payload, transcript }) => {
       const { docs: publishedArticles } = await payload.find({
+        overrideAccess: true,
         collection: 'articles',
         draft: false,
         locale: 'en',
@@ -493,6 +514,7 @@ export const mcpDataset: EvalCase[] = [
       'Take the published article "MCP Unpublish Target" offline, but keep the article and its version history so it can still be edited as a draft. Do not delete it.',
     setup: async ({ payload }) => {
       await payload.create({
+        overrideAccess: true,
         collection: 'articles',
         data: { _status: 'published', title: 'MCP Unpublish Target' },
         locale: 'en',
@@ -500,6 +522,7 @@ export const mcpDataset: EvalCase[] = [
     },
     verify: async ({ audit, expect, payload, transcript }) => {
       const { docs: unpublishedArticles } = await payload.find({
+        overrideAccess: true,
         collection: 'articles',
         draft: false,
         locale: 'en',
@@ -527,12 +550,14 @@ export const mcpDataset: EvalCase[] = [
       'Show me the currently published article titled "MCP Published Read Target". Ignore its newer unpublished draft.',
     setup: async ({ payload }) => {
       const article = await payload.create({
+        overrideAccess: true,
         collection: 'articles',
         data: { _status: 'published', title: 'MCP Published Read Target' },
         locale: 'en',
       })
 
       await payload.update({
+        overrideAccess: true,
         id: article.id,
         collection: 'articles',
         data: { title: 'MCP Draft Must Not Be Read' },
@@ -542,6 +567,7 @@ export const mcpDataset: EvalCase[] = [
     },
     verify: async ({ audit, expect, payload, transcript }) => {
       const { docs: publishedArticles } = await payload.find({
+        overrideAccess: true,
         collection: 'articles',
         draft: false,
         locale: 'en',
@@ -551,6 +577,7 @@ export const mcpDataset: EvalCase[] = [
 
       const publishedArticle = publishedArticles[0]
       const draftArticle = await payload.findByID({
+        overrideAccess: true,
         id: publishedArticle!.id,
         collection: 'articles',
         draft: true,
@@ -584,12 +611,14 @@ export const mcpDataset: EvalCase[] = [
       'Show me the latest draft of the article currently published as "MCP Draft Read Published Title".',
     setup: async ({ payload }) => {
       const article = await payload.create({
+        overrideAccess: true,
         collection: 'articles',
         data: { _status: 'published', title: 'MCP Draft Read Published Title' },
         locale: 'en',
       })
 
       await payload.update({
+        overrideAccess: true,
         id: article.id,
         collection: 'articles',
         data: { title: 'MCP Draft Read Latest Title' },
@@ -599,6 +628,7 @@ export const mcpDataset: EvalCase[] = [
     },
     verify: async ({ audit, expect, payload, transcript }) => {
       const { docs: draftArticles } = await payload.find({
+        overrideAccess: true,
         collection: 'articles',
         draft: true,
         locale: 'en',
@@ -632,12 +662,14 @@ export const mcpDataset: EvalCase[] = [
       'For the article "MCP English Publish Target", change the English title to "MCP English Published Title" and publish only English. Leave the Spanish published title and Spanish draft unchanged.',
     setup: async ({ payload }) => {
       const article = await payload.create({
+        overrideAccess: true,
         collection: 'articles',
         data: { _status: 'published', title: 'MCP English Publish Target' },
         locale: 'en',
       })
 
       await payload.update({
+        overrideAccess: true,
         id: article.id,
         collection: 'articles',
         data: { _status: 'published', title: 'MCP Spanish Published Title' },
@@ -646,6 +678,7 @@ export const mcpDataset: EvalCase[] = [
         publishAllLocales: false,
       })
       await payload.update({
+        overrideAccess: true,
         id: article.id,
         collection: 'articles',
         data: { title: 'MCP Spanish Draft Title' },
@@ -655,6 +688,7 @@ export const mcpDataset: EvalCase[] = [
     },
     verify: async ({ audit, expect, payload, transcript }) => {
       const { docs: publishedEnglishArticles } = await payload.find({
+        overrideAccess: true,
         collection: 'articles',
         draft: false,
         locale: 'en',
@@ -664,12 +698,14 @@ export const mcpDataset: EvalCase[] = [
 
       const publishedEnglish = publishedEnglishArticles[0]
       const publishedSpanish = await payload.findByID({
+        overrideAccess: true,
         id: publishedEnglish!.id,
         collection: 'articles',
         draft: false,
         locale: 'es',
       })
       const draftSpanish = await payload.findByID({
+        overrideAccess: true,
         id: publishedEnglish!.id,
         collection: 'articles',
         draft: true,
@@ -700,6 +736,7 @@ export const mcpDataset: EvalCase[] = [
       'Create a new article titled "MCP Newly Created Draft" as a draft. Leave it unpublished.',
     verify: async ({ audit, expect, payload, transcript }) => {
       const { docs } = await payload.find({
+        overrideAccess: true,
         collection: 'articles',
         draft: true,
         locale: 'en',
@@ -726,6 +763,7 @@ export const mcpDataset: EvalCase[] = [
     input: 'Create and publish a new article titled "MCP Newly Created Published".',
     verify: async ({ audit, expect, payload, transcript }) => {
       const { docs } = await payload.find({
+        overrideAccess: true,
         collection: 'articles',
         draft: false,
         locale: 'en',

--- a/test/payload-cloud/config.ts
+++ b/test/payload-cloud/config.ts
@@ -25,6 +25,7 @@ export default buildConfigWithDefaults({
   collections: [Documents, Media, Users],
   onInit: async (payload) => {
     await payload.create({
+      overrideAccess: true,
       collection: 'users',
       data: {
         email: devUser.email,

--- a/test/payload-cloud/int.spec.ts
+++ b/test/payload-cloud/int.spec.ts
@@ -81,6 +81,7 @@ describe('@payloadcms/payload--cloud', () => {
         expect(doc.filesize).toBe(originalStats.size)
 
         await payload.delete({
+          overrideAccess: true,
           collection: 'documents',
           id: doc.id,
         })

--- a/test/plugin-cloud-storage/buildPluginCloudStorageIntConfig.ts
+++ b/test/plugin-cloud-storage/buildPluginCloudStorageIntConfig.ts
@@ -221,6 +221,7 @@ export function buildPluginCloudStorageIntConfig({
     }*/
 
       await payload.create({
+        overrideAccess: true,
         collection: 'users',
         data: {
           email: devUser.email,

--- a/test/plugin-cloud-storage/int.compositePrefixes.int.spec.ts
+++ b/test/plugin-cloud-storage/int.compositePrefixes.int.spec.ts
@@ -71,6 +71,7 @@ describe('@payloadcms/plugin-cloud-storage (composite prefixes)', () => {
         const docPrefix = 'user-123'
 
         const upload = await payload.create({
+          overrideAccess: true,
           collection: mediaWithCompositePrefixesSlug,
           data: {
             prefix: docPrefix,
@@ -95,6 +96,7 @@ describe('@payloadcms/plugin-cloud-storage (composite prefixes)', () => {
 
       it('can upload with composite prefixes (collection prefix only)', async () => {
         const upload = await payload.create({
+          overrideAccess: true,
           collection: mediaWithCompositePrefixesSlug,
           data: {},
           filePath: path.resolve(dirname, '../uploads/image.png'),

--- a/test/plugin-cloud-storage/int.spec.ts
+++ b/test/plugin-cloud-storage/int.spec.ts
@@ -47,6 +47,7 @@ async function verifyUploads({
   uploadId: number | string
 }) {
   const uploadData = (await payload.findByID({
+    overrideAccess: true,
     id: uploadId,
     collection: collectionSlug,
   })) as unknown as { filename: string; sizes: Record<string, { filename: string }> }
@@ -305,6 +306,7 @@ describe('@payloadcms/plugin-cloud-storage', () => {
 
         it('can upload', async () => {
           const upload = await payload.create({
+            overrideAccess: true,
             collection: mediaSlug,
             data: {},
             filePath: path.resolve(dirname, '../uploads/image.png'),
@@ -325,6 +327,7 @@ describe('@payloadcms/plugin-cloud-storage', () => {
 
         it('can upload with prefix', async () => {
           const upload = await payload.create({
+            overrideAccess: true,
             collection: mediaWithPrefixSlug,
             data: {},
             filePath: path.resolve(dirname, '../uploads/image.png'),
@@ -355,6 +358,7 @@ describe('@payloadcms/plugin-cloud-storage', () => {
           // Try to upload a JSON file to a collection that only accepts PNG
           await expect(
             payload.create({
+              overrideAccess: true,
               collection: restrictedMediaSlug,
               data: {},
               filePath: path.resolve(dirname, './test.json'),
@@ -371,6 +375,7 @@ describe('@payloadcms/plugin-cloud-storage', () => {
         it('should upload to S3 when mimeType validation passes', async () => {
           // Upload a valid PNG file
           const upload = await payload.create({
+            overrideAccess: true,
             collection: restrictedMediaSlug,
             data: {},
             filePath: path.resolve(dirname, './image.png'),
@@ -396,12 +401,14 @@ describe('@payloadcms/plugin-cloud-storage', () => {
 
         it('should store correct URLs for sized images', async () => {
           const upload = await payload.create({
+            overrideAccess: true,
             collection: mediaSlug,
             data: {},
             filePath: path.resolve(dirname, '../uploads/image.png'),
           })
 
           const apiResponse = await payload.findByID({
+            overrideAccess: true,
             id: upload.id,
             collection: mediaSlug,
           })
@@ -442,6 +449,7 @@ describe('@payloadcms/plugin-cloud-storage', () => {
 
         it('should handle collections without imageSizes correctly', async () => {
           const upload = await payload.create({
+            overrideAccess: true,
             collection: mediaWithPrefixSlug,
             data: {},
             filePath: path.resolve(dirname, '../uploads/image.png'),
@@ -474,6 +482,7 @@ describe('@payloadcms/plugin-cloud-storage', () => {
           // This test verifies that custom generateFileURL is used in beforeChange hook
           // when disablePayloadAccessControl: true, preventing "undefined" from appearing in URLs
           const upload = await payload.create({
+            overrideAccess: true,
             collection: mediaWithCustomURLSlug,
             data: {},
             filePath: path.resolve(dirname, '../uploads/image.png'),
@@ -502,6 +511,7 @@ describe('@payloadcms/plugin-cloud-storage', () => {
 
           // Verify the API response also returns the custom URL
           const apiResponse = await payload.findByID({
+            overrideAccess: true,
             id: upload.id,
             collection: mediaWithCustomURLSlug,
           })
@@ -512,6 +522,7 @@ describe('@payloadcms/plugin-cloud-storage', () => {
 
         it('should use custom generateFileURL even without disablePayloadAccessControl', async () => {
           const upload = await payload.create({
+            overrideAccess: true,
             collection: mediaWithGenerateFileURLSlug,
             data: {},
             filePath: path.resolve(dirname, '../uploads/image.png'),
@@ -538,6 +549,7 @@ describe('@payloadcms/plugin-cloud-storage', () => {
           expect(dbRecord.url).toMatch(/^https:\/\//)
 
           const apiResponse = await payload.findByID({
+            overrideAccess: true,
             id: upload.id,
             collection: mediaWithGenerateFileURLSlug,
           })
@@ -554,7 +566,7 @@ describe('@payloadcms/plugin-cloud-storage', () => {
       afterEach(async () => {
         for (const id of createdIDs) {
           try {
-            await payload.delete({ id, collection: testMetadataSlug })
+            await payload.delete({ overrideAccess: true, id, collection: testMetadataSlug })
           } catch (e) {
             // Ignore
           }
@@ -564,6 +576,7 @@ describe('@payloadcms/plugin-cloud-storage', () => {
 
       it('should automatically persist metadata returned by custom adapters', async () => {
         const upload = await payload.create({
+          overrideAccess: true,
           collection: testMetadataSlug,
           data: {
             testNote: 'Testing automatic metadata persistence',
@@ -652,6 +665,7 @@ describe('@payloadcms/plugin-cloud-storage', () => {
 
       it('should persist metadata on update operations', async () => {
         const upload = await payload.create({
+          overrideAccess: true,
           collection: testMetadataSlug,
           data: {
             testNote: 'Testing update metadata persistence',
@@ -665,6 +679,7 @@ describe('@payloadcms/plugin-cloud-storage', () => {
         const initialTimestamp = upload.uploadTimestamp
 
         const updatedUpload = await payload.update({
+          overrideAccess: true,
           id: upload.id,
           collection: testMetadataSlug,
           data: {
@@ -707,7 +722,11 @@ describe('@payloadcms/plugin-cloud-storage', () => {
       afterEach(async () => {
         for (const id of createdIDs) {
           try {
-            await payload.delete({ id, collection: mediaWithThrowingHookSlug })
+            await payload.delete({
+              overrideAccess: true,
+              id,
+              collection: mediaWithThrowingHookSlug,
+            })
           } catch (_) {
             // Ignore
           }
@@ -718,6 +737,7 @@ describe('@payloadcms/plugin-cloud-storage', () => {
       it('should surface user afterChange errors that throw during the plugin internal update on create', async () => {
         await expect(
           payload.create({
+            overrideAccess: true,
             collection: mediaWithThrowingHookSlug,
             data: { shouldThrow: true },
             filePath: path.resolve(dirname, '../uploads/image.png'),
@@ -735,6 +755,7 @@ describe('@payloadcms/plugin-cloud-storage', () => {
         })
 
         const initial = await payload.create({
+          overrideAccess: true,
           collection: mediaWithThrowingHookSlug,
           data: { shouldThrow: false },
           file: buildFile('initial.png'),
@@ -750,6 +771,7 @@ describe('@payloadcms/plugin-cloud-storage', () => {
 
         await expect(
           payload.update({
+            overrideAccess: true,
             id: initial.id,
             collection: mediaWithThrowingHookSlug,
             data: { shouldThrow: true },
@@ -770,7 +792,7 @@ describe('@payloadcms/plugin-cloud-storage', () => {
       afterEach(async () => {
         for (const id of createdIDs) {
           try {
-            await payload.delete({ id, collection: mediaWithOverwriteSlug })
+            await payload.delete({ overrideAccess: true, id, collection: mediaWithOverwriteSlug })
           } catch (_) {
             // Ignore
           }
@@ -788,6 +810,7 @@ describe('@payloadcms/plugin-cloud-storage', () => {
         })
 
         const initial = (await payload.create({
+          overrideAccess: true,
           collection: mediaWithOverwriteSlug,
           data: {},
           file: buildFile('overwrite.png'),
@@ -814,6 +837,7 @@ describe('@payloadcms/plugin-cloud-storage', () => {
         }
 
         const updated = (await payload.update({
+          overrideAccess: true,
           id: initial.id,
           collection: mediaWithOverwriteSlug,
           data: {},

--- a/test/plugin-ecommerce/app/(shop)/shop/order/[id]/page.tsx
+++ b/test/plugin-ecommerce/app/(shop)/shop/order/[id]/page.tsx
@@ -11,6 +11,7 @@ export const Page = async ({ params: paramsPromise }: { params: Promise<{ id: st
   const orderID = searchParams.id
 
   const order = await payload.findByID({
+    overrideAccess: true,
     collection: 'orders',
     id: orderID,
     depth: 2,

--- a/test/plugin-ecommerce/app/(shop)/shop/page.tsx
+++ b/test/plugin-ecommerce/app/(shop)/shop/page.tsx
@@ -12,6 +12,7 @@ export const Page = async () => {
   })
 
   const products = await payload.find({
+    overrideAccess: true,
     collection: 'products',
     depth: 2,
     limit: 10,

--- a/test/plugin-ecommerce/config.ts
+++ b/test/plugin-ecommerce/config.ts
@@ -38,6 +38,7 @@ export default buildConfigWithDefaults({
   maxDepth: 10,
   onInit: async (payload) => {
     await payload.create({
+      overrideAccess: true,
       collection: 'users',
       data: {
         email: devUser.email,

--- a/test/plugin-ecommerce/int.spec.ts
+++ b/test/plugin-ecommerce/int.spec.ts
@@ -63,6 +63,7 @@ describe('ecommerce', () => {
 
   it('should add a variants collection', async () => {
     const variants = await payload.find({
+      overrideAccess: true,
       collection: 'variants',
       depth: 0,
       limit: 1,
@@ -303,12 +304,14 @@ describe('ecommerce', () => {
     beforeAll(async () => {
       // Get an existing product and variant from seed data
       const products = await payload.find({
+        overrideAccess: true,
         collection: 'products',
         limit: 1,
       })
       productId = products.docs[0]?.id as string
 
       const variants = await payload.find({
+        overrideAccess: true,
         collection: 'variants',
         limit: 1,
       })
@@ -764,12 +767,14 @@ describe('ecommerce', () => {
 
     beforeAll(async () => {
       const products = await payload.find({
+        overrideAccess: true,
         collection: 'products',
         limit: 1,
       })
       productId = products.docs[0]?.id as string
 
       const variants = await payload.find({
+        overrideAccess: true,
         collection: 'variants',
         limit: 1,
       })
@@ -785,6 +790,7 @@ describe('ecommerce', () => {
 
       // Create a user and log in
       const testUser = await payload.create({
+        overrideAccess: true,
         collection: 'users',
         data: {
           email: `merge-test-${Date.now()}@test.com`,
@@ -870,6 +876,7 @@ describe('ecommerce', () => {
 
       // Create a user and log in
       const testUser = await payload.create({
+        overrideAccess: true,
         collection: 'users',
         data: {
           email: `merge-combine-${Date.now()}@test.com`,
@@ -934,6 +941,7 @@ describe('ecommerce', () => {
       )
 
       const testUser = await payload.create({
+        overrideAccess: true,
         collection: 'users',
         data: {
           email: `merge-delete-${Date.now()}@test.com`,
@@ -1014,6 +1022,7 @@ describe('ecommerce', () => {
       const { cartId: guestCartId } = await createGuestCartWithItems(restClient, productId)
 
       const testUser = await payload.create({
+        overrideAccess: true,
         collection: 'users',
         data: {
           email: `merge-invalid-${Date.now()}@test.com`,
@@ -1057,6 +1066,7 @@ describe('ecommerce', () => {
 
     beforeAll(async () => {
       const products = await payload.find({
+        overrideAccess: true,
         collection: 'products',
         limit: 1,
       })
@@ -1065,6 +1075,7 @@ describe('ecommerce', () => {
 
     it('should allow authenticated users to access their cart without secret', async () => {
       const testUser = await payload.create({
+        overrideAccess: true,
         collection: 'users',
         data: {
           email: `auth-cart-${Date.now()}@test.com`,
@@ -1101,6 +1112,7 @@ describe('ecommerce', () => {
 
     it('should allow authenticated users to add items without secret', async () => {
       const testUser = await payload.create({
+        overrideAccess: true,
         collection: 'users',
         data: {
           email: `auth-add-${Date.now()}@test.com`,
@@ -1143,6 +1155,7 @@ describe('ecommerce', () => {
 
     it('should not generate secret for authenticated user carts', async () => {
       const testUser = await payload.create({
+        overrideAccess: true,
         collection: 'users',
         data: {
           email: `auth-nosecret-${Date.now()}@test.com`,
@@ -1178,6 +1191,7 @@ describe('ecommerce', () => {
 
     beforeAll(async () => {
       const products = await payload.find({
+        overrideAccess: true,
         collection: 'products',
         limit: 1,
       })
@@ -1193,6 +1207,7 @@ describe('ecommerce', () => {
 
       // Create a user
       const testUser = await payload.create({
+        overrideAccess: true,
         collection: 'users',
         data: {
           email: `transfer-${Date.now()}@test.com`,

--- a/test/plugin-ecommerce/seed/index.ts
+++ b/test/plugin-ecommerce/seed/index.ts
@@ -18,6 +18,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
 
   try {
     const customer = await payload.create({
+      overrideAccess: true,
       collection: 'users',
       data: {
         email: 'customer@payloadcms.com',
@@ -27,6 +28,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
     })
 
     const sizeVariantType = await payload.create({
+      overrideAccess: true,
       collection: 'variantTypes',
       data: {
         name: 'size',
@@ -37,6 +39,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
     const [small, medium, large, xlarge] = await Promise.all(
       sizeVariantOptions.map((option) => {
         return payload.create({
+          overrideAccess: true,
           collection: 'variantOptions',
           data: {
             ...option,
@@ -47,6 +50,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
     )
 
     const colorVariantType = await payload.create({
+      overrideAccess: true,
       collection: 'variantTypes',
       data: {
         name: 'color',
@@ -57,6 +61,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
     const [black, white] = await Promise.all(
       colorVariantOptions.map((option) => {
         return payload.create({
+          overrideAccess: true,
           collection: 'variantOptions',
           data: {
             ...option,
@@ -67,6 +72,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
     )
 
     const hoodieProduct = await payload.create({
+      overrideAccess: true,
       collection: 'products',
       data: {
         name: 'Hoodie',
@@ -76,6 +82,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
     })
 
     const hoodieSmallWhite = await payload.create({
+      overrideAccess: true,
       collection: 'variants',
       data: {
         product: hoodieProduct.id,
@@ -87,6 +94,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
     })
 
     const hoodieMediumWhite = await payload.create({
+      overrideAccess: true,
       collection: 'variants',
       data: {
         product: hoodieProduct.id,
@@ -98,6 +106,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
     })
 
     const hatProduct = await payload.create({
+      overrideAccess: true,
       collection: 'products',
       data: {
         name: 'Hat',
@@ -109,6 +118,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
     })
 
     const pendingPaymentRecord = await payload.create({
+      overrideAccess: true,
       collection: 'transactions',
       data: {
         currency: 'USD',
@@ -123,6 +133,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
     })
 
     const succeededPaymentRecord = await payload.create({
+      overrideAccess: true,
       collection: 'transactions',
       data: {
         currency: 'USD',

--- a/test/plugin-form-builder/components/views/UploadFormTest/index.tsx
+++ b/test/plugin-form-builder/components/views/UploadFormTest/index.tsx
@@ -34,6 +34,7 @@ async function UploadFormTestViewAsync({
   })
 
   const { docs } = await payload.find({
+    overrideAccess: true,
     collection: 'forms',
     depth: 0,
     limit: 100,

--- a/test/plugin-form-builder/config.ts
+++ b/test/plugin-form-builder/config.ts
@@ -62,6 +62,7 @@ export default buildConfigWithDefaults({
   },
   onInit: async (payload) => {
     await payload.create({
+      overrideAccess: true,
       collection: 'users',
       data: {
         email: devUser.email,

--- a/test/plugin-form-builder/int.spec.ts
+++ b/test/plugin-form-builder/int.spec.ts
@@ -74,6 +74,7 @@ describe('@payloadcms/plugin-form-builder', () => {
     }
 
     form = (await payload.create({
+      overrideAccess: true,
       collection: formsSlug,
       data: formConfig,
     })) as unknown as Form
@@ -85,12 +86,15 @@ describe('@payloadcms/plugin-form-builder', () => {
 
   describe('plugin collections', () => {
     it('adds forms collection', async () => {
-      const { docs: forms } = await payload.find({ collection: formsSlug })
+      const { docs: forms } = await payload.find({ overrideAccess: true, collection: formsSlug })
       expect(forms.length).toBeGreaterThan(0)
     })
 
     it('adds form submissions collection', async () => {
-      const { docs: formSubmissions } = await payload.find({ collection: formSubmissionsSlug })
+      const { docs: formSubmissions } = await payload.find({
+        overrideAccess: true,
+        collection: formSubmissionsSlug,
+      })
       expect(formSubmissions).toHaveLength(1)
     })
   })
@@ -140,6 +144,7 @@ describe('@payloadcms/plugin-form-builder', () => {
       }
 
       const testForm = await payload.create({
+        overrideAccess: true,
         collection: formsSlug,
         data: formConfig,
       })
@@ -188,6 +193,7 @@ describe('@payloadcms/plugin-form-builder', () => {
       }
 
       const testForm = await payload.create({
+        overrideAccess: true,
         collection: formsSlug,
         data: formConfig,
       })
@@ -199,6 +205,7 @@ describe('@payloadcms/plugin-form-builder', () => {
   describe('form submissions and validations', () => {
     it('can create a form submission', async () => {
       const formSubmission = await payload.create({
+        overrideAccess: true,
         collection: formSubmissionsSlug,
         data: {
           form: form.id,
@@ -222,6 +229,7 @@ describe('@payloadcms/plugin-form-builder', () => {
     it('does not create a form submission for a non-existing form', async () => {
       const req = async () =>
         payload.create({
+          overrideAccess: true,
           collection: formSubmissionsSlug,
           data: {
             form: '659c7c2f98ffb5d83df9dadb',
@@ -614,7 +622,7 @@ describe('@payloadcms/plugin-form-builder', () => {
     afterEach(async () => {
       for (const id of createdSubmissionIds) {
         try {
-          await payload.delete({ collection: formSubmissionsSlug, id })
+          await payload.delete({ overrideAccess: true, collection: formSubmissionsSlug, id })
         } catch {
           // ignore if already deleted
         }
@@ -623,7 +631,7 @@ describe('@payloadcms/plugin-form-builder', () => {
 
       for (const id of createdFormIds) {
         try {
-          await payload.delete({ collection: formsSlug, id })
+          await payload.delete({ overrideAccess: true, collection: formsSlug, id })
         } catch {
           // ignore if already deleted
         }
@@ -632,7 +640,7 @@ describe('@payloadcms/plugin-form-builder', () => {
 
       for (const id of createdMediaIds) {
         try {
-          await payload.delete({ collection: mediaSlug, id })
+          await payload.delete({ overrideAccess: true, collection: mediaSlug, id })
         } catch {
           // ignore if already deleted
         }
@@ -641,7 +649,7 @@ describe('@payloadcms/plugin-form-builder', () => {
 
       for (const id of createdDocumentIds) {
         try {
-          await payload.delete({ collection: documentsSlug, id })
+          await payload.delete({ overrideAccess: true, collection: documentsSlug, id })
         } catch {
           // ignore if already deleted
         }
@@ -684,6 +692,7 @@ describe('@payloadcms/plugin-form-builder', () => {
     describe('form creation with upload fields', () => {
       it('should create a form with a single upload field', async () => {
         const testForm = await payload.create({
+          overrideAccess: true,
           collection: formsSlug,
           data: {
             confirmationType: 'message',
@@ -711,6 +720,7 @@ describe('@payloadcms/plugin-form-builder', () => {
 
       it('should create a form with multiple upload fields', async () => {
         const testForm = await payload.create({
+          overrideAccess: true,
           collection: formsSlug,
           data: {
             confirmationType: 'message',
@@ -738,6 +748,7 @@ describe('@payloadcms/plugin-form-builder', () => {
 
       it('should create a form with mixed field types including upload', async () => {
         const testForm = await payload.create({
+          overrideAccess: true,
           collection: formsSlug,
           data: {
             confirmationType: 'message',
@@ -761,6 +772,7 @@ describe('@payloadcms/plugin-form-builder', () => {
     describe('required field validation', () => {
       it('should reject submission when required upload field is missing', async () => {
         const testForm = await payload.create({
+          overrideAccess: true,
           collection: formsSlug,
           data: {
             confirmationType: 'message',
@@ -782,6 +794,7 @@ describe('@payloadcms/plugin-form-builder', () => {
 
         await expect(
           payload.create({
+            overrideAccess: true,
             collection: formSubmissionsSlug,
             data: {
               form: testForm.id,
@@ -793,6 +806,7 @@ describe('@payloadcms/plugin-form-builder', () => {
 
       it('should reject submission when required upload field has empty string', async () => {
         const testForm = await payload.create({
+          overrideAccess: true,
           collection: formsSlug,
           data: {
             confirmationType: 'message',
@@ -814,6 +828,7 @@ describe('@payloadcms/plugin-form-builder', () => {
 
         await expect(
           payload.create({
+            overrideAccess: true,
             collection: formSubmissionsSlug,
             data: {
               form: testForm.id,
@@ -826,6 +841,7 @@ describe('@payloadcms/plugin-form-builder', () => {
       it('should accept submission when required upload field has valid file ID', async () => {
         // Create a test media document
         const mediaDoc = await payload.create({
+          overrideAccess: true,
           collection: mediaSlug,
           data: { alt: 'test' },
           filePath: testImagePath,
@@ -834,6 +850,7 @@ describe('@payloadcms/plugin-form-builder', () => {
         createdMediaIds.push(mediaDoc.id)
 
         const testForm = await payload.create({
+          overrideAccess: true,
           collection: formsSlug,
           data: {
             confirmationType: 'message',
@@ -853,6 +870,7 @@ describe('@payloadcms/plugin-form-builder', () => {
         createdFormIds.push(testForm.id)
 
         const submission = await payload.create({
+          overrideAccess: true,
           collection: formSubmissionsSlug,
           data: {
             form: testForm.id,
@@ -873,6 +891,7 @@ describe('@payloadcms/plugin-form-builder', () => {
     describe('optional field handling', () => {
       it('should accept submission when optional upload field is omitted', async () => {
         const testForm = await payload.create({
+          overrideAccess: true,
           collection: formsSlug,
           data: {
             confirmationType: 'message',
@@ -893,6 +912,7 @@ describe('@payloadcms/plugin-form-builder', () => {
         createdFormIds.push(testForm.id)
 
         const submission = await payload.create({
+          overrideAccess: true,
           collection: formSubmissionsSlug,
           data: {
             form: testForm.id,
@@ -907,6 +927,7 @@ describe('@payloadcms/plugin-form-builder', () => {
 
       it('should accept submission with only some upload fields filled', async () => {
         const mediaDoc = await payload.create({
+          overrideAccess: true,
           collection: mediaSlug,
           data: { alt: 'test' },
           filePath: testImagePath,
@@ -915,6 +936,7 @@ describe('@payloadcms/plugin-form-builder', () => {
         createdMediaIds.push(mediaDoc.id)
 
         const testForm = await payload.create({
+          overrideAccess: true,
           collection: formsSlug,
           data: {
             confirmationType: 'message',
@@ -946,6 +968,7 @@ describe('@payloadcms/plugin-form-builder', () => {
         createdFormIds.push(testForm.id)
 
         const submission = await payload.create({
+          overrideAccess: true,
           collection: formSubmissionsSlug,
           data: {
             form: testForm.id,
@@ -963,6 +986,7 @@ describe('@payloadcms/plugin-form-builder', () => {
       it('should reject file with disallowed mime type', async () => {
         // Create a PDF document in documents collection
         const pdfDoc = await payload.create({
+          overrideAccess: true,
           collection: documentsSlug,
           data: {},
           filePath: testPdfPath,
@@ -971,6 +995,7 @@ describe('@payloadcms/plugin-form-builder', () => {
         createdDocumentIds.push(pdfDoc.id)
 
         const testForm = await payload.create({
+          overrideAccess: true,
           collection: formsSlug,
           data: {
             confirmationType: 'message',
@@ -994,6 +1019,7 @@ describe('@payloadcms/plugin-form-builder', () => {
         // This should fail because we're referencing a file from the wrong collection
         await expect(
           payload.create({
+            overrideAccess: true,
             collection: formSubmissionsSlug,
             data: {
               form: testForm.id,
@@ -1005,6 +1031,7 @@ describe('@payloadcms/plugin-form-builder', () => {
 
       it('should accept file with allowed mime type', async () => {
         const mediaDoc = await payload.create({
+          overrideAccess: true,
           collection: mediaSlug,
           data: { alt: 'test' },
           filePath: testImagePath,
@@ -1013,6 +1040,7 @@ describe('@payloadcms/plugin-form-builder', () => {
         createdMediaIds.push(mediaDoc.id)
 
         const testForm = await payload.create({
+          overrideAccess: true,
           collection: formsSlug,
           data: {
             confirmationType: 'message',
@@ -1033,6 +1061,7 @@ describe('@payloadcms/plugin-form-builder', () => {
         createdFormIds.push(testForm.id)
 
         const submission = await payload.create({
+          overrideAccess: true,
           collection: formSubmissionsSlug,
           data: {
             form: testForm.id,
@@ -1049,6 +1078,7 @@ describe('@payloadcms/plugin-form-builder', () => {
     describe('file reference validation', () => {
       it('should reject non-existent file ID', async () => {
         const testForm = await payload.create({
+          overrideAccess: true,
           collection: formsSlug,
           data: {
             confirmationType: 'message',
@@ -1069,6 +1099,7 @@ describe('@payloadcms/plugin-form-builder', () => {
 
         await expect(
           payload.create({
+            overrideAccess: true,
             collection: formSubmissionsSlug,
             data: {
               form: testForm.id,
@@ -1082,6 +1113,7 @@ describe('@payloadcms/plugin-form-builder', () => {
     describe('other form data integrity', () => {
       it('should save all non-upload fields when upload succeeds', async () => {
         const mediaDoc = await payload.create({
+          overrideAccess: true,
           collection: mediaSlug,
           data: { alt: 'test' },
           filePath: testImagePath,
@@ -1090,6 +1122,7 @@ describe('@payloadcms/plugin-form-builder', () => {
         createdMediaIds.push(mediaDoc.id)
 
         const testForm = await payload.create({
+          overrideAccess: true,
           collection: formsSlug,
           data: {
             confirmationType: 'message',
@@ -1106,6 +1139,7 @@ describe('@payloadcms/plugin-form-builder', () => {
         createdFormIds.push(testForm.id)
 
         const submission = await payload.create({
+          overrideAccess: true,
           collection: formSubmissionsSlug,
           data: {
             form: testForm.id,
@@ -1135,6 +1169,7 @@ describe('@payloadcms/plugin-form-builder', () => {
 
       it('should handle form with no upload fields same as before', async () => {
         const testForm = await payload.create({
+          overrideAccess: true,
           collection: formsSlug,
           data: {
             confirmationType: 'message',
@@ -1147,6 +1182,7 @@ describe('@payloadcms/plugin-form-builder', () => {
         createdFormIds.push(testForm.id)
 
         const submission = await payload.create({
+          overrideAccess: true,
           collection: formSubmissionsSlug,
           data: {
             form: testForm.id,
@@ -1164,6 +1200,7 @@ describe('@payloadcms/plugin-form-builder', () => {
     describe('direct file upload via REST', () => {
       it('should upload file directly with form submission', async () => {
         const testForm = await payload.create({
+          overrideAccess: true,
           collection: formsSlug,
           data: {
             confirmationType: 'message',
@@ -1219,6 +1256,7 @@ describe('@payloadcms/plugin-form-builder', () => {
 
         // Verify the media document was created
         const mediaDoc = await payload.findByID({
+          overrideAccess: true,
           collection: mediaSlug,
           id: avatarMediaId,
         })
@@ -1230,6 +1268,7 @@ describe('@payloadcms/plugin-form-builder', () => {
 
       it('should reject direct upload when MIME type is not allowed', async () => {
         const testForm = await payload.create({
+          overrideAccess: true,
           collection: formsSlug,
           data: {
             confirmationType: 'message',
@@ -1274,6 +1313,7 @@ describe('@payloadcms/plugin-form-builder', () => {
 
       it('should create submission with mixed direct upload and other fields', async () => {
         const testForm = await payload.create({
+          overrideAccess: true,
           collection: formsSlug,
           data: {
             confirmationType: 'message',
@@ -1345,6 +1385,7 @@ describe('@payloadcms/plugin-form-builder', () => {
       it('should still accept pre-uploaded file IDs for backwards compatibility', async () => {
         // Pre-upload a file
         const mediaDoc = await payload.create({
+          overrideAccess: true,
           collection: mediaSlug,
           data: { alt: 'test' },
           filePath: testImagePath,
@@ -1353,6 +1394,7 @@ describe('@payloadcms/plugin-form-builder', () => {
         createdMediaIds.push(mediaDoc.id)
 
         const testForm = await payload.create({
+          overrideAccess: true,
           collection: formsSlug,
           data: {
             confirmationType: 'message',
@@ -1403,6 +1445,7 @@ describe('@payloadcms/plugin-form-builder', () => {
     describe('submissionUploads population', () => {
       it('should populate submissionUploads when direct file upload succeeds', async () => {
         const testForm = await payload.create({
+          overrideAccess: true,
           collection: formsSlug,
           data: {
             confirmationType: 'message',
@@ -1463,6 +1506,7 @@ describe('@payloadcms/plugin-form-builder', () => {
 
       it('should populate submissionUploads when pre-uploaded file ID is provided', async () => {
         const mediaDoc = await payload.create({
+          overrideAccess: true,
           collection: mediaSlug,
           data: { alt: 'pre-upload' },
           filePath: testImagePath,
@@ -1470,6 +1514,7 @@ describe('@payloadcms/plugin-form-builder', () => {
         createdMediaIds.push(mediaDoc.id)
 
         const testForm = await payload.create({
+          overrideAccess: true,
           collection: formsSlug,
           data: {
             confirmationType: 'message',
@@ -1512,6 +1557,7 @@ describe('@payloadcms/plugin-form-builder', () => {
 
       it('should not populate submissionUploads when form has no upload fields', async () => {
         const testForm = await payload.create({
+          overrideAccess: true,
           collection: formsSlug,
           data: {
             confirmationType: 'message',
@@ -1550,6 +1596,7 @@ describe('@payloadcms/plugin-form-builder', () => {
 
       it('should populate one submissionUploads entry per file for multiple direct uploads', async () => {
         const testForm = await payload.create({
+          overrideAccess: true,
           collection: formsSlug,
           data: {
             confirmationType: 'message',
@@ -1613,6 +1660,7 @@ describe('@payloadcms/plugin-form-builder', () => {
       it('should populate submissionUploads for hasMany + polymorphic (multi-file media + single document)', async () => {
         // Pre-upload two media files and one document
         const media1 = await payload.create({
+          overrideAccess: true,
           collection: mediaSlug,
           data: { alt: 'photo-1' },
           filePath: testImagePath,
@@ -1620,6 +1668,7 @@ describe('@payloadcms/plugin-form-builder', () => {
         createdMediaIds.push(media1.id)
 
         const media2 = await payload.create({
+          overrideAccess: true,
           collection: mediaSlug,
           data: { alt: 'photo-2' },
           filePath: testImagePath,
@@ -1627,6 +1676,7 @@ describe('@payloadcms/plugin-form-builder', () => {
         createdMediaIds.push(media2.id)
 
         const docFile = await payload.create({
+          overrideAccess: true,
           collection: documentsSlug,
           data: {},
           filePath: testPdfPath,
@@ -1634,6 +1684,7 @@ describe('@payloadcms/plugin-form-builder', () => {
         createdDocumentIds.push(docFile.id)
 
         const testForm = await payload.create({
+          overrideAccess: true,
           collection: formsSlug,
           data: {
             confirmationType: 'message',
@@ -1714,6 +1765,7 @@ describe('@payloadcms/plugin-form-builder', () => {
     describe('multiple guard', () => {
       it('should reject direct upload of multiple files when multiple is false', async () => {
         const testForm = await payload.create({
+          overrideAccess: true,
           collection: formsSlug,
           data: {
             confirmationType: 'message',
@@ -1769,11 +1821,13 @@ describe('@payloadcms/plugin-form-builder', () => {
 
       it('should reject comma-separated pre-uploaded IDs when multiple is false', async () => {
         const mediaDoc1 = await payload.create({
+          overrideAccess: true,
           collection: mediaSlug,
           data: { alt: 'first' },
           filePath: testImagePath,
         })
         const mediaDoc2 = await payload.create({
+          overrideAccess: true,
           collection: mediaSlug,
           data: { alt: 'second' },
           filePath: testImagePath,
@@ -1782,6 +1836,7 @@ describe('@payloadcms/plugin-form-builder', () => {
         createdMediaIds.push(mediaDoc1.id, mediaDoc2.id)
 
         const testForm = await payload.create({
+          overrideAccess: true,
           collection: formsSlug,
           data: {
             confirmationType: 'message',
@@ -1802,6 +1857,7 @@ describe('@payloadcms/plugin-form-builder', () => {
 
         await expect(
           payload.create({
+            overrideAccess: true,
             collection: formSubmissionsSlug,
             data: {
               form: testForm.id,
@@ -1818,6 +1874,7 @@ describe('@payloadcms/plugin-form-builder', () => {
         // To test the defence-in-depth guard in handleUploads, create a valid form and call
         // the hook directly with a formConfig that excludes the form's uploadCollection.
         const testForm = await payload.create({
+          overrideAccess: true,
           collection: formsSlug,
           data: {
             confirmationType: 'message',
@@ -1867,6 +1924,7 @@ describe('@payloadcms/plugin-form-builder', () => {
     describe('dangling doc cleanup', () => {
       it('should delete successfully created docs when a later file fails validation', async () => {
         const testForm = await payload.create({
+          overrideAccess: true,
           collection: formsSlug,
           data: {
             confirmationType: 'message',
@@ -1888,7 +1946,11 @@ describe('@payloadcms/plugin-form-builder', () => {
         createdFormIds.push(testForm.id)
 
         // Capture media count before the submission attempt
-        const mediaBefore = await payload.find({ collection: mediaSlug, limit: 0 })
+        const mediaBefore = await payload.find({
+          overrideAccess: true,
+          collection: mediaSlug,
+          limit: 0,
+        })
         const countBefore = mediaBefore.totalDocs
 
         const formData = new FormData()
@@ -1919,7 +1981,11 @@ describe('@payloadcms/plugin-form-builder', () => {
         expect(response.status).toBe(400)
 
         // The image doc created before the PDF validation failure should have been cleaned up
-        const mediaAfter = await payload.find({ collection: mediaSlug, limit: 0 })
+        const mediaAfter = await payload.find({
+          overrideAccess: true,
+          collection: mediaSlug,
+          limit: 0,
+        })
 
         expect(mediaAfter.totalDocs).toBe(countBefore)
       })

--- a/test/plugin-form-builder/seed/index.ts
+++ b/test/plugin-form-builder/seed/index.ts
@@ -8,6 +8,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
 
   try {
     await payload.create({
+      overrideAccess: true,
       collection: 'users',
       data: {
         email: 'demo@payloadcms.com',
@@ -17,6 +18,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
     })
 
     await payload.create({
+      overrideAccess: true,
       collection: pagesSlug,
       data: {
         slug: 'home',
@@ -26,6 +28,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
     })
 
     const { id: formID } = await payload.create({
+      overrideAccess: true,
       collection: formsSlug,
       data: {
         confirmationType: 'message',
@@ -79,6 +82,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
     })
 
     const { id: dateFormID } = await payload.create({
+      overrideAccess: true,
       collection: formsSlug,
       data: {
         confirmationType: 'message',
@@ -138,6 +142,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
     })
 
     await payload.create({
+      overrideAccess: true,
       collection: formSubmissionsSlug,
       data: {
         form: formID,
@@ -155,6 +160,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
     })
 
     await payload.create({
+      overrideAccess: true,
       collection: pagesSlug,
       data: {
         slug: 'contact',
@@ -165,6 +171,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
 
     // Create a form with upload field for e2e testing
     await payload.create({
+      overrideAccess: true,
       collection: formsSlug,
       data: {
         confirmationType: 'message',
@@ -220,6 +227,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
 
     // Create a form with optional upload and MIME type restrictions
     await payload.create({
+      overrideAccess: true,
       collection: formsSlug,
       data: {
         confirmationType: 'message',
@@ -276,6 +284,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
     // Create a form with multiple-file upload field (media) + single upload field (documents)
     // Used to test hasMany + polymorphic submissionUploads coverage
     await payload.create({
+      overrideAccess: true,
       collection: formsSlug,
       data: {
         confirmationType: 'message',

--- a/test/plugin-import-export/field-hooks.int.spec.ts
+++ b/test/plugin-import-export/field-hooks.int.spec.ts
@@ -22,6 +22,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
   beforeAll(async () => {
     ;({ payload, restClient } = await initPayloadInt(dirname))
     const loginResult = await payload.login({
+      overrideAccess: true,
       collection: 'users',
       data: { email: devUser.email, password: devUser.password },
     })
@@ -35,12 +36,17 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
 
   afterEach(async () => {
     const existing = await payload.find({
+      overrideAccess: true,
       collection: postsWithFieldHooksSlug,
       limit: 1000,
       pagination: false,
     })
     for (const doc of existing.docs) {
-      await payload.delete({ collection: postsWithFieldHooksSlug, id: doc.id })
+      await payload.delete({
+        overrideAccess: true,
+        collection: postsWithFieldHooksSlug,
+        id: doc.id,
+      })
     }
   })
 
@@ -51,11 +57,13 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
   describe('field-level export hooks', () => {
     it('should transform CSV output using field-level export hook', async () => {
       const post = await payload.create({
+        overrideAccess: true,
         collection: postsWithFieldHooksSlug,
         data: { customExport: 'raw value', title: 'Field Export Test' },
       })
 
       let exportDoc = await payload.create({
+        overrideAccess: true,
         collection: 'posts-with-field-hooks-export',
         data: {
           collectionSlug: postsWithFieldHooksSlug,
@@ -66,6 +74,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       })
 
       exportDoc = await payload.findByID({
+        overrideAccess: true,
         id: exportDoc.id,
         collection: 'posts-with-field-hooks-export',
       })
@@ -79,11 +88,13 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
 
     it('should receive format: csv during CSV export', async () => {
       const post = await payload.create({
+        overrideAccess: true,
         collection: postsWithFieldHooksSlug,
         data: { customExport: 'test', title: 'Format CSV Test' },
       })
 
       let exportDoc = await payload.create({
+        overrideAccess: true,
         collection: 'posts-with-field-hooks-export',
         data: {
           collectionSlug: postsWithFieldHooksSlug,
@@ -94,6 +105,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       })
 
       exportDoc = await payload.findByID({
+        overrideAccess: true,
         id: exportDoc.id,
         collection: 'posts-with-field-hooks-export',
       })
@@ -107,11 +119,13 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
 
     it('should receive format: json during JSON export', async () => {
       const post = await payload.create({
+        overrideAccess: true,
         collection: postsWithFieldHooksSlug,
         data: { customExport: 'test', title: 'Format JSON Test' },
       })
 
       let exportDoc = await payload.create({
+        overrideAccess: true,
         collection: 'posts-with-field-hooks-export',
         data: {
           collectionSlug: postsWithFieldHooksSlug,
@@ -122,6 +136,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       })
 
       exportDoc = await payload.findByID({
+        overrideAccess: true,
         id: exportDoc.id,
         collection: 'posts-with-field-hooks-export',
       })
@@ -135,6 +150,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
 
     it('should transform deeply nested fields (group > named tab > field)', async () => {
       const post = await payload.create({
+        overrideAccess: true,
         collection: postsWithFieldHooksSlug,
         data: {
           group: { namedTab: { deepField: 'deep value' } },
@@ -143,6 +159,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       })
 
       let exportDoc = await payload.create({
+        overrideAccess: true,
         collection: 'posts-with-field-hooks-export',
         data: {
           collectionSlug: postsWithFieldHooksSlug,
@@ -153,6 +170,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       })
 
       exportDoc = await payload.findByID({
+        overrideAccess: true,
         id: exportDoc.id,
         collection: 'posts-with-field-hooks-export',
       })
@@ -166,6 +184,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
 
     it('should transform deeply nested fields in CSV preview (group > named tab > field)', async () => {
       const post = await payload.create({
+        overrideAccess: true,
         collection: postsWithFieldHooksSlug,
         data: {
           group: { namedTab: { deepField: 'preview deep value' } },
@@ -208,6 +227,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       }
 
       let importDoc = await payload.create({
+        overrideAccess: true,
         collection: 'posts-with-field-hooks-import',
         data: { collectionSlug: postsWithFieldHooksSlug, importMode: 'create' },
         file,
@@ -215,6 +235,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       })
 
       importDoc = await payload.findByID({
+        overrideAccess: true,
         id: importDoc.id,
         collection: 'posts-with-field-hooks-import',
       })
@@ -223,6 +244,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
 
       // Import hook appends '_imported_csv' to the value
       const imported = await payload.find({
+        overrideAccess: true,
         collection: postsWithFieldHooksSlug,
         where: { customImport: { equals: 'original_value_imported_csv' } },
       })
@@ -241,6 +263,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       }
 
       let importDoc = await payload.create({
+        overrideAccess: true,
         collection: 'posts-with-field-hooks-import',
         data: {
           collectionSlug: postsWithFieldHooksSlug,
@@ -252,6 +275,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       })
 
       importDoc = await payload.findByID({
+        overrideAccess: true,
         id: importDoc.id,
         collection: 'posts-with-field-hooks-import',
       })
@@ -260,6 +284,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
 
       // Import hook appends '_imported_json' to the value
       const imported = await payload.find({
+        overrideAccess: true,
         collection: postsWithFieldHooksSlug,
         where: { customImport: { equals: 'json_value_imported_json' } },
       })
@@ -274,6 +299,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
   describe('synthetic import hooks should not clobber existing data with empty cells', () => {
     it('should preserve existing number value when CSV update row has a blank count cell', async () => {
       const existing = await payload.create({
+        overrideAccess: true,
         collection: postsWithFieldHooksSlug,
         data: { count: 5, title: 'Empty Cell Update Number Test' },
       })
@@ -287,6 +313,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       }
 
       let importDoc = await payload.create({
+        overrideAccess: true,
         collection: 'posts-with-field-hooks-import',
         data: {
           collectionSlug: postsWithFieldHooksSlug,
@@ -298,6 +325,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       })
 
       importDoc = await payload.findByID({
+        overrideAccess: true,
         id: importDoc.id,
         collection: 'posts-with-field-hooks-import',
       })
@@ -305,6 +333,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       expect(importDoc.status).toBe('completed')
 
       const after = await payload.findByID({
+        overrideAccess: true,
         id: existing.id,
         collection: postsWithFieldHooksSlug,
       })
@@ -324,11 +353,13 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       // The field-level hook transforms the value first, then collection-level
       // hook can see the already-transformed data.
       const post = await payload.create({
+        overrideAccess: true,
         collection: postsWithFieldHooksSlug,
         data: { customExport: 'raw', title: 'Order Test' },
       })
 
       let exportDoc = await payload.create({
+        overrideAccess: true,
         collection: 'posts-with-field-hooks-export',
         data: {
           collectionSlug: postsWithFieldHooksSlug,
@@ -339,6 +370,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       })
 
       exportDoc = await payload.findByID({
+        overrideAccess: true,
         id: exportDoc.id,
         collection: 'posts-with-field-hooks-export',
       })
@@ -359,11 +391,13 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
   describe('reusable field configs', () => {
     it('should apply field-level hooks from a shared field definition', async () => {
       const post = await payload.create({
+        overrideAccess: true,
         collection: postsWithFieldHooksSlug,
         data: { email: 'USER@EXAMPLE.COM', title: 'Reusable Field Test' },
       })
 
       let exportDoc = await payload.create({
+        overrideAccess: true,
         collection: 'posts-with-field-hooks-export',
         data: {
           collectionSlug: postsWithFieldHooksSlug,
@@ -374,6 +408,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       })
 
       exportDoc = await payload.findByID({
+        overrideAccess: true,
         id: exportDoc.id,
         collection: 'posts-with-field-hooks-export',
       })
@@ -394,11 +429,13 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
     it('should use default flattening when export hook returns undefined', async () => {
       // A field without any hooks should flatten normally (default behavior)
       const post = await payload.create({
+        overrideAccess: true,
         collection: postsWithFieldHooksSlug,
         data: { secret: 'plain-text', title: 'Default Behavior Test' },
       })
 
       let exportDoc = await payload.create({
+        overrideAccess: true,
         collection: 'posts-with-field-hooks-export',
         data: {
           collectionSlug: postsWithFieldHooksSlug,
@@ -409,6 +446,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       })
 
       exportDoc = await payload.findByID({
+        overrideAccess: true,
         id: exportDoc.id,
         collection: 'posts-with-field-hooks-export',
       })
@@ -428,6 +466,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
   describe('field-level hooks inside arrays', () => {
     it('should run field-level export hook on array item sub-fields (CSV)', async () => {
       const post = await payload.create({
+        overrideAccess: true,
         collection: postsWithFieldHooksSlug,
         data: {
           items: [{ note: 'first' }, { note: 'second' }],
@@ -436,6 +475,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       })
 
       let exportDoc = await payload.create({
+        overrideAccess: true,
         collection: 'posts-with-field-hooks-export',
         data: {
           collectionSlug: postsWithFieldHooksSlug,
@@ -446,6 +486,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       })
 
       exportDoc = await payload.findByID({
+        overrideAccess: true,
         id: exportDoc.id,
         collection: 'posts-with-field-hooks-export',
       })
@@ -459,6 +500,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
 
     it('should run field-level export hook on array item sub-fields (JSON)', async () => {
       const post = await payload.create({
+        overrideAccess: true,
         collection: postsWithFieldHooksSlug,
         data: {
           items: [{ note: 'alpha' }, { note: 'beta' }],
@@ -467,6 +509,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       })
 
       let exportDoc = await payload.create({
+        overrideAccess: true,
         collection: 'posts-with-field-hooks-export',
         data: {
           collectionSlug: postsWithFieldHooksSlug,
@@ -477,6 +520,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       })
 
       exportDoc = await payload.findByID({
+        overrideAccess: true,
         id: exportDoc.id,
         collection: 'posts-with-field-hooks-export',
       })
@@ -498,6 +542,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       }
 
       let importDoc = await payload.create({
+        overrideAccess: true,
         collection: 'posts-with-field-hooks-import',
         data: { collectionSlug: postsWithFieldHooksSlug, importMode: 'create' },
         file,
@@ -505,6 +550,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       })
 
       importDoc = await payload.findByID({
+        overrideAccess: true,
         id: importDoc.id,
         collection: 'posts-with-field-hooks-import',
       })
@@ -512,6 +558,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       expect(importDoc.status).toBe('completed')
 
       const imported = await payload.find({
+        overrideAccess: true,
         collection: postsWithFieldHooksSlug,
         where: { title: { equals: 'Array Import CSV' } },
       })
@@ -532,6 +579,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       }
 
       let importDoc = await payload.create({
+        overrideAccess: true,
         collection: 'posts-with-field-hooks-import',
         data: {
           collectionSlug: postsWithFieldHooksSlug,
@@ -543,6 +591,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       })
 
       importDoc = await payload.findByID({
+        overrideAccess: true,
         id: importDoc.id,
         collection: 'posts-with-field-hooks-import',
       })
@@ -550,6 +599,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       expect(importDoc.status).toBe('completed')
 
       const imported = await payload.find({
+        overrideAccess: true,
         collection: postsWithFieldHooksSlug,
         where: { title: { equals: 'Array Import JSON' } },
       })
@@ -562,6 +612,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
   describe('field-level hooks inside blocks', () => {
     it('should run field-level export hook on block sub-fields (CSV)', async () => {
       const post = await payload.create({
+        overrideAccess: true,
         collection: postsWithFieldHooksSlug,
         data: {
           content: [
@@ -573,6 +624,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       })
 
       let exportDoc = await payload.create({
+        overrideAccess: true,
         collection: 'posts-with-field-hooks-export',
         data: {
           collectionSlug: postsWithFieldHooksSlug,
@@ -583,6 +635,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       })
 
       exportDoc = await payload.findByID({
+        overrideAccess: true,
         id: exportDoc.id,
         collection: 'posts-with-field-hooks-export',
       })
@@ -596,6 +649,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
 
     it('should run field-level export hook on block sub-fields (JSON)', async () => {
       const post = await payload.create({
+        overrideAccess: true,
         collection: postsWithFieldHooksSlug,
         data: {
           content: [{ blockType: 'textBlock', body: 'foo' }],
@@ -604,6 +658,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       })
 
       let exportDoc = await payload.create({
+        overrideAccess: true,
         collection: 'posts-with-field-hooks-export',
         data: {
           collectionSlug: postsWithFieldHooksSlug,
@@ -614,6 +669,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       })
 
       exportDoc = await payload.findByID({
+        overrideAccess: true,
         id: exportDoc.id,
         collection: 'posts-with-field-hooks-export',
       })
@@ -634,6 +690,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       }
 
       let importDoc = await payload.create({
+        overrideAccess: true,
         collection: 'posts-with-field-hooks-import',
         data: { collectionSlug: postsWithFieldHooksSlug, importMode: 'create' },
         file,
@@ -641,6 +698,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       })
 
       importDoc = await payload.findByID({
+        overrideAccess: true,
         id: importDoc.id,
         collection: 'posts-with-field-hooks-import',
       })
@@ -648,6 +706,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       expect(importDoc.status).toBe('completed')
 
       const imported = await payload.find({
+        overrideAccess: true,
         collection: postsWithFieldHooksSlug,
         where: { title: { equals: 'Blocks Import CSV' } },
       })
@@ -670,6 +729,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       }
 
       let importDoc = await payload.create({
+        overrideAccess: true,
         collection: 'posts-with-field-hooks-import',
         data: {
           collectionSlug: postsWithFieldHooksSlug,
@@ -681,6 +741,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       })
 
       importDoc = await payload.findByID({
+        overrideAccess: true,
         id: importDoc.id,
         collection: 'posts-with-field-hooks-import',
       })
@@ -688,6 +749,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       expect(importDoc.status).toBe('completed')
 
       const imported = await payload.find({
+        overrideAccess: true,
         collection: postsWithFieldHooksSlug,
         where: { title: { equals: 'Blocks Import JSON' } },
       })
@@ -720,6 +782,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       }
 
       let importDoc = await payload.create({
+        overrideAccess: true,
         collection: 'posts-with-field-hooks-import',
         data: {
           collectionSlug: postsWithFieldHooksSlug,
@@ -731,6 +794,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       })
 
       importDoc = await payload.findByID({
+        overrideAccess: true,
         id: importDoc.id,
         collection: 'posts-with-field-hooks-import',
       })
@@ -738,6 +802,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       expect(importDoc.status).toBe('completed')
 
       const imported = await payload.find({
+        overrideAccess: true,
         collection: postsWithFieldHooksSlug,
         where: { title: { equals: 'Sibling Echo Test' } },
       })
@@ -767,6 +832,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       }
 
       let importDoc = await payload.create({
+        overrideAccess: true,
         collection: 'posts-with-field-hooks-import',
         data: { collectionSlug: postsWithFieldHooksSlug, importMode: 'create' },
         file,
@@ -774,6 +840,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       })
 
       importDoc = await payload.findByID({
+        overrideAccess: true,
         id: importDoc.id,
         collection: 'posts-with-field-hooks-import',
       })
@@ -781,6 +848,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       expect(importDoc.status).toBe('completed')
 
       const imported = await payload.find({
+        overrideAccess: true,
         collection: postsWithFieldHooksSlug,
         sort: 'title',
         where: { title: { in: ['Crash Row 1', 'Crash Row 2', 'Crash Row 3'] } },
@@ -807,6 +875,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       }
 
       let importDoc = await payload.create({
+        overrideAccess: true,
         collection: 'posts-with-field-hooks-import',
         data: {
           collectionSlug: postsWithFieldHooksSlug,
@@ -818,6 +887,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       })
 
       importDoc = await payload.findByID({
+        overrideAccess: true,
         id: importDoc.id,
         collection: 'posts-with-field-hooks-import',
       })
@@ -825,6 +895,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       expect(importDoc.status).toBe('completed')
 
       const imported = await payload.find({
+        overrideAccess: true,
         collection: postsWithFieldHooksSlug,
         sort: 'title',
         where: { title: { in: ['JSON Crash 1', 'JSON Crash 2', 'JSON Crash 3'] } },
@@ -840,20 +911,24 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
     it('should isolate a thrown beforeExport hook to its doc during CSV export', async () => {
       const docs = await Promise.all([
         payload.create({
+          overrideAccess: true,
           collection: postsWithFieldHooksSlug,
           data: { mayCrash: 'safe-a', title: 'Export Crash A' },
         }),
         payload.create({
+          overrideAccess: true,
           collection: postsWithFieldHooksSlug,
           data: { mayCrash: 'CRASH', title: 'Export Crash B' },
         }),
         payload.create({
+          overrideAccess: true,
           collection: postsWithFieldHooksSlug,
           data: { mayCrash: 'safe-c', title: 'Export Crash C' },
         }),
       ])
 
       let exportDoc = await payload.create({
+        overrideAccess: true,
         collection: 'posts-with-field-hooks-export',
         data: {
           collectionSlug: postsWithFieldHooksSlug,
@@ -864,6 +939,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       })
 
       exportDoc = await payload.findByID({
+        overrideAccess: true,
         id: exportDoc.id,
         collection: 'posts-with-field-hooks-export',
       })
@@ -881,20 +957,24 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
     it('should isolate a thrown beforeExport hook to its doc during JSON export', async () => {
       const docs = await Promise.all([
         payload.create({
+          overrideAccess: true,
           collection: postsWithFieldHooksSlug,
           data: { mayCrash: 'json-safe-a', title: 'JSON Export Crash A' },
         }),
         payload.create({
+          overrideAccess: true,
           collection: postsWithFieldHooksSlug,
           data: { mayCrash: 'CRASH', title: 'JSON Export Crash B' },
         }),
         payload.create({
+          overrideAccess: true,
           collection: postsWithFieldHooksSlug,
           data: { mayCrash: 'json-safe-c', title: 'JSON Export Crash C' },
         }),
       ])
 
       let exportDoc = await payload.create({
+        overrideAccess: true,
         collection: 'posts-with-field-hooks-export',
         data: {
           collectionSlug: postsWithFieldHooksSlug,
@@ -905,6 +985,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       })
 
       exportDoc = await payload.findByID({
+        overrideAccess: true,
         id: exportDoc.id,
         collection: 'posts-with-field-hooks-export',
       })
@@ -932,11 +1013,13 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
   describe('field-level hooks under unnamed presentational wrappers', () => {
     it('should fire export hook on a field nested in a row wrapper (CSV)', async () => {
       const post = await payload.create({
+        overrideAccess: true,
         collection: postsWithFieldHooksSlug,
         data: { rowField: 'inside-row', title: 'Row Wrapper Export' },
       })
 
       let exportDoc = await payload.create({
+        overrideAccess: true,
         collection: 'posts-with-field-hooks-export',
         data: {
           collectionSlug: postsWithFieldHooksSlug,
@@ -947,6 +1030,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       })
 
       exportDoc = await payload.findByID({
+        overrideAccess: true,
         id: exportDoc.id,
         collection: 'posts-with-field-hooks-export',
       })
@@ -967,6 +1051,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       }
 
       let importDoc = await payload.create({
+        overrideAccess: true,
         collection: 'posts-with-field-hooks-import',
         data: { collectionSlug: postsWithFieldHooksSlug, importMode: 'create' },
         file,
@@ -974,6 +1059,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       })
 
       importDoc = await payload.findByID({
+        overrideAccess: true,
         id: importDoc.id,
         collection: 'posts-with-field-hooks-import',
       })
@@ -981,6 +1067,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       expect(importDoc.status).toBe('completed')
 
       const imported = await payload.find({
+        overrideAccess: true,
         collection: postsWithFieldHooksSlug,
         where: { title: { equals: 'Row Wrapper Import' } },
       })
@@ -990,11 +1077,13 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
 
     it('should fire export hook on a field nested in a collapsible wrapper (CSV)', async () => {
       const post = await payload.create({
+        overrideAccess: true,
         collection: postsWithFieldHooksSlug,
         data: { collapsibleField: 'inside-collapsible', title: 'Collapsible Wrapper Export' },
       })
 
       let exportDoc = await payload.create({
+        overrideAccess: true,
         collection: 'posts-with-field-hooks-export',
         data: {
           collectionSlug: postsWithFieldHooksSlug,
@@ -1005,6 +1094,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       })
 
       exportDoc = await payload.findByID({
+        overrideAccess: true,
         id: exportDoc.id,
         collection: 'posts-with-field-hooks-export',
       })
@@ -1025,6 +1115,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       }
 
       let importDoc = await payload.create({
+        overrideAccess: true,
         collection: 'posts-with-field-hooks-import',
         data: { collectionSlug: postsWithFieldHooksSlug, importMode: 'create' },
         file,
@@ -1032,6 +1123,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       })
 
       importDoc = await payload.findByID({
+        overrideAccess: true,
         id: importDoc.id,
         collection: 'posts-with-field-hooks-import',
       })
@@ -1039,6 +1131,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       expect(importDoc.status).toBe('completed')
 
       const imported = await payload.find({
+        overrideAccess: true,
         collection: postsWithFieldHooksSlug,
         where: { title: { equals: 'Collapsible Wrapper Import' } },
       })
@@ -1062,6 +1155,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       }
 
       let importDoc = await payload.create({
+        overrideAccess: true,
         collection: 'posts-with-field-hooks-import',
         data: {
           collectionSlug: postsWithFieldHooksSlug,
@@ -1073,6 +1167,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       })
 
       importDoc = await payload.findByID({
+        overrideAccess: true,
         id: importDoc.id,
         collection: 'posts-with-field-hooks-import',
       })
@@ -1080,6 +1175,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       expect(importDoc.status).toBe('completed')
 
       const imported = await payload.find({
+        overrideAccess: true,
         collection: postsWithFieldHooksSlug,
         where: { title: { equals: 'Top Doc Access' } },
       })

--- a/test/plugin-import-export/hooks.int.spec.ts
+++ b/test/plugin-import-export/hooks.int.spec.ts
@@ -25,6 +25,7 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
   beforeAll(async () => {
     ;({ payload, restClient } = await initPayloadInt(dirname))
     const loginResult = await payload.login({
+      overrideAccess: true,
       collection: 'users',
       data: { email: devUser.email, password: devUser.password },
     })
@@ -40,7 +41,7 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
     resetHookSpies()
     for (const id of createdHookPostIDs) {
       await payload
-        .delete({ collection: postsWithHooksSlug, id })
+        .delete({ overrideAccess: true, collection: postsWithHooksSlug, id })
         .catch((err) => payload.logger.warn({ err, id, msg: 'hooks.int.spec cleanup failed' }))
     }
     createdHookPostIDs.length = 0
@@ -53,12 +54,14 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
   describe('export hooks', () => {
     it('should call export.hooks.before with correct args and apply its return value to CSV output', async () => {
       const post = await payload.create({
+        overrideAccess: true,
         collection: postsWithHooksSlug,
         data: { title: 'Hook Test', secret: 'top-secret', count: 1 },
       })
       createdHookPostIDs.push(post.id)
 
       let exportDoc = await payload.create({
+        overrideAccess: true,
         collection: 'posts-with-hooks-export',
         user,
         data: {
@@ -69,6 +72,7 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
       })
 
       exportDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'posts-with-hooks-export',
         id: exportDoc.id,
       })
@@ -96,12 +100,14 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
 
     it('should call export.hooks.after with correct args after write', async () => {
       const post = await payload.create({
+        overrideAccess: true,
         collection: postsWithHooksSlug,
         data: { title: 'After Hook Test', secret: 'hidden', count: 2 },
       })
       createdHookPostIDs.push(post.id)
 
       let exportDoc = await payload.create({
+        overrideAccess: true,
         collection: 'posts-with-hooks-export',
         user,
         data: {
@@ -112,6 +118,7 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
       })
 
       exportDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'posts-with-hooks-export',
         id: exportDoc.id,
       })
@@ -129,12 +136,14 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
 
     it('should call export.hooks.before for JSON exports with nested docs', async () => {
       const post = await payload.create({
+        overrideAccess: true,
         collection: postsWithHooksSlug,
         data: { title: 'JSON Hook Test', secret: 'json-secret', count: 3 },
       })
       createdHookPostIDs.push(post.id)
 
       let exportDoc = await payload.create({
+        overrideAccess: true,
         collection: 'posts-with-hooks-export',
         user,
         data: {
@@ -145,6 +154,7 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
       })
 
       exportDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'posts-with-hooks-export',
         id: exportDoc.id,
       })
@@ -164,6 +174,7 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
       const posts = await Promise.all(
         Array.from({ length: 5 }, (_, i) =>
           payload.create({
+            overrideAccess: true,
             collection: postsWithHooksSlug,
             data: { title: `Batch Post ${i}`, count: i },
           }),
@@ -173,6 +184,7 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
 
       // posts-with-hooks is configured with batchSize: 2 — 5 docs → 3 batches
       let exportDoc = await payload.create({
+        overrideAccess: true,
         collection: 'posts-with-hooks-export',
         user,
         data: {
@@ -182,6 +194,7 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
       })
 
       exportDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'posts-with-hooks-export',
         id: exportDoc.id,
       })
@@ -196,6 +209,7 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
 
     it('should call export.hooks.before via streaming download', async () => {
       const post = await payload.create({
+        overrideAccess: true,
         collection: postsWithHooksSlug,
         data: { title: 'Download Hook Test', secret: 'streamed-secret', count: 4 },
       })
@@ -235,6 +249,7 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
       }
 
       let importDoc = await payload.create({
+        overrideAccess: true,
         collection: 'posts-with-hooks-import',
         user,
         data: { collectionSlug: postsWithHooksSlug, importMode: 'create' },
@@ -242,6 +257,7 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
       })
 
       importDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'posts-with-hooks-import',
         id: importDoc.id,
       })
@@ -262,6 +278,7 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
 
       // before hook appends '_imported' to title — verify it landed in DB
       const importedDocs = await payload.find({
+        overrideAccess: true,
         collection: postsWithHooksSlug,
         where: { title: { equals: 'Original Title_imported' } },
       })
@@ -279,6 +296,7 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
       }
 
       let importDoc = await payload.create({
+        overrideAccess: true,
         collection: 'posts-with-hooks-import',
         user,
         data: { collectionSlug: postsWithHooksSlug, importMode: 'create' },
@@ -286,6 +304,7 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
       })
 
       importDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'posts-with-hooks-import',
         id: importDoc.id,
       })
@@ -301,6 +320,7 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
       expect(afterArgs.result.errors).toHaveLength(0)
 
       const imported = await payload.find({
+        overrideAccess: true,
         collection: postsWithHooksSlug,
         where: { title: { equals: 'After Hook Post_imported' } },
       })
@@ -317,6 +337,7 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
       }
 
       let importDoc = await payload.create({
+        overrideAccess: true,
         collection: 'posts-with-hooks-import',
         user,
         data: { collectionSlug: postsWithHooksSlug, importMode: 'create' },
@@ -324,6 +345,7 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
       })
 
       importDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'posts-with-hooks-import',
         id: importDoc.id,
       })
@@ -337,6 +359,7 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
       expect(afterArgs.originalData[0]).toMatchObject({ title: 'OriginalData Post', count: 42 })
 
       const imported = await payload.find({
+        overrideAccess: true,
         collection: postsWithHooksSlug,
         where: { title: { equals: 'OriginalData Post_imported' } },
       })
@@ -353,6 +376,7 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
       }
 
       let importDoc = await payload.create({
+        overrideAccess: true,
         collection: 'posts-with-hooks-import',
         user,
         data: { collectionSlug: postsWithHooksSlug, importMode: 'create', format: 'json' },
@@ -360,6 +384,7 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
       })
 
       importDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'posts-with-hooks-import',
         id: importDoc.id,
       })
@@ -369,6 +394,7 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
       expect(hookCalls.importBefore[0]!.format).toBe('json')
 
       const imported = await payload.find({
+        overrideAccess: true,
         collection: postsWithHooksSlug,
         where: { title: { equals: 'JSON Import Hook_imported' } },
       })
@@ -393,6 +419,7 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
       }
 
       let importDoc = await payload.create({
+        overrideAccess: true,
         collection: 'posts-with-hooks-import',
         user,
         data: { collectionSlug: postsWithHooksSlug, importMode: 'create', format: 'json' },
@@ -400,6 +427,7 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
       })
 
       importDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'posts-with-hooks-import',
         id: importDoc.id,
       })
@@ -421,6 +449,7 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
       expect(afterOriginalData.email).toBe('TEST@EXAMPLE.COM')
 
       const imported = await payload.find({
+        overrideAccess: true,
         collection: postsWithHooksSlug,
         where: { title: { equals: 'JSON Original Data Test_imported' } },
       })
@@ -439,6 +468,7 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
 
       // posts-with-hooks is configured with batchSize: 2 — 4 rows → 2 batches
       let importDoc = await payload.create({
+        overrideAccess: true,
         collection: 'posts-with-hooks-import',
         user,
         data: {
@@ -449,6 +479,7 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
       })
 
       importDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'posts-with-hooks-import',
         id: importDoc.id,
       })
@@ -460,6 +491,7 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
       expect(hookCalls.importBefore[0]!.totalBatches).toBe(2)
 
       const imported = await payload.find({
+        overrideAccess: true,
         collection: postsWithHooksSlug,
         where: { title: { contains: 'Batch Import' } },
         limit: 10,
@@ -473,19 +505,21 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
 
     afterEach(async () => {
       for (const id of createdIDs) {
-        await payload.delete({ collection: postsWithColumnMapSlug, id })
+        await payload.delete({ overrideAccess: true, collection: postsWithColumnMapSlug, id })
       }
       createdIDs.length = 0
     })
 
     it('should rename CSV columns via collection-level export.hooks.before', async () => {
       const post = await payload.create({
+        overrideAccess: true,
         collection: postsWithColumnMapSlug,
         data: { title: 'Rename Me', excerpt: 'Original excerpt', count: 42 },
       })
       createdIDs.push(post.id)
 
       let exportDoc = await payload.create({
+        overrideAccess: true,
         collection: 'posts-with-column-map-export',
         user,
         data: {
@@ -496,6 +530,7 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
       })
 
       exportDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'posts-with-column-map-export',
         id: exportDoc.id,
       })
@@ -514,12 +549,14 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
 
     it('should rename a single CSV column via field-level beforeExport mutation', async () => {
       const post = await payload.create({
+        overrideAccess: true,
         collection: postsWithColumnMapSlug,
         data: { title: 'Field Rename', excerpt: 'x', count: 1, sharedName: 'shared value' },
       })
       createdIDs.push(post.id)
 
       let exportDoc = await payload.create({
+        overrideAccess: true,
         collection: 'posts-with-column-map-export',
         user,
         data: {
@@ -530,6 +567,7 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
       })
 
       exportDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'posts-with-column-map-export',
         id: exportDoc.id,
       })
@@ -543,6 +581,7 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
 
     it('should reflect collection-level export.hooks.before in CSV export preview', async () => {
       const post = await payload.create({
+        overrideAccess: true,
         collection: postsWithColumnMapSlug,
         data: { title: 'Preview Rename', excerpt: 'preview excerpt', count: 11 },
       })
@@ -580,6 +619,7 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
 
     it('should reflect collection-level export.hooks.before in JSON export preview', async () => {
       const post = await payload.create({
+        overrideAccess: true,
         collection: postsWithColumnMapSlug,
         data: { title: 'JSON Preview Rename', excerpt: 'json preview', count: 22 },
       })
@@ -608,12 +648,14 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
 
     it('should rename JSON keys via collection-level export.hooks.before', async () => {
       const post = await payload.create({
+        overrideAccess: true,
         collection: postsWithColumnMapSlug,
         data: { title: 'JSON Rename', excerpt: 'json excerpt', count: 7 },
       })
       createdIDs.push(post.id)
 
       let exportDoc = await payload.create({
+        overrideAccess: true,
         collection: 'posts-with-column-map-export',
         user,
         data: {
@@ -624,6 +666,7 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
       })
 
       exportDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'posts-with-column-map-export',
         id: exportDoc.id,
       })
@@ -645,7 +688,7 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
     afterEach(async () => {
       for (const id of createdIDs) {
         await payload
-          .delete({ collection: postsWithColumnMapSlug, id })
+          .delete({ overrideAccess: true, collection: postsWithColumnMapSlug, id })
           .catch((err) => payload.logger.warn({ err, id, msg: 'column-map cleanup failed' }))
       }
       createdIDs.length = 0
@@ -664,6 +707,7 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
       }
 
       const importDoc = await payload.create({
+        overrideAccess: true,
         collection: 'posts-with-column-map-import',
         user,
         data: {
@@ -676,6 +720,7 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
       expect(importDoc.id).toBeDefined()
 
       const imported = await payload.find({
+        overrideAccess: true,
         collection: postsWithColumnMapSlug,
         sort: 'title',
         where: { title: { in: ['Imported A', 'Imported B'] } },
@@ -714,6 +759,7 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
       }
 
       await payload.create({
+        overrideAccess: true,
         collection: 'posts-with-column-map-import',
         user,
         data: {
@@ -724,6 +770,7 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
       })
 
       const imported = await payload.find({
+        overrideAccess: true,
         collection: postsWithColumnMapSlug,
         sort: 'title',
         where: { title: { in: ['JSON A', 'JSON B'] } },
@@ -811,6 +858,7 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
       }
 
       await payload.create({
+        overrideAccess: true,
         collection: 'posts-with-column-map-import',
         user,
         data: {
@@ -821,6 +869,7 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
       })
 
       const imported = await payload.find({
+        overrideAccess: true,
         collection: postsWithColumnMapSlug,
         where: { title: { equals: 'Dropped Test' } },
       })

--- a/test/plugin-import-export/int.spec.ts
+++ b/test/plugin-import-export/int.spec.ts
@@ -28,6 +28,7 @@ describe('@payloadcms/plugin-import-export', () => {
   beforeAll(async () => {
     ;({ payload, restClient } = await initPayloadInt(dirname))
     const loginResult = await payload.login({
+      overrideAccess: true,
       collection: 'users',
       data: {
         email: devUser.email,
@@ -37,6 +38,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
     user = loginResult.user!
     const userDocs = await payload.find({
+      overrideAccess: true,
       collection: 'users',
       where: {
         email: { equals: regularUser.email },
@@ -93,6 +95,7 @@ describe('@payloadcms/plugin-import-export', () => {
   describe('exports', () => {
     it('should create a file for collection csv from defined fields', async () => {
       let doc = await payload.create({
+        overrideAccess: true,
         collection: 'exports',
         user,
         data: {
@@ -107,9 +110,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       doc = await payload.findByID({
+        overrideAccess: true,
         collection: 'exports',
         id: doc.id,
       })
@@ -129,6 +133,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
     it('should create a file for collection csv with all documents when limit 0', async () => {
       let doc = await payload.create({
+        overrideAccess: true,
         collection: 'exports',
         user,
         data: {
@@ -138,14 +143,16 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       doc = await payload.findByID({
+        overrideAccess: true,
         collection: 'exports',
         id: doc.id,
       })
 
       const { totalDocs: totalNumberOfDocs } = await payload.count({
+        overrideAccess: true,
         collection: 'pages',
       })
 
@@ -158,6 +165,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
     it('should create a file for collection csv with all documents when no limit', async () => {
       let doc = await payload.create({
+        overrideAccess: true,
         collection: 'exports',
         user,
         data: {
@@ -166,14 +174,16 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       doc = await payload.findByID({
+        overrideAccess: true,
         collection: 'exports',
         id: doc.id,
       })
 
       const { totalDocs: totalNumberOfDocs } = await payload.count({
+        overrideAccess: true,
         collection: 'pages',
       })
 
@@ -186,6 +196,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
     it('should create a file for collection csv from limit and page 1', async () => {
       let doc = await payload.create({
+        overrideAccess: true,
         collection: 'exports',
         user,
         data: {
@@ -196,14 +207,16 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       doc = await payload.findByID({
+        overrideAccess: true,
         collection: 'exports',
         id: doc.id,
       })
 
       const pages = await payload.find({
+        overrideAccess: true,
         collection: 'pages',
         limit: 100,
         page: 1,
@@ -221,6 +234,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
     it('should create a file for collection csv from limit and page 2', async () => {
       let doc = await payload.create({
+        overrideAccess: true,
         collection: 'exports',
         user,
         data: {
@@ -231,14 +245,16 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       doc = await payload.findByID({
+        overrideAccess: true,
         collection: 'exports',
         id: doc.id,
       })
 
       const pages = await payload.find({
+        overrideAccess: true,
         collection: 'pages',
         limit: 100,
         page: 2,
@@ -257,6 +273,7 @@ describe('@payloadcms/plugin-import-export', () => {
     it('should not create a file for collection csv when limit < 0', async () => {
       await expect(
         payload.create({
+          overrideAccess: true,
           collection: 'exports',
           user,
           data: {
@@ -270,6 +287,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
     it('should create a file for collection csv with any positive limit value', async () => {
       let doc = await payload.create({
+        overrideAccess: true,
         collection: 'exports',
         user,
         data: {
@@ -279,9 +297,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       doc = await payload.findByID({
+        overrideAccess: true,
         collection: 'exports',
         id: doc.id,
       })
@@ -291,6 +310,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
     it('should export results sorted ASC by title when sort="title"', async () => {
       let doc = await payload.create({
+        overrideAccess: true,
         collection: 'exports',
         user,
         data: {
@@ -303,9 +323,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       doc = await payload.findByID({
+        overrideAccess: true,
         collection: 'exports',
         id: doc.id,
       })
@@ -320,6 +341,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
     it('should export results sorted DESC by title when sort="-title"', async () => {
       let doc = await payload.create({
+        overrideAccess: true,
         collection: 'exports',
         user,
         data: {
@@ -332,9 +354,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       doc = await payload.findByID({
+        overrideAccess: true,
         collection: 'exports',
         id: doc.id,
       })
@@ -349,6 +372,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
     it('should create a file for collection csv with draft data', async () => {
       const draftPage = await payload.create({
+        overrideAccess: true,
         collection: 'pages',
         user,
         data: {
@@ -358,6 +382,7 @@ describe('@payloadcms/plugin-import-export', () => {
       })
 
       await payload.update({
+        overrideAccess: true,
         collection: 'pages',
         id: draftPage.id,
         data: {
@@ -367,6 +392,7 @@ describe('@payloadcms/plugin-import-export', () => {
       })
 
       let doc = await payload.create({
+        overrideAccess: true,
         collection: 'exports',
         user,
         data: {
@@ -380,9 +406,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       doc = await payload.findByID({
+        overrideAccess: true,
         collection: 'exports',
         id: doc.id,
       })
@@ -398,6 +425,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
     it('should create a file for collection csv from one locale', async () => {
       let doc = await payload.create({
+        overrideAccess: true,
         collection: 'exports',
         user,
         data: {
@@ -411,9 +439,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       doc = await payload.findByID({
+        overrideAccess: true,
         collection: 'exports',
         id: doc.id,
       })
@@ -428,6 +457,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
     it('should create a file for collection csv from multiple locales', async () => {
       let doc = await payload.create({
+        overrideAccess: true,
         collection: 'exports',
         user,
         data: {
@@ -441,9 +471,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       doc = await payload.findByID({
+        overrideAccess: true,
         collection: 'exports',
         id: doc.id,
       })
@@ -459,6 +490,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
     it('should create a file for collection csv from array', async () => {
       let doc = await payload.create({
+        overrideAccess: true,
         collection: 'exports',
         user,
         data: {
@@ -471,9 +503,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       doc = await payload.findByID({
+        overrideAccess: true,
         collection: 'exports',
         id: doc.id,
       })
@@ -491,6 +524,7 @@ describe('@payloadcms/plugin-import-export', () => {
     it('should create a CSV file with columns matching the order of the fields array', async () => {
       const fields = ['id', 'group.value', 'group.array.field1', 'title', 'createdAt', 'updatedAt']
       const doc = await payload.create({
+        overrideAccess: true,
         collection: 'exports',
         user,
         data: {
@@ -503,9 +537,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       const exportDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'exports',
         id: doc.id,
       })
@@ -525,6 +560,7 @@ describe('@payloadcms/plugin-import-export', () => {
     it('should create a CSV file with virtual fields', async () => {
       const fields = ['id', 'virtual', 'virtualRelationship']
       const doc = await payload.create({
+        overrideAccess: true,
         collection: 'exports',
         user,
         data: {
@@ -537,9 +573,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       const exportDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'exports',
         id: doc.id,
       })
@@ -554,6 +591,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
     it('should create a file for collection csv from array.subfield', async () => {
       let doc = await payload.create({
+        overrideAccess: true,
         collection: 'exports',
         user,
         data: {
@@ -566,9 +604,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       doc = await payload.findByID({
+        overrideAccess: true,
         collection: 'exports',
         id: doc.id,
       })
@@ -585,6 +624,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
     it('should create a file for collection csv from hasMany field', async () => {
       let doc = await payload.create({
+        overrideAccess: true,
         collection: 'exports',
         user,
         data: {
@@ -597,9 +637,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       doc = await payload.findByID({
+        overrideAccess: true,
         collection: 'exports',
         id: doc.id,
       })
@@ -617,6 +658,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
     it('should create a file for collection csv from blocks field', async () => {
       let doc = await payload.create({
+        overrideAccess: true,
         collection: 'exports',
         user,
         data: {
@@ -629,9 +671,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       doc = await payload.findByID({
+        overrideAccess: true,
         collection: 'exports',
         id: doc.id,
       })
@@ -646,6 +689,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
     it('should create a csv of all fields when fields is empty', async () => {
       const doc = await payload.create({
+        overrideAccess: true,
         collection: 'exports',
         user,
         data: {
@@ -658,9 +702,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       const exportDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'exports',
         id: doc.id,
       })
@@ -685,6 +730,7 @@ describe('@payloadcms/plugin-import-export', () => {
         'namedTab.tabToCSV',
       ]
       const doc = await payload.create({
+        overrideAccess: true,
         collection: 'exports',
         user,
         data: {
@@ -697,9 +743,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       const exportDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'exports',
         id: doc.id,
       })
@@ -720,6 +767,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
     it('should create a JSON file for collection', async () => {
       let doc = await payload.create({
+        overrideAccess: true,
         collection: 'exports',
         user,
         data: {
@@ -733,9 +781,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       doc = await payload.findByID({
+        overrideAccess: true,
         collection: 'exports',
         id: doc.id,
       })
@@ -776,6 +825,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
     it('should create an export with every field when no fields are defined', async () => {
       let doc = await payload.create({
+        overrideAccess: true,
         collection: 'exports',
         user,
         data: {
@@ -785,9 +835,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       doc = await payload.findByID({
+        overrideAccess: true,
         collection: 'exports',
         id: doc.id,
       })
@@ -804,6 +855,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
     it('should create jobs task for exports', async () => {
       const doc = await payload.create({
+        overrideAccess: true,
         collection: 'exports' as CollectionSlug,
         user,
         data: {
@@ -820,6 +872,7 @@ describe('@payloadcms/plugin-import-export', () => {
       const {
         docs: [job],
       } = await payload.find({
+        overrideAccess: true,
         collection: 'payload-jobs',
         sort: '-createdAt',
       })
@@ -840,9 +893,10 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(input.userID).toBeDefined()
       expect(input.userCollection).toBeDefined()
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       const exportDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'exports' as CollectionSlug,
         id: doc.id,
       })
@@ -856,6 +910,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
     it('should export a large dataset without any duplicates', async () => {
       const doc = await payload.create({
+        overrideAccess: true,
         collection: 'exports',
         user,
         data: {
@@ -865,9 +920,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       const exportDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'exports',
         id: doc.id,
       })
@@ -890,6 +946,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
     it('should only include selected fields in CSV export, nothing else', async () => {
       const doc = await payload.create({
+        overrideAccess: true,
         collection: 'posts-export',
         user,
         data: {
@@ -901,6 +958,7 @@ describe('@payloadcms/plugin-import-export', () => {
       })
 
       const exportDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'posts-export',
         id: doc.id,
       })
@@ -918,6 +976,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
     it('should preserve user-specified field order in CSV export', async () => {
       const doc = await payload.create({
+        overrideAccess: true,
         collection: 'posts-export',
         user,
         data: {
@@ -929,6 +988,7 @@ describe('@payloadcms/plugin-import-export', () => {
       })
 
       const exportDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'posts-export',
         id: doc.id,
       })
@@ -945,6 +1005,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
     it('should export polymorphic relationship fields to CSV', async () => {
       const doc = await payload.create({
+        overrideAccess: true,
         collection: 'exports',
         user,
         data: {
@@ -957,9 +1018,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       const exportDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'exports',
         id: doc.id,
       })
@@ -979,6 +1041,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
     it('should not produce duplicate columns for hasOne polymorphic relationship export', async () => {
       const doc = await payload.create({
+        overrideAccess: true,
         collection: 'exports',
         user,
         data: {
@@ -991,9 +1054,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       const exportDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'exports',
         id: doc.id,
       })
@@ -1016,6 +1080,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
     it('should export hasMany monomorphic relationship fields to CSV', async () => {
       const doc = await payload.create({
+        overrideAccess: true,
         collection: 'exports',
         user,
         data: {
@@ -1028,9 +1093,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       const exportDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'exports',
         id: doc.id,
       })
@@ -1051,6 +1117,7 @@ describe('@payloadcms/plugin-import-export', () => {
       for (let i = 0; i < 100000; i++) {
         promises.push(
           await payload.create({
+            overrideAccess: true,
             collection: 'pages',
             data: {
               title: `Array ${i}`,
@@ -1078,6 +1145,7 @@ describe('@payloadcms/plugin-import-export', () => {
       await Promise.all(promises)
 
       let doc = await payload.create({
+        overrideAccess: true,
         collection: 'exports',
         user,
         data: {
@@ -1087,9 +1155,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       doc = await payload.findByID({
+        overrideAccess: true,
         collection: 'exports',
         id: doc.id,
       })
@@ -1105,6 +1174,7 @@ describe('@payloadcms/plugin-import-export', () => {
     describe('schema-based column inference', () => {
       it('should generate columns from schema without scanning documents', async () => {
         let doc = await payload.create({
+          overrideAccess: true,
           collection: 'exports',
           user,
           data: {
@@ -1117,9 +1187,10 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
         doc = await payload.findByID({
+          overrideAccess: true,
           collection: 'exports',
           id: doc.id,
         })
@@ -1140,6 +1211,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
       it('should include all locale columns when locale is all', async () => {
         let doc = await payload.create({
+          overrideAccess: true,
           collection: 'exports',
           user,
           data: {
@@ -1153,9 +1225,10 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
         doc = await payload.findByID({
+          overrideAccess: true,
           collection: 'exports',
           id: doc.id,
         })
@@ -1172,6 +1245,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
       it('should generate correct columns for empty export', async () => {
         let doc = await payload.create({
+          overrideAccess: true,
           collection: 'exports',
           user,
           data: {
@@ -1184,9 +1258,10 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
         doc = await payload.findByID({
+          overrideAccess: true,
           collection: 'exports',
           id: doc.id,
         })
@@ -1203,6 +1278,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
       it('should include virtual fields in export columns (they have values)', async () => {
         let doc = await payload.create({
+          overrideAccess: true,
           collection: 'exports',
           user,
           data: {
@@ -1214,9 +1290,10 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
         doc = await payload.findByID({
+          overrideAccess: true,
           collection: 'exports',
           id: doc.id,
         })
@@ -1234,6 +1311,7 @@ describe('@payloadcms/plugin-import-export', () => {
     describe('beforeExport derived columns positioning', () => {
       it('should position derived columns at the base field position and remove the original column', async () => {
         const page = await payload.create({
+          overrideAccess: true,
           collection: 'pages',
           data: {
             title: 'Derived Columns Test',
@@ -1245,6 +1323,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
         const fields = ['id', 'title', 'customRelationship', 'excerpt']
         let doc = await payload.create({
+          overrideAccess: true,
           collection: 'exports',
           user,
           data: {
@@ -1255,9 +1334,9 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
-        doc = await payload.findByID({ collection: 'exports', id: doc.id })
+        doc = await payload.findByID({ overrideAccess: true, collection: 'exports', id: doc.id })
         const csvPath = path.join(dirname, './uploads', doc.filename as string)
         const data = await readCSV(csvPath)
         const columns = Object.keys(data[0])
@@ -1277,11 +1356,12 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(emailIdx).toBe(titleIdx + 2)
         expect(excerptIdx).toBeGreaterThan(emailIdx)
 
-        await payload.delete({ collection: 'pages', id: page.id })
+        await payload.delete({ overrideAccess: true, collection: 'pages', id: page.id })
       })
 
       it('should remove original column when beforeExport hook writes _name and _email (no _id)', async () => {
         const page = await payload.create({
+          overrideAccess: true,
           collection: 'pages',
           data: {
             title: 'NameEmail Derived Test',
@@ -1293,6 +1373,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
         const fields = ['id', 'title', 'customRelNameEmail', 'excerpt']
         let doc = await payload.create({
+          overrideAccess: true,
           collection: 'exports',
           user,
           data: {
@@ -1303,9 +1384,9 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
-        doc = await payload.findByID({ collection: 'exports', id: doc.id })
+        doc = await payload.findByID({ overrideAccess: true, collection: 'exports', id: doc.id })
         const csvPath = path.join(dirname, './uploads', doc.filename as string)
         const data = await readCSV(csvPath)
         const columns = Object.keys(data[0])
@@ -1327,11 +1408,12 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(data[0].customRelNameEmail_name).toBe('name value')
         expect(data[0].customRelNameEmail_email).toBe(user.email)
 
-        await payload.delete({ collection: 'pages', id: page.id })
+        await payload.delete({ overrideAccess: true, collection: 'pages', id: page.id })
       })
 
       it('should remove original column when beforeExport hook writes _id and _locationName', async () => {
         const page = await payload.create({
+          overrideAccess: true,
           collection: 'pages',
           data: {
             title: 'IdLocationName Derived Test',
@@ -1343,6 +1425,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
         const fields = ['id', 'title', 'customRelIdName', 'excerpt']
         let doc = await payload.create({
+          overrideAccess: true,
           collection: 'exports',
           user,
           data: {
@@ -1353,9 +1436,9 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
-        doc = await payload.findByID({ collection: 'exports', id: doc.id })
+        doc = await payload.findByID({ overrideAccess: true, collection: 'exports', id: doc.id })
         const csvPath = path.join(dirname, './uploads', doc.filename as string)
         const data = await readCSV(csvPath)
         const columns = Object.keys(data[0])
@@ -1377,11 +1460,12 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(data[0].customRelIdName_id).toBe(String(user.id))
         expect(data[0].customRelIdName_locationName).toBe('name value')
 
-        await payload.delete({ collection: 'pages', id: page.id })
+        await payload.delete({ overrideAccess: true, collection: 'pages', id: page.id })
       })
 
       it('should keep derived columns before trailing fields and match preview column order', async () => {
         const page = await payload.create({
+          overrideAccess: true,
           collection: 'pages',
           data: {
             title: 'Derived Position With Preview Test',
@@ -1395,6 +1479,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
         // Export
         let doc = await payload.create({
+          overrideAccess: true,
           collection: 'exports',
           user,
           data: {
@@ -1405,9 +1490,9 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
-        doc = await payload.findByID({ collection: 'exports', id: doc.id })
+        doc = await payload.findByID({ overrideAccess: true, collection: 'exports', id: doc.id })
         const csvPath = path.join(dirname, './uploads', doc.filename as string)
         const data = await readCSV(csvPath)
         const exportColumns = Object.keys(data[0])
@@ -1439,11 +1524,12 @@ describe('@payloadcms/plugin-import-export', () => {
 
         expect(previewResponse.columns).toStrictEqual(exportColumns)
 
-        await payload.delete({ collection: 'pages', id: page.id })
+        await payload.delete({ overrideAccess: true, collection: 'pages', id: page.id })
       })
 
       it('should respect custom field order with beforeExport field first and match preview column order', async () => {
         const page = await payload.create({
+          overrideAccess: true,
           collection: 'pages',
           data: {
             title: 'Custom Order beforeExport First Test',
@@ -1458,6 +1544,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
         // Export
         let doc = await payload.create({
+          overrideAccess: true,
           collection: 'exports',
           user,
           data: {
@@ -1468,9 +1555,9 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
-        doc = await payload.findByID({ collection: 'exports', id: doc.id })
+        doc = await payload.findByID({ overrideAccess: true, collection: 'exports', id: doc.id })
         const csvPath = path.join(dirname, './uploads', doc.filename as string)
         const data = await readCSV(csvPath)
         const exportColumns = Object.keys(data[0])
@@ -1503,7 +1590,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
         expect(previewResponse.columns).toStrictEqual(exportColumns)
 
-        await payload.delete({ collection: 'pages', id: page.id })
+        await payload.delete({ overrideAccess: true, collection: 'pages', id: page.id })
       })
     })
 
@@ -1511,6 +1598,7 @@ describe('@payloadcms/plugin-import-export', () => {
       it('should export date fields as ISO strings', async () => {
         const dateValue = '2026-01-22T00:00:00.000Z'
         const page = await payload.create({
+          overrideAccess: true,
           collection: 'pages',
           data: {
             title: 'Date Export Test',
@@ -1520,6 +1608,7 @@ describe('@payloadcms/plugin-import-export', () => {
         })
 
         let doc = await payload.create({
+          overrideAccess: true,
           collection: 'exports',
           user,
           data: {
@@ -1530,24 +1619,26 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
-        doc = await payload.findByID({ collection: 'exports', id: doc.id })
+        doc = await payload.findByID({ overrideAccess: true, collection: 'exports', id: doc.id })
         const csvPath = path.join(dirname, './uploads', doc.filename as string)
         const data = await readCSV(csvPath)
 
         expect(data[0].date).toBe('2026-01-22T00:00:00.000Z')
 
-        await payload.delete({ collection: 'pages', id: page.id })
+        await payload.delete({ overrideAccess: true, collection: 'pages', id: page.id })
       })
 
       it('should handle null date values', async () => {
         const page = await payload.create({
+          overrideAccess: true,
           collection: 'pages',
           data: { title: 'Null Date Test', date: null, _status: 'published' },
         })
 
         let doc = await payload.create({
+          overrideAccess: true,
           collection: 'exports',
           user,
           data: {
@@ -1558,19 +1649,20 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
-        doc = await payload.findByID({ collection: 'exports', id: doc.id })
+        doc = await payload.findByID({ overrideAccess: true, collection: 'exports', id: doc.id })
         const csvPath = path.join(dirname, './uploads', doc.filename as string)
         const data = await readCSV(csvPath)
 
         expect(data[0].date).toBe('')
 
-        await payload.delete({ collection: 'pages', id: page.id })
+        await payload.delete({ overrideAccess: true, collection: 'pages', id: page.id })
       })
 
       it('should not include timezone column when only date field is selected', async () => {
         const page = await payload.create({
+          overrideAccess: true,
           collection: 'pages',
           data: {
             title: 'Date With TZ Test',
@@ -1581,6 +1673,7 @@ describe('@payloadcms/plugin-import-export', () => {
         })
 
         let doc = await payload.create({
+          overrideAccess: true,
           collection: 'exports',
           user,
           data: {
@@ -1591,9 +1684,9 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
-        doc = await payload.findByID({ collection: 'exports', id: doc.id })
+        doc = await payload.findByID({ overrideAccess: true, collection: 'exports', id: doc.id })
         const csvPath = path.join(dirname, './uploads', doc.filename as string)
         const csvContent = fs.readFileSync(csvPath, 'utf-8')
         const headerLine = csvContent.split('\n')[0]
@@ -1601,11 +1694,12 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(headerLine).toContain('dateWithTimezone')
         expect(headerLine).not.toContain('dateWithTimezone_tz')
 
-        await payload.delete({ collection: 'pages', id: page.id })
+        await payload.delete({ overrideAccess: true, collection: 'pages', id: page.id })
       })
 
       it('should not create duplicate columns when selecting both date and timezone fields', async () => {
         const page = await payload.create({
+          overrideAccess: true,
           collection: 'pages',
           data: {
             title: 'Date With TZ Duplicate Test',
@@ -1616,6 +1710,7 @@ describe('@payloadcms/plugin-import-export', () => {
         })
 
         let doc = await payload.create({
+          overrideAccess: true,
           collection: 'exports',
           user,
           data: {
@@ -1626,9 +1721,9 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
-        doc = await payload.findByID({ collection: 'exports', id: doc.id })
+        doc = await payload.findByID({ overrideAccess: true, collection: 'exports', id: doc.id })
         const csvPath = path.join(dirname, './uploads', doc.filename as string)
         const csvContent = fs.readFileSync(csvPath, 'utf-8')
         const headerLine = csvContent.split('\n')[0]
@@ -1641,7 +1736,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(data[0].dateWithTimezone).toBe('2026-01-25T12:00:00.000Z')
         expect(data[0].dateWithTimezone_tz).toBe('Europe/London')
 
-        await payload.delete({ collection: 'pages', id: page.id })
+        await payload.delete({ overrideAccess: true, collection: 'pages', id: page.id })
       })
     })
 
@@ -1689,6 +1784,7 @@ describe('@payloadcms/plugin-import-export', () => {
         }
 
         const testPage = await payload.create({
+          overrideAccess: true,
           collection: 'pages',
           data: {
             title: 'JSON Serialization Test',
@@ -1704,6 +1800,7 @@ describe('@payloadcms/plugin-import-export', () => {
         })
 
         let exportDoc = await payload.create({
+          overrideAccess: true,
           collection: 'exports',
           user,
           data: {
@@ -1715,9 +1812,10 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
         exportDoc = await payload.findByID({
+          overrideAccess: true,
           collection: 'exports',
           id: exportDoc.id,
         })
@@ -1759,6 +1857,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(flattenedRichTextKeys).toHaveLength(0)
 
         await payload.delete({
+          overrideAccess: true,
           collection: 'pages',
           id: testPage.id,
         })
@@ -1778,6 +1877,7 @@ describe('@payloadcms/plugin-import-export', () => {
         }
 
         const testPage = await payload.create({
+          overrideAccess: true,
           collection: 'pages',
           data: {
             title: 'JSON Roundtrip CSV Test',
@@ -1793,6 +1893,7 @@ describe('@payloadcms/plugin-import-export', () => {
         })
 
         let exportDoc = await payload.create({
+          overrideAccess: true,
           collection: 'exports',
           user,
           data: {
@@ -1804,9 +1905,10 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
         exportDoc = await payload.findByID({
+          overrideAccess: true,
           collection: 'exports',
           id: exportDoc.id,
         })
@@ -1814,11 +1916,13 @@ describe('@payloadcms/plugin-import-export', () => {
         const csvPath = path.join(dirname, './uploads', exportDoc.filename as string)
 
         await payload.delete({
+          overrideAccess: true,
           collection: 'pages',
           id: testPage.id,
         })
 
         let importDoc = await payload.create({
+          overrideAccess: true,
           collection: 'imports',
           user,
           data: {
@@ -1833,9 +1937,10 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
         importDoc = await payload.findByID({
+          overrideAccess: true,
           collection: 'imports',
           id: importDoc.id,
         })
@@ -1844,6 +1949,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(importDoc.summary?.imported).toBe(1)
 
         const importedPages = await payload.find({
+          overrideAccess: true,
           collection: 'pages',
           where: {
             title: { equals: 'JSON Roundtrip CSV Test' },
@@ -1868,6 +1974,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(blockRichText?.root?.type).toBe('root')
 
         await payload.delete({
+          overrideAccess: true,
           collection: 'pages',
           where: {
             title: { equals: 'JSON Roundtrip CSV Test' },
@@ -1877,6 +1984,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
       it('should roundtrip a block containing a nested array with richText through CSV export/import', async () => {
         const testPage = await payload.create({
+          overrideAccess: true,
           collection: 'pages',
           data: {
             title: 'FAQ Block Roundtrip Test',
@@ -1893,6 +2001,7 @@ describe('@payloadcms/plugin-import-export', () => {
         })
 
         let exportDoc = await payload.create({
+          overrideAccess: true,
           collection: 'exports',
           user,
           data: {
@@ -1902,15 +2011,20 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
-        exportDoc = await payload.findByID({ collection: 'exports', id: exportDoc.id })
+        exportDoc = await payload.findByID({
+          overrideAccess: true,
+          collection: 'exports',
+          id: exportDoc.id,
+        })
 
         const csvPath = path.join(dirname, './uploads', exportDoc.filename as string)
 
-        await payload.delete({ collection: 'pages', id: testPage.id })
+        await payload.delete({ overrideAccess: true, collection: 'pages', id: testPage.id })
 
         let importDoc = await payload.create({
+          overrideAccess: true,
           collection: 'imports',
           user,
           data: { collectionSlug: 'pages', importMode: 'create' },
@@ -1922,13 +2036,18 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
-        importDoc = await payload.findByID({ collection: 'imports', id: importDoc.id })
+        importDoc = await payload.findByID({
+          overrideAccess: true,
+          collection: 'imports',
+          id: importDoc.id,
+        })
         expect(importDoc.status).toBe('completed')
         expect(importDoc.summary?.imported).toBe(1)
 
         const importedPages = await payload.find({
+          overrideAccess: true,
           collection: 'pages',
           where: { title: { equals: 'FAQ Block Roundtrip Test' } },
         })
@@ -1952,6 +2071,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(typeof faqs[1]?.answer).not.toBe('string')
 
         await payload.delete({
+          overrideAccess: true,
           collection: 'pages',
           where: { title: { equals: 'FAQ Block Roundtrip Test' } },
         })
@@ -1961,6 +2081,7 @@ describe('@payloadcms/plugin-import-export', () => {
         const jsonData = { level: 'nested', data: [1, 2, 3] }
 
         const testPage = await payload.create({
+          overrideAccess: true,
           collection: 'pages',
           data: {
             title: 'Nested Array Test',
@@ -1981,6 +2102,7 @@ describe('@payloadcms/plugin-import-export', () => {
         })
 
         let exportDoc = await payload.create({
+          overrideAccess: true,
           collection: 'exports',
           user,
           data: {
@@ -1992,9 +2114,10 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
         exportDoc = await payload.findByID({
+          overrideAccess: true,
           collection: 'exports',
           id: exportDoc.id,
         })
@@ -2017,11 +2140,13 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(row.group_array_1_field1).toBe('nested-array-2')
 
         await payload.delete({
+          overrideAccess: true,
           collection: 'pages',
           id: testPage.id,
         })
 
         let importDoc = await payload.create({
+          overrideAccess: true,
           collection: 'imports',
           user,
           data: {
@@ -2036,9 +2161,10 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
         importDoc = await payload.findByID({
+          overrideAccess: true,
           collection: 'imports',
           id: importDoc.id,
         })
@@ -2046,6 +2172,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(importDoc.status).toBe('completed')
 
         const importedPages = await payload.find({
+          overrideAccess: true,
           collection: 'pages',
           where: {
             title: { equals: 'Nested Array Test' },
@@ -2067,6 +2194,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(imported?.group?.array?.[1]?.field1).toBe('nested-array-2')
 
         await payload.delete({
+          overrideAccess: true,
           collection: 'pages',
           where: {
             title: { equals: 'Nested Array Test' },
@@ -2079,6 +2207,7 @@ describe('@payloadcms/plugin-import-export', () => {
         const updatedJson = { version: 2, data: 'updated', extra: [1, 2, 3] }
 
         const existingPage = await payload.create({
+          overrideAccess: true,
           collection: 'pages',
           data: {
             title: 'JSON Update Mode Test',
@@ -2096,6 +2225,7 @@ describe('@payloadcms/plugin-import-export', () => {
         const csvBuffer = Buffer.from(csvContent)
 
         let importDoc = await payload.create({
+          overrideAccess: true,
           collection: 'imports',
           user,
           data: {
@@ -2111,9 +2241,10 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
         importDoc = await payload.findByID({
+          overrideAccess: true,
           collection: 'imports',
           id: importDoc.id,
         })
@@ -2123,6 +2254,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(importDoc.summary?.issues).toBe(0)
 
         const updatedPage = await payload.findByID({
+          overrideAccess: true,
           collection: 'pages',
           id: existingPage.id,
         })
@@ -2131,6 +2263,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect((updatedPage.richTextField as typeof richTextData)?.root?.type).toBe('root')
 
         await payload.delete({
+          overrideAccess: true,
           collection: 'pages',
           id: existingPage.id,
         })
@@ -2143,6 +2276,7 @@ describe('@payloadcms/plugin-import-export', () => {
         const updatedExistingJson = { id: 'existing', value: 150, modified: true }
 
         const existingPage = await payload.create({
+          overrideAccess: true,
           collection: 'pages',
           data: {
             title: `JSON Upsert Existing ${timestamp}`,
@@ -2159,6 +2293,7 @@ describe('@payloadcms/plugin-import-export', () => {
         const csvBuffer = Buffer.from(csvContent)
 
         let importDoc = await payload.create({
+          overrideAccess: true,
           collection: 'imports',
           user,
           data: {
@@ -2174,9 +2309,10 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
         importDoc = await payload.findByID({
+          overrideAccess: true,
           collection: 'imports',
           id: importDoc.id,
         })
@@ -2187,6 +2323,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(importDoc.summary?.issues).toBe(0)
 
         const updatedPage = await payload.findByID({
+          overrideAccess: true,
           collection: 'pages',
           id: existingPage.id,
         })
@@ -2194,6 +2331,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(updatedPage.jsonField).toEqual(updatedExistingJson)
 
         const newPages = await payload.find({
+          overrideAccess: true,
           collection: 'pages',
           where: {
             title: { equals: `JSON Upsert New ${timestamp}` },
@@ -2205,6 +2343,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect((newPages.docs[0]?.richTextField as typeof richTextData)?.root?.type).toBe('root')
 
         await payload.delete({
+          overrideAccess: true,
           collection: 'pages',
           where: {
             or: [
@@ -2231,6 +2370,7 @@ describe('@payloadcms/plugin-import-export', () => {
         const csvBuffer = Buffer.from(csvContent)
 
         let importDoc = await payload.create({
+          overrideAccess: true,
           collection: 'imports',
           user,
           data: {
@@ -2245,9 +2385,10 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
         importDoc = await payload.findByID({
+          overrideAccess: true,
           collection: 'imports',
           id: importDoc.id,
         })
@@ -2256,6 +2397,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(importDoc.summary?.imported).toBe(1)
 
         const importedPage = await payload.find({
+          overrideAccess: true,
           collection: 'pages',
           where: {
             title: { equals: 'Manual CSV Import' },
@@ -2266,6 +2408,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(importedPage.docs[0]?.jsonField).toEqual(manualJson)
 
         await payload.delete({
+          overrideAccess: true,
           collection: 'pages',
           where: {
             title: { equals: 'Manual CSV Import' },
@@ -2279,6 +2422,7 @@ describe('@payloadcms/plugin-import-export', () => {
         const jsonV3 = { version: 3, items: ['a', 'b', 'c'] }
 
         const page = await payload.create({
+          overrideAccess: true,
           collection: 'pages',
           data: {
             title: 'Sequential Import Test',
@@ -2293,6 +2437,7 @@ describe('@payloadcms/plugin-import-export', () => {
         let csvBuffer = Buffer.from(csvContent)
 
         let importDoc = await payload.create({
+          overrideAccess: true,
           collection: 'imports',
           user,
           data: {
@@ -2308,9 +2453,10 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
         let updatedPage = await payload.findByID({
+          overrideAccess: true,
           collection: 'pages',
           id: page.id,
         })
@@ -2323,6 +2469,7 @@ describe('@payloadcms/plugin-import-export', () => {
         csvBuffer = Buffer.from(csvContent)
 
         importDoc = await payload.create({
+          overrideAccess: true,
           collection: 'imports',
           user,
           data: {
@@ -2338,15 +2485,17 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
         updatedPage = await payload.findByID({
+          overrideAccess: true,
           collection: 'pages',
           id: page.id,
         })
         expect(updatedPage.jsonField).toEqual(jsonV3)
 
         await payload.delete({
+          overrideAccess: true,
           collection: 'pages',
           id: page.id,
         })
@@ -2356,6 +2505,7 @@ describe('@payloadcms/plugin-import-export', () => {
     describe('Excel compatibility', () => {
       it('should include UTF-8 BOM at the start of CSV files', async () => {
         const page = await payload.create({
+          overrideAccess: true,
           collection: 'pages',
           data: {
             title: 'BOM Test',
@@ -2365,6 +2515,7 @@ describe('@payloadcms/plugin-import-export', () => {
         })
 
         let doc = await payload.create({
+          overrideAccess: true,
           collection: 'exports',
           user,
           data: {
@@ -2375,9 +2526,9 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
-        doc = await payload.findByID({ collection: 'exports', id: doc.id })
+        doc = await payload.findByID({ overrideAccess: true, collection: 'exports', id: doc.id })
         const csvPath = path.join(dirname, './uploads', doc.filename as string)
         const buffer = fs.readFileSync(csvPath)
 
@@ -2385,7 +2536,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(buffer[1]).toBe(0xbb)
         expect(buffer[2]).toBe(0xbf)
 
-        await payload.delete({ collection: 'pages', id: page.id })
+        await payload.delete({ overrideAccess: true, collection: 'pages', id: page.id })
       })
 
       it('should correctly encode UTF-8 characters for Excel', async () => {
@@ -2393,6 +2544,7 @@ describe('@payloadcms/plugin-import-export', () => {
         const unicodeExcerpt = 'Ñoño señor • bullet points • áéíóú'
 
         const page = await payload.create({
+          overrideAccess: true,
           collection: 'pages',
           data: {
             title: unicodeTitle,
@@ -2402,6 +2554,7 @@ describe('@payloadcms/plugin-import-export', () => {
         })
 
         let doc = await payload.create({
+          overrideAccess: true,
           collection: 'exports',
           user,
           data: {
@@ -2412,9 +2565,9 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
-        doc = await payload.findByID({ collection: 'exports', id: doc.id })
+        doc = await payload.findByID({ overrideAccess: true, collection: 'exports', id: doc.id })
         const csvPath = path.join(dirname, './uploads', doc.filename as string)
 
         const rawContent = fs.readFileSync(csvPath, 'utf-8')
@@ -2427,7 +2580,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(data[0].title).toBe(unicodeTitle)
         expect(data[0].excerpt).toBe(unicodeExcerpt)
 
-        await payload.delete({ collection: 'pages', id: page.id })
+        await payload.delete({ overrideAccess: true, collection: 'pages', id: page.id })
       })
 
       it('should handle special CSV characters that could break Excel parsing', async () => {
@@ -2435,6 +2588,7 @@ describe('@payloadcms/plugin-import-export', () => {
         const specialCharsExcerpt = 'Line1\nLine2\nLine3 with\ttabs'
 
         const page = await payload.create({
+          overrideAccess: true,
           collection: 'pages',
           data: {
             title: specialCharsTitle,
@@ -2444,6 +2598,7 @@ describe('@payloadcms/plugin-import-export', () => {
         })
 
         let doc = await payload.create({
+          overrideAccess: true,
           collection: 'exports',
           user,
           data: {
@@ -2454,16 +2609,16 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
-        doc = await payload.findByID({ collection: 'exports', id: doc.id })
+        doc = await payload.findByID({ overrideAccess: true, collection: 'exports', id: doc.id })
         const csvPath = path.join(dirname, './uploads', doc.filename as string)
         const data = await readCSV(csvPath)
 
         expect(data[0].title).toBe(specialCharsTitle)
         expect(data[0].excerpt).toBe(specialCharsExcerpt)
 
-        await payload.delete({ collection: 'pages', id: page.id })
+        await payload.delete({ overrideAccess: true, collection: 'pages', id: page.id })
       })
 
       it('should preserve Hebrew characters in CSV download via streaming endpoint', async () => {
@@ -2471,6 +2626,7 @@ describe('@payloadcms/plugin-import-export', () => {
         const hebrewLocalized = 'בדיקה עברית'
 
         const page = await payload.create({
+          overrideAccess: true,
           collection: 'pages',
           data: {
             title: hebrewTitle,
@@ -2511,7 +2667,7 @@ describe('@payloadcms/plugin-import-export', () => {
         const content = buffer.toString('utf-8')
         expect(content).toContain(hebrewLocalized)
 
-        await payload.delete({ collection: 'pages', id: page.id })
+        await payload.delete({ overrideAccess: true, collection: 'pages', id: page.id })
       })
 
       it('should preserve Hebrew characters in job-created CSV export', async () => {
@@ -2519,6 +2675,7 @@ describe('@payloadcms/plugin-import-export', () => {
         const hebrewLocalized = 'שלום עולם'
 
         const page = await payload.create({
+          overrideAccess: true,
           collection: 'pages',
           data: {
             title: hebrewTitle,
@@ -2529,6 +2686,7 @@ describe('@payloadcms/plugin-import-export', () => {
         })
 
         let doc = await payload.create({
+          overrideAccess: true,
           collection: 'exports',
           user,
           data: {
@@ -2540,9 +2698,9 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
-        doc = await payload.findByID({ collection: 'exports', id: doc.id })
+        doc = await payload.findByID({ overrideAccess: true, collection: 'exports', id: doc.id })
 
         // Verify filename includes collection slug and csv extension
         expect(doc.filename).toContain('-pages')
@@ -2565,7 +2723,7 @@ describe('@payloadcms/plugin-import-export', () => {
         const data = await readCSV(csvPath)
         expect(data[0].localized).toBe(hebrewLocalized)
 
-        await payload.delete({ collection: 'pages', id: page.id })
+        await payload.delete({ overrideAccess: true, collection: 'pages', id: page.id })
       })
 
       it('should preserve Hebrew characters in hook-created CSV export (no jobs queue)', async () => {
@@ -2573,6 +2731,7 @@ describe('@payloadcms/plugin-import-export', () => {
         const hebrewContent = 'טקסט בעברית'
 
         const post = await payload.create({
+          overrideAccess: true,
           collection: 'posts',
           data: {
             title: hebrewTitle,
@@ -2582,6 +2741,7 @@ describe('@payloadcms/plugin-import-export', () => {
         })
 
         const doc = await payload.create({
+          overrideAccess: true,
           collection: 'posts-export',
           user,
           data: {
@@ -2593,6 +2753,7 @@ describe('@payloadcms/plugin-import-export', () => {
         })
 
         const exportDoc = await payload.findByID({
+          overrideAccess: true,
           collection: 'posts-export',
           id: doc.id,
         })
@@ -2618,13 +2779,14 @@ describe('@payloadcms/plugin-import-export', () => {
         const data = await readCSV(csvPath)
         expect(data[0].title).toBe(hebrewTitle)
 
-        await payload.delete({ collection: 'posts', id: post.id })
+        await payload.delete({ overrideAccess: true, collection: 'posts', id: post.id })
       })
     })
 
     describe('fields', () => {
       it('should export checkbox field as true/false strings', async () => {
         let doc = await payload.create({
+          overrideAccess: true,
           collection: 'exports',
           user,
           data: {
@@ -2635,9 +2797,9 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
-        doc = await payload.findByID({ collection: 'exports', id: doc.id })
+        doc = await payload.findByID({ overrideAccess: true, collection: 'exports', id: doc.id })
         const data = await readCSV(path.join(dirname, './uploads', doc.filename as string))
 
         expect(data).toHaveLength(3)
@@ -2650,6 +2812,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
       it('should export select field values', async () => {
         let doc = await payload.create({
+          overrideAccess: true,
           collection: 'exports',
           user,
           data: {
@@ -2660,9 +2823,9 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
-        doc = await payload.findByID({ collection: 'exports', id: doc.id })
+        doc = await payload.findByID({ overrideAccess: true, collection: 'exports', id: doc.id })
         const data = await readCSV(path.join(dirname, './uploads', doc.filename as string))
 
         expect(data).toHaveLength(3)
@@ -2673,6 +2836,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
       it('should export select hasMany field values', async () => {
         let doc = await payload.create({
+          overrideAccess: true,
           collection: 'exports',
           user,
           data: {
@@ -2683,9 +2847,9 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
-        doc = await payload.findByID({ collection: 'exports', id: doc.id })
+        doc = await payload.findByID({ overrideAccess: true, collection: 'exports', id: doc.id })
         const data = await readCSV(path.join(dirname, './uploads', doc.filename as string))
 
         expect(data).toHaveLength(3)
@@ -2695,6 +2859,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
       it('should export radio field values', async () => {
         let doc = await payload.create({
+          overrideAccess: true,
           collection: 'exports',
           user,
           data: {
@@ -2705,9 +2870,9 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
-        doc = await payload.findByID({ collection: 'exports', id: doc.id })
+        doc = await payload.findByID({ overrideAccess: true, collection: 'exports', id: doc.id })
         const data = await readCSV(path.join(dirname, './uploads', doc.filename as string))
 
         expect(data).toHaveLength(3)
@@ -2718,6 +2883,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
       it('should export email field values', async () => {
         let doc = await payload.create({
+          overrideAccess: true,
           collection: 'exports',
           user,
           data: {
@@ -2728,9 +2894,9 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
-        doc = await payload.findByID({ collection: 'exports', id: doc.id })
+        doc = await payload.findByID({ overrideAccess: true, collection: 'exports', id: doc.id })
         const data = await readCSV(path.join(dirname, './uploads', doc.filename as string))
 
         expect(data).toHaveLength(3)
@@ -2740,6 +2906,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
       it('should export textarea field with multiline content', async () => {
         let doc = await payload.create({
+          overrideAccess: true,
           collection: 'exports',
           user,
           data: {
@@ -2750,9 +2917,9 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
-        doc = await payload.findByID({ collection: 'exports', id: doc.id })
+        doc = await payload.findByID({ overrideAccess: true, collection: 'exports', id: doc.id })
         const data = await readCSV(path.join(dirname, './uploads', doc.filename as string))
 
         expect(data).toHaveLength(3)
@@ -2763,6 +2930,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
       it('should export code field values', async () => {
         let doc = await payload.create({
+          overrideAccess: true,
           collection: 'exports',
           user,
           data: {
@@ -2773,9 +2941,9 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
-        doc = await payload.findByID({ collection: 'exports', id: doc.id })
+        doc = await payload.findByID({ overrideAccess: true, collection: 'exports', id: doc.id })
         const data = await readCSV(path.join(dirname, './uploads', doc.filename as string))
 
         expect(data).toHaveLength(3)
@@ -2784,6 +2952,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
       it('should export point field values', async () => {
         let doc = await payload.create({
+          overrideAccess: true,
           collection: 'exports',
           user,
           data: {
@@ -2794,9 +2963,9 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
-        doc = await payload.findByID({ collection: 'exports', id: doc.id })
+        doc = await payload.findByID({ overrideAccess: true, collection: 'exports', id: doc.id })
         const data = await readCSV(path.join(dirname, './uploads', doc.filename as string))
 
         expect(data).toHaveLength(3)
@@ -2805,6 +2974,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
       it('should export hasMany text field values', async () => {
         let doc = await payload.create({
+          overrideAccess: true,
           collection: 'exports',
           user,
           data: {
@@ -2815,9 +2985,9 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
-        doc = await payload.findByID({ collection: 'exports', id: doc.id })
+        doc = await payload.findByID({ overrideAccess: true, collection: 'exports', id: doc.id })
         const data = await readCSV(path.join(dirname, './uploads', doc.filename as string))
 
         expect(data).toHaveLength(3)
@@ -2826,6 +2996,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
       it('should export upload field values as IDs', async () => {
         let doc = await payload.create({
+          overrideAccess: true,
           collection: 'exports',
           user,
           data: {
@@ -2836,9 +3007,9 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
-        doc = await payload.findByID({ collection: 'exports', id: doc.id })
+        doc = await payload.findByID({ overrideAccess: true, collection: 'exports', id: doc.id })
         const data = await readCSV(path.join(dirname, './uploads', doc.filename as string))
 
         expect(data).toHaveLength(3)
@@ -2856,6 +3027,7 @@ describe('@payloadcms/plugin-import-export', () => {
         for (const id of createdCustomIdPages) {
           try {
             await payload.delete({
+              overrideAccess: true,
               collection: customIdPagesSlug as CollectionSlug,
               id,
             })
@@ -2868,6 +3040,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
       it('should export documents with custom text IDs to CSV', async () => {
         await payload.create({
+          overrideAccess: true,
           collection: customIdPagesSlug as CollectionSlug,
           data: {
             id: 'export-custom-1',
@@ -2876,6 +3049,7 @@ describe('@payloadcms/plugin-import-export', () => {
         })
 
         await payload.create({
+          overrideAccess: true,
           collection: customIdPagesSlug as CollectionSlug,
           data: {
             id: 'export-custom-2',
@@ -2886,6 +3060,7 @@ describe('@payloadcms/plugin-import-export', () => {
         createdCustomIdPages.push('export-custom-1', 'export-custom-2')
 
         let exportDoc = await payload.create({
+          overrideAccess: true,
           collection: 'exports',
           user,
           data: {
@@ -2898,9 +3073,10 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
         exportDoc = await payload.findByID({
+          overrideAccess: true,
           collection: 'exports',
           id: exportDoc.id,
         })
@@ -2922,6 +3098,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
       it('should export documents with custom text IDs to JSON', async () => {
         await payload.create({
+          overrideAccess: true,
           collection: customIdPagesSlug as CollectionSlug,
           data: {
             id: 'export-json-1',
@@ -2930,6 +3107,7 @@ describe('@payloadcms/plugin-import-export', () => {
         })
 
         await payload.create({
+          overrideAccess: true,
           collection: customIdPagesSlug as CollectionSlug,
           data: {
             id: 'export-json-2',
@@ -2940,6 +3118,7 @@ describe('@payloadcms/plugin-import-export', () => {
         createdCustomIdPages.push('export-json-1', 'export-json-2')
 
         let exportDoc = await payload.create({
+          overrideAccess: true,
           collection: 'exports',
           user,
           data: {
@@ -2952,9 +3131,10 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
         exportDoc = await payload.findByID({
+          overrideAccess: true,
           collection: 'exports',
           id: exportDoc.id,
         })
@@ -2979,6 +3159,7 @@ describe('@payloadcms/plugin-import-export', () => {
   describe('imports', () => {
     beforeEach(async () => {
       await payload.delete({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           id: { exists: true },
@@ -2986,6 +3167,7 @@ describe('@payloadcms/plugin-import-export', () => {
       })
 
       await payload.delete({
+        overrideAccess: true,
         collection: 'imports',
         where: {
           id: { exists: true },
@@ -2997,6 +3179,7 @@ describe('@payloadcms/plugin-import-export', () => {
       const createdPages = []
       for (let i = 0; i < 3; i++) {
         const page = await payload.create({
+          overrideAccess: true,
           collection: 'pages',
           data: {
             title: `Import Test ${i}`,
@@ -3010,6 +3193,7 @@ describe('@payloadcms/plugin-import-export', () => {
       }
 
       const exportDoc = await payload.create({
+        overrideAccess: true,
         collection: 'exports',
         user,
         data: {
@@ -3022,9 +3206,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       const exportedDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'exports',
         id: exportDoc.id,
       })
@@ -3032,6 +3217,7 @@ describe('@payloadcms/plugin-import-export', () => {
       const csvPath = path.join(dirname, './uploads', exportedDoc.filename as string)
 
       await payload.delete({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           title: { contains: 'Import Test ' },
@@ -3039,6 +3225,7 @@ describe('@payloadcms/plugin-import-export', () => {
       })
 
       let importDoc = await payload.create({
+        overrideAccess: true,
         collection: 'imports',
         user,
         data: {
@@ -3053,9 +3240,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       importDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'imports',
         id: importDoc.id,
       })
@@ -3072,6 +3260,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(importDoc.summary?.issues).toBe(0)
 
       const importedPages = await payload.find({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           title: { contains: 'Import Test ' },
@@ -3104,6 +3293,7 @@ describe('@payloadcms/plugin-import-export', () => {
       const jsonBuffer = Buffer.from(JSON.stringify(testData))
 
       let importDoc = await payload.create({
+        overrideAccess: true,
         collection: 'imports',
         user,
         data: {
@@ -3118,9 +3308,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       importDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'imports',
         id: importDoc.id,
       })
@@ -3130,6 +3321,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(importDoc.summary?.issues).toBe(0)
 
       const importedPages = await payload.find({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           title: { contains: 'JSON Import ' },
@@ -3144,6 +3336,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
     it('should update existing documents in update mode', async () => {
       const page1 = await payload.create({
+        overrideAccess: true,
         collection: 'pages',
         data: {
           title: 'Update Test 1',
@@ -3154,6 +3347,7 @@ describe('@payloadcms/plugin-import-export', () => {
       })
 
       const page2 = await payload.create({
+        overrideAccess: true,
         collection: 'pages',
         data: {
           title: 'Update Test 2',
@@ -3183,6 +3377,7 @@ describe('@payloadcms/plugin-import-export', () => {
       const csvBuffer = Buffer.from(csvContent)
 
       let importDoc = await payload.create({
+        overrideAccess: true,
         collection: 'imports',
         user,
         data: {
@@ -3198,9 +3393,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       importDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'imports',
         id: importDoc.id,
       })
@@ -3211,6 +3407,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(importDoc.summary?.issues).toBe(0)
 
       const updatedPage1 = await payload.findByID({
+        overrideAccess: true,
         collection: 'pages',
         id: page1.id,
       })
@@ -3222,6 +3419,7 @@ describe('@payloadcms/plugin-import-export', () => {
     it('should handle upsert mode correctly', async () => {
       const timestamp = Date.now()
       const existingPage = await payload.create({
+        overrideAccess: true,
         collection: 'pages',
         draft: false,
         data: {
@@ -3251,6 +3449,7 @@ describe('@payloadcms/plugin-import-export', () => {
       const csvBuffer = Buffer.from(csvContent)
 
       const initialImportDoc = await payload.create({
+        overrideAccess: true,
         collection: 'imports',
         user,
         data: {
@@ -3266,9 +3465,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       const importDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'imports',
         id: initialImportDoc.id,
       })
@@ -3299,6 +3499,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(draftPage.excerpt).toBe('updated')
 
       const newPages = await payload.find({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           title: { equals: `Upsert Test ${timestamp} New` },
@@ -3317,6 +3518,7 @@ describe('@payloadcms/plugin-import-export', () => {
       const csvBuffer = Buffer.from(csvContent)
 
       let importDoc = await payload.create({
+        overrideAccess: true,
         collection: 'imports',
         user,
         data: {
@@ -3331,9 +3533,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       importDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'imports',
         id: importDoc.id,
       })
@@ -3343,6 +3546,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(importDoc.summary?.issues).toBe(0)
 
       const importedPages = await payload.find({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           title: { contains: 'Localized Import ' },
@@ -3357,6 +3561,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
     it('should import localized fields from CSV with multiple locales', async () => {
       await payload.delete({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           title: { contains: 'Localized ' },
@@ -3371,6 +3576,7 @@ describe('@payloadcms/plugin-import-export', () => {
       const csvBuffer = Buffer.from(csvContent)
 
       let importDoc = await payload.create({
+        overrideAccess: true,
         collection: 'imports',
         user,
         data: {
@@ -3385,9 +3591,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       importDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'imports',
         id: importDoc.id,
       })
@@ -3397,6 +3604,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(importDoc.summary?.issues).toBe(0)
 
       const importedPagesEn = await payload.find({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           title: { contains: 'Multi-locale Import ' },
@@ -3409,6 +3617,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(importedPagesEn.docs[0]?.localized).toBe('English text 1')
 
       const importedPagesEs = await payload.find({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           title: { contains: 'Multi-locale Import ' },
@@ -3432,6 +3641,7 @@ describe('@payloadcms/plugin-import-export', () => {
       const csvBuffer = Buffer.from(csvContent)
 
       let importDoc = await payload.create({
+        overrideAccess: true,
         collection: 'imports',
         user,
         data: {
@@ -3446,9 +3656,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       importDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'imports',
         id: importDoc.id,
       })
@@ -3459,6 +3670,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
       // Verify English (defaultLocale) has the correct English values, not German
       const importedPagesEn = await payload.find({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           title: { contains: 'Locale Order Test ' },
@@ -3473,6 +3685,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
       // Verify German has the correct German values, not missing
       const importedPagesDe = await payload.find({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           title: { contains: 'Locale Order Test ' },
@@ -3487,6 +3700,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
       // Verify Spanish has the correct Spanish values
       const importedPagesEs = await payload.find({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           title: { contains: 'Locale Order Test ' },
@@ -3501,6 +3715,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
       // Cleanup
       await payload.delete({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           title: { contains: 'Locale Order Test ' },
@@ -3517,6 +3732,7 @@ describe('@payloadcms/plugin-import-export', () => {
       const csvBuffer = Buffer.from(csvContent)
 
       let importDoc = await payload.create({
+        overrideAccess: true,
         collection: 'imports',
         user,
         data: {
@@ -3531,9 +3747,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       importDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'imports',
         id: importDoc.id,
       })
@@ -3543,6 +3760,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(importDoc.summary?.issues).toBe(0)
 
       const importedPages = await payload.find({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           title: { contains: 'Array Import ' },
@@ -3566,6 +3784,7 @@ describe('@payloadcms/plugin-import-export', () => {
       const csvBuffer = Buffer.from(csvContent)
 
       let importDoc = await payload.create({
+        overrideAccess: true,
         collection: 'imports',
         user,
         data: {
@@ -3580,9 +3799,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       importDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'imports',
         id: importDoc.id,
       })
@@ -3592,6 +3812,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(importDoc.summary?.issues).toBe(0)
 
       const importedPages = await payload.find({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           title: { equals: 'Blocks Import 1' },
@@ -3622,6 +3843,7 @@ describe('@payloadcms/plugin-import-export', () => {
       const csvBuffer = Buffer.from(csvContent)
 
       let importDoc = await payload.create({
+        overrideAccess: true,
         collection: 'imports',
         user,
         data: {
@@ -3637,9 +3859,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       importDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'imports',
         id: importDoc.id,
       })
@@ -3656,6 +3879,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(importDoc.summary?.issues).toBe(0)
 
       const importedPages = await payload.find({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           title: { contains: 'HasMany ' },
@@ -3690,6 +3914,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
     it('should import relationship fields from CSV', async () => {
       const users = await payload.find({
+        overrideAccess: true,
         collection: 'users',
         limit: 3,
       })
@@ -3705,6 +3930,7 @@ describe('@payloadcms/plugin-import-export', () => {
       const csvBuffer = Buffer.from(csvContent)
 
       let importDoc = await payload.create({
+        overrideAccess: true,
         collection: 'imports',
         user,
         data: {
@@ -3719,9 +3945,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       importDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'imports',
         id: importDoc.id,
       })
@@ -3731,6 +3958,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(importDoc.summary?.issues).toBe(0)
 
       const importedPages = await payload.find({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           title: { contains: 'Relationship Import ' },
@@ -3750,12 +3978,13 @@ describe('@payloadcms/plugin-import-export', () => {
     })
 
     it('should handle explicit null vs empty polymorphic relationships in import', async () => {
-      const users = await payload.find({ collection: 'users', limit: 1 })
-      const posts = await payload.find({ collection: 'posts', limit: 1 })
+      const users = await payload.find({ overrideAccess: true, collection: 'users', limit: 1 })
+      const posts = await payload.find({ overrideAccess: true, collection: 'posts', limit: 1 })
       const userId = users.docs[0]?.id
       const postId = posts.docs[0]?.id
 
       const existingPage = await payload.create({
+        overrideAccess: true,
         collection: 'pages',
         data: {
           title: 'Original Title',
@@ -3777,6 +4006,7 @@ describe('@payloadcms/plugin-import-export', () => {
       ].join('\n')
 
       let importDoc = await payload.create({
+        overrideAccess: true,
         collection: 'imports',
         user,
         data: {
@@ -3792,9 +4022,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       importDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'imports',
         id: importDoc.id,
       })
@@ -3804,6 +4035,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(importDoc.summary?.updated).toBe(1)
 
       const updatedPage = await payload.findByID({
+        overrideAccess: true,
         collection: 'pages',
         id: existingPage.id,
       })
@@ -3814,6 +4046,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(updatedPage.hasManyPolymorphic).toHaveLength(1)
 
       await payload.delete({
+        overrideAccess: true,
         collection: 'pages',
         id: existingPage.id,
       })
@@ -3821,10 +4054,12 @@ describe('@payloadcms/plugin-import-export', () => {
 
     it('should import polymorphic relationship fields from CSV', async () => {
       const users = await payload.find({
+        overrideAccess: true,
         collection: 'users',
         limit: 1,
       })
       const posts = await payload.find({
+        overrideAccess: true,
         collection: 'posts',
         limit: 2,
       })
@@ -3839,6 +4074,7 @@ describe('@payloadcms/plugin-import-export', () => {
       const csvBuffer = Buffer.from(csvContent)
 
       let importDoc = await payload.create({
+        overrideAccess: true,
         collection: 'imports',
         user,
         data: {
@@ -3853,9 +4089,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       importDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'imports',
         id: importDoc.id,
       })
@@ -3865,6 +4102,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(importDoc.summary?.issues).toBe(0)
 
       const importedPages = await payload.find({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           title: { equals: 'Polymorphic Import 1' },
@@ -3897,6 +4135,7 @@ describe('@payloadcms/plugin-import-export', () => {
       const csvBuffer = Buffer.from(csvContent)
 
       let importDoc = await payload.create({
+        overrideAccess: true,
         collection: 'imports',
         user,
         data: {
@@ -3911,9 +4150,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       importDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'imports',
         id: importDoc.id,
       })
@@ -3923,6 +4163,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(importDoc.summary?.issues).toBe(0)
 
       const importedPages = await payload.find({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           title: { equals: 'Virtual Import Test' },
@@ -3943,6 +4184,7 @@ describe('@payloadcms/plugin-import-export', () => {
       const csvBuffer = Buffer.from(csvContent)
 
       let importDoc = await payload.create({
+        overrideAccess: true,
         collection: 'imports',
         user,
         data: {
@@ -3957,9 +4199,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       importDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'imports',
         id: importDoc.id,
       })
@@ -3969,6 +4212,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(importDoc.summary?.issues).toBe(0)
 
       const draftPages = await payload.find({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           title: { contains: 'Draft Import ' },
@@ -3980,6 +4224,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(draftPages.docs[0]?._status).toBe('draft')
 
       const publishedPages = await payload.find({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           title: { contains: 'Published Import ' },
@@ -4001,6 +4246,7 @@ describe('@payloadcms/plugin-import-export', () => {
       const csvBuffer = Buffer.from(csvContent)
 
       let importDoc = await payload.create({
+        overrideAccess: true,
         collection: 'imports',
         user,
         data: {
@@ -4015,9 +4261,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       importDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'imports',
         id: importDoc.id,
       })
@@ -4027,6 +4274,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(importDoc.summary?.issues).toBe(0)
 
       const pages = await payload.find({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           title: { contains: 'Default Status Test ' },
@@ -4044,6 +4292,7 @@ describe('@payloadcms/plugin-import-export', () => {
       const missingFieldBuffer = Buffer.from(missingFieldCsv)
 
       let importDoc1 = await payload.create({
+        overrideAccess: true,
         collection: 'imports',
         user,
         data: {
@@ -4058,9 +4307,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       importDoc1 = await payload.findByID({
+        overrideAccess: true,
         collection: 'imports',
         id: importDoc1.id,
       })
@@ -4073,6 +4323,7 @@ describe('@payloadcms/plugin-import-export', () => {
       const invalidTypeBuffer = Buffer.from(invalidTypeCsv)
 
       let importDoc2 = await payload.create({
+        overrideAccess: true,
         collection: 'imports',
         user,
         data: {
@@ -4087,9 +4338,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       importDoc2 = await payload.findByID({
+        overrideAccess: true,
         collection: 'imports',
         id: importDoc2.id,
       })
@@ -4102,6 +4354,7 @@ describe('@payloadcms/plugin-import-export', () => {
       const nonExistentBuffer = Buffer.from(nonExistentCsv)
 
       let importDoc3 = await payload.create({
+        overrideAccess: true,
         collection: 'imports',
         user,
         data: {
@@ -4117,9 +4370,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       importDoc3 = await payload.findByID({
+        overrideAccess: true,
         collection: 'imports',
         id: importDoc3.id,
       })
@@ -4141,6 +4395,7 @@ describe('@payloadcms/plugin-import-export', () => {
       const mixedBuffer = Buffer.from(mixedCsv)
 
       let importDoc = await payload.create({
+        overrideAccess: true,
         collection: 'imports',
         user,
         data: {
@@ -4155,9 +4410,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       importDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'imports',
         id: importDoc.id,
       })
@@ -4222,6 +4478,7 @@ describe('@payloadcms/plugin-import-export', () => {
       const csvBuffer = Buffer.from(csvContent)
 
       let importDoc = await payload.create({
+        overrideAccess: true,
         collection: 'imports',
         user,
         data: {
@@ -4236,9 +4493,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       importDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'imports',
         id: importDoc.id,
       })
@@ -4248,6 +4506,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(importDoc.summary?.issues).toBe(0)
 
       const importedPages = await payload.find({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           title: { equals: 'Nested Group Import' },
@@ -4271,6 +4530,7 @@ describe('@payloadcms/plugin-import-export', () => {
       const csvBuffer = Buffer.from(csvContent)
 
       let importDoc = await payload.create({
+        overrideAccess: true,
         collection: 'imports',
         user,
         data: {
@@ -4285,9 +4545,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       importDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'imports',
         id: importDoc.id,
       })
@@ -4297,6 +4558,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(importDoc.summary?.issues).toBe(0)
 
       const importedPages = await payload.find({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           title: { equals: 'Tab Import Test' },
@@ -4328,6 +4590,7 @@ describe('@payloadcms/plugin-import-export', () => {
       const csvBuffer = Buffer.from(csvContent)
 
       let importDoc = await payload.create({
+        overrideAccess: true,
         collection: 'imports',
         user,
         data: {
@@ -4342,9 +4605,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       importDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'imports',
         id: importDoc.id,
       })
@@ -4354,6 +4618,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(importDoc.summary?.issues).toBe(0)
 
       const importedPages = await payload.find({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           title: { equals: 'Disabled Fields Test' },
@@ -4380,6 +4645,7 @@ describe('@payloadcms/plugin-import-export', () => {
       const csvBuffer = Buffer.from(csvContent)
 
       const doc = await payload.create({
+        overrideAccess: true,
         collection: 'imports' as CollectionSlug,
         user,
         data: {
@@ -4395,6 +4661,7 @@ describe('@payloadcms/plugin-import-export', () => {
       })
 
       const { docs: jobs } = await payload.find({
+        overrideAccess: true,
         collection: 'payload-jobs' as CollectionSlug,
         where: {
           taskSlug: { equals: 'createCollectionImport' },
@@ -4419,9 +4686,10 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(input.importCollection).toStrictEqual('imports')
       expect(input.userCollection).toBeDefined()
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       const importDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'imports' as CollectionSlug,
         id: doc.id,
       })
@@ -4436,6 +4704,7 @@ describe('@payloadcms/plugin-import-export', () => {
       const typedImportDoc = importDoc as ImportDocWithStatus
 
       const importedPages = await payload.find({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           title: { contains: 'Jobs Import ' },
@@ -4452,6 +4721,7 @@ describe('@payloadcms/plugin-import-export', () => {
       const createdPages = []
       for (let i = 0; i < 3; i++) {
         const page = await payload.create({
+          overrideAccess: true,
           collection: 'pages',
           data: {
             title: `Roundtrip Test ${i}`,
@@ -4470,6 +4740,7 @@ describe('@payloadcms/plugin-import-export', () => {
       }
 
       const exportDoc = await payload.create({
+        overrideAccess: true,
         collection: 'exports',
         user,
         data: {
@@ -4490,9 +4761,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       const exportedDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'exports',
         id: exportDoc.id,
       })
@@ -4504,6 +4776,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(exportedData[0].group_custom).toBe('group custom value toCSV')
 
       await payload.delete({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           title: { contains: 'Roundtrip Test ' },
@@ -4511,6 +4784,7 @@ describe('@payloadcms/plugin-import-export', () => {
       })
 
       let importDoc = await payload.create({
+        overrideAccess: true,
         collection: 'imports',
         user,
         data: {
@@ -4525,9 +4799,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       importDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'imports',
         id: importDoc.id,
       })
@@ -4537,6 +4812,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(importDoc.summary?.issues).toBe(0)
 
       const importedPages = await payload.find({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           title: { contains: 'Roundtrip Test ' },
@@ -4553,10 +4829,12 @@ describe('@payloadcms/plugin-import-export', () => {
 
     it('should handle all field types in export/import roundtrip', async () => {
       const testUser = await payload.find({
+        overrideAccess: true,
         collection: 'users',
         limit: 1,
       })
       const testPost = await payload.create({
+        overrideAccess: true,
         collection: 'posts',
         data: {
           title: 'Test Post for Roundtrip',
@@ -4564,6 +4842,7 @@ describe('@payloadcms/plugin-import-export', () => {
       })
 
       const testPage = await payload.create({
+        overrideAccess: true,
         collection: 'pages',
         data: {
           title: 'Complete Roundtrip Test',
@@ -4610,6 +4889,7 @@ describe('@payloadcms/plugin-import-export', () => {
       })
 
       const exportDoc = await payload.create({
+        overrideAccess: true,
         collection: 'exports',
         user,
         data: {
@@ -4623,9 +4903,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       const exportedDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'exports',
         id: exportDoc.id,
       })
@@ -4633,11 +4914,13 @@ describe('@payloadcms/plugin-import-export', () => {
       const csvPath = path.join(dirname, './uploads', exportedDoc.filename as string)
 
       await payload.delete({
+        overrideAccess: true,
         collection: 'pages',
         id: testPage.id,
       })
 
       let importDoc = await payload.create({
+        overrideAccess: true,
         collection: 'imports',
         user,
         data: {
@@ -4652,9 +4935,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       importDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'imports',
         id: importDoc.id,
       })
@@ -4664,6 +4948,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(importDoc.summary?.issues).toBe(0)
 
       const importedPages = await payload.find({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           title: { equals: 'Complete Roundtrip Test' },
@@ -4693,6 +4978,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(imported?.group?.array).toHaveLength(1)
 
       await payload.delete({
+        overrideAccess: true,
         collection: 'posts',
         id: testPost.id,
       })
@@ -4708,6 +4994,7 @@ describe('@payloadcms/plugin-import-export', () => {
         const csvBuffer = Buffer.from(csvContent)
 
         let importDoc = await payload.create({
+          overrideAccess: true,
           collection: 'imports',
           user,
           data: {
@@ -4722,9 +5009,10 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
         importDoc = await payload.findByID({
+          overrideAccess: true,
           collection: 'imports',
           id: importDoc.id,
         })
@@ -4734,6 +5022,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(importDoc.summary?.issues).toBe(0)
 
         const importedPages = await payload.find({
+          overrideAccess: true,
           collection: 'pages',
           where: {
             title: { contains: 'Batch Test ' },
@@ -4744,6 +5033,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(importedPages.totalDocs).toBe(250)
 
         await payload.delete({
+          overrideAccess: true,
           collection: 'pages',
           where: {
             title: { contains: 'Batch Test ' },
@@ -4762,6 +5052,7 @@ describe('@payloadcms/plugin-import-export', () => {
         const csvBuffer = Buffer.from(csvContent)
 
         let importDoc = await payload.create({
+          overrideAccess: true,
           collection: 'imports',
           user,
           data: {
@@ -4776,9 +5067,10 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
         importDoc = await payload.findByID({
+          overrideAccess: true,
           collection: 'imports',
           id: importDoc.id,
         })
@@ -4788,6 +5080,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(importDoc.summary?.issues).toBe(2)
 
         await payload.delete({
+          overrideAccess: true,
           collection: 'pages',
           where: {
             title: { contains: 'Valid Doc ' },
@@ -4797,6 +5090,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
       it('should report row numbers in errors correctly', async () => {
         const testUser = await payload.find({
+          overrideAccess: true,
           collection: 'users',
           limit: 1,
         })
@@ -4811,6 +5105,7 @@ describe('@payloadcms/plugin-import-export', () => {
         const csvBuffer = Buffer.from(csvContent)
 
         let importDoc = await payload.create({
+          overrideAccess: true,
           collection: 'imports',
           user,
           data: {
@@ -4825,9 +5120,10 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
         importDoc = await payload.findByID({
+          overrideAccess: true,
           collection: 'imports',
           id: importDoc.id,
         })
@@ -4843,6 +5139,7 @@ describe('@payloadcms/plugin-import-export', () => {
         }
 
         await payload.delete({
+          overrideAccess: true,
           collection: 'pages',
           where: {
             title: { contains: 'Row ' },
@@ -4859,6 +5156,7 @@ describe('@payloadcms/plugin-import-export', () => {
         const csvBuffer = Buffer.from(csvContent)
 
         let importDoc = await payload.create({
+          overrideAccess: true,
           collection: 'imports',
           user,
           data: {
@@ -4873,9 +5171,10 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
         importDoc = await payload.findByID({
+          overrideAccess: true,
           collection: 'imports',
           id: importDoc.id,
         })
@@ -4885,6 +5184,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(importDoc.summary?.issues).toBe(0)
 
         const importedPagesEn = await payload.find({
+          overrideAccess: true,
           collection: 'pages',
           where: {
             title: { contains: 'Batch Localized ' },
@@ -4897,6 +5197,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(importedPagesEn.docs[0]?.localized).toContain('English')
 
         const importedPagesEs = await payload.find({
+          overrideAccess: true,
           collection: 'pages',
           where: {
             title: { contains: 'Batch Localized ' },
@@ -4908,6 +5209,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(importedPagesEs.docs[0]?.localized).toContain('Spanish')
 
         await payload.delete({
+          overrideAccess: true,
           collection: 'pages',
           where: {
             title: { contains: 'Batch Localized ' },
@@ -4921,6 +5223,7 @@ describe('@payloadcms/plugin-import-export', () => {
         const csvBuffer = Buffer.from(csvContent)
 
         let importDoc = await payload.create({
+          overrideAccess: true,
           collection: 'imports',
           user,
           data: {
@@ -4935,9 +5238,10 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
         importDoc = await payload.findByID({
+          overrideAccess: true,
           collection: 'imports',
           id: importDoc.id,
         })
@@ -4947,6 +5251,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(importDoc.summary?.issues).toBe(0)
 
         const publishedPages = await payload.find({
+          overrideAccess: true,
           collection: 'pages',
           where: {
             title: { contains: 'Default Status Test ' },
@@ -4960,6 +5265,7 @@ describe('@payloadcms/plugin-import-export', () => {
         })
 
         await payload.delete({
+          overrideAccess: true,
           collection: 'pages',
           where: {
             title: { contains: 'Default Status Test ' },
@@ -4973,6 +5279,7 @@ describe('@payloadcms/plugin-import-export', () => {
         const csvBuffer = Buffer.from(csvContent)
 
         let importDoc = await payload.create({
+          overrideAccess: true,
           collection: 'imports',
           user,
           data: {
@@ -4987,9 +5294,10 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
         importDoc = await payload.findByID({
+          overrideAccess: true,
           collection: 'imports',
           id: importDoc.id,
         })
@@ -4999,6 +5307,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(importDoc.summary?.issues).toBe(0)
 
         const draftPages = await payload.find({
+          overrideAccess: true,
           collection: 'pages',
           where: {
             title: { contains: 'Explicit Draft Test ' },
@@ -5012,6 +5321,7 @@ describe('@payloadcms/plugin-import-export', () => {
         })
 
         await payload.delete({
+          overrideAccess: true,
           collection: 'pages',
           where: {
             title: { contains: 'Explicit Draft Test ' },
@@ -5025,6 +5335,7 @@ describe('@payloadcms/plugin-import-export', () => {
         const csvBuffer = Buffer.from(csvContent)
 
         let importDoc = await payload.create({
+          overrideAccess: true,
           collection: 'imports',
           user,
           data: {
@@ -5040,9 +5351,10 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
         importDoc = await payload.findByID({
+          overrideAccess: true,
           collection: 'imports',
           id: importDoc.id,
         })
@@ -5052,6 +5364,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(importDoc.summary?.issues).toBe(0)
 
         const publishedPages = await payload.find({
+          overrideAccess: true,
           collection: 'pages',
           where: {
             title: { contains: 'Upsert New Published Test ' },
@@ -5065,6 +5378,7 @@ describe('@payloadcms/plugin-import-export', () => {
         })
 
         await payload.delete({
+          overrideAccess: true,
           collection: 'pages',
           where: {
             title: { contains: 'Upsert New Published Test ' },
@@ -5078,6 +5392,7 @@ describe('@payloadcms/plugin-import-export', () => {
         const csvBuffer = Buffer.from(csvContent)
 
         let importDoc = await payload.create({
+          overrideAccess: true,
           collection: 'imports',
           user,
           data: {
@@ -5092,9 +5407,10 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
         importDoc = await payload.findByID({
+          overrideAccess: true,
           collection: 'imports',
           id: importDoc.id,
         })
@@ -5104,6 +5420,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(importDoc.summary?.issues).toBe(0)
 
         const importedPages = await payload.find({
+          overrideAccess: true,
           collection: 'pages',
           where: {
             title: { contains: 'Manual Locale Test ' },
@@ -5119,6 +5436,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(sortedDocs[1]?.localized).toBe('Default locale content 2')
 
         await payload.delete({
+          overrideAccess: true,
           collection: 'pages',
           where: {
             title: { contains: 'Manual Locale Test ' },
@@ -5139,6 +5457,7 @@ describe('@payloadcms/plugin-import-export', () => {
         const csvBuffer = Buffer.from(csvContent)
 
         let importDoc = await payload.create({
+          overrideAccess: true,
           collection: 'imports',
           user,
           data: {
@@ -5153,14 +5472,19 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
-        importDoc = await payload.findByID({ collection: 'imports', id: importDoc.id })
+        importDoc = await payload.findByID({
+          overrideAccess: true,
+          collection: 'imports',
+          id: importDoc.id,
+        })
 
         expect(importDoc.status).toBe('completed')
         expect(importDoc.summary?.imported).toBe(4)
 
         const importedPages = await payload.find({
+          overrideAccess: true,
           collection: 'pages',
           where: { title: { contains: 'Checkbox Import ' } },
           sort: 'title',
@@ -5179,6 +5503,7 @@ describe('@payloadcms/plugin-import-export', () => {
         )
 
         await payload.delete({
+          overrideAccess: true,
           collection: 'pages',
           where: { title: { contains: 'Checkbox Import ' } },
         })
@@ -5194,6 +5519,7 @@ describe('@payloadcms/plugin-import-export', () => {
         const csvBuffer = Buffer.from(csvContent)
 
         let importDoc = await payload.create({
+          overrideAccess: true,
           collection: 'imports',
           user,
           data: {
@@ -5208,14 +5534,19 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
-        importDoc = await payload.findByID({ collection: 'imports', id: importDoc.id })
+        importDoc = await payload.findByID({
+          overrideAccess: true,
+          collection: 'imports',
+          id: importDoc.id,
+        })
 
         expect(importDoc.status).toBe('completed')
         expect(importDoc.summary?.imported).toBe(3)
 
         const importedPages = await payload.find({
+          overrideAccess: true,
           collection: 'pages',
           where: { title: { contains: 'Select Import ' } },
           sort: 'title',
@@ -5233,6 +5564,7 @@ describe('@payloadcms/plugin-import-export', () => {
         )
 
         await payload.delete({
+          overrideAccess: true,
           collection: 'pages',
           where: { title: { contains: 'Select Import ' } },
         })
@@ -5248,6 +5580,7 @@ describe('@payloadcms/plugin-import-export', () => {
         const csvBuffer = Buffer.from(csvContent)
 
         let importDoc = await payload.create({
+          overrideAccess: true,
           collection: 'imports',
           user,
           data: {
@@ -5262,14 +5595,19 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
-        importDoc = await payload.findByID({ collection: 'imports', id: importDoc.id })
+        importDoc = await payload.findByID({
+          overrideAccess: true,
+          collection: 'imports',
+          id: importDoc.id,
+        })
 
         expect(importDoc.status).toBe('completed')
         expect(importDoc.summary?.imported).toBe(3)
 
         const importedPages = await payload.find({
+          overrideAccess: true,
           collection: 'pages',
           where: { title: { contains: 'Radio Import ' } },
           sort: 'title',
@@ -5281,6 +5619,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(importedPages.docs.find((d) => d.title === 'Radio Import 3')?.radio).toBe('radio3')
 
         await payload.delete({
+          overrideAccess: true,
           collection: 'pages',
           where: { title: { contains: 'Radio Import ' } },
         })
@@ -5295,6 +5634,7 @@ describe('@payloadcms/plugin-import-export', () => {
         const csvBuffer = Buffer.from(csvContent)
 
         let importDoc = await payload.create({
+          overrideAccess: true,
           collection: 'imports',
           user,
           data: {
@@ -5309,14 +5649,19 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
-        importDoc = await payload.findByID({ collection: 'imports', id: importDoc.id })
+        importDoc = await payload.findByID({
+          overrideAccess: true,
+          collection: 'imports',
+          id: importDoc.id,
+        })
 
         expect(importDoc.status).toBe('completed')
         expect(importDoc.summary?.imported).toBe(2)
 
         const importedPages = await payload.find({
+          overrideAccess: true,
           collection: 'pages',
           where: { title: { contains: 'Email Import ' } },
           sort: 'title',
@@ -5331,6 +5676,7 @@ describe('@payloadcms/plugin-import-export', () => {
         )
 
         await payload.delete({
+          overrideAccess: true,
           collection: 'pages',
           where: { title: { contains: 'Email Import ' } },
         })
@@ -5342,6 +5688,7 @@ describe('@payloadcms/plugin-import-export', () => {
         const csvBuffer = Buffer.from(csvContent)
 
         let importDoc = await payload.create({
+          overrideAccess: true,
           collection: 'imports',
           user,
           data: {
@@ -5356,14 +5703,19 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
-        importDoc = await payload.findByID({ collection: 'imports', id: importDoc.id })
+        importDoc = await payload.findByID({
+          overrideAccess: true,
+          collection: 'imports',
+          id: importDoc.id,
+        })
 
         expect(importDoc.status).toBe('completed')
         expect(importDoc.summary?.imported).toBe(1)
 
         const importedPages = await payload.find({
+          overrideAccess: true,
           collection: 'pages',
           where: { title: { equals: 'Textarea Import 1' } },
         })
@@ -5373,6 +5725,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(importedPages.docs[0]?.textarea).toContain('Line 2')
 
         await payload.delete({
+          overrideAccess: true,
           collection: 'pages',
           where: { title: { equals: 'Textarea Import 1' } },
         })
@@ -5384,6 +5737,7 @@ describe('@payloadcms/plugin-import-export', () => {
         const csvBuffer = Buffer.from(csvContent)
 
         let importDoc = await payload.create({
+          overrideAccess: true,
           collection: 'imports',
           user,
           data: {
@@ -5398,14 +5752,19 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
-        importDoc = await payload.findByID({ collection: 'imports', id: importDoc.id })
+        importDoc = await payload.findByID({
+          overrideAccess: true,
+          collection: 'imports',
+          id: importDoc.id,
+        })
 
         expect(importDoc.status).toBe('completed')
         expect(importDoc.summary?.imported).toBe(1)
 
         const importedPages = await payload.find({
+          overrideAccess: true,
           collection: 'pages',
           where: { title: { equals: 'Code Import 1' } },
         })
@@ -5414,6 +5773,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(importedPages.docs[0]?.code).toBe('function hello() { return 42; }')
 
         await payload.delete({
+          overrideAccess: true,
           collection: 'pages',
           where: { title: { equals: 'Code Import 1' } },
         })
@@ -5428,6 +5788,7 @@ describe('@payloadcms/plugin-import-export', () => {
         const csvBuffer = Buffer.from(csvContent)
 
         let importDoc = await payload.create({
+          overrideAccess: true,
           collection: 'imports',
           user,
           data: {
@@ -5442,14 +5803,19 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
-        importDoc = await payload.findByID({ collection: 'imports', id: importDoc.id })
+        importDoc = await payload.findByID({
+          overrideAccess: true,
+          collection: 'imports',
+          id: importDoc.id,
+        })
 
         expect(importDoc.status).toBe('completed')
         expect(importDoc.summary?.imported).toBe(2)
 
         const importedPages = await payload.find({
+          overrideAccess: true,
           collection: 'pages',
           where: { title: { contains: 'Point Import ' } },
           sort: 'title',
@@ -5464,6 +5830,7 @@ describe('@payloadcms/plugin-import-export', () => {
         ])
 
         await payload.delete({
+          overrideAccess: true,
           collection: 'pages',
           where: { title: { contains: 'Point Import ' } },
         })
@@ -5479,6 +5846,7 @@ describe('@payloadcms/plugin-import-export', () => {
         const csvBuffer = Buffer.from(csvContent)
 
         let importDoc = await payload.create({
+          overrideAccess: true,
           collection: 'imports',
           user,
           data: {
@@ -5493,14 +5861,19 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
-        importDoc = await payload.findByID({ collection: 'imports', id: importDoc.id })
+        importDoc = await payload.findByID({
+          overrideAccess: true,
+          collection: 'imports',
+          id: importDoc.id,
+        })
 
         expect(importDoc.status).toBe('completed')
         expect(importDoc.summary?.imported).toBe(3)
 
         const importedPages = await payload.find({
+          overrideAccess: true,
           collection: 'pages',
           where: { title: { contains: 'SelectHasMany Import ' } },
           sort: 'title',
@@ -5518,6 +5891,7 @@ describe('@payloadcms/plugin-import-export', () => {
         ).toEqual(['tagA', 'tagB', 'tagC'])
 
         await payload.delete({
+          overrideAccess: true,
           collection: 'pages',
           where: { title: { contains: 'SelectHasMany Import ' } },
         })
@@ -5533,6 +5907,7 @@ describe('@payloadcms/plugin-import-export', () => {
         const csvBuffer = Buffer.from(csvContent)
 
         let importDoc = await payload.create({
+          overrideAccess: true,
           collection: 'imports',
           user,
           data: {
@@ -5547,14 +5922,19 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
-        importDoc = await payload.findByID({ collection: 'imports', id: importDoc.id })
+        importDoc = await payload.findByID({
+          overrideAccess: true,
+          collection: 'imports',
+          id: importDoc.id,
+        })
 
         expect(importDoc.status).toBe('completed')
         expect(importDoc.summary?.imported).toBe(3)
 
         const importedPages = await payload.find({
+          overrideAccess: true,
           collection: 'pages',
           where: { title: { contains: 'TextHasMany Import ' } },
           sort: 'title',
@@ -5572,6 +5952,7 @@ describe('@payloadcms/plugin-import-export', () => {
         ).toEqual(['a', 'b', 'c'])
 
         await payload.delete({
+          overrideAccess: true,
           collection: 'pages',
           where: { title: { contains: 'TextHasMany Import ' } },
         })
@@ -5582,6 +5963,7 @@ describe('@payloadcms/plugin-import-export', () => {
         const imageFile = await getFileByPath(imageFilePath)
 
         const media = await payload.create({
+          overrideAccess: true,
           collection: 'media',
           data: {
             alt: 'Import Test Media',
@@ -5597,6 +5979,7 @@ describe('@payloadcms/plugin-import-export', () => {
         const csvBuffer = Buffer.from(csvContent)
 
         let importDoc = await payload.create({
+          overrideAccess: true,
           collection: 'imports',
           user,
           data: {
@@ -5611,14 +5994,19 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
-        importDoc = await payload.findByID({ collection: 'imports', id: importDoc.id })
+        importDoc = await payload.findByID({
+          overrideAccess: true,
+          collection: 'imports',
+          id: importDoc.id,
+        })
 
         expect(importDoc.status).toBe('completed')
         expect(importDoc.summary?.imported).toBe(2)
 
         const importedPages = await payload.find({
+          overrideAccess: true,
           collection: 'pages',
           where: { title: { contains: 'Upload Import ' } },
           sort: 'title',
@@ -5630,10 +6018,12 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(importedPages.docs[1]?.upload).toBe(media.id)
 
         await payload.delete({
+          overrideAccess: true,
           collection: 'pages',
           where: { title: { contains: 'Upload Import ' } },
         })
         await payload.delete({
+          overrideAccess: true,
           collection: 'media',
           id: media.id,
         })
@@ -5647,6 +6037,7 @@ describe('@payloadcms/plugin-import-export', () => {
         for (const id of createdCustomIdPages) {
           try {
             await payload.delete({
+              overrideAccess: true,
               collection: customIdPagesSlug as CollectionSlug,
               id,
             })
@@ -5667,6 +6058,7 @@ describe('@payloadcms/plugin-import-export', () => {
         const jsonBuffer = Buffer.from(JSON.stringify(testData))
 
         const importDoc = await payload.create({
+          overrideAccess: true,
           collection: 'imports',
           user,
           data: {
@@ -5681,9 +6073,10 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
         const completedImport = await payload.findByID({
+          overrideAccess: true,
           collection: 'imports',
           id: importDoc.id,
         })
@@ -5693,6 +6086,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(completedImport.summary?.issues).toBe(0)
 
         const importedPages = await payload.find({
+          overrideAccess: true,
           collection: customIdPagesSlug as CollectionSlug,
           sort: 'id',
         })
@@ -5711,6 +6105,7 @@ describe('@payloadcms/plugin-import-export', () => {
         const csvBuffer = Buffer.from(csvContent)
 
         const importDoc = await payload.create({
+          overrideAccess: true,
           collection: 'imports',
           user,
           data: {
@@ -5725,9 +6120,10 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
         const completedImport = await payload.findByID({
+          overrideAccess: true,
           collection: 'imports',
           id: importDoc.id,
         })
@@ -5736,6 +6132,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(completedImport.summary?.imported).toBe(2)
 
         const importedPages = await payload.find({
+          overrideAccess: true,
           collection: customIdPagesSlug as CollectionSlug,
           where: {
             id: { in: ['custom-csv-1', 'custom-csv-2'] },
@@ -5759,6 +6156,7 @@ describe('@payloadcms/plugin-import-export', () => {
         const jsonBuffer = Buffer.from(JSON.stringify(testData))
 
         const importDoc = await payload.create({
+          overrideAccess: true,
           collection: 'imports',
           user,
           data: {
@@ -5774,9 +6172,10 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
         const completedImport = await payload.findByID({
+          overrideAccess: true,
           collection: 'imports',
           id: importDoc.id,
         })
@@ -5785,6 +6184,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(completedImport.summary?.imported).toBe(2)
 
         const importedPages = await payload.find({
+          overrideAccess: true,
           collection: customIdPagesSlug as CollectionSlug,
           where: {
             id: { in: ['upsert-custom-1', 'upsert-custom-2'] },
@@ -5801,6 +6201,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
       it('should update existing documents with custom IDs in upsert mode', async () => {
         await payload.create({
+          overrideAccess: true,
           collection: customIdPagesSlug,
           data: {
             id: 'existing-custom-1',
@@ -5815,6 +6216,7 @@ describe('@payloadcms/plugin-import-export', () => {
         const jsonBuffer = Buffer.from(JSON.stringify(testData))
 
         const importDoc = await payload.create({
+          overrideAccess: true,
           collection: 'imports',
           user,
           data: {
@@ -5830,9 +6232,10 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
         const completedImport = await payload.findByID({
+          overrideAccess: true,
           collection: 'imports',
           id: importDoc.id,
         })
@@ -5841,6 +6244,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(completedImport.summary?.updated).toBe(1)
 
         const updatedPage = await payload.findByID({
+          overrideAccess: true,
           collection: customIdPagesSlug as CollectionSlug,
           id: 'existing-custom-1',
         })
@@ -5850,6 +6254,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
       it('should update existing documents with custom IDs in update mode', async () => {
         await payload.create({
+          overrideAccess: true,
           collection: customIdPagesSlug as CollectionSlug,
           data: {
             id: 'update-mode-custom-1',
@@ -5864,6 +6269,7 @@ describe('@payloadcms/plugin-import-export', () => {
         const jsonBuffer = Buffer.from(JSON.stringify(testData))
 
         const importDoc = await payload.create({
+          overrideAccess: true,
           collection: 'imports',
           data: {
             collectionSlug: customIdPagesSlug,
@@ -5879,9 +6285,10 @@ describe('@payloadcms/plugin-import-export', () => {
           user,
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
         const completedImport = await payload.findByID({
+          overrideAccess: true,
           id: importDoc.id,
           collection: 'imports',
         })
@@ -5890,6 +6297,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(completedImport.summary?.updated).toBe(1)
 
         const updatedPage = await payload.findByID({
+          overrideAccess: true,
           id: 'update-mode-custom-1',
           collection: customIdPagesSlug as CollectionSlug,
         })
@@ -5903,6 +6311,7 @@ describe('@payloadcms/plugin-import-export', () => {
         const jsonBuffer = Buffer.from(JSON.stringify(testData))
 
         const importDoc = await payload.create({
+          overrideAccess: true,
           collection: 'imports',
           data: {
             collectionSlug: customIdPagesSlug,
@@ -5918,9 +6327,10 @@ describe('@payloadcms/plugin-import-export', () => {
           user,
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
         const completedImport = await payload.findByID({
+          overrideAccess: true,
           id: importDoc.id,
           collection: 'imports',
         })
@@ -5985,6 +6395,7 @@ describe('@payloadcms/plugin-import-export', () => {
     describe('posts-exports-only', () => {
       it('should export from posts-exports-only collection (no jobs queue)', async () => {
         const doc = await payload.create({
+          overrideAccess: true,
           collection: 'exports',
           user,
           data: {
@@ -5993,9 +6404,10 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
         const exportDoc = await payload.findByID({
+          overrideAccess: true,
           collection: 'exports',
           id: doc.id,
         })
@@ -6011,6 +6423,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
       it('should not allow restricted user to export from posts-exports-only (access control)', async () => {
         const doc = await payload.create({
+          overrideAccess: true,
           collection: 'exports',
           user: restrictedUser,
           data: {
@@ -6022,6 +6435,7 @@ describe('@payloadcms/plugin-import-export', () => {
         const {
           docs: [latestJob],
         } = await payload.find({
+          overrideAccess: true,
           collection: 'payload-jobs',
           sort: '-createdAt',
           limit: 1,
@@ -6029,9 +6443,10 @@ describe('@payloadcms/plugin-import-export', () => {
 
         expect(latestJob).toBeDefined()
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
         const exportDoc = await payload.findByID({
+          overrideAccess: true,
           collection: 'exports',
           id: doc.id,
         })
@@ -6049,6 +6464,7 @@ describe('@payloadcms/plugin-import-export', () => {
         const csvBuffer = Buffer.from(csvContent)
 
         let importDoc = await payload.create({
+          overrideAccess: true,
           collection: 'imports',
           user,
           data: {
@@ -6063,9 +6479,10 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
         importDoc = await payload.findByID({
+          overrideAccess: true,
           collection: 'imports',
           id: importDoc.id,
         })
@@ -6075,6 +6492,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(importDoc.summary?.issues).toBe(0)
 
         const importedDocs = await payload.find({
+          overrideAccess: true,
           collection: 'posts-imports-only',
           where: {
             title: { contains: 'Sync Import Test' },
@@ -6084,6 +6502,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(importedDocs.totalDocs).toBe(3)
 
         await payload.delete({
+          overrideAccess: true,
           collection: 'posts-imports-only',
           where: {
             title: { contains: 'Sync Import Test' },
@@ -6096,6 +6515,7 @@ describe('@payloadcms/plugin-import-export', () => {
         const csvBuffer = Buffer.from(csvContent)
 
         let importDoc = await payload.create({
+          overrideAccess: true,
           collection: 'imports',
           user: restrictedUser,
           data: {
@@ -6110,7 +6530,7 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
         importDoc = await payload.findByID({
           collection: 'imports',
@@ -6123,6 +6543,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(importDoc.summary?.issues).toBeGreaterThan(0)
 
         const importedDocs = await payload.find({
+          overrideAccess: true,
           collection: 'posts-imports-only',
           where: {
             title: { contains: 'Restricted Import Test' },
@@ -6138,6 +6559,7 @@ describe('@payloadcms/plugin-import-export', () => {
         const csvBuffer = Buffer.from(csvContent)
 
         let importDoc = await payload.create({
+          overrideAccess: true,
           collection: 'imports',
           user,
           data: {
@@ -6152,9 +6574,10 @@ describe('@payloadcms/plugin-import-export', () => {
           },
         })
 
-        await payload.jobs.run()
+        await payload.jobs.run({ overrideAccess: true })
 
         importDoc = await payload.findByID({
+          overrideAccess: true,
           collection: 'imports',
           id: importDoc.id,
         })
@@ -6164,6 +6587,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(importDoc.summary?.issues).toBe(0)
 
         const draftDocs = await payload.find({
+          overrideAccess: true,
           collection: 'posts-imports-only',
           where: {
             title: { contains: 'Default Draft Config Test' },
@@ -6177,6 +6601,7 @@ describe('@payloadcms/plugin-import-export', () => {
         })
 
         const publishedDocs = await payload.find({
+          overrideAccess: true,
           collection: 'posts-imports-only',
           where: {
             title: { equals: 'Default Draft Config Override Test' },
@@ -6188,6 +6613,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(publishedDocs.docs[0]?._status).toBe('published')
 
         await payload.delete({
+          overrideAccess: true,
           collection: 'posts-imports-only',
           where: {
             or: [
@@ -6204,6 +6630,7 @@ describe('@payloadcms/plugin-import-export', () => {
     it('should respect access control when export uses jobs queue', async () => {
       for (let i = 0; i < 3; i++) {
         await payload.create({
+          overrideAccess: true,
           collection: 'pages',
           data: {
             title: `Access Control Export Test ${i}`,
@@ -6212,6 +6639,7 @@ describe('@payloadcms/plugin-import-export', () => {
       }
 
       const doc = await payload.create({
+        overrideAccess: true,
         collection: 'exports',
         user,
         data: {
@@ -6221,9 +6649,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       const exportDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'exports',
         id: doc.id,
       })
@@ -6240,6 +6669,7 @@ describe('@payloadcms/plugin-import-export', () => {
       const csvBuffer = Buffer.from(csvContent)
 
       const importDoc = await payload.create({
+        overrideAccess: true,
         collection: 'imports',
         user,
         data: {
@@ -6254,9 +6684,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       const updatedImportDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'imports',
         id: importDoc.id,
       })
@@ -6265,6 +6696,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(updatedImportDoc.summary?.imported).toBe(2)
 
       const importedDocs = await payload.find({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           title: { contains: 'Jobs Queue Import' },
@@ -6274,6 +6706,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(importedDocs.totalDocs).toBe(2)
 
       await payload.delete({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           title: { contains: 'Jobs Queue Import' },
@@ -6285,6 +6718,7 @@ describe('@payloadcms/plugin-import-export', () => {
   describe('preview endpoints', () => {
     it('should return export preview data for CSV format', async () => {
       await payload.create({
+        overrideAccess: true,
         collection: 'pages',
         data: {
           title: 'Preview Export Test 1',
@@ -6294,6 +6728,7 @@ describe('@payloadcms/plugin-import-export', () => {
       })
 
       await payload.create({
+        overrideAccess: true,
         collection: 'pages',
         data: {
           title: 'Preview Export Test 2',
@@ -6326,6 +6761,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(response.docs[0]).toHaveProperty('title')
 
       await payload.delete({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           title: { contains: 'Preview Export Test' },
@@ -6335,6 +6771,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
     it('should return export preview data for JSON format', async () => {
       await payload.create({
+        overrideAccess: true,
         collection: 'pages',
         data: {
           title: 'JSON Preview Export Test',
@@ -6368,6 +6805,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(response.docs[0]?.group?.value).toBe('nested group value')
 
       await payload.delete({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           title: { equals: 'JSON Preview Export Test' },
@@ -6484,6 +6922,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
     it('should apply beforeExport hook customizations in export preview and remove replaced columns', async () => {
       const page = await payload.create({
+        overrideAccess: true,
         collection: 'pages',
         data: {
           title: 'Preview beforeExport Test',
@@ -6544,11 +6983,12 @@ describe('@payloadcms/plugin-import-export', () => {
       // excerpt should still be present
       expect(doc.excerpt).toBe('preview excerpt')
 
-      await payload.delete({ collection: 'pages', id: page.id })
+      await payload.delete({ overrideAccess: true, collection: 'pages', id: page.id })
     })
 
     it('should remove replaced columns from preview when no fields are selected', async () => {
       const page = await payload.create({
+        overrideAccess: true,
         collection: 'pages',
         data: {
           title: 'Preview No Fields beforeExport Test',
@@ -6596,7 +7036,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(responseColumns).not.toContain('customRelIdName')
       expect(doc).not.toHaveProperty('customRelIdName')
 
-      await payload.delete({ collection: 'pages', id: page.id })
+      await payload.delete({ overrideAccess: true, collection: 'pages', id: page.id })
     })
 
     it('should handle invalid collection slug in import preview', async () => {
@@ -6805,6 +7245,7 @@ describe('@payloadcms/plugin-import-export', () => {
     it('should respect preview limit (max 10)', async () => {
       for (let i = 0; i < 15; i++) {
         await payload.create({
+          overrideAccess: true,
           collection: 'pages',
           data: {
             title: `Preview Limit Test ${i}`,
@@ -6832,6 +7273,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(response.docs.length).toBeLessThanOrEqual(10)
 
       await payload.delete({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           title: { contains: 'Preview Limit Test' },
@@ -6842,6 +7284,7 @@ describe('@payloadcms/plugin-import-export', () => {
     it('should respect export limit when paginating preview (limit 11, per page 10)', async () => {
       for (let i = 0; i < 15; i++) {
         await payload.create({
+          overrideAccess: true,
           collection: 'pages',
           data: {
             title: `Preview Pagination Test ${i}`,
@@ -6915,6 +7358,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(responsePage2.hasPrevPage).toBe(true)
 
       await payload.delete({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           title: { contains: 'Preview Pagination Test' },
@@ -6925,6 +7369,7 @@ describe('@payloadcms/plugin-import-export', () => {
     it('should return empty docs when preview page exceeds export limit boundary', async () => {
       for (let i = 0; i < 5; i++) {
         await payload.create({
+          overrideAccess: true,
           collection: 'pages',
           data: {
             title: `Preview Boundary Test ${i}`,
@@ -6964,6 +7409,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(response.hasNextPage).toBe(false)
 
       await payload.delete({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           title: { contains: 'Preview Boundary Test' },
@@ -6989,6 +7435,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(previewResponse.columns.length).toBeGreaterThan(0)
 
       const exportDoc = await payload.create({
+        overrideAccess: true,
         collection: 'posts-export',
         user,
         data: {
@@ -6999,6 +7446,7 @@ describe('@payloadcms/plugin-import-export', () => {
       })
 
       const finalExportDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'posts-export',
         id: exportDoc.id,
       })
@@ -7032,6 +7480,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(previewResponse.columns.length).toBeGreaterThan(0)
 
       const exportDoc = await payload.create({
+        overrideAccess: true,
         collection: 'posts-export',
         user,
         data: {
@@ -7043,6 +7492,7 @@ describe('@payloadcms/plugin-import-export', () => {
       })
 
       const finalExportDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'posts-export',
         id: exportDoc.id,
       })
@@ -7060,6 +7510,7 @@ describe('@payloadcms/plugin-import-export', () => {
   describe('rich text field handling', () => {
     it('should preserve Lexical numeric properties on JSON export/import', async () => {
       const page = await payload.create({
+        overrideAccess: true,
         collection: 'pages',
         data: {
           title: 'Rich Text JSON Test',
@@ -7074,6 +7525,7 @@ describe('@payloadcms/plugin-import-export', () => {
       })
 
       const exportDoc = await payload.create({
+        overrideAccess: true,
         collection: 'exports',
         user,
         data: {
@@ -7085,9 +7537,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       const exportedDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'exports',
         id: exportDoc.id,
       })
@@ -7099,6 +7552,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(exportedData[0].blocks[0].richText.root.children[0].version).toBe(1)
 
       await payload.delete({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           id: { equals: page.id },
@@ -7107,6 +7561,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
       const jsonBuffer = Buffer.from(JSON.stringify(exportedData))
       let importDoc = await payload.create({
+        overrideAccess: true,
         collection: 'imports',
         user,
         data: {
@@ -7121,9 +7576,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       importDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'imports',
         id: importDoc.id,
       })
@@ -7131,6 +7587,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(importDoc.status).toBe('completed')
 
       const importedPage = await payload.find({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           title: { equals: 'Rich Text JSON Test' },
@@ -7144,6 +7601,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(richText?.root?.version).toBe(1)
 
       await payload.delete({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           title: { equals: 'Rich Text JSON Test' },
@@ -7153,6 +7611,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
     it('should export rich text inside blocks to CSV and import back', async () => {
       const page = await payload.create({
+        overrideAccess: true,
         collection: 'pages',
         data: {
           title: 'Rich Text CSV Block Test',
@@ -7167,6 +7626,7 @@ describe('@payloadcms/plugin-import-export', () => {
       })
 
       const exportDoc = await payload.create({
+        overrideAccess: true,
         collection: 'exports',
         user,
         data: {
@@ -7178,9 +7638,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       const exportedDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'exports',
         id: exportDoc.id,
       })
@@ -7188,6 +7649,7 @@ describe('@payloadcms/plugin-import-export', () => {
       const csvPath = path.join(dirname, './uploads', exportedDoc.filename as string)
 
       await payload.delete({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           id: { equals: page.id },
@@ -7195,6 +7657,7 @@ describe('@payloadcms/plugin-import-export', () => {
       })
 
       let importDoc = await payload.create({
+        overrideAccess: true,
         collection: 'imports',
         user,
         data: {
@@ -7209,9 +7672,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       importDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'imports',
         id: importDoc.id,
       })
@@ -7219,6 +7683,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(importDoc.status).toBe('completed')
 
       const importedPage = await payload.find({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           title: { equals: 'Rich Text CSV Block Test' },
@@ -7232,6 +7697,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(richText?.root?.children?.length).toBeGreaterThan(0)
 
       await payload.delete({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           title: { equals: 'Rich Text CSV Block Test' },
@@ -7252,6 +7718,7 @@ describe('@payloadcms/plugin-import-export', () => {
       const csvBuffer = Buffer.from(csvContent)
 
       let importDoc = await payload.create({
+        overrideAccess: true,
         collection: 'imports',
         user,
         data: {
@@ -7266,9 +7733,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       importDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'imports',
         id: importDoc.id,
       })
@@ -7277,6 +7745,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(importDoc.summary?.imported).toBeGreaterThanOrEqual(1)
 
       const importedDocs = await payload.find({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           title: { contains: 'Error Recovery Test' },
@@ -7286,6 +7755,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(importedDocs.totalDocs).toBeGreaterThanOrEqual(1)
 
       await payload.delete({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           title: { contains: 'Error Recovery Test' },
@@ -7305,6 +7775,7 @@ describe('@payloadcms/plugin-import-export', () => {
       const csvBuffer = Buffer.from(csvContent)
 
       let importDoc = await payload.create({
+        overrideAccess: true,
         collection: 'imports',
         user,
         data: {
@@ -7319,9 +7790,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       importDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'imports',
         id: importDoc.id,
       })
@@ -7331,6 +7803,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(importDoc.summary?.total).toBeGreaterThanOrEqual(importDoc.summary?.imported || 0)
 
       await payload.delete({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           title: { contains: 'Partial Fail Test' },
@@ -7343,6 +7816,7 @@ describe('@payloadcms/plugin-import-export', () => {
       const csvBuffer = Buffer.from(malformedCSV)
 
       let importDoc = await payload.create({
+        overrideAccess: true,
         collection: 'imports',
         user,
         data: {
@@ -7357,9 +7831,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       importDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'imports',
         id: importDoc.id,
       })
@@ -7371,6 +7846,7 @@ describe('@payloadcms/plugin-import-export', () => {
   describe('custom field functions edge cases', () => {
     it('should handle beforeExport hook that returns undefined', async () => {
       const page = await payload.create({
+        overrideAccess: true,
         collection: 'pages',
         data: {
           title: 'ToCSV Undefined Test',
@@ -7379,6 +7855,7 @@ describe('@payloadcms/plugin-import-export', () => {
       })
 
       const exportDoc = await payload.create({
+        overrideAccess: true,
         collection: 'exports',
         user,
         data: {
@@ -7391,9 +7868,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       const exportedDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'exports',
         id: exportDoc.id,
       })
@@ -7405,6 +7883,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(data[0].custom).toBe('test value toCSV')
 
       await payload.delete({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           id: { equals: page.id },
@@ -7414,6 +7893,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
     it('should apply beforeImport hook to reconstruct relationships', async () => {
       const page = await payload.create({
+        overrideAccess: true,
         collection: 'pages',
         data: {
           title: 'FromCSV Relationship Test',
@@ -7423,6 +7903,7 @@ describe('@payloadcms/plugin-import-export', () => {
       })
 
       const exportDoc = await payload.create({
+        overrideAccess: true,
         collection: 'exports',
         user,
         data: {
@@ -7435,9 +7916,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       const exportedDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'exports',
         id: exportDoc.id,
       })
@@ -7449,6 +7931,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(exportedData[0].title).toBe('FromCSV Relationship Test')
 
       await payload.delete({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           id: { equals: page.id },
@@ -7456,6 +7939,7 @@ describe('@payloadcms/plugin-import-export', () => {
       })
 
       let importDoc = await payload.create({
+        overrideAccess: true,
         collection: 'imports',
         user,
         data: {
@@ -7470,9 +7954,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       importDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'imports',
         id: importDoc.id,
       })
@@ -7480,6 +7965,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(importDoc.status).toBe('completed')
 
       const importedPage = await payload.find({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           title: { equals: 'FromCSV Relationship Test' },
@@ -7490,6 +7976,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(importedPage.docs[0]?.title).toBe('FromCSV Relationship Test')
 
       await payload.delete({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           title: { equals: 'FromCSV Relationship Test' },
@@ -7501,6 +7988,7 @@ describe('@payloadcms/plugin-import-export', () => {
   describe('disabled fields in complex structures', () => {
     it('should exclude disabled fields from export', async () => {
       const page = await payload.create({
+        overrideAccess: true,
         collection: 'pages',
         data: {
           title: 'Disabled Field Test',
@@ -7512,6 +8000,7 @@ describe('@payloadcms/plugin-import-export', () => {
       })
 
       const exportDoc = await payload.create({
+        overrideAccess: true,
         collection: 'exports',
         user,
         data: {
@@ -7524,9 +8013,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       const exportedDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'exports',
         id: exportDoc.id,
       })
@@ -7538,6 +8028,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(data[0].group_ignore).toBeUndefined()
 
       await payload.delete({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           id: { equals: page.id },
@@ -7570,6 +8061,7 @@ describe('@payloadcms/plugin-import-export', () => {
       const jsonBuffer = Buffer.from(JSON.stringify(nestedData))
 
       let importDoc = await payload.create({
+        overrideAccess: true,
         collection: 'imports',
         user,
         data: {
@@ -7584,9 +8076,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       importDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'imports',
         id: importDoc.id,
       })
@@ -7595,6 +8088,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(importDoc.summary?.imported).toBe(1)
 
       const importedPage = await payload.find({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           title: { equals: 'Deeply Nested Test' },
@@ -7611,6 +8105,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect((doc?.blocks?.[0] as { title?: string })?.title).toBe('Hero Block Title')
 
       await payload.delete({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           title: { equals: 'Deeply Nested Test' },
@@ -7620,6 +8115,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
     it('should handle JSON export and import roundtrip with all field types', async () => {
       const page = await payload.create({
+        overrideAccess: true,
         collection: 'pages',
         data: {
           title: 'JSON Roundtrip Test',
@@ -7639,6 +8135,7 @@ describe('@payloadcms/plugin-import-export', () => {
       })
 
       const exportDoc = await payload.create({
+        overrideAccess: true,
         collection: 'exports',
         user,
         data: {
@@ -7650,9 +8147,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       const exportedDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'exports',
         id: exportDoc.id,
       })
@@ -7665,6 +8163,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(exportedData[0].hasManyNumber).toEqual([1, 2, 3, 4, 5])
 
       await payload.delete({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           id: { equals: page.id },
@@ -7673,6 +8172,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
       const jsonBuffer = Buffer.from(JSON.stringify(exportedData))
       let importDoc = await payload.create({
+        overrideAccess: true,
         collection: 'imports',
         user,
         data: {
@@ -7687,9 +8187,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       importDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'imports',
         id: importDoc.id,
       })
@@ -7697,6 +8198,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(importDoc.status).toBe('completed')
 
       const importedPage = await payload.find({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           title: { equals: 'JSON Roundtrip Test' },
@@ -7711,6 +8213,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(imported?.group?.value).toBe('group value')
 
       await payload.delete({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           title: { equals: 'JSON Roundtrip Test' },
@@ -7722,15 +8225,18 @@ describe('@payloadcms/plugin-import-export', () => {
   describe('limit and pagination edge cases', () => {
     it('should handle page exceeding total pages', async () => {
       await payload.create({
+        overrideAccess: true,
         collection: 'pages',
         data: { title: 'Pagination Test 1', _status: 'published' },
       })
       await payload.create({
+        overrideAccess: true,
         collection: 'pages',
         data: { title: 'Pagination Test 2', _status: 'published' },
       })
 
       const exportDoc = await payload.create({
+        overrideAccess: true,
         collection: 'exports',
         user,
         data: {
@@ -7744,9 +8250,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       const exportedDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'exports',
         id: exportDoc.id,
       })
@@ -7758,6 +8265,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(data.length).toBeLessThanOrEqual(2)
 
       await payload.delete({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           title: { contains: 'Pagination Test' },
@@ -7768,12 +8276,14 @@ describe('@payloadcms/plugin-import-export', () => {
     it('should handle very large limit values', async () => {
       for (let i = 0; i < 5; i++) {
         await payload.create({
+          overrideAccess: true,
           collection: 'pages',
           data: { title: `Large Limit Test ${i}` },
         })
       }
 
       const exportDoc = await payload.create({
+        overrideAccess: true,
         collection: 'exports',
         user,
         data: {
@@ -7786,9 +8296,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       const exportedDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'exports',
         id: exportDoc.id,
       })
@@ -7800,6 +8311,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(data).toHaveLength(5)
 
       await payload.delete({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           title: { contains: 'Large Limit Test' },
@@ -7809,15 +8321,18 @@ describe('@payloadcms/plugin-import-export', () => {
 
     it('should export correctly with limit=1', async () => {
       await payload.create({
+        overrideAccess: true,
         collection: 'pages',
         data: { title: 'Single Limit Test 1' },
       })
       await payload.create({
+        overrideAccess: true,
         collection: 'pages',
         data: { title: 'Single Limit Test 2' },
       })
 
       const exportDoc = await payload.create({
+        overrideAccess: true,
         collection: 'exports',
         user,
         data: {
@@ -7830,9 +8345,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       const exportedDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'exports',
         id: exportDoc.id,
       })
@@ -7843,6 +8359,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(data).toHaveLength(1)
 
       await payload.delete({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           title: { contains: 'Single Limit Test' },
@@ -7857,6 +8374,7 @@ describe('@payloadcms/plugin-import-export', () => {
       for (let i = 0; i < 100; i++) {
         promises.push(
           payload.create({
+            overrideAccess: true,
             collection: 'pages',
             data: {
               title: `Stream Test ${i}`,
@@ -7869,6 +8387,7 @@ describe('@payloadcms/plugin-import-export', () => {
       await Promise.all(promises)
 
       const exportDoc = await payload.create({
+        overrideAccess: true,
         collection: 'exports',
         user,
         data: {
@@ -7880,9 +8399,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       const exportedDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'exports',
         id: exportDoc.id,
       })
@@ -7894,6 +8414,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(data).toHaveLength(100)
 
       await payload.delete({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           title: { contains: 'Stream Test' },
@@ -7903,6 +8424,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
     it('should handle empty result set in streaming export', async () => {
       const exportDoc = await payload.create({
+        overrideAccess: true,
         collection: 'exports',
         user,
         data: {
@@ -7914,9 +8436,10 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       const exportedDoc = await payload.findByID({
+        overrideAccess: true,
         collection: 'exports',
         id: exportDoc.id,
       })
@@ -7933,6 +8456,7 @@ describe('@payloadcms/plugin-import-export', () => {
       const csv2 = `title\n"Concurrent Import B1 ${timestamp}"\n"Concurrent Import B2 ${timestamp}"`
 
       const import1 = await payload.create({
+        overrideAccess: true,
         collection: 'imports',
         user,
         data: {
@@ -7948,6 +8472,7 @@ describe('@payloadcms/plugin-import-export', () => {
       })
 
       const import2 = await payload.create({
+        overrideAccess: true,
         collection: 'imports',
         user,
         data: {
@@ -7962,11 +8487,11 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       const [finalImport1, finalImport2] = await Promise.all([
-        payload.findByID({ collection: 'imports', id: import1.id }),
-        payload.findByID({ collection: 'imports', id: import2.id }),
+        payload.findByID({ overrideAccess: true, collection: 'imports', id: import1.id }),
+        payload.findByID({ overrideAccess: true, collection: 'imports', id: import2.id }),
       ])
 
       expect(finalImport1.status).toBe('completed')
@@ -7975,6 +8500,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(finalImport2.summary?.imported).toBe(2)
 
       const allDocs = await payload.find({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           and: [
@@ -7987,6 +8513,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(allDocs.totalDocs).toBe(4)
 
       await payload.delete({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           title: { contains: String(timestamp) },
@@ -7997,6 +8524,7 @@ describe('@payloadcms/plugin-import-export', () => {
     it('should handle export during active import', async () => {
       for (let i = 0; i < 5; i++) {
         await payload.create({
+          overrideAccess: true,
           collection: 'pages',
           data: { title: `Concurrent Export Source ${i}`, _status: 'published' },
         })
@@ -8005,6 +8533,7 @@ describe('@payloadcms/plugin-import-export', () => {
       const csvData =
         'title\n"Concurrent Import During Export 1"\n"Concurrent Import During Export 2"'
       const importDoc = await payload.create({
+        overrideAccess: true,
         collection: 'imports',
         user,
         data: {
@@ -8020,6 +8549,7 @@ describe('@payloadcms/plugin-import-export', () => {
       })
 
       const exportDoc = await payload.create({
+        overrideAccess: true,
         collection: 'exports',
         user,
         data: {
@@ -8031,11 +8561,11 @@ describe('@payloadcms/plugin-import-export', () => {
         },
       })
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       const [finalImport, finalExport] = await Promise.all([
-        payload.findByID({ collection: 'imports', id: importDoc.id }),
-        payload.findByID({ collection: 'exports', id: exportDoc.id }),
+        payload.findByID({ overrideAccess: true, collection: 'imports', id: importDoc.id }),
+        payload.findByID({ overrideAccess: true, collection: 'exports', id: exportDoc.id }),
       ])
 
       expect(finalImport.status).toBe('completed')
@@ -8049,6 +8579,7 @@ describe('@payloadcms/plugin-import-export', () => {
       }
 
       await payload.delete({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           or: [
@@ -8067,6 +8598,7 @@ describe('@payloadcms/plugin-import-export', () => {
       // Create 10 test documents (more than the limit of 5)
       for (let i = 0; i < 10; i++) {
         const doc = await payload.create({
+          overrideAccess: true,
           collection: 'posts-with-limits',
           data: { title: `Limit Test Post ${i}` },
         })
@@ -8080,6 +8612,7 @@ describe('@payloadcms/plugin-import-export', () => {
         for (const id of createdPostIds) {
           try {
             await payload.delete({
+              overrideAccess: true,
               collection: 'posts-with-limits',
               id,
             })
@@ -8094,6 +8627,7 @@ describe('@payloadcms/plugin-import-export', () => {
     describe('export max limit', () => {
       it('should limit export to maxLimit when no user limit specified', async () => {
         const exportDoc = await payload.create({
+          overrideAccess: true,
           collection: 'posts-with-limits-export',
           user,
           data: {
@@ -8112,6 +8646,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
       it('should clamp user limit to maxLimit when user limit exceeds maxLimit', async () => {
         const exportDoc = await payload.create({
+          overrideAccess: true,
           collection: 'posts-with-limits-export',
           user,
           data: {
@@ -8131,6 +8666,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
       it('should use user limit when it is below maxLimit', async () => {
         const exportDoc = await payload.create({
+          overrideAccess: true,
           collection: 'posts-with-limits-export',
           user,
           data: {
@@ -8185,6 +8721,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(preview.docs).toHaveLength(5)
 
         const exportDoc = await payload.create({
+          overrideAccess: true,
           collection: 'posts-with-limits-export',
           user,
           data: {
@@ -8255,6 +8792,7 @@ describe('@payloadcms/plugin-import-export', () => {
         const csvBuffer = Buffer.from(csv)
 
         const importDoc = await payload.create({
+          overrideAccess: true,
           collection: 'posts-with-limits-import',
           user,
           data: {
@@ -8274,6 +8812,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(importDoc.summary?.issues).toBeGreaterThan(0)
 
         const importedDocs = await payload.find({
+          overrideAccess: true,
           collection: 'posts-with-limits',
           where: {
             title: { contains: 'Exceed Limit Import' },
@@ -8291,6 +8830,7 @@ describe('@payloadcms/plugin-import-export', () => {
         const csvBuffer = Buffer.from(csv)
 
         const importDoc = await payload.create({
+          overrideAccess: true,
           collection: 'posts-with-limits-import',
           user,
           data: {
@@ -8310,6 +8850,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(importDoc.summary?.issues).toBe(0)
 
         await payload.delete({
+          overrideAccess: true,
           collection: 'posts-with-limits',
           where: {
             title: { contains: 'Exact Limit Import' },
@@ -8325,6 +8866,7 @@ describe('@payloadcms/plugin-import-export', () => {
         const csvBuffer = Buffer.from(csv)
 
         const importDoc = await payload.create({
+          overrideAccess: true,
           collection: 'posts-with-limits-import',
           user,
           data: {
@@ -8344,6 +8886,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(importDoc.summary?.issues).toBe(0)
 
         await payload.delete({
+          overrideAccess: true,
           collection: 'posts-with-limits',
           where: {
             title: { contains: 'Below Limit Import' },
@@ -8398,6 +8941,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(exceedsResult.totalDocs).toBe(10)
 
         const failedImport = await payload.create({
+          overrideAccess: true,
           collection: 'posts-with-limits-import',
           user,
           data: {
@@ -8435,6 +8979,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(withinResult.totalDocs).toBe(5)
 
         const successImport = await payload.create({
+          overrideAccess: true,
           collection: 'posts-with-limits-import',
           user,
           data: {
@@ -8453,6 +8998,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(successImport.summary?.imported).toBe(5)
 
         await payload.delete({
+          overrideAccess: true,
           collection: 'posts-with-limits',
           where: {
             title: { contains: 'Predict Success' },
@@ -8467,6 +9013,7 @@ describe('@payloadcms/plugin-import-export', () => {
       beforeAll(async () => {
         // Find the dev user and set their limit to 7
         const devUserDocs = await payload.find({
+          overrideAccess: true,
           collection: 'users',
           where: { email: { equals: devUser.email } },
         })
@@ -8474,6 +9021,7 @@ describe('@payloadcms/plugin-import-export', () => {
         const devUserId = devUserDocs.docs[0]?.id
 
         const updatedUserDoc = await payload.update({
+          overrideAccess: true,
           id: devUserId,
           collection: 'users',
           data: { limit: 7 },
@@ -8485,6 +9033,7 @@ describe('@payloadcms/plugin-import-export', () => {
         // Create 10 test documents (more than both the dynamic export limit of 7 and static import limit of 5)
         for (let i = 0; i < 10; i++) {
           const doc = await payload.create({
+            overrideAccess: true,
             collection: 'posts-with-limits',
             data: { title: `Dynamic Limit Post ${i}` },
           })
@@ -8496,6 +9045,7 @@ describe('@payloadcms/plugin-import-export', () => {
       afterAll(async () => {
         // Reset the dev user's limit
         const devUserDocs = await payload.find({
+          overrideAccess: true,
           collection: 'users',
           where: { email: { equals: devUser.email } },
         })
@@ -8503,6 +9053,7 @@ describe('@payloadcms/plugin-import-export', () => {
         const devUserId = devUserDocs.docs[0]?.id
 
         await payload.update({
+          overrideAccess: true,
           id: devUserId,
           collection: 'users',
           data: { limit: null as unknown as number },
@@ -8510,6 +9061,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
         // Restore the original user login state
         const loginResult = await payload.login({
+          overrideAccess: true,
           collection: 'users',
           data: {
             email: devUser.email,
@@ -8523,6 +9075,7 @@ describe('@payloadcms/plugin-import-export', () => {
         for (const id of createdPostIds) {
           try {
             await payload.delete({
+              overrideAccess: true,
               id,
               collection: 'posts-with-limits',
             })
@@ -8536,6 +9089,7 @@ describe('@payloadcms/plugin-import-export', () => {
       describe('export with dynamic user limit of 7', () => {
         it('should export up to 7 documents when user limit is set to 7', async () => {
           const exportDoc = await payload.create({
+            overrideAccess: true,
             collection: 'posts-with-limits-export',
             data: {
               collectionSlug: 'posts-with-limits',
@@ -8554,6 +9108,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
         it('should clamp request limit to dynamic maxLimit of 7', async () => {
           const exportDoc = await payload.create({
+            overrideAccess: true,
             collection: 'posts-with-limits-export',
             data: {
               collectionSlug: 'posts-with-limits',
@@ -8573,6 +9128,7 @@ describe('@payloadcms/plugin-import-export', () => {
 
         it('should allow export with limit below dynamic maxLimit of 7', async () => {
           const exportDoc = await payload.create({
+            overrideAccess: true,
             collection: 'posts-with-limits-export',
             data: {
               collectionSlug: 'posts-with-limits',
@@ -8628,6 +9184,7 @@ describe('@payloadcms/plugin-import-export', () => {
           expect(preview.exportTotalDocs).toBe(7)
 
           const exportDoc = await payload.create({
+            overrideAccess: true,
             collection: 'posts-with-limits-export',
             data: {
               collectionSlug: 'posts-with-limits',
@@ -8699,6 +9256,7 @@ describe('@payloadcms/plugin-import-export', () => {
           const csvBuffer = Buffer.from(csv)
 
           const importDoc = await payload.create({
+            overrideAccess: true,
             collection: 'posts-with-limits-import',
             data: {
               collectionSlug: 'posts-with-limits',
@@ -8717,6 +9275,7 @@ describe('@payloadcms/plugin-import-export', () => {
           expect(importDoc.summary?.imported).toBe(0)
 
           await payload.delete({
+            overrideAccess: true,
             collection: 'posts-with-limits',
             where: {
               title: { contains: 'Dynamic Import Exceed' },
@@ -8733,6 +9292,7 @@ describe('@payloadcms/plugin-import-export', () => {
           const csvBuffer = Buffer.from(csv)
 
           const importDoc = await payload.create({
+            overrideAccess: true,
             collection: 'posts-with-limits-import',
             data: {
               collectionSlug: 'posts-with-limits',
@@ -8751,6 +9311,7 @@ describe('@payloadcms/plugin-import-export', () => {
           expect(importDoc.summary?.imported).toBe(5)
 
           await payload.delete({
+            overrideAccess: true,
             collection: 'posts-with-limits',
             where: {
               title: { contains: 'Dynamic Import Within' },
@@ -8803,6 +9364,7 @@ describe('@payloadcms/plugin-import-export', () => {
       for (const id of createdPostIDs) {
         try {
           await payload.delete({
+            overrideAccess: true,
             collection: postsWithS3Slug as CollectionSlug,
             id,
           })
@@ -8819,6 +9381,7 @@ describe('@payloadcms/plugin-import-export', () => {
       const csvBuffer = Buffer.from(csvContent)
 
       const importDoc = await payload.create({
+        overrideAccess: true,
         collection: 'posts-with-s3-import' as CollectionSlug,
         user,
         data: {
@@ -8838,6 +9401,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect((importDoc as any).summary?.issues).toBe(0)
 
       const posts = await payload.find({
+        overrideAccess: true,
         collection: postsWithS3Slug as CollectionSlug,
         where: {
           title: { contains: 'S3 Import Test' },
@@ -8851,10 +9415,12 @@ describe('@payloadcms/plugin-import-export', () => {
     it('should export to S3 and verify file is accessible', async () => {
       const testPosts = await Promise.all([
         payload.create({
+          overrideAccess: true,
           collection: postsWithS3Slug as CollectionSlug,
           data: { title: 'S3 Export Test 1' },
         }),
         payload.create({
+          overrideAccess: true,
           collection: postsWithS3Slug as CollectionSlug,
           data: { title: 'S3 Export Test 2' },
         }),
@@ -8863,6 +9429,7 @@ describe('@payloadcms/plugin-import-export', () => {
       testPosts.forEach((post) => createdPostIDs.push(post.id))
 
       const exportDoc = await payload.create({
+        overrideAccess: true,
         collection: 'posts-with-s3-export' as CollectionSlug,
         user,
         data: {
@@ -8895,6 +9462,7 @@ describe('@payloadcms/plugin-import-export', () => {
       const csvBuffer = Buffer.from(csvContent)
 
       const importDoc = await payload.create({
+        overrideAccess: true,
         collection: 'posts-with-s3-import' as CollectionSlug,
         user,
         data: {
@@ -8921,6 +9489,7 @@ describe('@payloadcms/plugin-import-export', () => {
       const jsonBuffer = Buffer.from(jsonContent)
 
       const importDoc = await payload.create({
+        overrideAccess: true,
         collection: 'posts-with-s3-import' as CollectionSlug,
         user,
         data: {
@@ -8939,6 +9508,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect((importDoc as any).summary?.imported).toBe(2)
 
       const posts = await payload.find({
+        overrideAccess: true,
         collection: postsWithS3Slug as CollectionSlug,
         where: {
           title: { contains: 'S3 JSON Import' },

--- a/test/plugin-import-export/seed/index.ts
+++ b/test/plugin-import-export/seed/index.ts
@@ -20,6 +20,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
   payload.logger.info('Seeding data...')
   try {
     const user = await payload.create({
+      overrideAccess: true,
       collection: 'users',
       data: {
         email: devUser.email,
@@ -28,6 +29,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
       },
     })
     const restricted = await payload.create({
+      overrideAccess: true,
       collection: 'users',
       data: {
         email: regularUser.email,
@@ -40,6 +42,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
     // create an absurd amount of posts - we need to test large data exports
     for (let i = 0; i < 100; i++) {
       const post = await payload.create({
+        overrideAccess: true,
         collection: 'posts',
         data: {
           title: `Post ${i}`,
@@ -55,6 +58,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
     // create pages
     for (let i = 0; i < 195; i++) {
       await payload.create({
+        overrideAccess: true,
         collection: 'pages',
         data: {
           title: `Doc ${i}`,
@@ -64,6 +68,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
 
     for (let i = 0; i < 5; i++) {
       await payload.create({
+        overrideAccess: true,
         collection: 'pages',
         data: {
           title: `Title ${i}`,
@@ -75,6 +80,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
     }
     for (let i = 0; i < 5; i++) {
       const doc = await payload.create({
+        overrideAccess: true,
         collection: 'pages',
         data: {
           title: `Localized ${i}`,
@@ -83,6 +89,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
         locale: 'en',
       })
       await payload.update({
+        overrideAccess: true,
         collection: 'pages',
         id: doc.id,
         data: {
@@ -91,6 +98,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
         locale: 'es',
       })
       await payload.update({
+        overrideAccess: true,
         collection: 'pages',
         id: doc.id,
         data: {
@@ -103,6 +111,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
     // Seed Hebrew-only pages
     for (let i = 0; i < 5; i++) {
       await payload.create({
+        overrideAccess: true,
         collection: 'pages',
         data: {
           title: `Hebrew ${i}`,
@@ -113,6 +122,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
     }
     for (let i = 0; i < 5; i++) {
       await payload.create({
+        overrideAccess: true,
         collection: 'pages',
         data: {
           title: `Array ${i}`,
@@ -131,6 +141,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
     }
     for (let i = 0; i < 5; i++) {
       await payload.create({
+        overrideAccess: true,
         collection: 'pages',
         data: {
           title: `Array Subfield ${i}`,
@@ -150,6 +161,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
 
     for (let i = 0; i < 5; i++) {
       await payload.create({
+        overrideAccess: true,
         collection: 'pages',
         data: {
           author: user.id,
@@ -160,6 +172,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
 
     for (let i = 0; i < 5; i++) {
       await payload.create({
+        overrideAccess: true,
         collection: 'pages',
         data: {
           customRelationship: user.id,
@@ -170,6 +183,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
 
     for (let i = 0; i < 5; i++) {
       await payload.create({
+        overrideAccess: true,
         collection: 'pages',
         data: {
           title: `hasMany Number ${i}`,
@@ -180,6 +194,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
 
     for (let i = 0; i < 5; i++) {
       await payload.create({
+        overrideAccess: true,
         collection: 'pages',
         data: {
           title: `Blocks ${i}`,
@@ -200,6 +215,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
 
     for (let i = 0; i < 5; i++) {
       await payload.create({
+        overrideAccess: true,
         collection: 'pages',
         data: {
           title: `JSON ${i}`,
@@ -209,6 +225,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
 
     for (let i = 0; i < 5; i++) {
       await payload.create({
+        overrideAccess: true,
         collection: 'pages',
         data: {
           title: `Jobs ${i}`,
@@ -219,6 +236,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
     // Seed pages with checkbox field
     for (let i = 0; i < 3; i++) {
       await payload.create({
+        overrideAccess: true,
         collection: 'pages',
         data: {
           title: `Checkbox ${i}`,
@@ -231,6 +249,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
     for (let i = 0; i < 3; i++) {
       const options = ['option1', 'option2', 'option3'] as const
       await payload.create({
+        overrideAccess: true,
         collection: 'pages',
         data: {
           title: `Select ${i}`,
@@ -247,6 +266,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
         ['tagB', 'tagC', 'tagD'],
       ]
       await payload.create({
+        overrideAccess: true,
         collection: 'pages',
         data: {
           title: `SelectMany ${i}`,
@@ -259,6 +279,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
     for (let i = 0; i < 3; i++) {
       const radios = ['radio1', 'radio2', 'radio3'] as const
       await payload.create({
+        overrideAccess: true,
         collection: 'pages',
         data: {
           title: `Radio ${i}`,
@@ -270,6 +291,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
     // Seed pages with email field
     for (let i = 0; i < 3; i++) {
       await payload.create({
+        overrideAccess: true,
         collection: 'pages',
         data: {
           title: `Email ${i}`,
@@ -281,6 +303,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
     // Seed pages with textarea field
     for (let i = 0; i < 3; i++) {
       await payload.create({
+        overrideAccess: true,
         collection: 'pages',
         data: {
           title: `Textarea ${i}`,
@@ -292,6 +315,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
     // Seed pages with code field
     for (let i = 0; i < 3; i++) {
       await payload.create({
+        overrideAccess: true,
         collection: 'pages',
         data: {
           title: `Code ${i}`,
@@ -303,6 +327,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
     // Seed pages with point field
     for (let i = 0; i < 3; i++) {
       await payload.create({
+        overrideAccess: true,
         collection: 'pages',
         data: {
           title: `Point ${i}`,
@@ -314,6 +339,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
     // Seed pages with hasMany text field
     for (let i = 0; i < 3; i++) {
       await payload.create({
+        overrideAccess: true,
         collection: 'pages',
         data: {
           title: `TextMany ${i}`,
@@ -329,6 +355,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
     const mediaIds: (number | string)[] = []
     for (let i = 0; i < 3; i++) {
       const media = await payload.create({
+        overrideAccess: true,
         collection: mediaSlug,
         data: {
           alt: `Test Media ${i}`,
@@ -344,6 +371,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
     // Seed pages with upload field
     for (let i = 0; i < 3; i++) {
       await payload.create({
+        overrideAccess: true,
         collection: 'pages',
         data: {
           title: `Upload ${i}`,
@@ -356,6 +384,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
     if (posts[1]?.id) {
       for (let i = 0; i < 2; i++) {
         await payload.create({
+          overrideAccess: true,
           collection: 'pages',
           data: {
             title: `Monomorphic ${i}`,
@@ -369,6 +398,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
     if (posts[0]?.id && posts[1]?.id) {
       for (let i = 0; i < 5; i++) {
         await payload.create({
+          overrideAccess: true,
           collection: 'pages',
           data: {
             title: `Polymorphic ${i}`,
@@ -394,6 +424,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
     // Seed posts-exports-only collection
     for (let i = 0; i < 25; i++) {
       await payload.create({
+        overrideAccess: true,
         collection: postsExportsOnlySlug,
         data: {
           title: `Export Only Post ${i}`,
@@ -404,6 +435,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
     // Seed posts-imports-only collection
     for (let i = 0; i < 25; i++) {
       await payload.create({
+        overrideAccess: true,
         collection: postsImportsOnlySlug,
         data: {
           title: `Import Only Post ${i}`,
@@ -413,6 +445,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
 
     for (let i = 0; i < 25; i++) {
       await payload.create({
+        overrideAccess: true,
         collection: postsNoJobsQueueSlug,
         data: {
           title: `Post with no jobs queue active ${i}`,
@@ -422,6 +455,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
 
     for (let i = 0; i < 10; i++) {
       await payload.create({
+        overrideAccess: true,
         collection: 'posts-with-limits',
         data: {
           title: `Post with limit ${i}`,

--- a/test/plugin-mcp/int.spec.ts
+++ b/test/plugin-mcp/int.spec.ts
@@ -769,6 +769,7 @@ describe('@payloadcms/plugin-mcp', () => {
       )
 
       const { docs } = await payload.find({
+        overrideAccess: true,
         collection: 'modified-prompts',
         where: {
           user: {
@@ -800,6 +801,7 @@ describe('@payloadcms/plugin-mcp', () => {
       expect(resourceResponse.contents[1].text).toContain(`This was requested by user: ${userId}`)
 
       const { docs } = await payload.find({
+        overrideAccess: true,
         collection: 'returned-resources',
         where: {
           user: {
@@ -829,6 +831,7 @@ describe('@payloadcms/plugin-mcp', () => {
       expect(resourceResponse.contents[1].text).toContain(`This was requested by user: ${userId}`)
 
       const { docs } = await payload.find({
+        overrideAccess: true,
         collection: 'returned-resources',
         where: {
           user: {
@@ -867,6 +870,7 @@ describe('@payloadcms/plugin-mcp', () => {
       expect(callResponse.content[0].text).toContain('** on a 6-sided die!')
 
       const { docs } = await payload.find({
+        overrideAccess: true,
         collection: 'rolls',
         where: {
           user: {
@@ -893,12 +897,12 @@ describe('@payloadcms/plugin-mcp', () => {
       uploadServers.length = 0
 
       for (const id of createdMediaIDs) {
-        await payload.delete({ collection: 'media', id })
+        await payload.delete({ overrideAccess: true, collection: 'media', id })
       }
       createdMediaIDs.length = 0
 
       for (const id of createdPostIDs) {
-        await payload.delete({ collection: 'posts', id })
+        await payload.delete({ overrideAccess: true, collection: 'posts', id })
       }
       createdPostIDs.length = 0
     })
@@ -1059,7 +1063,9 @@ describe('@payloadcms/plugin-mcp', () => {
       createdMediaIDs.push(...result.docs.map(({ doc }) => doc.id))
 
       const [storedPNG, storedJPEG] = await Promise.all(
-        result.docs.map(({ doc }) => payload.findByID({ collection: 'media', id: doc.id })),
+        result.docs.map(({ doc }) =>
+          payload.findByID({ overrideAccess: true, collection: 'media', id: doc.id }),
+        ),
       )
 
       expect(result.errors).toEqual([])
@@ -1104,6 +1110,7 @@ describe('@payloadcms/plugin-mcp', () => {
       createdMediaIDs.push(createdMedia.id)
 
       const storedMedia = await payload.findByID({
+        overrideAccess: true,
         id: createdMedia.id,
         collection: 'media',
       })
@@ -1116,6 +1123,7 @@ describe('@payloadcms/plugin-mcp', () => {
 
     it('should replace an upload document from base64', async ({ mcp }) => {
       const media = await payload.create({
+        overrideAccess: true,
         collection: 'media',
         data: {
           alt: 'Original asset',
@@ -1145,6 +1153,7 @@ describe('@payloadcms/plugin-mcp', () => {
       })
 
       const storedMedia = await payload.findByID({
+        overrideAccess: true,
         id: media.id,
         collection: 'media',
       })
@@ -1231,7 +1240,7 @@ describe('@payloadcms/plugin-mcp', () => {
         expect(updated.filename).toBe('mcp-updated.png')
       } finally {
         if (id !== undefined) {
-          await payload.delete({ id, collection: 'media' })
+          await payload.delete({ overrideAccess: true, id, collection: 'media' })
         }
       }
     })
@@ -1284,6 +1293,7 @@ describe('@payloadcms/plugin-mcp', () => {
       createdPostIDs.push(createdPost.id)
 
       const storedPost = await payload.findByID({
+        overrideAccess: true,
         id: createdPost.id,
         collection: 'posts',
         draft: false,
@@ -1352,6 +1362,7 @@ describe('@payloadcms/plugin-mcp', () => {
       createdMediaIDs.push(createdMedia.id)
 
       const storedMedia = await payload.findByID({
+        overrideAccess: true,
         id: createdMedia.id,
         collection: 'media',
       })
@@ -1364,6 +1375,7 @@ describe('@payloadcms/plugin-mcp', () => {
 
     it('should call findDocuments', async ({ mcp }) => {
       const post = await payload.create({
+        overrideAccess: true,
         collection: 'posts',
         data: {
           content: 'Content for test post.',
@@ -1400,6 +1412,7 @@ describe('@payloadcms/plugin-mcp', () => {
       mcp,
     }) => {
       await payload.create({
+        overrideAccess: true,
         collection: 'posts',
         data: {
           content: 'Content that should be omitted',
@@ -1430,6 +1443,7 @@ describe('@payloadcms/plugin-mcp', () => {
 
     it('should call countDocuments', async ({ mcp }) => {
       const product = await payload.create({
+        overrideAccess: true,
         collection: 'products',
         data: {
           price: 25,
@@ -1455,11 +1469,12 @@ describe('@payloadcms/plugin-mcp', () => {
 
       expect(result.totalDocs).toBeGreaterThanOrEqual(1)
 
-      await payload.delete({ id: product.id, collection: 'products' })
+      await payload.delete({ overrideAccess: true, id: product.id, collection: 'products' })
     })
 
     it('should call duplicateDocument', async ({ mcp }) => {
       const product = await payload.create({
+        overrideAccess: true,
         collection: 'products',
         data: {
           price: 35,
@@ -1485,8 +1500,8 @@ describe('@payloadcms/plugin-mcp', () => {
       expect(duplicated.id).not.toBe(product.id)
       expect(duplicated.title).toBe('Duplicated Product')
 
-      await payload.delete({ id: duplicated.id, collection: 'products' })
-      await payload.delete({ id: product.id, collection: 'products' })
+      await payload.delete({ overrideAccess: true, id: duplicated.id, collection: 'products' })
+      await payload.delete({ overrideAccess: true, id: product.id, collection: 'products' })
     })
 
     it('should not enable duplicateDocument for auth collections by default', async ({ mcp }) => {
@@ -1523,6 +1538,7 @@ describe('@payloadcms/plugin-mcp', () => {
 
     it('should call findDistinct', async ({ mcp }) => {
       const product = await payload.create({
+        overrideAccess: true,
         collection: 'products',
         data: {
           price: 45,
@@ -1543,11 +1559,12 @@ describe('@payloadcms/plugin-mcp', () => {
 
       expect(result.values.some((value) => value.title === 'Distinct Product')).toBe(true)
 
-      await payload.delete({ id: product.id, collection: 'products' })
+      await payload.delete({ overrideAccess: true, id: product.id, collection: 'products' })
     })
 
     it('should call collection version tools', async ({ mcp }) => {
       const post = await payload.create({
+        overrideAccess: true,
         collection: 'posts',
         data: {
           content: 'Initial version content',
@@ -1556,6 +1573,7 @@ describe('@payloadcms/plugin-mcp', () => {
       })
 
       await payload.update({
+        overrideAccess: true,
         id: post.id,
         collection: 'posts',
         data: {
@@ -1564,6 +1582,7 @@ describe('@payloadcms/plugin-mcp', () => {
       })
 
       const versions = await payload.findVersions({
+        overrideAccess: true,
         collection: 'posts',
         limit: 1,
         sort: '-updatedAt',
@@ -1630,13 +1649,14 @@ describe('@payloadcms/plugin-mcp', () => {
       const restored = getToolDoc<{ id: number | string }>(restoreResponse)
       expect(restored.id).toBe(post.id)
 
-      await payload.delete({ id: post.id, collection: 'posts' })
+      await payload.delete({ overrideAccess: true, id: post.id, collection: 'posts' })
     })
 
     it('should pass populate, joins, trash, and pagination to findDocuments list queries', async ({
       mcp,
     }) => {
       const post = await payload.create({
+        overrideAccess: true,
         collection: 'posts',
         data: {
           author: userId,
@@ -1676,12 +1696,13 @@ describe('@payloadcms/plugin-mcp', () => {
         )
       } finally {
         findSpy.mockRestore()
-        await payload.delete({ id: post.id, collection: 'posts' })
+        await payload.delete({ overrideAccess: true, id: post.id, collection: 'posts' })
       }
     })
 
     it('should pass populate, joins, and trash to findDocuments ID queries', async ({ mcp }) => {
       const post = await payload.create({
+        overrideAccess: true,
         collection: 'posts',
         data: {
           author: userId,
@@ -1718,12 +1739,13 @@ describe('@payloadcms/plugin-mcp', () => {
         )
       } finally {
         findByIDSpy.mockRestore()
-        await payload.delete({ id: post.id, collection: 'posts' })
+        await payload.delete({ overrideAccess: true, id: post.id, collection: 'posts' })
       }
     })
 
     it('should call updateDocument', async ({ mcp }) => {
       const post = await payload.create({
+        overrideAccess: true,
         collection: 'posts',
         data: {
           content: 'Content for test post to update.',
@@ -1759,6 +1781,7 @@ describe('@payloadcms/plugin-mcp', () => {
 
     it('should forward publishAllLocales when updating a document', async ({ mcp }) => {
       const post = await payload.create({
+        overrideAccess: true,
         collection: 'posts',
         data: {
           title: 'English draft title',
@@ -1769,6 +1792,7 @@ describe('@payloadcms/plugin-mcp', () => {
 
       try {
         await payload.update({
+          overrideAccess: true,
           id: post.id,
           collection: 'posts',
           data: { title: 'Spanish draft title' },
@@ -1793,12 +1817,14 @@ describe('@payloadcms/plugin-mcp', () => {
           name: 'updateDocument',
         })
         const publishedPost = await payload.findByID({
+          overrideAccess: true,
           id: post.id,
           collection: 'posts',
           draft: false,
           locale: 'all',
         })
         const spanishDraft = await payload.findByID({
+          overrideAccess: true,
           id: post.id,
           collection: 'posts',
           draft: true,
@@ -1812,12 +1838,13 @@ describe('@payloadcms/plugin-mcp', () => {
         expect(spanishDraft.title).toBe('Spanish draft title')
         expect(spanishDraft._status).toBe('draft')
       } finally {
-        await payload.delete({ collection: 'posts', id: post.id })
+        await payload.delete({ overrideAccess: true, collection: 'posts', id: post.id })
       }
     })
 
     it('should call updateDocument with nullable union type field set to null', async ({ mcp }) => {
       const post = await payload.create({
+        overrideAccess: true,
         collection: 'posts',
         data: {
           content: 'Content to be cleared',
@@ -1845,11 +1872,12 @@ describe('@payloadcms/plugin-mcp', () => {
       )
       expect(callResponse.content[0].text).toContain('"content":null')
 
-      await payload.delete({ id: post.id, collection: 'posts' })
+      await payload.delete({ overrideAccess: true, id: post.id, collection: 'posts' })
     })
 
     it('should call updateDocument with relationship union type field', async ({ mcp }) => {
       const post = await payload.create({
+        overrideAccess: true,
         collection: 'posts',
         data: {
           title: 'Union Type Relationship Test',
@@ -1878,11 +1906,12 @@ describe('@payloadcms/plugin-mcp', () => {
       const updatedDoc = getToolDoc(callResponse)
       expect(updatedDoc.author).toBe(userId)
 
-      await payload.delete({ id: post.id, collection: 'posts' })
+      await payload.delete({ overrideAccess: true, id: post.id, collection: 'posts' })
     })
 
     it('should call updateDocument with select to limit returned fields', async ({ mcp }) => {
       const post = await payload.create({
+        overrideAccess: true,
         collection: 'posts',
         data: {
           content: 'Original content',
@@ -1914,6 +1943,7 @@ describe('@payloadcms/plugin-mcp', () => {
 
     it('should call deleteDocuments', async ({ mcp }) => {
       const post = await payload.create({
+        overrideAccess: true,
         collection: 'posts',
         data: {
           content: 'Content for test post to delete.',
@@ -1944,6 +1974,7 @@ describe('@payloadcms/plugin-mcp', () => {
 
     it('should call updateDocument with object where clause', async ({ mcp }) => {
       const matching = await payload.create({
+        overrideAccess: true,
         collection: 'posts',
         data: {
           content: 'Original content',
@@ -1951,6 +1982,7 @@ describe('@payloadcms/plugin-mcp', () => {
         },
       })
       const excluded = await payload.create({
+        overrideAccess: true,
         collection: 'posts',
         data: {
           content: 'Original content',
@@ -1981,16 +2013,21 @@ describe('@payloadcms/plugin-mcp', () => {
       expect(callResponse.content[0].text).toContain('Updated: 1 documents')
       expect(callResponse.content[0].text).toContain('"content":"Updated by object where"')
 
-      const untouched = await payload.findByID({ id: excluded.id, collection: 'posts' })
+      const untouched = await payload.findByID({
+        overrideAccess: true,
+        id: excluded.id,
+        collection: 'posts',
+      })
 
       expect(untouched.content).toBe('Original content')
 
-      await payload.delete({ id: matching.id, collection: 'posts' })
-      await payload.delete({ id: excluded.id, collection: 'posts' })
+      await payload.delete({ overrideAccess: true, id: matching.id, collection: 'posts' })
+      await payload.delete({ overrideAccess: true, id: excluded.id, collection: 'posts' })
     })
 
     it('should call deleteDocuments with object where clause', async ({ mcp }) => {
       await payload.create({
+        overrideAccess: true,
         collection: 'posts',
         data: {
           content: 'Content for object where delete.',
@@ -1998,6 +2035,7 @@ describe('@payloadcms/plugin-mcp', () => {
         },
       })
       await payload.create({
+        overrideAccess: true,
         collection: 'posts',
         data: {
           content: 'Content for object where delete.',
@@ -2072,7 +2110,7 @@ describe('@payloadcms/plugin-mcp', () => {
       expect(callResponse.content[1].type).toBe('text')
       expect(callResponse.content[1].text).toContain('Override MCP response for Posts!')
 
-      await payload.delete({ id: createdDoc.id, collection: 'posts' })
+      await payload.delete({ overrideAccess: true, id: createdDoc.id, collection: 'posts' })
     })
 
     it('should handle point fields with object format in updateDocument', async ({ mcp }) => {
@@ -2080,6 +2118,7 @@ describe('@payloadcms/plugin-mcp', () => {
       const client = await mcp.connect(apiKey)
 
       const createdPost = await payload.create({
+        overrideAccess: true,
         collection: 'posts',
         data: {
           location: [-118.2437, 34.0522],
@@ -2113,7 +2152,7 @@ describe('@payloadcms/plugin-mcp', () => {
       expect(callResponse.content[1].type).toBe('text')
       expect(callResponse.content[1].text).toContain('Override MCP response for Posts!')
 
-      await payload.delete({ id: createdPost.id, collection: 'posts' })
+      await payload.delete({ overrideAccess: true, id: createdPost.id, collection: 'posts' })
     })
   })
 
@@ -2186,6 +2225,7 @@ describe('@payloadcms/plugin-mcp', () => {
 
     it('should update a page layout that contains blocks', async ({ mcp }) => {
       const page = await payload.create({
+        overrideAccess: true,
         collection: 'pages',
         data: {
           title: 'Page to Update',
@@ -2226,6 +2266,7 @@ describe('@payloadcms/plugin-mcp', () => {
       expect(callResponse.content[0].text).toContain('"body":"Updated body text."')
 
       const updatedPage = await payload.findByID({
+        overrideAccess: true,
         collection: 'pages',
         id: page.id,
       })
@@ -2271,12 +2312,13 @@ describe('@payloadcms/plugin-mcp', () => {
 
       const { id: createdId } = getCreatedDocument<{ id: string }>(callResponse)
       if (createdId) {
-        await payload.delete({ id: createdId, collection: 'posts' })
+        await payload.delete({ overrideAccess: true, id: createdId, collection: 'posts' })
       }
     })
 
     it('should ignore virtual fields when updating a post via MCP', async ({ mcp }) => {
       const post = await payload.create({
+        overrideAccess: true,
         collection: 'posts',
         data: { title: 'Virtual Field Update Test' },
       })
@@ -2297,13 +2339,14 @@ describe('@payloadcms/plugin-mcp', () => {
       expect(text).toContain('"title":"Virtual Field Updated Title"')
       expect(text).not.toContain('"computedTitle"')
 
-      await payload.delete({ id: post.id, collection: 'posts' })
+      await payload.delete({ overrideAccess: true, id: post.id, collection: 'posts' })
     })
   })
 
   describe('payloadAPI context', () => {
     it('should call operations with the payloadAPI context as MCP', async ({ mcp }) => {
       await payload.create({
+        overrideAccess: true,
         collection: 'posts',
         data: {
           content: 'Content for test post.',
@@ -2380,6 +2423,7 @@ describe('@payloadcms/plugin-mcp', () => {
 
     it('should find site-settings global with select', async ({ mcp }) => {
       await payload.updateGlobal({
+        overrideAccess: true,
         slug: 'site-settings',
         data: {
           contactEmail: 'test@example.com',
@@ -2485,6 +2529,7 @@ describe('@payloadcms/plugin-mcp', () => {
 
     it('should call global version tools', async ({ mcp }) => {
       await payload.updateGlobal({
+        overrideAccess: true,
         slug: 'site-settings',
         data: {
           maintenanceMode: false,
@@ -2494,6 +2539,7 @@ describe('@payloadcms/plugin-mcp', () => {
       })
 
       await payload.updateGlobal({
+        overrideAccess: true,
         slug: 'site-settings',
         data: {
           maintenanceMode: true,
@@ -2503,6 +2549,7 @@ describe('@payloadcms/plugin-mcp', () => {
       })
 
       const versions = await payload.findGlobalVersions({
+        overrideAccess: true,
         slug: 'site-settings',
         limit: 1,
         sort: '-updatedAt',
@@ -2869,7 +2916,7 @@ describe('@payloadcms/plugin-mcp', () => {
 
     afterEach(async () => {
       for (const id of createdIDs) {
-        await payload.delete({ collection: 'posts', id })
+        await payload.delete({ overrideAccess: true, collection: 'posts', id })
       }
       createdIDs.length = 0
     })
@@ -2878,6 +2925,7 @@ describe('@payloadcms/plugin-mcp', () => {
       mcp,
     }) => {
       const doc = await payload.create({
+        overrideAccess: true,
         collection: 'posts',
         data: {
           title: 'Minified JSON Test',
@@ -2933,6 +2981,7 @@ describe('@payloadcms/plugin-mcp', () => {
 
     it('should return minified JSON in findByID resource responses', async ({ mcp }) => {
       const doc = await payload.create({
+        overrideAccess: true,
         collection: 'posts',
         data: {
           title: 'Minified JSON FindByID Test',
@@ -3022,6 +3071,7 @@ describe('@payloadcms/plugin-mcp', () => {
     it('should update post to add translation', async ({ mcp }) => {
       // First create a post in English
       const englishPost = await payload.create({
+        overrideAccess: true,
         collection: 'posts',
         data: {
           content: 'English Content',
@@ -3054,6 +3104,7 @@ describe('@payloadcms/plugin-mcp', () => {
     it('should find post in specific locale', async ({ mcp }) => {
       // Create a post with English and Spanish translations
       const post = await payload.create({
+        overrideAccess: true,
         collection: 'posts',
         data: {
           content: 'English Content',
@@ -3062,6 +3113,7 @@ describe('@payloadcms/plugin-mcp', () => {
       })
 
       await payload.update({
+        overrideAccess: true,
         id: post.id,
         collection: 'posts',
         data: {
@@ -3093,6 +3145,7 @@ describe('@payloadcms/plugin-mcp', () => {
     it('should find post with locale "all"', async ({ mcp }) => {
       // Create a post with multiple translations
       const post = await payload.create({
+        overrideAccess: true,
         collection: 'posts',
         data: {
           content: 'English Content',
@@ -3101,6 +3154,7 @@ describe('@payloadcms/plugin-mcp', () => {
       })
 
       await payload.update({
+        overrideAccess: true,
         id: post.id,
         collection: 'posts',
         data: {
@@ -3111,6 +3165,7 @@ describe('@payloadcms/plugin-mcp', () => {
       })
 
       await payload.update({
+        overrideAccess: true,
         id: post.id,
         collection: 'posts',
         data: {
@@ -3147,6 +3202,7 @@ describe('@payloadcms/plugin-mcp', () => {
     it('should use fallback locale when translation does not exist', async ({ mcp }) => {
       // Create a post only in English with explicit content
       const post = await payload.create({
+        overrideAccess: true,
         collection: 'posts',
         data: {
           title: 'English Only Title',

--- a/test/plugin-mcp/int.spec.ts
+++ b/test/plugin-mcp/int.spec.ts
@@ -3613,6 +3613,7 @@ describe('@payloadcms/plugin-mcp', () => {
 
       it('should find documents in field-types collection', async ({ mcp }) => {
         const created = await (payload as any).create({
+          overrideAccess: true,
           collection: 'field-types',
           data: { textField: 'Findable doc', numberField: 7 },
         })
@@ -3639,6 +3640,7 @@ describe('@payloadcms/plugin-mcp', () => {
     describe('Update', () => {
       it('should update document with group field', async ({ mcp }) => {
         const created = await (payload as any).create({
+          overrideAccess: true,
           collection: 'field-types',
           data: {
             textField: 'Group update test',
@@ -3679,6 +3681,7 @@ describe('@payloadcms/plugin-mcp', () => {
         mcp,
       }) => {
         const created = await (payload as any).create({
+          overrideAccess: true,
           collection: 'field-types',
           data: {
             numberField: 1,
@@ -3710,6 +3713,7 @@ describe('@payloadcms/plugin-mcp', () => {
         mcp,
       }) => {
         const created = await (payload as any).create({
+          overrideAccess: true,
           collection: 'field-types',
           data: {
             textField: 'Collapsible update test',
@@ -3741,6 +3745,7 @@ describe('@payloadcms/plugin-mcp', () => {
 
       it('should update document with array field', async ({ mcp }) => {
         const created = await (payload as any).create({
+          overrideAccess: true,
           collection: 'field-types',
           data: {
             textField: 'Array update test',

--- a/test/plugin-mcp/seed/index.ts
+++ b/test/plugin-mcp/seed/index.ts
@@ -4,6 +4,7 @@ import { devUser } from '../../credentials.js'
 
 export const seed = async (payload: Payload) => {
   const { totalDocs } = await payload.count({
+    overrideAccess: true,
     collection: 'users',
     where: {
       email: {
@@ -14,6 +15,7 @@ export const seed = async (payload: Payload) => {
 
   if (!totalDocs) {
     await payload.create({
+      overrideAccess: true,
       collection: 'users',
       data: devUser,
     })

--- a/test/plugin-multi-tenant/config.base.ts
+++ b/test/plugin-multi-tenant/config.base.ts
@@ -151,6 +151,7 @@ export const baseConfig: Partial<Config> = {
       const tenant = getTenantFromCookie(req.headers, 'text')
       if (tenant) {
         const fullTenant = await req.payload.findByID({
+          overrideAccess: true,
           collection: 'tenants',
           id: tenant,
         })

--- a/test/plugin-multi-tenant/int.spec.ts
+++ b/test/plugin-multi-tenant/int.spec.ts
@@ -47,6 +47,7 @@ describe('@payloadcms/plugin-multi-tenant', () => {
   describe('tenants', () => {
     it('should create a tenant', async () => {
       const tenant1 = await payload.create({
+        overrideAccess: true,
         collection: tenantsSlug,
         data: {
           name: 'tenant1',
@@ -65,6 +66,7 @@ describe('@payloadcms/plugin-multi-tenant', () => {
 
       beforeEach(async () => {
         anchorBarRelationships = await payload.find({
+          overrideAccess: true,
           collection: 'relationships',
           where: {
             'tenant.name': {
@@ -74,6 +76,7 @@ describe('@payloadcms/plugin-multi-tenant', () => {
         })
 
         blueDogRelationships = await payload.find({
+          overrideAccess: true,
           collection: 'relationships',
           where: {
             'tenant.name': {
@@ -91,6 +94,7 @@ describe('@payloadcms/plugin-multi-tenant', () => {
 
       it('ensure relationship document with relationship within same tenant can be created', async () => {
         const newRelationship = await payload.create({
+          overrideAccess: true,
           collection: 'relationships',
           data: {
             title: 'Relationship to Anchor Bar',
@@ -110,6 +114,7 @@ describe('@payloadcms/plugin-multi-tenant', () => {
       it('ensure relationship document with relationship to different tenant cannot be created if tenant header passed', async () => {
         await expect(
           payload.create({
+            overrideAccess: true,
             collection: 'relationships',
             data: {
               title: 'Relationship to Blue Dog',
@@ -128,6 +133,7 @@ describe('@payloadcms/plugin-multi-tenant', () => {
         // Should filter based on data.tenant instead of tenant cookie
         await expect(
           payload.create({
+            overrideAccess: true,
             collection: 'relationships',
             data: {
               title: 'Relationship to Blue Dog',
@@ -146,6 +152,7 @@ describe('@payloadcms/plugin-multi-tenant', () => {
     it('should return Forbidden error (not 500) for user with no tenants', async () => {
       // Create a user with no tenant memberships
       const noTenantUser = await payload.create({
+        overrideAccess: true,
         collection: usersSlug,
         data: {
           email: 'no-tenants@test.com',
@@ -156,10 +163,12 @@ describe('@payloadcms/plugin-multi-tenant', () => {
 
       // Create a tenant and document for testing
       const tenant = await payload.create({
+        overrideAccess: true,
         collection: tenantsSlug,
         data: { name: 'Test Tenant', domain: 'test-tenant.test' },
       })
       const doc = await payload.create({
+        overrideAccess: true,
         collection: relationshipsSlug,
         data: { tenant: tenant.id, title: 'Test Doc' },
       })
@@ -176,14 +185,15 @@ describe('@payloadcms/plugin-multi-tenant', () => {
       ).rejects.toThrow('You are not allowed to perform this action.')
 
       // Cleanup
-      await payload.delete({ id: doc.id, collection: relationshipsSlug })
-      await payload.delete({ id: tenant.id, collection: tenantsSlug })
-      await payload.delete({ id: noTenantUser.id, collection: usersSlug })
+      await payload.delete({ overrideAccess: true, id: doc.id, collection: relationshipsSlug })
+      await payload.delete({ overrideAccess: true, id: tenant.id, collection: tenantsSlug })
+      await payload.delete({ overrideAccess: true, id: noTenantUser.id, collection: usersSlug })
     })
 
     it('should allow user with no tenants to access their own user document', async () => {
       // Create a user with no tenant memberships
       const noTenantUser = await payload.create({
+        overrideAccess: true,
         collection: usersSlug,
         data: {
           email: 'no-tenants-self@test.com',
@@ -204,12 +214,13 @@ describe('@payloadcms/plugin-multi-tenant', () => {
       expect(result.docs[0]?.id).toBe(noTenantUser.id)
 
       // Cleanup
-      await payload.delete({ id: noTenantUser.id, collection: usersSlug })
+      await payload.delete({ overrideAccess: true, id: noTenantUser.id, collection: usersSlug })
     })
 
     it('should allow admin with empty tenants array to access all documents', async () => {
       // Create an admin user with empty tenants array
       const adminUser = await payload.create({
+        overrideAccess: true,
         collection: usersSlug,
         data: {
           email: 'admin-empty-tenants@test.com',
@@ -221,10 +232,12 @@ describe('@payloadcms/plugin-multi-tenant', () => {
 
       // Create a tenant and document
       const tenant = await payload.create({
+        overrideAccess: true,
         collection: tenantsSlug,
         data: { name: 'Admin Test Tenant', domain: 'admin-test.test' },
       })
       const doc = await payload.create({
+        overrideAccess: true,
         collection: relationshipsSlug,
         data: { tenant: tenant.id, title: 'Admin Test Doc' },
       })
@@ -240,9 +253,9 @@ describe('@payloadcms/plugin-multi-tenant', () => {
       expect(result.docs).toHaveLength(1)
 
       // Cleanup
-      await payload.delete({ id: doc.id, collection: relationshipsSlug })
-      await payload.delete({ id: tenant.id, collection: tenantsSlug })
-      await payload.delete({ id: adminUser.id, collection: usersSlug })
+      await payload.delete({ overrideAccess: true, id: doc.id, collection: relationshipsSlug })
+      await payload.delete({ overrideAccess: true, id: tenant.id, collection: tenantsSlug })
+      await payload.delete({ overrideAccess: true, id: adminUser.id, collection: usersSlug })
     })
   })
 
@@ -250,16 +263,19 @@ describe('@payloadcms/plugin-multi-tenant', () => {
     it('should enforce tenant access when user object is fetched from database', async () => {
       // Create two tenants
       const tenantA = await payload.create({
+        overrideAccess: true,
         collection: tenantsSlug,
         data: { name: 'Tenant A', domain: 'tenant-a.test' },
       })
       const tenantB = await payload.create({
+        overrideAccess: true,
         collection: tenantsSlug,
         data: { name: 'Tenant B', domain: 'tenant-b.test' },
       })
 
       // Create a user assigned ONLY to Tenant A
       const user = await payload.create({
+        overrideAccess: true,
         collection: usersSlug,
         data: {
           email: 'user-tenant-a@test.com',
@@ -270,6 +286,7 @@ describe('@payloadcms/plugin-multi-tenant', () => {
 
       // Create a document in Tenant B (user should NOT have access)
       const doc = await payload.create({
+        overrideAccess: true,
         collection: relationshipsSlug,
         data: { tenant: tenantB.id, title: 'Tenant B Doc' },
       })
@@ -277,6 +294,7 @@ describe('@payloadcms/plugin-multi-tenant', () => {
       // Fetch user from database - this returns a user WITHOUT .collection property
       // Bug: when user.collection is undefined, tenant access check is bypassed
       const fetchedUser = await payload.findByID({
+        overrideAccess: true,
         id: user.id,
         collection: usersSlug,
       })
@@ -292,30 +310,37 @@ describe('@payloadcms/plugin-multi-tenant', () => {
       expect(result.docs).toHaveLength(0)
 
       // Cleanup
-      await payload.delete({ id: doc.id, collection: relationshipsSlug })
-      await payload.delete({ id: user.id, collection: usersSlug })
-      await payload.delete({ id: tenantA.id, collection: tenantsSlug })
-      await payload.delete({ id: tenantB.id, collection: tenantsSlug })
+      await payload.delete({ overrideAccess: true, id: doc.id, collection: relationshipsSlug })
+      await payload.delete({ overrideAccess: true, id: user.id, collection: usersSlug })
+      await payload.delete({ overrideAccess: true, id: tenantA.id, collection: tenantsSlug })
+      await payload.delete({ overrideAccess: true, id: tenantB.id, collection: tenantsSlug })
     })
   })
 
   describe('tenant cleanup on delete', () => {
     it('should delete a tenant that has a global collection document without hanging', async () => {
       const tenant = await payload.create({
+        overrideAccess: true,
         collection: tenantsSlug,
         data: { name: 'Cleanup Tenant', domain: 'cleanup-tenant.test' },
       })
 
       await payload.create({
+        overrideAccess: true,
         collection: menuSlug,
         data: { tenant: tenant.id, title: 'Cleanup Menu' },
       })
 
-      const deletedTenant = await payload.delete({ id: tenant.id, collection: tenantsSlug })
+      const deletedTenant = await payload.delete({
+        overrideAccess: true,
+        id: tenant.id,
+        collection: tenantsSlug,
+      })
 
       expect(deletedTenant.id).toBe(tenant.id)
 
       const remainingTenants = await payload.find({
+        overrideAccess: true,
         collection: tenantsSlug,
         where: { id: { equals: tenant.id } },
       })
@@ -327,16 +352,19 @@ describe('@payloadcms/plugin-multi-tenant', () => {
   describe('hasMany tenant field filtering', () => {
     it('should not double-wrap tenant arrays in filterOptions', async () => {
       const tenant1 = await payload.create({
+        overrideAccess: true,
         collection: tenantsSlug,
         data: { name: 'Tenant 1', domain: 'tenant1.test' },
       })
       const tenant2 = await payload.create({
+        overrideAccess: true,
         collection: tenantsSlug,
         data: { name: 'Tenant 2', domain: 'tenant2.test' },
       })
 
       // Create a post with multiple tenants (hasMany: true)
       const post = await payload.create({
+        overrideAccess: true,
         collection: multiTenantPostsSlug,
         data: {
           title: 'Multi-tenant post',
@@ -361,9 +389,9 @@ describe('@payloadcms/plugin-multi-tenant', () => {
       expect(Array.isArray(filter.tenant.in[1])).toBe(false)
 
       // Cleanup
-      await payload.delete({ id: post.id, collection: multiTenantPostsSlug })
-      await payload.delete({ id: tenant1.id, collection: tenantsSlug })
-      await payload.delete({ id: tenant2.id, collection: tenantsSlug })
+      await payload.delete({ overrideAccess: true, id: post.id, collection: multiTenantPostsSlug })
+      await payload.delete({ overrideAccess: true, id: tenant1.id, collection: tenantsSlug })
+      await payload.delete({ overrideAccess: true, id: tenant2.id, collection: tenantsSlug })
     })
   })
 })

--- a/test/plugin-multi-tenant/seed/index.ts
+++ b/test/plugin-multi-tenant/seed/index.ts
@@ -6,6 +6,7 @@ import { foldersSlug, menuItemsSlug, menuSlug, tenantsSlug, usersSlug } from '..
 export const seed = async (payload: Payload) => {
   // create tenants
   const blueDogTenant = await payload.create({
+    overrideAccess: true,
     collection: tenantsSlug,
     data: {
       name: 'Blue Dog',
@@ -13,6 +14,7 @@ export const seed = async (payload: Payload) => {
     },
   })
   const steelCatTenant = await payload.create({
+    overrideAccess: true,
     collection: tenantsSlug,
     data: {
       name: 'Steel Cat',
@@ -20,6 +22,7 @@ export const seed = async (payload: Payload) => {
     },
   })
   const anchorBarTenant = await payload.create({
+    overrideAccess: true,
     collection: tenantsSlug,
     data: {
       name: 'Anchor Bar',
@@ -28,6 +31,7 @@ export const seed = async (payload: Payload) => {
     },
   })
   const publicTenant = await payload.create({
+    overrideAccess: true,
     collection: tenantsSlug,
     data: {
       name: 'Public Tenant',
@@ -38,6 +42,7 @@ export const seed = async (payload: Payload) => {
 
   // Create folders for Blue Dog
   const blueDogDocumentsFolder = await payload.create({
+    overrideAccess: true,
     collection: foldersSlug,
     data: {
       name: 'Blue Dog Documents',
@@ -45,6 +50,7 @@ export const seed = async (payload: Payload) => {
     },
   })
   const blueDogArchivesFolder = await payload.create({
+    overrideAccess: true,
     collection: foldersSlug,
     data: {
       name: 'Blue Dog Archives',
@@ -52,6 +58,7 @@ export const seed = async (payload: Payload) => {
     },
   })
   const blueDogRecipesFolder = await payload.create({
+    overrideAccess: true,
     collection: foldersSlug,
     data: {
       name: 'Blue Dog Recipes',
@@ -62,6 +69,7 @@ export const seed = async (payload: Payload) => {
 
   // Create folders for Steel Cat
   const steelCatDocumentsFolder = await payload.create({
+    overrideAccess: true,
     collection: foldersSlug,
     data: {
       name: 'Steel Cat Documents',
@@ -69,6 +77,7 @@ export const seed = async (payload: Payload) => {
     },
   })
   const steelCatArchivesFolder = await payload.create({
+    overrideAccess: true,
     collection: foldersSlug,
     data: {
       name: 'Steel Cat Archives',
@@ -78,6 +87,7 @@ export const seed = async (payload: Payload) => {
 
   // Create folders for Anchor Bar
   const anchorBarFilesFolder = await payload.create({
+    overrideAccess: true,
     collection: foldersSlug,
     data: {
       name: 'Anchor Bar Files',
@@ -87,6 +97,7 @@ export const seed = async (payload: Payload) => {
 
   // Create blue dog menu items (some in folders, some at root)
   await payload.create({
+    overrideAccess: true,
     collection: menuItemsSlug,
     data: {
       name: 'Chorizo Con Queso and Chips',
@@ -95,6 +106,7 @@ export const seed = async (payload: Payload) => {
     },
   })
   await payload.create({
+    overrideAccess: true,
     collection: menuItemsSlug,
     data: {
       name: 'Garlic Parmesan Tots',
@@ -103,6 +115,7 @@ export const seed = async (payload: Payload) => {
     },
   })
   await payload.create({
+    overrideAccess: true,
     collection: menuItemsSlug,
     data: {
       name: 'Spicy Mac',
@@ -112,6 +125,7 @@ export const seed = async (payload: Payload) => {
   })
   // Menu items at root (no folder)
   await payload.create({
+    overrideAccess: true,
     collection: menuItemsSlug,
     data: {
       name: 'Veggie Wrap',
@@ -119,6 +133,7 @@ export const seed = async (payload: Payload) => {
     },
   })
   await payload.create({
+    overrideAccess: true,
     collection: menuItemsSlug,
     data: {
       name: 'House Salad',
@@ -126,6 +141,7 @@ export const seed = async (payload: Payload) => {
     },
   })
   await payload.create({
+    overrideAccess: true,
     collection: menuItemsSlug,
     data: {
       name: 'Draft Beer',
@@ -134,6 +150,7 @@ export const seed = async (payload: Payload) => {
   })
 
   await payload.create({
+    overrideAccess: true,
     collection: 'relationships',
     data: {
       title: 'Owned by blue dog',
@@ -142,6 +159,7 @@ export const seed = async (payload: Payload) => {
   })
 
   await payload.create({
+    overrideAccess: true,
     collection: 'relationships',
     data: {
       title: 'Owned by steelcat',
@@ -150,6 +168,7 @@ export const seed = async (payload: Payload) => {
   })
 
   await payload.create({
+    overrideAccess: true,
     collection: 'relationships',
     data: {
       title: 'Owned by bar with no ac',
@@ -158,6 +177,7 @@ export const seed = async (payload: Payload) => {
   })
 
   await payload.create({
+    overrideAccess: true,
     collection: 'relationships',
     data: {
       title: 'Owned by public tenant',
@@ -167,6 +187,7 @@ export const seed = async (payload: Payload) => {
 
   // Create steel cat menu items (in folders)
   await payload.create({
+    overrideAccess: true,
     collection: menuItemsSlug,
     data: {
       name: 'Pretzel Bites',
@@ -175,6 +196,7 @@ export const seed = async (payload: Payload) => {
     },
   })
   await payload.create({
+    overrideAccess: true,
     collection: menuItemsSlug,
     data: {
       name: 'Buffalo Chicken Dip',
@@ -183,6 +205,7 @@ export const seed = async (payload: Payload) => {
     },
   })
   await payload.create({
+    overrideAccess: true,
     collection: menuItemsSlug,
     data: {
       name: 'Pulled Pork Nachos',
@@ -193,6 +216,7 @@ export const seed = async (payload: Payload) => {
 
   // Create anchor bar menu items (in folders)
   await payload.create({
+    overrideAccess: true,
     collection: menuItemsSlug,
     data: {
       name: 'Peanuts',
@@ -203,6 +227,7 @@ export const seed = async (payload: Payload) => {
     locale: 'en',
   })
   await payload.create({
+    overrideAccess: true,
     collection: menuItemsSlug,
     data: {
       name: 'Pretzels',
@@ -213,6 +238,7 @@ export const seed = async (payload: Payload) => {
     locale: 'en',
   })
   await payload.create({
+    overrideAccess: true,
     collection: menuItemsSlug,
     data: {
       name: 'Popcorn',
@@ -225,6 +251,7 @@ export const seed = async (payload: Payload) => {
 
   // Public tenant menu items
   await payload.create({
+    overrideAccess: true,
     collection: menuItemsSlug,
     data: {
       name: 'Free Pizza',
@@ -232,6 +259,7 @@ export const seed = async (payload: Payload) => {
     },
   })
   await payload.create({
+    overrideAccess: true,
     collection: menuItemsSlug,
     data: {
       name: 'Free Dogs',
@@ -241,6 +269,7 @@ export const seed = async (payload: Payload) => {
 
   // create users
   await payload.create({
+    overrideAccess: true,
     collection: usersSlug,
     data: {
       ...credentials.admin,
@@ -249,6 +278,7 @@ export const seed = async (payload: Payload) => {
   })
 
   await payload.create({
+    overrideAccess: true,
     collection: usersSlug,
     data: {
       ...credentials.blueDog,
@@ -262,6 +292,7 @@ export const seed = async (payload: Payload) => {
   })
 
   await payload.create({
+    overrideAccess: true,
     collection: usersSlug,
     data: {
       ...credentials.owner,
@@ -279,6 +310,7 @@ export const seed = async (payload: Payload) => {
 
   // create menus
   await payload.create({
+    overrideAccess: true,
     collection: menuSlug,
     data: {
       description: 'This collection behaves like globals, 1 document per tenant. No list view.',
@@ -287,6 +319,7 @@ export const seed = async (payload: Payload) => {
     },
   })
   await payload.create({
+    overrideAccess: true,
     collection: menuSlug,
     data: {
       description: 'This collection behaves like globals, 1 document per tenant. No list view.',
@@ -296,6 +329,7 @@ export const seed = async (payload: Payload) => {
   })
 
   await payload.create({
+    overrideAccess: true,
     collection: usersSlug,
     data: {
       ...credentials.steelCat,
@@ -310,6 +344,7 @@ export const seed = async (payload: Payload) => {
 
   // User with mixed tenant roles: admin for Steel Cat, member for Blue Dog
   await payload.create({
+    overrideAccess: true,
     collection: usersSlug,
     data: {
       ...credentials.memberUser,
@@ -333,6 +368,7 @@ export const seed = async (payload: Payload) => {
 
   // Create a user with no tenant associations
   await payload.create({
+    overrideAccess: true,
     collection: usersSlug,
     data: {
       ...credentials.noTenant,

--- a/test/plugin-nested-docs/config.ts
+++ b/test/plugin-nested-docs/config.ts
@@ -25,6 +25,7 @@ export default buildConfigWithDefaults({
   },
   onInit: async (payload) => {
     await payload.create({
+      overrideAccess: true,
       collection: 'users',
       data: {
         email: devUser.email,

--- a/test/plugin-nested-docs/int.spec.ts
+++ b/test/plugin-nested-docs/int.spec.ts
@@ -26,6 +26,7 @@ describe('@payloadcms/plugin-nested-docs', () => {
   describe('seed', () => {
     it('should populate two levels of breadcrumbs', async () => {
       const query = await payload.find({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           slug: {
@@ -39,6 +40,7 @@ describe('@payloadcms/plugin-nested-docs', () => {
 
     it('should populate three levels of breadcrumbs', async () => {
       const query = await payload.find({
+        overrideAccess: true,
         collection: 'pages',
         where: {
           slug: {
@@ -58,6 +60,7 @@ describe('@payloadcms/plugin-nested-docs', () => {
     it('should update more than 10 (default limit) breadcrumbs', async () => {
       // create a parent doc
       const parentDoc = await payload.create({
+        overrideAccess: true,
         collection: 'pages',
         data: {
           title: '11 children',
@@ -68,6 +71,7 @@ describe('@payloadcms/plugin-nested-docs', () => {
       // create 11 children docs
       for (let i = 0; i < 11; i++) {
         await payload.create({
+          overrideAccess: true,
           collection: 'pages',
           data: {
             title: `Child ${i + 1}`,
@@ -79,6 +83,7 @@ describe('@payloadcms/plugin-nested-docs', () => {
       }
       // update parent doc
       await payload.update({
+        overrideAccess: true,
         collection: 'pages',
         id: parentDoc.id,
         data: {
@@ -90,6 +95,7 @@ describe('@payloadcms/plugin-nested-docs', () => {
 
       // read children docs
       const { docs } = await payload.find({
+        overrideAccess: true,
         collection: 'pages',
         limit: 0,
         where: {
@@ -113,6 +119,7 @@ describe('@payloadcms/plugin-nested-docs', () => {
 
     it('should return breadcrumbs as an array of objects', async () => {
       const parentDoc = await payload.create({
+        overrideAccess: true,
         collection: 'pages',
         data: {
           title: 'parent doc',
@@ -122,6 +129,7 @@ describe('@payloadcms/plugin-nested-docs', () => {
       })
 
       const childDoc = await payload.create({
+        overrideAccess: true,
         collection: 'pages',
         data: {
           title: 'child doc',
@@ -143,6 +151,7 @@ describe('@payloadcms/plugin-nested-docs', () => {
 
     it('should update child doc breadcrumb without affecting any other data', async () => {
       const parentDoc = await payload.create({
+        overrideAccess: true,
         collection: 'pages',
         data: {
           title: 'parent doc',
@@ -151,6 +160,7 @@ describe('@payloadcms/plugin-nested-docs', () => {
       })
 
       const childDoc = await payload.create({
+        overrideAccess: true,
         collection: 'pages',
         data: {
           title: 'child doc',
@@ -161,6 +171,7 @@ describe('@payloadcms/plugin-nested-docs', () => {
       })
 
       await payload.update({
+        overrideAccess: true,
         collection: 'pages',
         id: parentDoc.id,
         data: {
@@ -172,6 +183,7 @@ describe('@payloadcms/plugin-nested-docs', () => {
 
       const updatedChild = await payload
         .find({
+          overrideAccess: true,
           collection: 'pages',
           where: {
             id: {
@@ -199,7 +211,7 @@ describe('@payloadcms/plugin-nested-docs', () => {
     afterEach(async () => {
       // Clean up in reverse order (children before parents)
       for (const id of [...createdPageIDs].reverse()) {
-        await payload.delete({ collection: 'pages', id })
+        await payload.delete({ overrideAccess: true, collection: 'pages', id })
       }
       createdPageIDs.length = 0
     })
@@ -207,6 +219,7 @@ describe('@payloadcms/plugin-nested-docs', () => {
     it('should preserve published version of child when parent is saved and child has unpublished draft', async () => {
       // Step 1: Create parent page and publish it
       const parentDoc = await payload.create({
+        overrideAccess: true,
         collection: 'pages',
         data: {
           title: 'Version Parent',
@@ -218,6 +231,7 @@ describe('@payloadcms/plugin-nested-docs', () => {
 
       // Step 2: Create child page and publish it
       const childDoc = await payload.create({
+        overrideAccess: true,
         collection: 'pages',
         data: {
           title: 'Version Child',
@@ -230,6 +244,7 @@ describe('@payloadcms/plugin-nested-docs', () => {
 
       // Verify initial published state
       const initialPublished = await payload.findByID({
+        overrideAccess: true,
         id: childDoc.id,
         collection: 'pages',
         draft: false,
@@ -239,6 +254,7 @@ describe('@payloadcms/plugin-nested-docs', () => {
 
       // Step 3: Make unpublished changes to child (creates a draft version)
       await payload.update({
+        overrideAccess: true,
         id: childDoc.id,
         collection: 'pages',
         data: {
@@ -249,6 +265,7 @@ describe('@payloadcms/plugin-nested-docs', () => {
 
       // Step 4: Re-publish the parent (triggers resaveChildren)
       await payload.update({
+        overrideAccess: true,
         id: parentDoc.id,
         collection: 'pages',
         data: {
@@ -260,6 +277,7 @@ describe('@payloadcms/plugin-nested-docs', () => {
 
       // Step 5: Verify the child's published version is still accessible
       const publishedChild = await payload.findByID({
+        overrideAccess: true,
         id: childDoc.id,
         collection: 'pages',
         draft: false,
@@ -272,6 +290,7 @@ describe('@payloadcms/plugin-nested-docs', () => {
 
       // Step 6: Verify the draft version is also still accessible
       const draftChild = await payload.findByID({
+        overrideAccess: true,
         id: childDoc.id,
         collection: 'pages',
         draft: true,
@@ -283,6 +302,7 @@ describe('@payloadcms/plugin-nested-docs', () => {
 
     it('should update breadcrumbs for draft-only children when parent is saved', async () => {
       const parentDoc = await payload.create({
+        overrideAccess: true,
         collection: 'pages',
         data: {
           title: 'Draft Parent',
@@ -294,6 +314,7 @@ describe('@payloadcms/plugin-nested-docs', () => {
 
       // Create a child that is never published (draft-only)
       const draftChild = await payload.create({
+        overrideAccess: true,
         collection: 'pages',
         data: {
           title: 'Draft Only Child',
@@ -308,6 +329,7 @@ describe('@payloadcms/plugin-nested-docs', () => {
 
       // Update the parent
       await payload.update({
+        overrideAccess: true,
         id: parentDoc.id,
         collection: 'pages',
         data: {
@@ -319,6 +341,7 @@ describe('@payloadcms/plugin-nested-docs', () => {
 
       // Draft-only child should have updated breadcrumbs
       const updatedDraftChild = await payload.findByID({
+        overrideAccess: true,
         id: draftChild.id,
         collection: 'pages',
         draft: true,
@@ -330,6 +353,7 @@ describe('@payloadcms/plugin-nested-docs', () => {
 
     it('should update breadcrumbs for both published and draft versions when parent changes', async () => {
       const parent = await payload.create({
+        overrideAccess: true,
         collection: 'pages',
         data: {
           title: 'Breadcrumb Parent',
@@ -340,6 +364,7 @@ describe('@payloadcms/plugin-nested-docs', () => {
       createdPageIDs.push(parent.id)
 
       const child = await payload.create({
+        overrideAccess: true,
         collection: 'pages',
         data: {
           title: 'Breadcrumb Child',
@@ -352,6 +377,7 @@ describe('@payloadcms/plugin-nested-docs', () => {
 
       // Create draft edit on child
       await payload.update({
+        overrideAccess: true,
         id: child.id,
         collection: 'pages',
         data: {
@@ -362,6 +388,7 @@ describe('@payloadcms/plugin-nested-docs', () => {
 
       // Update parent slug
       await payload.update({
+        overrideAccess: true,
         id: parent.id,
         collection: 'pages',
         data: {
@@ -372,6 +399,7 @@ describe('@payloadcms/plugin-nested-docs', () => {
 
       // Published child has updated breadcrumbs and is accessible
       const published = await payload.findByID({
+        overrideAccess: true,
         id: child.id,
         collection: 'pages',
         draft: false,
@@ -382,6 +410,7 @@ describe('@payloadcms/plugin-nested-docs', () => {
 
       // Draft child also has updated breadcrumbs
       const draft = await payload.findByID({
+        overrideAccess: true,
         id: child.id,
         collection: 'pages',
         draft: true,
@@ -396,6 +425,7 @@ describe('@payloadcms/plugin-nested-docs', () => {
   describe('scheduled publish', () => {
     it('should allow scheduled publish on a collection with a nested-docs breadcrumbs field', async () => {
       const draft = await payload.create({
+        overrideAccess: true,
         collection: 'pages',
         data: {
           title: 'Scheduled Page',
@@ -409,6 +439,7 @@ describe('@payloadcms/plugin-nested-docs', () => {
       const currentDate = new Date()
 
       await payload.jobs.queue({
+        overrideAccess: true,
         input: {
           doc: {
             relationTo: 'pages',
@@ -426,9 +457,10 @@ describe('@payloadcms/plugin-nested-docs', () => {
 
       await wait(4000)
 
-      await payload.jobs.run()
+      await payload.jobs.run({ overrideAccess: true })
 
       const retrieved = await payload.findByID({
+        overrideAccess: true,
         id: draft.id,
         collection: 'pages',
         draft: false,
@@ -436,7 +468,7 @@ describe('@payloadcms/plugin-nested-docs', () => {
 
       expect(retrieved._status).toBe('published')
 
-      await payload.delete({ collection: 'pages', id: draft.id })
+      await payload.delete({ overrideAccess: true, collection: 'pages', id: draft.id })
     })
   })
 
@@ -470,12 +502,14 @@ describe('@payloadcms/plugin-nested-docs', () => {
 
     it('should allow custom breadcrumb and parent slugs', async () => {
       const parent = await payload.create({
+        overrideAccess: true,
         collection: 'categories',
         data: {
           name: 'parent',
         },
       })
       const child = await payload.create({
+        overrideAccess: true,
         collection: 'categories',
         data: {
           name: 'child',
@@ -483,6 +517,7 @@ describe('@payloadcms/plugin-nested-docs', () => {
         },
       })
       const grandchild = await payload.create({
+        overrideAccess: true,
         collection: 'categories',
         data: {
           name: 'grandchild',

--- a/test/plugin-nested-docs/seed/index.ts
+++ b/test/plugin-nested-docs/seed/index.ts
@@ -5,6 +5,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
 
   try {
     await payload.create({
+      overrideAccess: true,
       collection: 'users',
       data: {
         email: 'demo@payloadcms.com',
@@ -13,6 +14,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
     })
 
     const { id: parentID } = await payload.create({
+      overrideAccess: true,
       collection: 'pages',
       data: {
         slug: 'parent-page',
@@ -22,6 +24,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
     })
 
     const { id: childID } = await payload.create({
+      overrideAccess: true,
       collection: 'pages',
       data: {
         parent: parentID,
@@ -32,6 +35,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
     })
 
     await payload.create({
+      overrideAccess: true,
       collection: 'pages',
       data: {
         parent: childID,
@@ -42,6 +46,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
     })
 
     await payload.create({
+      overrideAccess: true,
       collection: 'pages',
       data: {
         slug: 'sister-page',

--- a/test/plugin-redirects/config.ts
+++ b/test/plugin-redirects/config.ts
@@ -49,6 +49,7 @@ export default buildConfigWithDefaults({
   },
   onInit: async (payload) => {
     await payload.create({
+      overrideAccess: true,
       collection: 'users',
       data: {
         email: devUser.email,

--- a/test/plugin-redirects/int.spec.ts
+++ b/test/plugin-redirects/int.spec.ts
@@ -20,6 +20,7 @@ describe('@payloadcms/plugin-redirects', () => {
     ;({ payload } = await initPayloadInt(dirname))
 
     page = await payload.create({
+      overrideAccess: true,
       collection: 'pages',
       data: {
         title: 'Test',
@@ -33,6 +34,7 @@ describe('@payloadcms/plugin-redirects', () => {
 
   it('should add a redirects collection', async () => {
     const redirect = await payload.find({
+      overrideAccess: true,
       collection: 'redirects',
       depth: 0,
       limit: 1,
@@ -43,6 +45,7 @@ describe('@payloadcms/plugin-redirects', () => {
 
   it('should add a redirect with to internal page', async () => {
     const redirect = await payload.create({
+      overrideAccess: true,
       collection: 'redirects',
       data: {
         from: '/test',
@@ -64,6 +67,7 @@ describe('@payloadcms/plugin-redirects', () => {
 
   it('should add a redirect with to custom url', async () => {
     const redirect = await payload.create({
+      overrideAccess: true,
       collection: 'redirects',
       data: {
         from: '/test2',

--- a/test/plugin-redirects/seed/index.ts
+++ b/test/plugin-redirects/seed/index.ts
@@ -8,6 +8,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
 
   try {
     await payload.create({
+      overrideAccess: true,
       collection: 'users',
       data: {
         email: 'demo@payloadcms.com',

--- a/test/plugin-search/config.ts
+++ b/test/plugin-search/config.ts
@@ -57,6 +57,7 @@ export default buildConfigWithDefaults({
   },
   onInit: async (payload) => {
     await payload.create({
+      overrideAccess: true,
       collection: 'users',
       data: {
         email: devUser.email,

--- a/test/plugin-search/int.spec.ts
+++ b/test/plugin-search/int.spec.ts
@@ -36,6 +36,7 @@ describe('@payloadcms/plugin-search', () => {
 
   beforeEach(async () => {
     await payload.delete({
+      overrideAccess: true,
       collection: 'search',
       depth: 0,
       where: {
@@ -46,6 +47,7 @@ describe('@payloadcms/plugin-search', () => {
     })
     await Promise.all([
       payload.delete({
+        overrideAccess: true,
         collection: postsSlug,
         depth: 0,
         where: {
@@ -55,6 +57,7 @@ describe('@payloadcms/plugin-search', () => {
         },
       }),
       payload.delete({
+        overrideAccess: true,
         collection: pagesSlug,
         depth: 0,
         where: {
@@ -72,6 +75,7 @@ describe('@payloadcms/plugin-search', () => {
 
   it('should add a search collection', async () => {
     const search = await payload.find({
+      overrideAccess: true,
       collection: 'search',
       depth: 0,
       limit: 1,
@@ -82,6 +86,7 @@ describe('@payloadcms/plugin-search', () => {
 
   it('should sync published pages to the search collection', async () => {
     const pageToSync = await payload.create({
+      overrideAccess: true,
       collection: 'pages',
       data: {
         _status: 'published',
@@ -91,6 +96,7 @@ describe('@payloadcms/plugin-search', () => {
     })
 
     const { docs: results } = await payload.find({
+      overrideAccess: true,
       collection: 'search',
       depth: 0,
       where: {
@@ -108,6 +114,7 @@ describe('@payloadcms/plugin-search', () => {
 
   it('should not sync drafts pages to the search collection', async () => {
     const draftPage = await payload.create({
+      overrideAccess: true,
       collection: 'pages',
       data: {
         _status: 'draft',
@@ -121,6 +128,7 @@ describe('@payloadcms/plugin-search', () => {
     await wait(200)
 
     const { docs: results } = await payload.find({
+      overrideAccess: true,
       collection: 'search',
       depth: 0,
       where: {
@@ -135,6 +143,7 @@ describe('@payloadcms/plugin-search', () => {
 
   it('should not delete a search doc if a published item has a new draft but remains published', async () => {
     const publishedPage = await payload.create({
+      overrideAccess: true,
       collection: 'pages',
       data: {
         _status: 'published',
@@ -147,6 +156,7 @@ describe('@payloadcms/plugin-search', () => {
     await wait(200)
 
     const { docs: results } = await payload.find({
+      overrideAccess: true,
       collection: 'search',
       depth: 0,
       where: {
@@ -160,6 +170,7 @@ describe('@payloadcms/plugin-search', () => {
 
     // Create a new draft
     await payload.update({
+      overrideAccess: true,
       collection: 'pages',
       id: publishedPage.id,
       draft: true,
@@ -171,6 +182,7 @@ describe('@payloadcms/plugin-search', () => {
 
     // This should remain with the published content
     const { docs: updatedResults } = await payload.find({
+      overrideAccess: true,
       collection: 'search',
       depth: 0,
       where: {
@@ -183,6 +195,7 @@ describe('@payloadcms/plugin-search', () => {
     expect(updatedResults).toHaveLength(1)
 
     await payload.update({
+      overrideAccess: true,
       collection: 'pages',
       id: publishedPage.id,
       data: {
@@ -193,6 +206,7 @@ describe('@payloadcms/plugin-search', () => {
 
     // Should now be deleted given we've unpublished the page
     const { docs: deletedResults } = await payload.find({
+      overrideAccess: true,
       collection: 'search',
       depth: 0,
       where: {
@@ -207,6 +221,7 @@ describe('@payloadcms/plugin-search', () => {
 
   it('should sync changes made to an existing search document', async () => {
     const pageToReceiveUpdates = await payload.create({
+      overrideAccess: true,
       collection: 'pages',
       data: {
         _status: 'published',
@@ -216,6 +231,7 @@ describe('@payloadcms/plugin-search', () => {
     })
 
     const { docs: results } = await payload.find({
+      overrideAccess: true,
       collection: 'search',
       depth: 0,
       where: {
@@ -231,6 +247,7 @@ describe('@payloadcms/plugin-search', () => {
     expect(results[0].excerpt).toBe('This is a test page')
 
     await payload.update({
+      overrideAccess: true,
       id: pageToReceiveUpdates.id,
       collection: 'pages',
       data: {
@@ -245,6 +262,7 @@ describe('@payloadcms/plugin-search', () => {
 
     // Do not add `limit` to this query, this way we can test if multiple documents were created
     const { docs: updatedResults } = await payload.find({
+      overrideAccess: true,
       collection: 'search',
       depth: 0,
       where: {
@@ -262,6 +280,7 @@ describe('@payloadcms/plugin-search', () => {
 
   it('should clear the search document when the original document is deleted', async () => {
     const page = await payload.create({
+      overrideAccess: true,
       collection: 'pages',
       data: {
         _status: 'published',
@@ -275,6 +294,7 @@ describe('@payloadcms/plugin-search', () => {
     await wait(200)
 
     const { docs: results } = await payload.find({
+      overrideAccess: true,
       collection: 'search',
       depth: 0,
       where: {
@@ -288,6 +308,7 @@ describe('@payloadcms/plugin-search', () => {
     expect(results[0].doc.value).toBe(page.id)
 
     await payload.delete({
+      overrideAccess: true,
       id: page.id,
       collection: 'pages',
     })
@@ -297,6 +318,7 @@ describe('@payloadcms/plugin-search', () => {
     await wait(200)
 
     const { docs: deletedResults } = await payload.find({
+      overrideAccess: true,
       collection: 'search',
       depth: 0,
       where: {
@@ -311,11 +333,13 @@ describe('@payloadcms/plugin-search', () => {
 
   it('should clear the proper search document when having the same doc.value but different doc.relationTo', async () => {
     const custom_id_1 = await payload.create({
+      overrideAccess: true,
       collection: 'custom-ids-1',
       data: { id: 'custom_id' },
     })
 
     await payload.create({
+      overrideAccess: true,
       collection: 'custom-ids-2',
       data: { id: 'custom_id' },
     })
@@ -325,6 +349,7 @@ describe('@payloadcms/plugin-search', () => {
     const {
       docs: [docBefore],
     } = await payload.find({
+      overrideAccess: true,
       collection: 'search',
       where: { 'doc.value': { equals: 'custom_id' } },
       limit: 1,
@@ -333,13 +358,14 @@ describe('@payloadcms/plugin-search', () => {
 
     expect(docBefore.doc.relationTo).toBe('custom-ids-1')
 
-    await payload.delete({ collection: 'custom-ids-1', id: custom_id_1.id })
+    await payload.delete({ overrideAccess: true, collection: 'custom-ids-1', id: custom_id_1.id })
 
     await wait(200)
 
     const {
       docs: [docAfter],
     } = await payload.find({
+      overrideAccess: true,
       collection: 'search',
       where: { 'doc.value': { equals: 'custom_id' } },
       limit: 1,
@@ -351,6 +377,7 @@ describe('@payloadcms/plugin-search', () => {
 
   it('should sync localized data', async () => {
     const createdDoc = await payload.create({
+      overrideAccess: true,
       collection: 'posts',
       data: {
         _status: 'published',
@@ -361,6 +388,7 @@ describe('@payloadcms/plugin-search', () => {
     })
 
     await payload.update({
+      overrideAccess: true,
       collection: 'posts',
       id: createdDoc.id,
       data: {
@@ -372,6 +400,7 @@ describe('@payloadcms/plugin-search', () => {
     })
 
     const syncedSearchData = await payload.find({
+      overrideAccess: true,
       collection: 'search',
       locale: 'es',
       where: {
@@ -395,6 +424,7 @@ describe('@payloadcms/plugin-search', () => {
     }
 
     await payload.create({
+      overrideAccess: true,
       collection: 'users',
       data: testCreds,
     })
@@ -450,6 +480,7 @@ describe('@payloadcms/plugin-search', () => {
 
   it('should delete existing search indexes before reindexing', async () => {
     await payload.create({
+      overrideAccess: true,
       collection: postsSlug,
       data: {
         title: 'post_1',
@@ -460,6 +491,7 @@ describe('@payloadcms/plugin-search', () => {
     await wait(200)
 
     await payload.create({
+      overrideAccess: true,
       collection: postsSlug,
       data: {
         title: 'post_2',
@@ -467,7 +499,7 @@ describe('@payloadcms/plugin-search', () => {
       },
     })
 
-    const { docs } = await payload.find({ collection: 'search' })
+    const { docs } = await payload.find({ overrideAccess: true, collection: 'search' })
 
     await wait(200)
 
@@ -482,6 +514,7 @@ describe('@payloadcms/plugin-search', () => {
     await wait(200)
 
     const { docs: results } = await payload.find({
+      overrideAccess: true,
       collection: 'search',
       depth: 0,
       where: {
@@ -499,6 +532,7 @@ describe('@payloadcms/plugin-search', () => {
   it('should reindex whole collections', async () => {
     await Promise.all([
       payload.create({
+        overrideAccess: true,
         collection: pagesSlug,
         data: {
           title: 'Test page title',
@@ -506,6 +540,7 @@ describe('@payloadcms/plugin-search', () => {
         },
       }),
       payload.create({
+        overrideAccess: true,
         collection: postsSlug,
         data: {
           title: 'Test page title',
@@ -517,6 +552,7 @@ describe('@payloadcms/plugin-search', () => {
     await wait(200)
 
     const { totalDocs: totalBeforeReindex } = await payload.count({
+      overrideAccess: true,
       collection: 'search',
     })
 
@@ -532,6 +568,7 @@ describe('@payloadcms/plugin-search', () => {
     expect(endpointRes.status).toBe(200)
 
     const { totalDocs: totalAfterReindex } = await payload.count({
+      overrideAccess: true,
       collection: 'search',
     })
 
@@ -541,14 +578,17 @@ describe('@payloadcms/plugin-search', () => {
   it('should report correct aggregate counts when reindexing multiple collections', async () => {
     await Promise.all([
       payload.create({
+        overrideAccess: true,
         collection: postsSlug,
         data: { title: 'Post one', _status: 'published' },
       }),
       payload.create({
+        overrideAccess: true,
         collection: postsSlug,
         data: { title: 'Post two', _status: 'published' },
       }),
       payload.create({
+        overrideAccess: true,
         collection: pagesSlug,
         data: { title: 'Page one', _status: 'published' },
       }),
@@ -572,18 +612,21 @@ describe('@payloadcms/plugin-search', () => {
   it('should index locale-specific data for all locales when reindexing multiple collections', async () => {
     // Create a post with distinct slugs per locale — these are mapped into the search doc via beforeSync
     const { id: postId } = await payload.create({
+      overrideAccess: true,
       collection: postsSlug,
       data: { title: 'Locale test post', _status: 'published', slug: 'post-slug-en' },
       locale: 'en',
     })
 
     await payload.update({
+      overrideAccess: true,
       collection: postsSlug,
       id: postId,
       data: { slug: 'post-slug-es' },
       locale: 'es',
     })
     await payload.update({
+      overrideAccess: true,
       collection: postsSlug,
       id: postId,
       data: { slug: 'post-slug-de' },
@@ -592,6 +635,7 @@ describe('@payloadcms/plugin-search', () => {
 
     // Create a page so both collections are reindexed together, exercising the multi-collection path
     await payload.create({
+      overrideAccess: true,
       collection: pagesSlug,
       data: { title: 'Locale test page', _status: 'published' },
     })
@@ -604,6 +648,7 @@ describe('@payloadcms/plugin-search', () => {
     expect(endpointRes.status).toBe(200)
 
     const { docs: searchDocs } = await payload.find({
+      overrideAccess: true,
       collection: 'search',
       depth: 0,
       where: {
@@ -616,9 +661,24 @@ describe('@payloadcms/plugin-search', () => {
     const searchDocId = searchDocs[0]!.id
 
     const [enDoc, esDoc, deDoc] = await Promise.all([
-      payload.findByID({ collection: 'search', id: searchDocId, locale: 'en' }),
-      payload.findByID({ collection: 'search', id: searchDocId, locale: 'es' }),
-      payload.findByID({ collection: 'search', id: searchDocId, locale: 'de' }),
+      payload.findByID({
+        overrideAccess: true,
+        collection: 'search',
+        id: searchDocId,
+        locale: 'en',
+      }),
+      payload.findByID({
+        overrideAccess: true,
+        collection: 'search',
+        id: searchDocId,
+        locale: 'es',
+      }),
+      payload.findByID({
+        overrideAccess: true,
+        collection: 'search',
+        id: searchDocId,
+        locale: 'de',
+      }),
     ])
 
     // With localization fallback: true, a missing locale update would silently fall back to 'en'
@@ -631,6 +691,7 @@ describe('@payloadcms/plugin-search', () => {
   it('should exclude drafts from reindexing by default', async () => {
     await Promise.all([
       payload.create({
+        overrideAccess: true,
         collection: pagesSlug,
         data: {
           title: 'Test page published',
@@ -638,6 +699,7 @@ describe('@payloadcms/plugin-search', () => {
         },
       }),
       payload.create({
+        overrideAccess: true,
         collection: pagesSlug,
         data: {
           title: 'Test page draft',
@@ -649,6 +711,7 @@ describe('@payloadcms/plugin-search', () => {
     await wait(200)
 
     const { totalDocs: totalBeforeReindex } = await payload.count({
+      overrideAccess: true,
       collection: 'search',
     })
 
@@ -666,6 +729,7 @@ describe('@payloadcms/plugin-search', () => {
     expect(endpointRes.status).toBe(200)
 
     const { totalDocs: totalAfterReindex } = await payload.count({
+      overrideAccess: true,
       collection: 'search',
     })
 
@@ -682,6 +746,7 @@ describe('@payloadcms/plugin-search', () => {
 
   it('should reindex all configured locales', async () => {
     const post = await payload.create({
+      overrideAccess: true,
       collection: postsSlug,
       locale: 'en',
       data: {
@@ -691,6 +756,7 @@ describe('@payloadcms/plugin-search', () => {
       },
     })
     await payload.update({
+      overrideAccess: true,
       collection: postsSlug,
       id: post.id,
       locale: 'es',
@@ -700,6 +766,7 @@ describe('@payloadcms/plugin-search', () => {
       },
     })
     await payload.update({
+      overrideAccess: true,
       collection: postsSlug,
       id: post.id,
       locale: 'de',
@@ -712,6 +779,7 @@ describe('@payloadcms/plugin-search', () => {
     const {
       docs: [postBeforeReindex],
     } = await payload.find({
+      overrideAccess: true,
       collection: 'search',
       locale: 'all',
       where: {
@@ -743,6 +811,7 @@ describe('@payloadcms/plugin-search', () => {
     const {
       docs: [postAfterReindex],
     } = await payload.find({
+      overrideAccess: true,
       collection: 'search',
       locale: 'all',
       where: {
@@ -765,6 +834,7 @@ describe('@payloadcms/plugin-search', () => {
   it('should sync trashed documents correctly with search plugin', async () => {
     // Create a published post
     const publishedPost = await payload.create({
+      overrideAccess: true,
       collection: postsSlug,
       data: {
         title: 'Post to be trashed',
@@ -778,6 +848,7 @@ describe('@payloadcms/plugin-search', () => {
 
     // Verify the search document was created
     const { docs: initialSearchResults } = await payload.find({
+      overrideAccess: true,
       collection: 'search',
       depth: 0,
       where: {
@@ -792,6 +863,7 @@ describe('@payloadcms/plugin-search', () => {
 
     // Soft delete the post (move to trash)
     await payload.update({
+      overrideAccess: true,
       collection: postsSlug,
       id: publishedPost.id,
       data: {
@@ -805,6 +877,7 @@ describe('@payloadcms/plugin-search', () => {
     // Verify the search document still exists but is properly synced
     // The search document should remain and be updated correctly
     const { docs: trashedSearchResults } = await payload.find({
+      overrideAccess: true,
       collection: 'search',
       depth: 0,
       where: {
@@ -819,6 +892,7 @@ describe('@payloadcms/plugin-search', () => {
 
     // Clean up by permanently deleting the trashed post
     await payload.delete({
+      overrideAccess: true,
       collection: postsSlug,
       id: publishedPost.id,
       trash: true, // permanently delete
@@ -832,6 +906,7 @@ describe('@payloadcms/plugin-search', () => {
 
       // Create a doc with syncEnglishOnly enabled
       const enDoc = await payload.create({
+        overrideAccess: true,
         collection: 'filtered-locales',
         data: {
           title: 'Filtered Doc',
@@ -842,6 +917,7 @@ describe('@payloadcms/plugin-search', () => {
 
       // Query for ALL search docs with locale: 'all' to see total count
       const { docs: allSearchDocs } = await payload.find({
+        overrideAccess: true,
         collection: 'search',
         locale: 'all',
         where: {
@@ -857,6 +933,7 @@ describe('@payloadcms/plugin-search', () => {
 
       // Verify the search doc exists for English locale
       const { docs } = await payload.find({
+        overrideAccess: true,
         collection: 'search',
         locale: 'all',
         where: {
@@ -877,6 +954,7 @@ describe('@payloadcms/plugin-search', () => {
 
       // Clean up
       await payload.delete({
+        overrideAccess: true,
         collection: 'filtered-locales',
         id: enDoc.id,
       })
@@ -888,6 +966,7 @@ describe('@payloadcms/plugin-search', () => {
 
       // Create a post
       const post = await payload.create({
+        overrideAccess: true,
         collection: postsSlug,
         data: {
           _status: 'published',
@@ -898,6 +977,7 @@ describe('@payloadcms/plugin-search', () => {
 
       // Update the post in Spanish locale
       await payload.update({
+        overrideAccess: true,
         collection: postsSlug,
         id: post.id,
         locale: 'es',
@@ -909,6 +989,7 @@ describe('@payloadcms/plugin-search', () => {
 
       // Update the post in German locale
       await payload.update({
+        overrideAccess: true,
         collection: postsSlug,
         id: post.id,
         locale: 'de',
@@ -920,6 +1001,7 @@ describe('@payloadcms/plugin-search', () => {
 
       // Query for search doc with locale: 'all'
       const { docs: allSearchDocs } = await payload.find({
+        overrideAccess: true,
         collection: 'search',
         locale: 'all',
         where: {
@@ -939,6 +1021,7 @@ describe('@payloadcms/plugin-search', () => {
 
       // Clean up
       await payload.delete({
+        overrideAccess: true,
         collection: postsSlug,
         id: post.id,
       })
@@ -949,6 +1032,7 @@ describe('@payloadcms/plugin-search', () => {
 
       // Create a doc with syncEnglishOnly disabled
       const doc = await payload.create({
+        overrideAccess: true,
         collection: 'filtered-locales',
         data: {
           title: 'Unfiltered Doc',
@@ -959,6 +1043,7 @@ describe('@payloadcms/plugin-search', () => {
 
       // Verify search doc exists for English
       const { docs: enSearchDocs } = await payload.find({
+        overrideAccess: true,
         collection: 'search',
         locale: 'en',
         where: {
@@ -971,6 +1056,7 @@ describe('@payloadcms/plugin-search', () => {
 
       // Verify search doc exists for Spanish
       const { docs: esSearchDocs } = await payload.find({
+        overrideAccess: true,
         collection: 'search',
         locale: 'es',
         where: {
@@ -983,6 +1069,7 @@ describe('@payloadcms/plugin-search', () => {
 
       // Verify search doc exists for German
       const { docs: deSearchDocs } = await payload.find({
+        overrideAccess: true,
         collection: 'search',
         locale: 'de',
         where: {
@@ -995,6 +1082,7 @@ describe('@payloadcms/plugin-search', () => {
 
       // Clean up
       await payload.delete({
+        overrideAccess: true,
         collection: 'filtered-locales',
         id: doc.id,
       })

--- a/test/plugin-search/seed/index.ts
+++ b/test/plugin-search/seed/index.ts
@@ -6,6 +6,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
 
   try {
     await payload.create({
+      overrideAccess: true,
       collection: 'users',
       data: {
         email: 'demo@payloadcms.com',

--- a/test/plugin-sentry/config.ts
+++ b/test/plugin-sentry/config.ts
@@ -24,6 +24,7 @@ export default buildConfigWithDefaults({
   collections: [Posts, Users],
   onInit: async (payload) => {
     await payload.create({
+      overrideAccess: true,
       collection: 'users',
       data: {
         email: devUser.email,

--- a/test/plugin-seo/config.ts
+++ b/test/plugin-seo/config.ts
@@ -57,6 +57,7 @@ export default buildConfigWithDefaults({
   },
   onInit: async (payload) => {
     await payload.create({
+      overrideAccess: true,
       collection: 'users',
       data: {
         email: devUser.email,

--- a/test/plugin-seo/int.spec.ts
+++ b/test/plugin-seo/int.spec.ts
@@ -29,12 +29,14 @@ describe('@payloadcms/plugin-seo', () => {
     const file = await getFileByPath(filePath)
 
     mediaDoc = await payload.create({
+      overrideAccess: true,
       collection: mediaSlug,
       data: {},
       file,
     })
 
     page = await payload.create({
+      overrideAccess: true,
       collection: 'pages',
       data: {
         title: 'Test page',
@@ -48,6 +50,7 @@ describe('@payloadcms/plugin-seo', () => {
     })
 
     mediaDoc2 = await payload.create({
+      overrideAccess: true,
       collection: mediaSlug,
       data: {},
       file,
@@ -63,6 +66,7 @@ describe('@payloadcms/plugin-seo', () => {
     // Update it to mediaDoc2 and we expect to see different previousValue and value in the hook
     const context: { identicalCount?: number } = {}
     await payload.update({
+      overrideAccess: true,
       collection: 'pages',
       id: page.id,
       data: {
@@ -81,6 +85,7 @@ describe('@payloadcms/plugin-seo', () => {
 
   it('should add meta title', async () => {
     const pageWithTitle = await payload.update({
+      overrideAccess: true,
       collection: 'pages',
       id: page.id,
       data: {
@@ -98,6 +103,7 @@ describe('@payloadcms/plugin-seo', () => {
 
   it('should add meta description', async () => {
     const pageWithDescription = await payload.update({
+      overrideAccess: true,
       collection: 'pages',
       id: page.id,
       data: {
@@ -115,6 +121,7 @@ describe('@payloadcms/plugin-seo', () => {
 
   it('should add meta image', async () => {
     const pageWithImage = await payload.update({
+      overrideAccess: true,
       collection: 'pages',
       id: page.id,
       data: {
@@ -132,6 +139,7 @@ describe('@payloadcms/plugin-seo', () => {
 
   it('should add custom meta field', async () => {
     const pageWithCustomField = await payload.update({
+      overrideAccess: true,
       collection: 'pages',
       id: page.id,
       data: {
@@ -149,6 +157,7 @@ describe('@payloadcms/plugin-seo', () => {
 
   it('should localize meta fields', async () => {
     const pageWithLocalizedMeta = await payload.update({
+      overrideAccess: true,
       collection: 'pages',
       id: page.id,
       data: {
@@ -169,6 +178,7 @@ describe('@payloadcms/plugin-seo', () => {
 
     // query the page in the default locale
     const pageInDefaultLocale = await payload.findByID({
+      overrideAccess: true,
       collection: 'pages',
       id: page.id,
       depth: 0,

--- a/test/plugin-seo/seed/index.ts
+++ b/test/plugin-seo/seed/index.ts
@@ -18,12 +18,14 @@ export const seed = async (payload: Payload): Promise<boolean> => {
     const file = await getFileByPath(filePath)
 
     const mediaDoc = await payload.create({
+      overrideAccess: true,
       collection: mediaSlug,
       data: {},
       file,
     })
 
     await payload.create({
+      overrideAccess: true,
       collection: 'pages',
       data: {
         slug: 'test-page',

--- a/test/plugin-stripe/config.ts
+++ b/test/plugin-stripe/config.ts
@@ -31,6 +31,7 @@ export default buildConfigWithDefaults({
   },
   onInit: async (payload) => {
     await payload.create({
+      overrideAccess: true,
       collection: 'users',
       data: {
         email: devUser.email,

--- a/test/plugin-stripe/int.spec.ts
+++ b/test/plugin-stripe/int.spec.ts
@@ -22,6 +22,7 @@ describe('Stripe Plugin', () => {
 
   it('should create products', async () => {
     const product = await payload.create({
+      overrideAccess: true,
       collection: 'products',
       data: {
         name: 'Test Product',

--- a/test/plugin-stripe/seed/index.ts
+++ b/test/plugin-stripe/seed/index.ts
@@ -6,6 +6,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
 
   try {
     await payload.create({
+      overrideAccess: true,
       collection: 'users',
       data: {
         email: 'demo@payloadcms.com',

--- a/test/plugin-stripe/webhooks/subscriptionCreatedOrUpdated.ts
+++ b/test/plugin-stripe/webhooks/subscriptionCreatedOrUpdated.ts
@@ -23,6 +23,7 @@ export const subscriptionCreatedOrUpdated = async (args) => {
     payload.logger.info(`- Looking up existing Payload product with Stripe ID: ${plan.product}...`)
 
     const productQuery = await payload.find({
+      overrideAccess: true,
       collection: 'products',
       depth: 0,
       where: {
@@ -50,6 +51,7 @@ export const subscriptionCreatedOrUpdated = async (args) => {
     )
 
     const customerReq: any = await payload.find({
+      overrideAccess: true,
       collection: 'customers',
       depth: 0,
       where: {
@@ -89,6 +91,7 @@ export const subscriptionCreatedOrUpdated = async (args) => {
 
       try {
         await payload.update({
+          overrideAccess: true,
           id: foundCustomer.id,
           collection: 'customers',
           data: {

--- a/test/plugin-stripe/webhooks/subscriptionDeleted.ts
+++ b/test/plugin-stripe/webhooks/subscriptionDeleted.ts
@@ -26,6 +26,7 @@ export const subscriptionDeleted = async (args) => {
     )
 
     const customerReq: any = await payload.find({
+      overrideAccess: true,
       collection: 'customers',
       depth: 0,
       where: {
@@ -49,6 +50,7 @@ export const subscriptionDeleted = async (args) => {
 
       try {
         await payload.update({
+          overrideAccess: true,
           id: foundCustomer.id,
           collection: 'customers',
           data: {

--- a/test/plugin-stripe/webhooks/syncPriceJSON.ts
+++ b/test/plugin-stripe/webhooks/syncPriceJSON.ts
@@ -16,6 +16,7 @@ export const syncPriceJSON = async (args) => {
     payload.logger.info(`- Looking up existing Payload product with Stripe ID: ${eventID}...`)
 
     const productQuery = await payload.find({
+      overrideAccess: true,
       collection: 'products',
       where: {
         stripeID: {
@@ -39,6 +40,7 @@ export const syncPriceJSON = async (args) => {
     const stripePrice = await stripe.prices.retrieve(default_price)
 
     await payload.update({
+      overrideAccess: true,
       id: payloadProductID,
       collection: 'products',
       data: {

--- a/test/plugins/config.ts
+++ b/test/plugins/config.ts
@@ -96,6 +96,7 @@ export default buildConfigWithDefaults({
   ],
   onInit: async (payload) => {
     await payload.create({
+      overrideAccess: true,
       collection: 'users',
       data: {
         email: devUser.email,

--- a/test/plugins/int.spec.ts
+++ b/test/plugins/int.spec.ts
@@ -25,6 +25,7 @@ describe('Collections - Plugins', () => {
 
   it('created pages collection', async () => {
     const { id } = await payload.create({
+      overrideAccess: true,
       collection: pagesSlug,
       data: {
         title: 'Test Page',


### PR DESCRIPTION
### What?

This updates Payload's first-party plugins and their tests for the new Local API access default introduced by the PR below this one.

- Trusted plugin hooks, background work, seeds, and test setup now use `overrideAccess: true` explicitly.
- MCP operations preserve the access mode selected by MCP authorization, including auth operations.
- Plugin behavior remains unchanged when the core default switches to enforcing access control.

### Why?

These calls previously relied on Local API access being bypassed by default. Making the intent explicit prevents first-party plugins from changing behavior when the new default lands.

### How?

Each Local API call was reviewed as either a trusted internal operation or a request-scoped operation. Only trusted calls receive `overrideAccess: true`; request-scoped MCP calls continue to use their configured authorization behavior.

### Stack

1. Core breaking change and codemod: [#17686](https://github.com/payloadcms/payload/pull/17686)
2. First-party plugins: this PR
3. Templates: [#17688](https://github.com/payloadcms/payload/pull/17688)

Documentation will follow separately after the enterprise plugins are updated.
