### PR TITLE
fix(ui): forward list filter to bulk actions when selecting all across pages

### DIFF
--- a/packages/ui/src/views/List/ListHeader/index.tsx
+++ b/packages/ui/src/views/List/ListHeader/index.tsx
@@ -60,7 +60,7 @@ export const CollectionListHeader: React.FC<ListHeaderProps> = ({
   const { config, getEntityConfig } = useConfig()
   const { drawerSlug, isInDrawer, selectedOption } = useListDrawerContext()
   const isTrashRoute = viewType === 'trash'
-  const { isGroupingBy } = useListQuery()
+  const { isGroupingBy, query } = useListQuery()
 
   if (isInDrawer) {
     return (
@@ -104,6 +104,7 @@ export const CollectionListHeader: React.FC<ListHeaderProps> = ({
             label={getTranslation(collectionConfig?.labels?.plural, i18n)}
             showSelectAllAcrossPages={!isGroupingBy}
             viewType={viewType}
+            where={query?.where}
           />
         ),
         <DefaultListViewTabs

--- a/packages/ui/src/views/List/index.client.tsx
+++ b/packages/ui/src/views/List/index.client.tsx
@@ -338,6 +338,7 @@ export function DefaultListView(props: ListViewClientProps) {
                         disableBulkEdit={disableBulkEdit}
                         label={collectionLabel}
                         showSelectAllAcrossPages={!isGroupingBy}
+                        where={query?.where}
                       />
                       <div className={`${baseClass}__list-selection-actions`}>
                         {enableRowSelections && typeof onBulkSelect === 'function'

--- a/test/bulk-edit/e2e.spec.ts
+++ b/test/bulk-edit/e2e.spec.ts
@@ -194,6 +194,66 @@ test.describe('Bulk Edit', () => {
     )
   })
 
+  test('should respect the list filter when unpublishing all across pages', async () => {
+    await deleteAllPosts()
+
+    const matchingDescription = 'unpublish-me'
+    const otherDescription = 'leave-me-alone'
+
+    for (let i = 1; i <= 3; i++) {
+      await createPost({ title: `Matching post ${i}`, description: matchingDescription })
+      await wait(50)
+    }
+
+    for (let i = 1; i <= 3; i++) {
+      await createPost({ title: `Other post ${i}`, description: otherDescription })
+      await wait(50)
+    }
+
+    await page.goto(postsUrl.list)
+    // Wait until page has limit in the url, to ensure it is fully loaded
+    await expect.poll(() => page.url(), { timeout: POLL_TOPASS_TIMEOUT }).toContain('limit=')
+
+    await addListFilter({
+      page,
+      fieldLabel: 'Description',
+      operatorLabel: 'equals',
+      value: matchingDescription,
+    })
+
+    await page.locator('input#select-all').check()
+    await page.locator('button#select-all-across-pages').click()
+
+    await page.locator('.list-selection__button[aria-label="Unpublish"]').click()
+    await page.locator('#unpublish-posts [data-dialog-action="confirm"]').click()
+
+    await expect
+      .poll(
+        async () => {
+          const { docs } = await payload.find({
+            collection: postsSlug,
+            where: { description: { equals: matchingDescription } },
+          })
+
+          return docs.every((doc) => doc._status === 'draft')
+        },
+        { timeout: POLL_TOPASS_TIMEOUT },
+      )
+      .toBe(true)
+
+    // Documents outside the filter must be untouched
+    const { docs: otherDocs } = await payload.find({
+      collection: postsSlug,
+      where: { description: { equals: otherDescription } },
+    })
+
+    expect(otherDocs).toHaveLength(3)
+
+    for (const doc of otherDocs) {
+      expect(doc._status).toBe('published')
+    }
+  })
+
   test('should update many', async () => {
     await deleteAllPosts()
 


### PR DESCRIPTION
Fixes #17670

### What?

`ListSelection` accepts a `where` prop and forwards it to `EditMany`, `PublishMany` and `UnpublishMany`, but the two main list-view call sites never pass it. This PR forwards the URL `where` query from `useListQuery()` at both call sites.

### Why?

When an editor filters a list, clicks "Select all N across pages" and then triggers a bulk action, the filter is dropped and the action hits every document matching only the action's base constraint.

The issue reports a concrete case: a collection filtered to 598 documents via `?where[pageType][equals]=atm`, bulk Unpublish, and 1772 documents get unpublished instead.

Three things in the current code line up with that:

1. `views/List/ListSelection/index.tsx` declares `where?: Where` and passes it to `EditMany`, `PublishMany` and `UnpublishMany`.
2. `views/List/GroupByHeader/index.tsx` already passes `where`, so the prop is the intended contract, and the two list-view call sites are the outliers.
3. `DeleteMany` is unaffected because it uses `baseWhere`, derived from `parseSearchParams(searchParams)` inside `ListSelection` itself. That matches the reported symptom exactly: Delete respects the filter, Edit/Publish/Unpublish do not.

Manual row selection is also unaffected, because that path sends `id IN [ids]`.

### How?

Two call sites, both reading the same `query.where` the list view already uses:

- `views/List/ListHeader/index.tsx` (desktop): destructure `query` from `useListQuery()` and pass `where={query?.where}`.
- `views/List/index.client.tsx` (smallBreak): pass `where={query?.where}`; `query` was already destructured there for the `hasWhereParam` effect.

Added an e2e test in `test/bulk-edit/e2e.spec.ts` that creates three matching and three non-matching published posts, filters the list, selects all across pages, unpublishes, and asserts that the three non-matching documents are still published.

### Testing performed

- `tsc --noEmit` on `packages/ui`: no new errors introduced. I compared against a baseline run on unmodified `main` and the output is identical.
- I was **not** able to run the e2e suite locally. `pnpm install` fails on Windows during `postinstall`: `@vercel/git-hooks` throws `EPERM: symlink` when creating `.git/hooks/applypatch-msg`, which aborts the lifecycle and leaves `node_modules/.bin` unpopulated. Completing the install with `--ignore-scripts` gets the workspace linked, but the dependent packages are then unbuilt, so `tsc` reports `TS6305` across the package and the Playwright suite can't start.

  The new test follows the existing `should unpublish many` test in the same file and reuses `addListFilter` from `test/__helpers/e2e/filters`, but it has not been executed. Flagging that explicitly rather than implying otherwise. Please have CI or a maintainer confirm it fails without the fix and passes with it.

### Notes for the reviewer

`query?.where` is written defensively even though `IListQueryContext.query` is non-optional, to match the surrounding usage in `index.client.tsx` (`hasWhereParam`, the `useEffect` dependency) and in the `ListQuery` provider itself.

I did not touch `HierarchyList/HierarchyListHeader`, which also renders a selection component. It uses `DocumentListSelection` rather than this `ListSelection`, so it's a separate path and out of scope here.

