### PR TITLE
fix(ui): keep list query params when refreshing after a bulk edit

### DIFF
--- a/packages/ui/src/elements/EditMany/DrawerContent.tsx
+++ b/packages/ui/src/elements/EditMany/DrawerContent.tsx
@@ -278,7 +278,11 @@ export const EditManyDrawerContent: React.FC<EditManyDrawerContentProps> = (prop
     router.replace(
       qs.stringify(
         {
-          ...parseSearchParams(searchParams),
+          // Read the live location instead of `useSearchParams()`, which is stale
+          // here: `ListQueryProvider` syncs the list query to the URL through the
+          // History API to avoid a re-render, and the hook never observes that.
+          // Spreading the stale value wipes columns/filters/limit off the URL.
+          ...parseSearchParams(new URLSearchParams(window.location.search)),
           _r: Date.now(), // Cache buster to force fresh data fetch. Prevents an e2e race condition where sometimes the data is not updated.
           page: selectAll ? '1' : undefined,
         },

--- a/test/bulk-edit/e2e.spec.ts
+++ b/test/bulk-edit/e2e.spec.ts
@@ -683,6 +683,44 @@ test.describe('Bulk Edit', () => {
     }
   })
 
+  test('should keep the list query params in the URL after a successful edit', async () => {
+    await deleteAllPosts()
+    await createPost({ title: 'Post 1' })
+
+    await page.goto(postsUrl.list)
+
+    // `ListQueryProvider` writes these through the History API rather than the
+    // router, so `useSearchParams()` never observes them. Waiting for `limit`
+    // makes that the explicit precondition instead of an incidental one.
+    await expect.poll(() => page.url(), { timeout: POLL_TOPASS_TIMEOUT }).toContain('limit=')
+
+    await page.locator('input#select-all').check()
+    await page.locator('.list-selection__button[aria-label="Edit"]').click()
+
+    const editDrawer = page.locator('dialog#edit-posts')
+    await expect(editDrawer).toBeVisible()
+
+    const fieldSelectControl = editDrawer.locator('.field-select .rs__control')
+    await expect(fieldSelectControl).toBeVisible()
+    await fieldSelectControl.click()
+    await getSelectMenu({ page }).locator('.rs__option:has-text("Title")').first().click()
+
+    await editDrawer.locator('input#field-title').fill('test')
+
+    // Assert on the refresh request rather than the settled URL: the provider
+    // re-adds the params on the next render, so the address bar self-heals and
+    // would hide a refresh that went out bare.
+    const refreshRequest = page.waitForRequest(
+      (request) => request.url().includes('/collections/posts') && request.url().includes('_r='),
+    )
+
+    await editDrawer.locator('button[type="submit"]:has-text("Publish changes")').click()
+
+    await expect(page.locator('.payload-toast-container .toast-success')).toBeVisible()
+
+    expect((await refreshRequest).url()).toContain('limit=')
+  })
+
   test('should not delete nested un-named tab array data', async () => {
     const originalDoc = await payload.create({
       collection: tabsSlug,


### PR DESCRIPTION
Fixes #17667.

## What

`EditMany`'s success handler rebuilt the post-save URL by spreading `parseSearchParams(searchParams)`. That value is stale in a list view, so the refresh navigated to a bare `?_r=<timestamp>` and dropped `columns`, `where`, `limit` and `sort`.

## Why `useSearchParams()` is stale here

`ListQueryProvider` deliberately writes the list query to the URL through the History API rather than the router, to avoid a re-render, in [`providers/ListQuery/index.tsx#L147-L158`](https://github.com/payloadcms/payload/blob/main/packages/ui/src/providers/ListQuery/index.tsx#L147-L158):

```ts
// Important: do not use router.replace here to avoid re-rendering.
if (router.replaceState) {
  router.replaceState(search)
}
```

Anything written that way never reaches `useSearchParams()`. The repo already documents this exact problem and already works around it in one place, in [`elements/Localizer/index.tsx#L63`](https://github.com/payloadcms/payload/blob/main/packages/ui/src/elements/Localizer/index.tsx#L63):

```ts
// can't use `useSearchParams` here because it is stale due to `window.history.pushState` in `ListQueryProvider`
const searchParams = new URLSearchParams(window.location.search)
```

`EditMany` has the same problem and was missed. This PR applies the same workaround, keeping `parseSearchParams` so nested params (`where[or][0][and][0]…`) still round-trip through `qs` at `depth: 10`.

## Verified by running it

`test/bulk-edit` e2e against the dev server, MongoDB in Docker, `CI=true` (so the run gets CI's 5 retries):

| | Result |
|---|---|
| With the fix | `1 passed` |
| Reverting only the `DrawerContent.tsx` change | `1 failed`, and it failed on **all 6 attempts**, so it isn't flaky |

The failure message is the bug itself:

```
Expected substring: "limit="
Received string:    "http://localhost:3000/admin/collections/posts?_r=1786054824496&_rsc=…"
```

And the dev server log shows the two refresh requests side by side:

```
with fix:     GET /admin/collections/posts?depth=1&limit=5&_r=1786054793304  200
without fix:  GET /admin/collections/posts?_r=1786054824496                  200
```

## A note on the test

My first attempt asserted on `page.url()` after the save, and it **passed without the fix**, which is what sent me looking. `ListQueryProvider` re-adds the params on the next render, so the address bar self-heals within a few hundred ms and hides the bare navigation. That matches the reporter's "depending on render timing the visible column loss either self-heals or becomes permanent."

So the test asserts on the refresh **request** via `page.waitForRequest`, which is the thing that actually goes out wrong. Flagging it because a settled-URL assertion here looks correct and silently tests nothing.

## Scope

I kept this to the handler the issue reports.

- The issue's second half, the List view's `upsertPreferences({ columns: columnsFromQuery })` trusting URL params, is a broader design question and I left it alone. With the bare navigation gone, the trigger for the preference overwrite is gone too.
- `queryString`'s `selectAll` branch (`DrawerContent.tsx#L252`) reads the same stale source. That path is what #17670 reports, and #17695 already addresses it by passing `where` down from `useListQuery()`, so I didn't touch it here to avoid two open PRs editing the same lines.

## What I did not verify

I did not run the full `bulk-edit` suite or a typecheck of the whole monorepo, only the new test plus the control. The change is one expression inside an event handler with no type change (`parseSearchParams` takes a `URLSearchParams` either way), so I'd expect CI to be the real check on the rest.

## Checklist

- [x] Tests added
- [ ] Documentation, no user-facing API change

