### PR TITLE
fix(ui): stop showing [Untitled] in the folder drawer during bulk edit

### DIFF
--- a/packages/ui/src/elements/FolderView/MoveDocToFolder/index.tsx
+++ b/packages/ui/src/elements/FolderView/MoveDocToFolder/index.tsx
@@ -73,7 +73,10 @@ export function MoveDocToFolder({
       collectionSlug={collectionSlug}
       docData={initialData as FolderOrDocument['value']}
       docID={id}
-      docTitle={title}
+      // In bulk edit there is no document, so `title` resolves to the `[Untitled]`
+      // placeholder. Passing `undefined` lets the button fall back to the
+      // collection's singular label instead of showing a fake document title.
+      docTitle={id ? title : undefined}
       folderCollectionSlug={folderCollectionSlug}
       folderFieldName={folderFieldName}
       fromFolderID={fromFolderID as number | string}

--- a/test/folders/e2e.spec.ts
+++ b/test/folders/e2e.spec.ts
@@ -564,6 +564,31 @@ test.describe('Folders', () => {
       )
     })
 
+    test('should not title the folder drawer "[Untitled]" when bulk editing', async () => {
+      await page.goto(postURL.list)
+
+      await page.locator('tbody .row-1 input[type="checkbox"]').check()
+      await page.locator('.edit-many__toggle').click()
+
+      const bulkEditForm = page.locator('form.edit-many__form')
+      await expect(bulkEditForm).toBeVisible()
+
+      await selectInput({
+        multiSelect: true,
+        options: ['Folder'],
+        page,
+        selectLocator: bulkEditForm.locator('.react-select'),
+      })
+
+      await bulkEditForm.locator('.move-doc-to-folder').click()
+
+      // There is no document in bulk edit, so the heading must fall back to the
+      // collection's singular label rather than the `[Untitled]` placeholder.
+      const drawerHeading = page.locator('dialog .drawer-action-header__title')
+      await expect(drawerHeading).toBeVisible()
+      await expect(drawerHeading).toHaveText('Select folder for Post')
+    })
+
     test('should resolve folder pills and not get stuck as Loading...', async () => {
       await selectFolderAndConfirmMoveFromList({ folderName: 'Move Into This Folder', page })
       const folderPill = page.locator('tbody .row-1 .move-doc-to-folder')


### PR DESCRIPTION
Fixes #17669

Targeting `3.x` per the PR template: this is a v3 bug fix. The folder UI was reworked into `Hierarchy` on `main`, where there is no `folder:` translation namespace and no `FolderView` directory, so the reported behaviour does not exist on v4.

### What?

Bulk editing a folder field opened the folder-select drawer titled **"Select folder for [Untitled]"**, even when a single, clearly named document was selected.

### Why?

The chain, traced on `3.x` at `57278bd9` (v3.87.1):

1. `elements/EditMany/DrawerContent.tsx:320` renders its fields inside a `DocumentInfoProvider` with `id={null}` and `initialData={{}}`, which is correct, since bulk edit has no document.
2. `providers/DocumentInfo/index.tsx:89` computes `title` via `formatDocTitle({ …, fallback: id?.toString() })`, so `fallback` is `undefined`.
3. `utilities/formatDocTitle/index.ts:76`, with no `useAsTitle` value and no string fallback, returns `` `[${i18n.t('general:untitled')}]` ``.
4. `FolderView/MoveDocToFolder/index.tsx:76` passed that value through as `docTitle`.
5. `MoveDocToFolderButton` already has the right fallback at line 137:
   ```ts
   const titleToRender = docTitle || getTranslation(getEntityConfig({ collectionSlug }).labels.singular, i18n)
   ```
   but it never ran, because `"[Untitled]"` is a truthy string.

So the correct behaviour was already implemented. It was just unreachable.

### How?

```diff
- docTitle={title}
+ docTitle={id ? title : undefined}
```

With no document id, `docTitle` is `undefined` and the existing fallback resolves to the collection's singular label: **"Select folder for Post"**.

This also improves `BulkUpload/EditForm`, the other consumer of `MoveDocToFolder`, where new uploads have no id yet.

Added an e2e test in `test/folders/e2e.spec.ts` under `Collection view actions`, which asserts the drawer heading is exactly `Select folder for Post` after opening the folder chip from the bulk edit form.

### Testing performed

I could **not** run the suite locally, and I would rather say so than imply otherwise. `pnpm install` fails on Windows during `postinstall`: `@vercel/git-hooks` throws `EPERM: symlink` creating `.git/hooks/applypatch-msg`, which aborts the lifecycle and leaves `node_modules/.bin` empty.

What I can state precisely:

- The change narrows a prop declared as `docTitle?: string` to `string | undefined`, so it cannot introduce a type error.
- The root cause is verified by reading the source at each of the five steps above rather than inferred, with file and line references so a reviewer can check each claim quickly.

Please have CI or a maintainer confirm the new test fails without the fix and passes with it.

### Notes for the reviewer

**Scope.** The issue also reports that the chip renders the `folder:noFolder` label even when every selected document is in a folder. That has a different root cause (bulk-edit fields are setters and do not load current values), and arguably no single correct value exists across N documents. I left it out to keep this to one logical change; happy to take it in a follow-up if you want it addressed.

**Why not a count-based heading.** The issue suggests reusing the Move flow's `"N Items"` title. `MoveToFolder` does support that via `action="moveItemsToFolder"`, but the count lives in `useSelection()`, and `MoveDocToFolder` is also rendered on the document edit view where no `SelectionProvider` exists, so a hook call there would break. Fields are also rendered generically by the form, so the count cannot be threaded down as a prop to one specific field. The singular-label fallback needs no new plumbing and is already the component's declared intent.

