### PR TITLE
fix(plugin-nested-docs): rethrow errors raised while re-saving children

### DIFF
--- a/packages/plugin-nested-docs/src/hooks/resaveChildren.ts
+++ b/packages/plugin-nested-docs/src/hooks/resaveChildren.ts
@@ -97,6 +97,16 @@ export const resaveChildren =
             400,
           )
         }
+
+        // Anything else has to propagate too. A failed child update has already
+        // killed the transaction the whole cascade shares, so swallowing here
+        // does not salvage the parent write — it only stops the caller from
+        // being told the write was discarded. Two ways to land in this branch:
+        // a non-validation failure (a database error), and a cascade deeper
+        // than one level, where the throw above has already turned the
+        // grandchild's ValidationError into an APIError that the next
+        // ancestor's `instanceof` check no longer recognises.
+        throw err
       }
     }
 

--- a/test/plugin-nested-docs/collections/Pages.ts
+++ b/test/plugin-nested-docs/collections/Pages.ts
@@ -1,6 +1,16 @@
-import type { CollectionConfig } from 'payload'
+import type { CollectionConfig, PayloadRequest } from 'payload'
 
 import { populateFullTitle } from './populateFullTitle.js'
+
+type Simulation = {
+  /** Make the child re-save throw something that is not a `ValidationError`. */
+  infraFailure?: boolean
+  /** Make the child re-save throw a `ValidationError`. */
+  staleReference?: boolean
+}
+
+const getSimulation = (req: PayloadRequest): Simulation =>
+  (req?.context?.simulate as Simulation) || {}
 
 export const Pages: CollectionConfig = {
   slug: 'pages',
@@ -19,6 +29,20 @@ export const Pages: CollectionConfig = {
   access: {
     read: () => true,
   },
+  hooks: {
+    beforeChange: [
+      ({ data, req }) => {
+        // Stands in for a non-validation failure during the re-save — the
+        // reporter names a database error. Anything of this shape is swallowed
+        // by the plugin's catch even one level deep.
+        if (data?.breaksOnResave && getSimulation(req).infraFailure) {
+          throw new Error('Simulated database failure while re-saving a child.')
+        }
+
+        return data
+      },
+    ],
+  },
   fields: [
     {
       name: 'title',
@@ -31,6 +55,21 @@ export const Pages: CollectionConfig = {
       label: 'Slug',
       type: 'text',
       required: true,
+    },
+    {
+      // Marks a document that should fail when the plugin re-saves it. Both
+      // failure modes are gated on request context as well, so they fire only
+      // for the one cascade a test drives and leave the rest of the suite alone.
+      name: 'breaksOnResave',
+      type: 'checkbox',
+      admin: {
+        hidden: true,
+      },
+      // Stands in for the reported cause: a document that is valid as stored and
+      // only fails when something re-validates it later — there, a required
+      // upload field whose media document had since been deleted.
+      validate: (value, { req }) =>
+        value && getSimulation(req).staleReference ? 'This field is invalid.' : true,
     },
     {
       name: 'fullTitle',

--- a/test/plugin-nested-docs/int.spec.ts
+++ b/test/plugin-nested-docs/int.spec.ts
@@ -497,4 +497,75 @@ describe('@payloadcms/plugin-nested-docs', () => {
       expect(grandchild.categorization[2].label).toStrictEqual('grandchild')
     })
   })
+
+  describe('error propagation', () => {
+    const createPage = async (data: Record<string, unknown>) =>
+      payload.create({
+        collection: 'pages',
+        data: { _status: 'published', ...data } as Page,
+      })
+
+    it('should surface a validation error raised two levels down the cascade', async () => {
+      const grandparent = await createPage({ title: 'Cascade A', slug: 'cascade-a' })
+      const parent = await createPage({
+        title: 'Cascade B',
+        slug: 'cascade-b',
+        parent: grandparent.id,
+      })
+      await createPage({
+        title: 'Cascade C',
+        slug: 'cascade-c',
+        breaksOnResave: true,
+        parent: parent.id,
+      })
+
+      // Updating A re-saves B, and B's own resaveChildren re-saves C. C's
+      // ValidationError is converted to an APIError one level down, so A's
+      // catch no longer recognises it and lets it go — while the failed update
+      // has already killed the transaction the three of them share.
+      await expect(
+        payload.update({
+          id: grandparent.id,
+          collection: 'pages',
+          context: { simulate: { staleReference: true } },
+          data: { title: 'Cascade A Updated', _status: 'published' },
+        }),
+      ).rejects.toThrow()
+
+      // What the caller was told and what the database holds now agree.
+      const stored = await payload.findByID({
+        id: grandparent.id,
+        collection: 'pages',
+        draft: false,
+      })
+
+      expect(stored.title).toBe('Cascade A')
+    })
+
+    it('should surface a non-validation error raised during a child re-save', async () => {
+      const parent = await createPage({ title: 'Infra A', slug: 'infra-a' })
+      await createPage({
+        title: 'Infra B',
+        slug: 'infra-b',
+        breaksOnResave: true,
+        parent: parent.id,
+      })
+
+      // This one needs no cascade depth at all: the catch only ever rethrows
+      // ValidationErrors, so a database error during the child re-save is
+      // swallowed on the first level.
+      await expect(
+        payload.update({
+          id: parent.id,
+          collection: 'pages',
+          context: { simulate: { infraFailure: true } },
+          data: { title: 'Infra A Updated', _status: 'published' },
+        }),
+      ).rejects.toThrow()
+
+      const stored = await payload.findByID({ id: parent.id, collection: 'pages', draft: false })
+
+      expect(stored.title).toBe('Infra A')
+    })
+  })
 })

--- a/test/plugin-nested-docs/payload-types.ts
+++ b/test/plugin-nested-docs/payload-types.ts
@@ -127,6 +127,7 @@ export interface Page {
   id: string;
   title: string;
   slug: string;
+  breaksOnResave?: boolean | null;
   fullTitle?: string | null;
   parent?: (string | null) | Page;
   breadcrumbs?:
@@ -277,6 +278,7 @@ export interface PayloadMigration {
 export interface PagesSelect<T extends boolean = true> {
   title?: T;
   slug?: T;
+  breaksOnResave?: T;
   fullTitle?: T;
   parent?: T;
   breadcrumbs?:


### PR DESCRIPTION
Fixes #17457.

## What

`resaveChildren` swallows errors raised while re-saving a child. The parent update then resolves with a fresh `updatedAt` on a transaction the failed child update has already rolled back. The caller is told the write landed, and it did not.

@michael-spanier reported it and @sam9191 corroborated it at 3.80.0. Between them they identify three ways to reach the swallow; this closes all three with one line.

## The catch

```js
} catch (err) {
  req.payload.logger.error(`Nested Docs plugin encountered an error while re-saving a child document.`)
  req.payload.logger.error(err)

  if (err instanceof ValidationError && err.data?.errors?.length) {
    throw new APIError('Could not publish or save changes: One or more children are invalid.', 400)
  }
}
```

Two of the three paths need no bundling and no dual-module context:

1. **Anything that is not a `ValidationError`**, a database error during the re-save for instance, falls straight off the end of the catch. One level deep is enough.
2. **A cascade deeper than one level.** The rethrow above does not rethrow the child's error, it *converts* it. So A → B → C, with C invalid: `resaveChildren(B)` turns C's `ValidationError` into an `APIError`, that propagates out of `update(B)` into `resaveChildren(A)`, whose `instanceof ValidationError` check is now false **by construction**, and it is swallowed. Error information survives exactly one cascade level.

The third one, `instanceof` failing across duplicate module copies in a bundled runtime, is the one the reporter observes in production and is the hardest to test; it lands in the same branch and is closed by the same line.

## The fix

```diff
   if (err instanceof ValidationError && err.data?.errors?.length) {
     throw new APIError('Could not publish or save changes: One or more children are invalid.', 400)
   }
+
+  throw err
 }
```

The friendly `APIError` for the common one-level validation case is untouched, so nothing that works today changes shape. The issue also floats making the check structural (`err?.name === 'ValidationError'`); I left it alone deliberately, because @sam9191 is right that it does not help. The first level still converts to `APIError`, so the second level swallows regardless of how the check is written. Rethrowing is the part that matters.

I did not take the issue's other suggested direction, running the re-save with `overrideValidation`. That would hide the invalid child rather than report it, and it is a policy call about what a nested-docs re-save is allowed to write. This change stays inside a decision the plugin has already made: it *has* decided that an invalid child should fail the parent. It just fails to honour that one level down.

## Verified by running it

Added `error propagation` to `test/plugin-nested-docs/int.spec.ts`, one test per non-bundled path. The fixture is a hidden `breaksOnResave` checkbox on `Pages` plus a `validate` and a `beforeChange` hook, both gated on request context so they fire only for the cascade a test drives and leave the other twelve tests alone.

| | MongoDB | PostgreSQL |
|---|---|---|
| With the fix | `Tests 14 passed (14)` | `Tests 14 passed (14)` |
| Reverting only `resaveChildren.ts` | `Tests 2 failed \| 12 passed` | `Tests 2 failed \| 12 passed` |

Both controls fail the same way, and the message is the bug itself rather than a proxy for it:

```
AssertionError: promise resolved "{ title: 'Cascade A Updated', …(9) }" instead of rejecting
AssertionError: promise resolved "{ title: 'Infra A Updated', …(9) }" instead of rejecting
```

I also confirmed the data-loss half separately, in a throwaway spec on the unfixed code, since the committed tests stop at the first assertion once the update resolves:

```
RESOLVED  title= Loss A Updated  updatedAt= 2026-08-06T23:45:53.107Z
STORED    title= Loss A          updatedAt= 2026-08-06T23:45:52.979Z
```

The resolved document and the database disagree, which is what the editor experiences as the `documentModified` modal on every subsequent save.

## What this changes for users

Saves that report success today will start failing loudly. That is the point of the change, but it is a behavioural one: an installation whose child documents have gone stale has been silently discarding parent edits, and after this it gets an error instead. The parent write was never persisted either way.

## What I did not verify

I ran `plugin-nested-docs` on MongoDB and PostgreSQL, not SQLite or Firestore. I did not build a bundled Next.js app to exercise the dual-module `instanceof` path the reporter sees in production. I am relying on their empirical evidence for that one, and the line closes it by construction rather than by type check. I did not run the e2e spec for this suite; the change is confined to an error path that the fixture opts into explicitly.

## Checklist

- [x] Tests added
- [ ] Documentation, no API change

