### PR TITLE
fix(plugin-cloud-storage): don't leave skipCloudStorage on a reused context

### DIFF
--- a/packages/plugin-cloud-storage/src/hooks/afterChange.ts
+++ b/packages/plugin-cloud-storage/src/hooks/afterChange.ts
@@ -54,7 +54,17 @@ export const getAfterChangeHook =
           if (!req.context) {
             req.context = {}
           }
-          req.context.skipCloudStorage = true
+
+          // Hold onto the object the flag is set on. The nested update below runs
+          // `createLocalReq`, which reassigns `req.context` to a fresh copy — so
+          // clearing `req.context.skipCloudStorage` afterwards would clear it off
+          // that copy and leave it set on the original. When a caller reuses one
+          // `context` across several Local API creates (the seed-script pattern),
+          // `createLocalReq` hands that same object to `req.context`, and the
+          // leftover flag makes every later upload return early: the document is
+          // written but no bytes reach storage.
+          const contextWithFlag = req.context
+          contextWithFlag.skipCloudStorage = true
 
           // Clear to prevent re-processing
           req.file = undefined
@@ -70,7 +80,7 @@ export const getAfterChangeHook =
               req,
             })
           } finally {
-            delete req.context.skipCloudStorage
+            delete contextWithFlag.skipCloudStorage
           }
 
           docWithMetadata = { ...doc, ...uploadMetadata }

--- a/test/plugin-cloud-storage/int.spec.ts
+++ b/test/plugin-cloud-storage/int.spec.ts
@@ -323,6 +323,38 @@ describe('@payloadcms/plugin-cloud-storage', () => {
           expect(upload.url).toEqual(`/api/${mediaSlug}/file/${String(upload.filename)}`)
         })
 
+        it('uploads every file when one context object is reused across creates', async () => {
+          // `createLocalReq` assigns this exact object to `req.context`, so
+          // anything a hook writes onto it survives into the next create.
+          const sharedContext: Record<string, unknown> = {}
+
+          const uploads = []
+
+          for (let i = 0; i < 3; i++) {
+            uploads.push(
+              await payload.create({
+                collection: mediaSlug,
+                context: sharedContext,
+                data: {},
+                filePath: path.resolve(dirname, '../uploads/image.png'),
+              }),
+            )
+          }
+
+          // The documents are written either way — only the bytes go missing.
+          for (const upload of uploads) {
+            await verifyUploads({
+              client,
+              collectionSlug: mediaSlug,
+              payload,
+              TEST_BUCKET,
+              uploadId: upload.id,
+            })
+          }
+
+          expect(sharedContext).not.toHaveProperty('skipCloudStorage')
+        })
+
         it('can upload with prefix', async () => {
           const upload = await payload.create({
             collection: mediaWithPrefixSlug,


### PR DESCRIPTION
Fixes #17546.

## What

Passing one `context` object across several Local API `create()` calls on an upload collection uploads only the **first** file. Every later create succeeds, writes a fully-populated document (`filename`, `mimeType`, `sizes`, `url`), and puts nothing in storage, with no error and no log line.

@edrpls traced the mechanism precisely in the issue; this confirms it and fixes the last link.

## The chain

1. `createLocalReq` assigns the caller's `context` to `req.context` **by reference** when the fresh req has none. [`getRequestContext`](https://github.com/payloadcms/payload/blob/main/packages/payload/src/utilities/createLocalReq.ts#L12-L21) returns `context` unchanged in that branch.
2. The hook sets `req.context.skipCloudStorage = true`, so it is now set on the *caller's* object.
3. The nested `payload.update({ ..., req })` runs `createLocalReq` again on that same req. `req.context` is non-empty now, so line 139 **reassigns** `req.context = { ...req.context, ...context }`, which is a new object.
4. `finally { delete req.context.skipCloudStorage }` deletes it from that new object.
5. The caller's object keeps the flag. The next `create()` binds it to `req.context` again, the hook returns early at its first line, and no upload happens.

Step 3 is the one that's easy to miss: the reassignment happens on the *same* `req`, so `req.context` silently stops pointing at what step 2 mutated.

## The fix

Capture the reference the flag is set on, and clear it from that:

```diff
+ const contextWithFlag = req.context
+ contextWithFlag.skipCloudStorage = true
  ...
  } finally {
-   delete req.context.skipCloudStorage
+   delete contextWithFlag.skipCloudStorage
  }
```

The recursion guard still works, because the nested `createLocalReq` copies `req.context` *including* the flag, so the nested hook still sees it and returns early. Only the cleanup changes.

I deliberately did **not** touch `getRequestContext`. Handing the caller's object over by reference is what lets hooks write back into a caller's context, and changing that would be a much broader behavioural change than this bug warrants.

## Verified by running it

Added `uploads every file when one context object is reused across creates` to `test/plugin-cloud-storage/int.spec.ts`. Three sequential creates sharing one `context`, then `HeadObject` against the bucket for every file and every generated size.

Run against LocalStack + MongoDB in Docker:

| | Result |
|---|---|
| With the fix | `Tests 1 passed` |
| Reverting only `afterChange.ts` | `Tests 1 failed` |

The control failure is the reported damage, not a proxy for it:

```
Error verifying uploads: [ 'image-1-400x400.png', 'image-1-900x450.png', 'image-1.png' ] NotFound
```

The first file (`image.png`) verifies fine; the **second** one and its sizes are absent from the bucket while its document row exists. Reverting the `finally` line alone is enough to reproduce.

Full suite after the change: `Test Files 2 passed · Tests 35 passed | 3 todo (38)`.

## Note on the assertion order

The test checks the bucket **before** asserting that `sharedContext` is clean. I had it the other way round first, and the control then failed on the context assertion. That is technically correct, but it would have let a future regression report the internal symptom instead of the missing object. The bucket check is the one that describes what users lose.

## What I did not verify

I ran the `plugin-cloud-storage` suite only, on MongoDB with the S3 adapter against LocalStack. I did not run the other `storage-*` suites (azure, gcs, r2, vercel-blob). The change is in the shared hook, so they exercise the same path, but I'm flagging it rather than implying I checked. Same for a real S3/R2 endpoint; the reporter covered R2.

## Checklist

- [x] Tests added
- [ ] Documentation, no API change

