### PR TITLE
fix(templates): migrate Local API access behavior

### DIFF
--- a/templates/_template/tests/helpers/seedUser.ts
+++ b/templates/_template/tests/helpers/seedUser.ts
@@ -14,6 +14,7 @@ export async function seedTestUser(): Promise<void> {
 
   // Delete existing test user if any
   await payload.delete({
+    overrideAccess: true,
     collection: 'users',
     where: {
       email: {
@@ -24,6 +25,7 @@ export async function seedTestUser(): Promise<void> {
 
   // Create fresh test user
   await payload.create({
+    overrideAccess: true,
     collection: 'users',
     data: testUser,
   })
@@ -36,6 +38,7 @@ export async function cleanupTestUser(): Promise<void> {
   const payload = await getPayload({ config })
 
   await payload.delete({
+    overrideAccess: true,
     collection: 'users',
     where: {
       email: {

--- a/templates/_template/tests/int/api.int.spec.ts
+++ b/templates/_template/tests/int/api.int.spec.ts
@@ -13,6 +13,7 @@ describe('API', () => {
 
   it('fetches users', async () => {
     const users = await payload.find({
+      overrideAccess: true,
       collection: 'users',
     })
     expect(users).toBeDefined()

--- a/templates/blank-tanstack/tests/helpers/seedUser.ts
+++ b/templates/blank-tanstack/tests/helpers/seedUser.ts
@@ -14,6 +14,7 @@ export async function seedTestUser(): Promise<void> {
 
   // Delete existing test user if any
   await payload.delete({
+    overrideAccess: true,
     collection: 'users',
     where: {
       email: {
@@ -24,6 +25,7 @@ export async function seedTestUser(): Promise<void> {
 
   // Create fresh test user
   await payload.create({
+    overrideAccess: true,
     collection: 'users',
     data: testUser,
   })
@@ -36,6 +38,7 @@ export async function cleanupTestUser(): Promise<void> {
   const payload = await getPayload({ config })
 
   await payload.delete({
+    overrideAccess: true,
     collection: 'users',
     where: {
       email: {

--- a/templates/blank-tanstack/tests/int/api.int.spec.ts
+++ b/templates/blank-tanstack/tests/int/api.int.spec.ts
@@ -13,6 +13,7 @@ describe('API', () => {
 
   it('fetches users', async () => {
     const users = await payload.find({
+      overrideAccess: true,
       collection: 'users',
     })
     expect(users).toBeDefined()

--- a/templates/blank/tests/helpers/seedUser.ts
+++ b/templates/blank/tests/helpers/seedUser.ts
@@ -14,6 +14,7 @@ export async function seedTestUser(): Promise<void> {
 
   // Delete existing test user if any
   await payload.delete({
+    overrideAccess: true,
     collection: 'users',
     where: {
       email: {
@@ -24,6 +25,7 @@ export async function seedTestUser(): Promise<void> {
 
   // Create fresh test user
   await payload.create({
+    overrideAccess: true,
     collection: 'users',
     data: testUser,
   })
@@ -36,6 +38,7 @@ export async function cleanupTestUser(): Promise<void> {
   const payload = await getPayload({ config })
 
   await payload.delete({
+    overrideAccess: true,
     collection: 'users',
     where: {
       email: {

--- a/templates/blank/tests/int/api.int.spec.ts
+++ b/templates/blank/tests/int/api.int.spec.ts
@@ -13,6 +13,7 @@ describe('API', () => {
 
   it('fetches users', async () => {
     const users = await payload.find({
+      overrideAccess: true,
       collection: 'users',
     })
     expect(users).toBeDefined()

--- a/templates/ecommerce/src/collections/Users/hooks/ensureFirstUserIsAdmin.ts
+++ b/templates/ecommerce/src/collections/Users/hooks/ensureFirstUserIsAdmin.ts
@@ -9,7 +9,12 @@ import type { User } from '@/payload-types'
 // it ensures that only admins can create and update the `roles` field
 export const ensureFirstUserIsAdmin: FieldHook<User> = async ({ operation, req, value }) => {
   if (operation === 'create') {
-    const users = await req.payload.find({ collection: 'users', depth: 0, limit: 0 })
+    const users = await req.payload.find({
+      overrideAccess: true,
+      collection: 'users',
+      depth: 0,
+      limit: 0,
+    })
     if (users.totalDocs === 0) {
       // if `admin` not in array of values, add it
       if (!(value || []).includes('admin')) {

--- a/templates/ecommerce/src/components/forms/FindOrderForm/sendOrderAccessEmail.ts
+++ b/templates/ecommerce/src/components/forms/FindOrderForm/sendOrderAccessEmail.ts
@@ -22,6 +22,7 @@ export async function sendOrderAccessEmail({
 
   try {
     const { docs: orders } = await payload.find({
+      overrideAccess: true,
       collection: 'orders',
       where: {
         and: [{ id: { equals: orderID } }, { customerEmail: { equals: email } }],

--- a/templates/ecommerce/src/endpoints/seed/index.ts
+++ b/templates/ecommerce/src/endpoints/seed/index.ts
@@ -91,6 +91,7 @@ export const seed = async ({
   await Promise.all(
     globals.map((global) =>
       payload.updateGlobal({
+        overrideAccess: true,
         slug: global,
         data: {
           navItems: [],
@@ -113,6 +114,7 @@ export const seed = async ({
   payload.logger.info(`— Seeding customer and customer data...`)
 
   await payload.delete({
+    overrideAccess: true,
     collection: 'users',
     depth: 0,
     where: {
@@ -151,6 +153,7 @@ export const seed = async ({
     hatsCategory,
   ] = await Promise.all([
     payload.create({
+      overrideAccess: true,
       collection: 'users',
       data: {
         name: 'Customer',
@@ -160,27 +163,32 @@ export const seed = async ({
       },
     }),
     payload.create({
+      overrideAccess: true,
       collection: 'media',
       data: imageHatData,
       file: imageHatBuffer,
     }),
     payload.create({
+      overrideAccess: true,
       collection: 'media',
       data: imageTshirtBlackData,
       file: imageTshirtBlackBuffer,
     }),
     payload.create({
+      overrideAccess: true,
       collection: 'media',
       data: imageTshirtWhiteData,
       file: imageTshirtWhiteBuffer,
     }),
     payload.create({
+      overrideAccess: true,
       collection: 'media',
       data: imageHero1Data,
       file: heroBuffer,
     }),
     ...categories.map((category) =>
       payload.create({
+        overrideAccess: true,
         collection: 'categories',
         data: {
           title: category,
@@ -193,6 +201,7 @@ export const seed = async ({
   payload.logger.info(`— Seeding variant types and options...`)
 
   const sizeVariantType = await payload.create({
+    overrideAccess: true,
     collection: 'variantTypes',
     data: {
       name: 'size',
@@ -204,6 +213,7 @@ export const seed = async ({
 
   for (const option of sizeVariantOptions) {
     const result = await payload.create({
+      overrideAccess: true,
       collection: 'variantOptions',
       data: {
         ...option,
@@ -216,6 +226,7 @@ export const seed = async ({
   const [small, medium, large, xlarge] = sizeVariantOptionsResults
 
   const colorVariantType = await payload.create({
+    overrideAccess: true,
     collection: 'variantTypes',
     data: {
       name: 'color',
@@ -226,6 +237,7 @@ export const seed = async ({
   const [black, white] = await Promise.all(
     colorVariantOptions.map((option) => {
       return payload.create({
+        overrideAccess: true,
         collection: 'variantOptions',
         data: {
           ...option,
@@ -238,6 +250,7 @@ export const seed = async ({
   payload.logger.info(`— Seeding products...`)
 
   const productHat = await payload.create({
+    overrideAccess: true,
     collection: 'products',
     depth: 0,
     data: productHatData({
@@ -250,6 +263,7 @@ export const seed = async ({
   })
 
   const productTshirt = await payload.create({
+    overrideAccess: true,
     collection: 'products',
     depth: 0,
     data: productTshirtData({
@@ -279,6 +293,7 @@ export const seed = async ({
   ] = await Promise.all(
     [small, medium, large, xlarge].map((variantOption) =>
       payload.create({
+        overrideAccess: true,
         collection: 'variants',
         depth: 0,
         data: productTshirtVariant({
@@ -292,6 +307,7 @@ export const seed = async ({
   await Promise.all(
     [small, medium, large, xlarge].map((variantOption) =>
       payload.create({
+        overrideAccess: true,
         collection: 'variants',
         depth: 0,
         data: productTshirtVariant({
@@ -306,6 +322,7 @@ export const seed = async ({
   payload.logger.info(`— Seeding contact form...`)
 
   const contactForm = await payload.create({
+    overrideAccess: true,
     collection: 'forms',
     depth: 0,
     data: contactFormData(),
@@ -315,6 +332,7 @@ export const seed = async ({
 
   const [_, contactPage] = await Promise.all([
     payload.create({
+      overrideAccess: true,
       collection: 'pages',
       depth: 0,
       data: homePageData({
@@ -323,6 +341,7 @@ export const seed = async ({
       }),
     }),
     payload.create({
+      overrideAccess: true,
       collection: 'pages',
       depth: 0,
       data: contactPageData({
@@ -334,6 +353,7 @@ export const seed = async ({
   payload.logger.info(`— Seeding addresses...`)
 
   const customerUSAddress = await payload.create({
+    overrideAccess: true,
     collection: 'addresses',
     depth: 0,
     data: {
@@ -343,6 +363,7 @@ export const seed = async ({
   })
 
   const customerUKAddress = await payload.create({
+    overrideAccess: true,
     collection: 'addresses',
     depth: 0,
     data: {
@@ -354,6 +375,7 @@ export const seed = async ({
   payload.logger.info(`— Seeding transactions...`)
 
   const pendingTransaction = await payload.create({
+    overrideAccess: true,
     collection: 'transactions',
     data: {
       currency: 'USD',
@@ -369,6 +391,7 @@ export const seed = async ({
   })
 
   const succeededTransaction = await payload.create({
+    overrideAccess: true,
     collection: 'transactions',
     data: {
       currency: 'USD',
@@ -393,6 +416,7 @@ export const seed = async ({
 
   // This cart is open as it's created now
   const openCart = await payload.create({
+    overrideAccess: true,
     collection: 'carts',
     data: {
       customer: customer.id,
@@ -411,6 +435,7 @@ export const seed = async ({
 
   // Cart is abandoned because it was created long in the past
   const abandonedCart = await payload.create({
+    overrideAccess: true,
     collection: 'carts',
     data: {
       currency: 'USD',
@@ -426,6 +451,7 @@ export const seed = async ({
 
   // Cart is purchased because it has a purchasedAt date
   const completedCart = await payload.create({
+    overrideAccess: true,
     collection: 'carts',
     data: {
       customer: customer.id,
@@ -456,6 +482,7 @@ export const seed = async ({
   payload.logger.info(`— Seeding orders...`)
 
   const orderInCompleted = await payload.create({
+    overrideAccess: true,
     collection: 'orders',
     data: {
       amount: 7499,
@@ -480,6 +507,7 @@ export const seed = async ({
   })
 
   const orderInProcessing = await payload.create({
+    overrideAccess: true,
     collection: 'orders',
     data: {
       amount: 7499,
@@ -507,6 +535,7 @@ export const seed = async ({
 
   await Promise.all([
     payload.updateGlobal({
+      overrideAccess: true,
       slug: 'header',
       data: {
         navItems: [
@@ -535,6 +564,7 @@ export const seed = async ({
       },
     }),
     payload.updateGlobal({
+      overrideAccess: true,
       slug: 'footer',
       data: {
         navItems: [

--- a/templates/ecommerce/tests/helpers/seedUser.ts
+++ b/templates/ecommerce/tests/helpers/seedUser.ts
@@ -14,6 +14,7 @@ export async function seedTestUser(): Promise<void> {
 
   // Delete existing test user if any
   await payload.delete({
+    overrideAccess: true,
     collection: 'users',
     where: {
       email: {
@@ -24,6 +25,7 @@ export async function seedTestUser(): Promise<void> {
 
   // Create fresh test user
   await payload.create({
+    overrideAccess: true,
     collection: 'users',
     data: testUser,
   })
@@ -36,6 +38,7 @@ export async function cleanupTestUser(): Promise<void> {
   const payload = await getPayload({ config })
 
   await payload.delete({
+    overrideAccess: true,
     collection: 'users',
     where: {
       email: {

--- a/templates/ecommerce/tests/int/api.int.spec.ts
+++ b/templates/ecommerce/tests/int/api.int.spec.ts
@@ -13,6 +13,7 @@ describe('API', () => {
 
   it('fetches users', async () => {
     const users = await payload.find({
+      overrideAccess: true,
       collection: 'users',
     })
     expect(users).toBeDefined()

--- a/templates/plugin/dev/int.spec.ts
+++ b/templates/plugin/dev/int.spec.ts
@@ -34,6 +34,7 @@ describe('Plugin integration tests', () => {
 
   test('can create post with custom text field added by plugin', async () => {
     const post = await payload.create({
+      overrideAccess: true,
       collection: 'posts',
       data: {
         addedByPlugin: 'added by plugin',
@@ -45,7 +46,7 @@ describe('Plugin integration tests', () => {
   test('plugin creates and seeds plugin-collection', async () => {
     expect(payload.collections['plugin-collection']).toBeDefined()
 
-    const { docs } = await payload.find({ collection: 'plugin-collection' })
+    const { docs } = await payload.find({ overrideAccess: true, collection: 'plugin-collection' })
 
     expect(docs).toHaveLength(1)
   })

--- a/templates/plugin/dev/seed.ts
+++ b/templates/plugin/dev/seed.ts
@@ -4,6 +4,7 @@ import { devUser } from './helpers/credentials.js'
 
 export const seed = async (payload: Payload) => {
   const { totalDocs } = await payload.count({
+    overrideAccess: true,
     collection: 'users',
     where: {
       email: {
@@ -14,6 +15,7 @@ export const seed = async (payload: Payload) => {
 
   if (!totalDocs) {
     await payload.create({
+      overrideAccess: true,
       collection: 'users',
       data: devUser,
     })

--- a/templates/plugin/src/components/BeforeDashboardServer.tsx
+++ b/templates/plugin/src/components/BeforeDashboardServer.tsx
@@ -3,9 +3,9 @@ import type { ServerComponentProps } from 'payload'
 import styles from './BeforeDashboardServer.module.css'
 
 export const BeforeDashboardServer = async (props: ServerComponentProps) => {
-  const { payload } = props
+  const { payload, req } = props
 
-  const { docs } = await payload.find({ collection: 'plugin-collection' })
+  const { docs } = await payload.find({ collection: 'plugin-collection', req })
 
   return (
     <div className={styles.wrapper}>

--- a/templates/plugin/src/index.ts
+++ b/templates/plugin/src/index.ts
@@ -91,6 +91,7 @@ export const myPlugin =
       }
 
       const { totalDocs } = await payload.count({
+        overrideAccess: true,
         collection: 'plugin-collection',
         where: {
           id: {
@@ -101,6 +102,7 @@ export const myPlugin =
 
       if (totalDocs === 0) {
         await payload.create({
+          overrideAccess: true,
           collection: 'plugin-collection',
           data: {
             id: 'seeded-by-plugin',

--- a/templates/website/src/collections/Posts/hooks/populateAuthors.ts
+++ b/templates/website/src/collections/Posts/hooks/populateAuthors.ts
@@ -12,6 +12,7 @@ export const populateAuthors: CollectionAfterReadHook = async ({ doc, req, req: 
     for (const author of doc.authors) {
       try {
         const authorDoc = await payload.findByID({
+          overrideAccess: true,
           id: typeof author === 'object' ? author?.id : author,
           collection: 'users',
           depth: 0,

--- a/templates/website/src/endpoints/seed/index.ts
+++ b/templates/website/src/endpoints/seed/index.ts
@@ -47,6 +47,7 @@ export const seed = async ({
   await Promise.all(
     globals.map((global) =>
       payload.updateGlobal({
+        overrideAccess: true,
         slug: global,
         data: {
           navItems: [],
@@ -72,6 +73,7 @@ export const seed = async ({
   payload.logger.info(`— Seeding demo author and user...`)
 
   await payload.delete({
+    overrideAccess: true,
     collection: 'users',
     depth: 0,
     where: {
@@ -100,6 +102,7 @@ export const seed = async ({
 
   const [demoAuthor, image1Doc, image2Doc, image3Doc, imageHomeDoc] = await Promise.all([
     payload.create({
+      overrideAccess: true,
       collection: 'users',
       data: {
         name: 'Demo Author',
@@ -108,27 +111,32 @@ export const seed = async ({
       },
     }),
     payload.create({
+      overrideAccess: true,
       collection: 'media',
       data: image1,
       file: image1Buffer,
     }),
     payload.create({
+      overrideAccess: true,
       collection: 'media',
       data: image2,
       file: image2Buffer,
     }),
     payload.create({
+      overrideAccess: true,
       collection: 'media',
       data: image2,
       file: image3Buffer,
     }),
     payload.create({
+      overrideAccess: true,
       collection: 'media',
       data: imageHero1,
       file: hero1Buffer,
     }),
     categories.map((category) =>
       payload.create({
+        overrideAccess: true,
         collection: 'categories',
         data: {
           title: category,
@@ -143,6 +151,7 @@ export const seed = async ({
   // Do not create posts with `Promise.all` because we want the posts to be created in order
   // This way we can sort them by `createdAt` or `publishedAt` and they will be in the expected order
   const post1Doc = await payload.create({
+    overrideAccess: true,
     collection: 'posts',
     depth: 0,
     context: {
@@ -152,6 +161,7 @@ export const seed = async ({
   })
 
   const post2Doc = await payload.create({
+    overrideAccess: true,
     collection: 'posts',
     depth: 0,
     context: {
@@ -161,6 +171,7 @@ export const seed = async ({
   })
 
   const post3Doc = await payload.create({
+    overrideAccess: true,
     collection: 'posts',
     depth: 0,
     context: {
@@ -171,6 +182,7 @@ export const seed = async ({
 
   // update each post with related posts
   await payload.update({
+    overrideAccess: true,
     id: post1Doc.id,
     collection: 'posts',
     data: {
@@ -178,6 +190,7 @@ export const seed = async ({
     },
   })
   await payload.update({
+    overrideAccess: true,
     id: post2Doc.id,
     collection: 'posts',
     data: {
@@ -185,6 +198,7 @@ export const seed = async ({
     },
   })
   await payload.update({
+    overrideAccess: true,
     id: post3Doc.id,
     collection: 'posts',
     data: {
@@ -195,6 +209,7 @@ export const seed = async ({
   payload.logger.info(`— Seeding contact form...`)
 
   const contactForm = await payload.create({
+    overrideAccess: true,
     collection: 'forms',
     depth: 0,
     data: contactFormData,
@@ -204,11 +219,13 @@ export const seed = async ({
 
   const [_, contactPage] = await Promise.all([
     payload.create({
+      overrideAccess: true,
       collection: 'pages',
       depth: 0,
       data: home({ heroImage: imageHomeDoc, metaImage: image2Doc }),
     }),
     payload.create({
+      overrideAccess: true,
       collection: 'pages',
       depth: 0,
       data: contactPageData({ contactForm: contactForm }),
@@ -219,6 +236,7 @@ export const seed = async ({
 
   await Promise.all([
     payload.updateGlobal({
+      overrideAccess: true,
       slug: 'header',
       data: {
         navItems: [
@@ -243,6 +261,7 @@ export const seed = async ({
       },
     }),
     payload.updateGlobal({
+      overrideAccess: true,
       slug: 'footer',
       data: {
         navItems: [

--- a/templates/website/src/search/beforeSync.ts
+++ b/templates/website/src/search/beforeSync.ts
@@ -32,6 +32,7 @@ export const beforeSyncWithSearch: BeforeSync = async ({ req, originalDoc, searc
       }
 
       const doc = await req.payload.findByID({
+        overrideAccess: true,
         collection: 'categories',
         id: category,
         disableErrors: true,

--- a/templates/website/tests/helpers/seedRelatedPosts.ts
+++ b/templates/website/tests/helpers/seedRelatedPosts.ts
@@ -33,6 +33,7 @@ export async function seedRelatedPosts(): Promise<void> {
   await deleteFixture({ payload })
 
   const category = await payload.create({
+    overrideAccess: true,
     collection: 'categories',
     data: {
       slug: relatedPostsFixture.categorySlug,
@@ -42,6 +43,7 @@ export async function seedRelatedPosts(): Promise<void> {
   })
 
   const image = await payload.create({
+    overrideAccess: true,
     collection: 'media',
     data: { alt: relatedPostsFixture.imageAlt },
     filePath: path.resolve(dirname, '../../src/endpoints/seed/image-post1.webp'),
@@ -49,6 +51,7 @@ export async function seedRelatedPosts(): Promise<void> {
   })
 
   const relatedPost = await payload.create({
+    overrideAccess: true,
     collection: 'posts',
     data: {
       _status: 'published',
@@ -62,6 +65,7 @@ export async function seedRelatedPosts(): Promise<void> {
   })
 
   await payload.create({
+    overrideAccess: true,
     collection: 'posts',
     data: {
       _status: 'published',
@@ -82,6 +86,7 @@ export async function cleanupRelatedPosts(): Promise<void> {
 
 async function deleteFixture({ payload }: { payload: Payload }): Promise<void> {
   await payload.delete({
+    overrideAccess: true,
     collection: 'posts',
     where: {
       slug: {
@@ -92,6 +97,7 @@ async function deleteFixture({ payload }: { payload: Payload }): Promise<void> {
   })
 
   await payload.delete({
+    overrideAccess: true,
     collection: 'categories',
     where: {
       slug: { equals: relatedPostsFixture.categorySlug },
@@ -100,6 +106,7 @@ async function deleteFixture({ payload }: { payload: Payload }): Promise<void> {
   })
 
   await payload.delete({
+    overrideAccess: true,
     collection: 'media',
     where: {
       alt: { equals: relatedPostsFixture.imageAlt },

--- a/templates/website/tests/helpers/seedUser.ts
+++ b/templates/website/tests/helpers/seedUser.ts
@@ -14,6 +14,7 @@ export async function seedTestUser(): Promise<void> {
 
   // Delete existing test user if any
   await payload.delete({
+    overrideAccess: true,
     collection: 'users',
     where: {
       email: {
@@ -24,6 +25,7 @@ export async function seedTestUser(): Promise<void> {
 
   // Create fresh test user
   await payload.create({
+    overrideAccess: true,
     collection: 'users',
     data: testUser,
   })
@@ -36,6 +38,7 @@ export async function cleanupTestUser(): Promise<void> {
   const payload = await getPayload({ config })
 
   await payload.delete({
+    overrideAccess: true,
     collection: 'users',
     where: {
       email: {

--- a/templates/website/tests/int/api.int.spec.ts
+++ b/templates/website/tests/int/api.int.spec.ts
@@ -13,6 +13,7 @@ describe('API', () => {
 
   it('fetches users', async () => {
     const users = await payload.find({
+      overrideAccess: true,
       collection: 'users',
     })
     expect(users).toBeDefined()

--- a/templates/with-cloudflare-d1/tests/helpers/seedUser.ts
+++ b/templates/with-cloudflare-d1/tests/helpers/seedUser.ts
@@ -14,6 +14,7 @@ export async function seedTestUser(): Promise<void> {
 
   // Delete existing test user if any
   await payload.delete({
+    overrideAccess: true,
     collection: 'users',
     where: {
       email: {
@@ -24,6 +25,7 @@ export async function seedTestUser(): Promise<void> {
 
   // Create fresh test user
   await payload.create({
+    overrideAccess: true,
     collection: 'users',
     data: testUser,
   })
@@ -36,6 +38,7 @@ export async function cleanupTestUser(): Promise<void> {
   const payload = await getPayload({ config })
 
   await payload.delete({
+    overrideAccess: true,
     collection: 'users',
     where: {
       email: {

--- a/templates/with-cloudflare-d1/tests/int/api.int.spec.ts
+++ b/templates/with-cloudflare-d1/tests/int/api.int.spec.ts
@@ -13,6 +13,7 @@ describe('API', () => {
 
   it('fetches users', async () => {
     const users = await payload.find({
+      overrideAccess: true,
       collection: 'users',
     })
     expect(users).toBeDefined()

--- a/templates/with-postgres/tests/helpers/seedUser.ts
+++ b/templates/with-postgres/tests/helpers/seedUser.ts
@@ -14,6 +14,7 @@ export async function seedTestUser(): Promise<void> {
 
   // Delete existing test user if any
   await payload.delete({
+    overrideAccess: true,
     collection: 'users',
     where: {
       email: {
@@ -24,6 +25,7 @@ export async function seedTestUser(): Promise<void> {
 
   // Create fresh test user
   await payload.create({
+    overrideAccess: true,
     collection: 'users',
     data: testUser,
   })
@@ -36,6 +38,7 @@ export async function cleanupTestUser(): Promise<void> {
   const payload = await getPayload({ config })
 
   await payload.delete({
+    overrideAccess: true,
     collection: 'users',
     where: {
       email: {

--- a/templates/with-postgres/tests/int/api.int.spec.ts
+++ b/templates/with-postgres/tests/int/api.int.spec.ts
@@ -13,6 +13,7 @@ describe('API', () => {
 
   it('fetches users', async () => {
     const users = await payload.find({
+      overrideAccess: true,
       collection: 'users',
     })
     expect(users).toBeDefined()

--- a/templates/with-vercel-mongodb/tests/helpers/seedUser.ts
+++ b/templates/with-vercel-mongodb/tests/helpers/seedUser.ts
@@ -14,6 +14,7 @@ export async function seedTestUser(): Promise<void> {
 
   // Delete existing test user if any
   await payload.delete({
+    overrideAccess: true,
     collection: 'users',
     where: {
       email: {
@@ -24,6 +25,7 @@ export async function seedTestUser(): Promise<void> {
 
   // Create fresh test user
   await payload.create({
+    overrideAccess: true,
     collection: 'users',
     data: testUser,
   })
@@ -36,6 +38,7 @@ export async function cleanupTestUser(): Promise<void> {
   const payload = await getPayload({ config })
 
   await payload.delete({
+    overrideAccess: true,
     collection: 'users',
     where: {
       email: {

--- a/templates/with-vercel-mongodb/tests/int/api.int.spec.ts
+++ b/templates/with-vercel-mongodb/tests/int/api.int.spec.ts
@@ -13,6 +13,7 @@ describe('API', () => {
 
   it('fetches users', async () => {
     const users = await payload.find({
+      overrideAccess: true,
       collection: 'users',
     })
     expect(users).toBeDefined()

--- a/templates/with-vercel-postgres/tests/helpers/seedUser.ts
+++ b/templates/with-vercel-postgres/tests/helpers/seedUser.ts
@@ -14,6 +14,7 @@ export async function seedTestUser(): Promise<void> {
 
   // Delete existing test user if any
   await payload.delete({
+    overrideAccess: true,
     collection: 'users',
     where: {
       email: {
@@ -24,6 +25,7 @@ export async function seedTestUser(): Promise<void> {
 
   // Create fresh test user
   await payload.create({
+    overrideAccess: true,
     collection: 'users',
     data: testUser,
   })
@@ -36,6 +38,7 @@ export async function cleanupTestUser(): Promise<void> {
   const payload = await getPayload({ config })
 
   await payload.delete({
+    overrideAccess: true,
     collection: 'users',
     where: {
       email: {

--- a/templates/with-vercel-postgres/tests/int/api.int.spec.ts
+++ b/templates/with-vercel-postgres/tests/int/api.int.spec.ts
@@ -13,6 +13,7 @@ describe('API', () => {
 
   it('fetches users', async () => {
     const users = await payload.find({
+      overrideAccess: true,
       collection: 'users',
     })
     expect(users).toBeDefined()

--- a/templates/with-vercel-website/src/collections/Posts/hooks/populateAuthors.ts
+++ b/templates/with-vercel-website/src/collections/Posts/hooks/populateAuthors.ts
@@ -12,6 +12,7 @@ export const populateAuthors: CollectionAfterReadHook = async ({ doc, req, req: 
     for (const author of doc.authors) {
       try {
         const authorDoc = await payload.findByID({
+          overrideAccess: true,
           id: typeof author === 'object' ? author?.id : author,
           collection: 'users',
           depth: 0,

--- a/templates/with-vercel-website/src/endpoints/seed/index.ts
+++ b/templates/with-vercel-website/src/endpoints/seed/index.ts
@@ -47,6 +47,7 @@ export const seed = async ({
   await Promise.all(
     globals.map((global) =>
       payload.updateGlobal({
+        overrideAccess: true,
         slug: global,
         data: {
           navItems: [],
@@ -72,6 +73,7 @@ export const seed = async ({
   payload.logger.info(`— Seeding demo author and user...`)
 
   await payload.delete({
+    overrideAccess: true,
     collection: 'users',
     depth: 0,
     where: {
@@ -100,6 +102,7 @@ export const seed = async ({
 
   const [demoAuthor, image1Doc, image2Doc, image3Doc, imageHomeDoc] = await Promise.all([
     payload.create({
+      overrideAccess: true,
       collection: 'users',
       data: {
         name: 'Demo Author',
@@ -108,27 +111,32 @@ export const seed = async ({
       },
     }),
     payload.create({
+      overrideAccess: true,
       collection: 'media',
       data: image1,
       file: image1Buffer,
     }),
     payload.create({
+      overrideAccess: true,
       collection: 'media',
       data: image2,
       file: image2Buffer,
     }),
     payload.create({
+      overrideAccess: true,
       collection: 'media',
       data: image2,
       file: image3Buffer,
     }),
     payload.create({
+      overrideAccess: true,
       collection: 'media',
       data: imageHero1,
       file: hero1Buffer,
     }),
     categories.map((category) =>
       payload.create({
+        overrideAccess: true,
         collection: 'categories',
         data: {
           title: category,
@@ -143,6 +151,7 @@ export const seed = async ({
   // Do not create posts with `Promise.all` because we want the posts to be created in order
   // This way we can sort them by `createdAt` or `publishedAt` and they will be in the expected order
   const post1Doc = await payload.create({
+    overrideAccess: true,
     collection: 'posts',
     depth: 0,
     context: {
@@ -152,6 +161,7 @@ export const seed = async ({
   })
 
   const post2Doc = await payload.create({
+    overrideAccess: true,
     collection: 'posts',
     depth: 0,
     context: {
@@ -161,6 +171,7 @@ export const seed = async ({
   })
 
   const post3Doc = await payload.create({
+    overrideAccess: true,
     collection: 'posts',
     depth: 0,
     context: {
@@ -171,6 +182,7 @@ export const seed = async ({
 
   // update each post with related posts
   await payload.update({
+    overrideAccess: true,
     id: post1Doc.id,
     collection: 'posts',
     data: {
@@ -178,6 +190,7 @@ export const seed = async ({
     },
   })
   await payload.update({
+    overrideAccess: true,
     id: post2Doc.id,
     collection: 'posts',
     data: {
@@ -185,6 +198,7 @@ export const seed = async ({
     },
   })
   await payload.update({
+    overrideAccess: true,
     id: post3Doc.id,
     collection: 'posts',
     data: {
@@ -195,6 +209,7 @@ export const seed = async ({
   payload.logger.info(`— Seeding contact form...`)
 
   const contactForm = await payload.create({
+    overrideAccess: true,
     collection: 'forms',
     depth: 0,
     data: contactFormData,
@@ -204,11 +219,13 @@ export const seed = async ({
 
   const [_, contactPage] = await Promise.all([
     payload.create({
+      overrideAccess: true,
       collection: 'pages',
       depth: 0,
       data: home({ heroImage: imageHomeDoc, metaImage: image2Doc }),
     }),
     payload.create({
+      overrideAccess: true,
       collection: 'pages',
       depth: 0,
       data: contactPageData({ contactForm: contactForm }),
@@ -219,6 +236,7 @@ export const seed = async ({
 
   await Promise.all([
     payload.updateGlobal({
+      overrideAccess: true,
       slug: 'header',
       data: {
         navItems: [
@@ -243,6 +261,7 @@ export const seed = async ({
       },
     }),
     payload.updateGlobal({
+      overrideAccess: true,
       slug: 'footer',
       data: {
         navItems: [

--- a/templates/with-vercel-website/src/search/beforeSync.ts
+++ b/templates/with-vercel-website/src/search/beforeSync.ts
@@ -32,6 +32,7 @@ export const beforeSyncWithSearch: BeforeSync = async ({ req, originalDoc, searc
       }
 
       const doc = await req.payload.findByID({
+        overrideAccess: true,
         collection: 'categories',
         id: category,
         disableErrors: true,

--- a/templates/with-vercel-website/tests/helpers/seedUser.ts
+++ b/templates/with-vercel-website/tests/helpers/seedUser.ts
@@ -14,6 +14,7 @@ export async function seedTestUser(): Promise<void> {
 
   // Delete existing test user if any
   await payload.delete({
+    overrideAccess: true,
     collection: 'users',
     where: {
       email: {
@@ -24,6 +25,7 @@ export async function seedTestUser(): Promise<void> {
 
   // Create fresh test user
   await payload.create({
+    overrideAccess: true,
     collection: 'users',
     data: testUser,
   })
@@ -36,6 +38,7 @@ export async function cleanupTestUser(): Promise<void> {
   const payload = await getPayload({ config })
 
   await payload.delete({
+    overrideAccess: true,
     collection: 'users',
     where: {
       email: {

--- a/templates/with-vercel-website/tests/int/api.int.spec.ts
+++ b/templates/with-vercel-website/tests/int/api.int.spec.ts
@@ -13,6 +13,7 @@ describe('API', () => {
 
   it('fetches users', async () => {
     const users = await payload.find({
+      overrideAccess: true,
       collection: 'users',
     })
     expect(users).toBeDefined()


### PR DESCRIPTION
### What?

This updates Payload templates for the new Local API access default introduced by the PRs below this one.

- Seeds, setup helpers, internal hooks, and plugin initialization use `overrideAccess: true` where they intentionally need trusted access.
- Authenticated examples pass their request so the current user is respected.
- Public website and storefront reads continue to use access control and do not opt out with `overrideAccess: true`.

### Why?

New projects should show the intended security model clearly. Trusted setup work needs an explicit bypass, while application reads should remain anonymous or user-scoped and respect collection access rules.

### How?

Template Local API calls were migrated and then reviewed by context instead of applying `overrideAccess: true` everywhere. Existing explicit and conditional access behavior was preserved.

### Stack

1. Core breaking change and codemod: [#17686](https://github.com/payloadcms/payload/pull/17686)
2. First-party plugins: [#17687](https://github.com/payloadcms/payload/pull/17687)
3. Templates: this PR

Documentation will follow separately after the enterprise plugins are updated.
