### PR TITLE
fix(ui): stabilize locale transitions and duplicate modal cleanup

### DIFF
--- a/packages/ui/src/elements/DuplicateDocument/SelectLocalesDrawer/index.tsx
+++ b/packages/ui/src/elements/DuplicateDocument/SelectLocalesDrawer/index.tsx
@@ -47,7 +47,7 @@ export const SelectLocalesDrawer: React.FC<SelectLocalesDrawerProps> = ({
   onConfirm,
 }) => {
   const { i18n, t } = useTranslation()
-  const { toggleModal } = useModal()
+  const { closeModal, toggleModal } = useModal()
   const [selectedLocales, setSelectedLocales] = useState<string[]>([])
 
   const localeOptions = useMemo(
@@ -72,8 +72,8 @@ export const SelectLocalesDrawer: React.FC<SelectLocalesDrawerProps> = ({
 
   const handleConfirm = useCallback(async () => {
     await onConfirm({ selectedLocales })
-    toggleModal(slug)
-  }, [onConfirm, selectedLocales, slug, toggleModal])
+    closeModal(slug)
+  }, [closeModal, onConfirm, selectedLocales, slug])
 
   return (
     <Drawer

--- a/packages/ui/src/providers/Locale/index.tsx
+++ b/packages/ui/src/providers/Locale/index.tsx
@@ -9,6 +9,7 @@ import { findLocaleFromCode } from '../../utilities/findLocaleFromCode.js'
 import { useAuth } from '../Auth/index.js'
 import { useConfig } from '../Config/index.js'
 import { useSearchParams } from '../RouterAdapter/index.js'
+import { useRouteTransition } from '../RouteTransition/index.js'
 
 const LocaleContext = createContext({} as Locale)
 
@@ -46,6 +47,7 @@ export const LocaleProvider: React.FC<{ children?: React.ReactNode; locale?: Loc
   } = useConfig()
 
   const { user } = useAuth()
+  const { isTransitioning } = useRouteTransition()
 
   const defaultLocale = localization ? localization.defaultLocale : 'en'
 
@@ -70,18 +72,12 @@ export const LocaleProvider: React.FC<{ children?: React.ReactNode; locale?: Loc
   const prevLocale = useRef<Locale>(locale)
 
   useEffect(() => {
-    /**
-     * We need to set `isLoading` back to false once the locale is detected to be different
-     * This happens when the user clicks an anchor link which appends the `?locale=` query param
-     * This triggers a client-side navigation, which re-renders the page with the new locale
-     * In Next.js, local state is persisted during this type of navigation because components are not unmounted
-     */
-    if (locale.code !== prevLocale.current.code) {
+    // Keep fields disabled until the new locale's document state finishes loading.
+    if (locale.code !== prevLocale.current.code && !isTransitioning) {
       setLocaleIsLoading(false)
+      prevLocale.current = locale
     }
-
-    prevLocale.current = locale
-  }, [locale])
+  }, [isTransitioning, locale])
 
   const fetchURL = formatAdminURL({
     apiRoute,


### PR DESCRIPTION
Keeps localized fields disabled until locale route transitions finish and reliably closes the locale-selection drawer after duplicating a document.

`LocaleProvider` previously cleared `localeIsLoading` as soon as it observed the new locale, before the transitioned document state had finished loading. `SelectLocalesDrawer` also toggled its modal after confirmation, allowing stale modal state to keep intercepting pointer events. The fix waits for `isTransitioning` to settle and uses idempotent `closeModal` cleanup.

The existing E2E tests cover both behaviors when run against the TanStack Start framework.