### PR TITLE
fix(plugin-multi-tenant): preserve tenant selection on hard reload

### DIFF
--- a/packages/plugin-multi-tenant/src/providers/TenantSelectionProvider/index.client.tsx
+++ b/packages/plugin-multi-tenant/src/providers/TenantSelectionProvider/index.client.tsx
@@ -120,6 +120,7 @@ export const TenantSelectionProviderClient = ({
   const router = useRouter()
   const userID = React.useMemo(() => user?.id, [user?.id])
   const prevUserID = React.useRef(userID)
+  const retriedBlindPass = React.useRef(false)
   const userChanged = userID !== prevUserID.current
   const [tenantOptions, setTenantOptions] = React.useState<OptionObject[]>(
     () => initialTenantOptions,
@@ -294,10 +295,21 @@ export const TenantSelectionProviderClient = ({
    * refresh that clears it. The cookie is cleared either way via `setTenant`.
    */
   React.useEffect(() => {
-    if (!initialValue) {
-      setTenant({ id: undefined, refresh: Boolean(getTenantCookie()) })
+    if (initialValue && !selectedTenantID) {
+      setSelectedTenantID(initialValue)
     }
-  }, [initialValue, setTenant])
+  }, [initialValue, selectedTenantID])
+
+  React.useEffect(() => {
+    if (!initialValue) {
+      if (initialTenantOptions.length > 0) {
+        setTenant({ id: undefined, refresh: Boolean(getTenantCookie()) })
+      } else if (!retriedBlindPass.current) {
+        retriedBlindPass.current = true
+        router.refresh()
+      }
+    }
+  }, [initialValue, initialTenantOptions.length, setTenant, router])
 
   /**
    * If there is no selected tenant ID and the entity type is 'global', set the first tenant as selected.


### PR DESCRIPTION
I was looking into the issue where super-admins lose their selected tenant whenever they do a hard reload (F5) on the page. 

**What was happening:**
On the initial page load, the `TenantSelectionProvider` was rendering without the user data (a blind pass). Because the `initialValue` was empty during this pass, the code assumed the cookie was stale and just deleted it. 

**How I fixed it:**
- I updated `TenantSelectionProviderClient` so it only deletes the cookie if it's *actually* stale (i.e., when we have `initialTenantOptions` from the server).
- If it's just a blind pass, it keeps the cookie safe and triggers a quick `router.refresh()` so the authenticated view can load properly.
- I also added a small effect to make sure the dropdown UI doesn't stay blank when the `initialValue` arrives slightly later.

I have tested this locally and the tenant selection now perfectly survives hard reloads without any infinite refresh loops. 
Please let me know if any changes are needed. Thanks! 