### PR TITLE
ci: abort bump when the computed version is already published 

### DIFF
--- a/tools/releaser/src/release-bump.spec.ts
+++ b/tools/releaser/src/release-bump.spec.ts
@@ -4,6 +4,7 @@ import { runReleaseBump } from './release-bump.js'
 
 const baseDeps = () => ({
   env: { GITHUB_TOKEN: 'token' } as NodeJS.ProcessEnv,
+  isPublished: vi.fn(async () => false),
   log: vi.fn(),
   readBranch: () => 'main',
   run: vi.fn(),
@@ -59,6 +60,42 @@ describe('runReleaseBump', () => {
 
     expect(next).toBe('4.0.0-beta.0')
     expect(deps.workspace.bumpVersion).toHaveBeenCalledWith('prerelease', { preid: 'beta' })
+  })
+
+  it('should abort before any git write when the computed version is already published', async () => {
+    const deps = makeDeps({ isPublished: vi.fn(async () => true) })
+
+    await expect(
+      runReleaseBump({ bump: 'prerelease', deps, dryRun: false, preid: 'canary' }),
+    ).rejects.toThrow(/already published/)
+
+    expect(deps.isPublished).toHaveBeenCalledWith({
+      name: 'payload',
+      version: '4.0.0-canary.10',
+    })
+    expect(deps.run).not.toHaveBeenCalled()
+  })
+
+  it('should abort when the registry check fails rather than assuming unpublished', async () => {
+    const deps = makeDeps({
+      isPublished: vi.fn(async () => {
+        throw new Error('503 Service Unavailable')
+      }),
+    })
+
+    await expect(
+      runReleaseBump({ bump: 'prerelease', deps, dryRun: false, preid: 'canary' }),
+    ).rejects.toThrow(/503/)
+
+    expect(deps.run).not.toHaveBeenCalled()
+  })
+
+  it('should run the already-published guard in dry-run too', async () => {
+    const deps = makeDeps({ isPublished: vi.fn(async () => true) })
+
+    await expect(
+      runReleaseBump({ bump: 'prerelease', deps, dryRun: true, preid: 'canary' }),
+    ).rejects.toThrow(/already published/)
   })
 
   it('should log the push and never execute it in dry-run', async () => {

--- a/tools/releaser/src/release-bump.ts
+++ b/tools/releaser/src/release-bump.ts
@@ -35,7 +35,7 @@ type ReleaseBumpDeps = {
   workspace: Pick<Workspace, 'bumpVersion' | 'version'>
 }
 
-/** Bellwether package for the already-published guard; every release publishes it. */
+/** Package for the already-published guard */
 const GUARD_PACKAGE = 'payload'
 
 export const runReleaseBump = async ({
@@ -64,12 +64,6 @@ export const runReleaseBump = async ({
   const nextVersion = await workspace.bumpVersion(validated.bump, { preid: validated.preid })
   const tag = `v${nextVersion}`
 
-  // The version is computed from main's committed version alone, so a committed
-  // version trailing the registry (another flow published in between) yields a
-  // version that is already on npm. Publishing would then skip every package as
-  // already-published and still mint a tag and draft release, leaving a tag that
-  // claims artifacts it did not build. Fail closed before any git write; a
-  // registry error throws here for the same reason.
   if (await isPublished({ name: GUARD_PACKAGE, version: nextVersion })) {
     throw new Error(
       `${GUARD_PACKAGE}@${nextVersion} is already published. main's committed version (${validated.version}) trails the registry — reseed it to the latest published version and re-dispatch.`,

--- a/tools/releaser/src/release-bump.ts
+++ b/tools/releaser/src/release-bump.ts
@@ -22,16 +22,21 @@ import { pathToFileURL } from 'url'
 import type { Workspace } from './lib/getWorkspace.js'
 
 import { assertBumpPreconditions } from './lib/assertBumpPreconditions.js'
+import { isVersionPublished } from './lib/getPackageRegistryVersions.js'
 import { getWorkspace } from './lib/getWorkspace.js'
 import { pushWithRebaseRetry } from './lib/pushWithRebaseRetry.js'
 
 type ReleaseBumpDeps = {
   env: NodeJS.ProcessEnv
+  isPublished: (args: { name: string; version: string }) => Promise<boolean>
   log: (message: string) => void
   readBranch: () => string
   run: (cmd: string) => void
   workspace: Pick<Workspace, 'bumpVersion' | 'version'>
 }
+
+/** Bellwether package for the already-published guard; every release publishes it. */
+const GUARD_PACKAGE = 'payload'
 
 export const runReleaseBump = async ({
   bump,
@@ -44,7 +49,7 @@ export const runReleaseBump = async ({
   dryRun: boolean
   preid: string
 }): Promise<string> => {
-  const { env, log, readBranch, run, workspace } = deps
+  const { env, isPublished, log, readBranch, run, workspace } = deps
 
   const validated = {
     branch: readBranch(),
@@ -58,6 +63,18 @@ export const runReleaseBump = async ({
 
   const nextVersion = await workspace.bumpVersion(validated.bump, { preid: validated.preid })
   const tag = `v${nextVersion}`
+
+  // The version is computed from main's committed version alone, so a committed
+  // version trailing the registry (another flow published in between) yields a
+  // version that is already on npm. Publishing would then skip every package as
+  // already-published and still mint a tag and draft release, leaving a tag that
+  // claims artifacts it did not build. Fail closed before any git write; a
+  // registry error throws here for the same reason.
+  if (await isPublished({ name: GUARD_PACKAGE, version: nextVersion })) {
+    throw new Error(
+      `${GUARD_PACKAGE}@${nextVersion} is already published. main's committed version (${validated.version}) trails the registry — reseed it to the latest published version and re-dispatch.`,
+    )
+  }
 
   log(`\n  ${validated.version} => ${nextVersion}  (tag ${tag})\n`)
 
@@ -90,6 +107,7 @@ async function main(): Promise<void> {
     bump,
     deps: {
       env: process.env,
+      isPublished: isVersionPublished,
       log: console.log,
       readBranch: () => execSync('git rev-parse --abbrev-ref HEAD', { encoding: 'utf8' }).trim(),
       run,


### PR DESCRIPTION
Adds an additional safe-guard in the version bump workflow that checks if the version has already been published before committing and pushing to main.
