### PR TITLE
fix: respect all logical query structures

### DIFF
--- a/packages/payload/src/database/queryValidation/validateQueryPaths.ts
+++ b/packages/payload/src/database/queryValidation/validateQueryPaths.ts
@@ -50,7 +50,7 @@ export async function validateQueryPaths({
     for (const path in where) {
       const constraint = where[path]
 
-      if ((path === 'and' || path === 'or') && Array.isArray(constraint)) {
+      if (['and', 'or'].includes(path.toLowerCase()) && Array.isArray(constraint)) {
         for (const item of constraint) {
           if (collectionConfig) {
             promises.push(
@@ -80,6 +80,8 @@ export async function validateQueryPaths({
             )
           }
         }
+      } else if (Array.isArray(constraint)) {
+        errors.push({ path })
       } else if (!Array.isArray(constraint)) {
         for (const operator in constraint) {
           const val = constraint[operator as keyof typeof constraint]

--- a/packages/payload/src/versions/drafts/appendVersionToQueryKey.spec.ts
+++ b/packages/payload/src/versions/drafts/appendVersionToQueryKey.spec.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+
+import { appendVersionToQueryKey } from './appendVersionToQueryKey.js'
+
+describe('appendVersionToQueryKey', () => {
+  it.each(['aNd', 'oR'])(
+    'preserves case-insensitive %s conditions when prefixing version fields',
+    (logicalOperator) => {
+      expect(
+        appendVersionToQueryKey({
+          [logicalOperator]: [
+            {
+              title: {
+                equals: 'example',
+              },
+            },
+          ],
+        }),
+      ).toStrictEqual({
+        [logicalOperator.toLowerCase()]: [
+          {
+            'version.title': {
+              equals: 'example',
+            },
+          },
+        ],
+      })
+    },
+  )
+})

--- a/packages/payload/src/versions/drafts/appendVersionToQueryKey.ts
+++ b/packages/payload/src/versions/drafts/appendVersionToQueryKey.ts
@@ -2,7 +2,7 @@ import type { Where } from '../../types/index.js'
 
 export const appendVersionToQueryKey = (query: Where = {}): Where => {
   return Object.entries(query).reduce((res, [key, val]) => {
-    if (['AND', 'and', 'OR', 'or'].includes(key) && Array.isArray(val)) {
+    if (['and', 'or'].includes(key.toLowerCase()) && Array.isArray(val)) {
       return {
         ...res,
         [key.toLowerCase()]: val.map((subQuery) => appendVersionToQueryKey(subQuery)),

--- a/test/access-control/int.spec.ts
+++ b/test/access-control/int.spec.ts
@@ -269,25 +269,40 @@ describe('Access Control', () => {
         expect(retrievedDoc.restrictedField).toBeUndefined()
       })
 
-      it('should error when querying field without read access', async () => {
-        const { id } = await createDoc({ restrictedField: 'restricted' })
+      it.each(['AND', 'OR', 'AnD', 'oR'])(
+        'validates field read access inside case-insensitive %s conditions',
+        async (logicalOperator) => {
+          const { id } = await createDoc({ restrictedField: 'example' })
 
+          await expect(
+            payload.find({
+              collection: slug,
+              overrideAccess: false,
+              where: {
+                [logicalOperator]: [
+                  {
+                    id: { equals: id },
+                  },
+                  {
+                    restrictedField: {
+                      equals: 'example',
+                    },
+                  },
+                ],
+              },
+            }),
+          ).rejects.toThrow('The following path cannot be queried: restrictedField')
+        },
+      )
+
+      it('rejects array-valued field conditions', async () => {
         await expect(
           payload.find({
             collection: slug,
             overrideAccess: false,
             where: {
-              and: [
-                {
-                  id: { equals: id },
-                },
-                {
-                  restrictedField: {
-                    equals: 'restricted',
-                  },
-                },
-              ],
-            },
+              restrictedField: [{ equals: 'example' }],
+            } as any,
           }),
         ).rejects.toThrow('The following path cannot be queried: restrictedField')
       })


### PR DESCRIPTION
`validateQueryPaths` recursively validates logical groups case-insensitively across collection and join filters. Draft/version query preprocessing applies the same normalization, and validation rejects array-valued field constraints that are not logical groups. Regression coverage exercises both query shapes.