### PR TITLE
fix: increase secret to 256 bits

### DIFF
--- a/packages/create-payload-app/src/lib/generate-secret.ts
+++ b/packages/create-payload-app/src/lib/generate-secret.ts
@@ -1,5 +1,5 @@
-import { randomBytes } from "crypto"
+import { randomBytes } from 'crypto'
 
 export function generateSecret(): string {
-  return randomBytes(32).toString("hex")
+  return randomBytes(32).toString('hex')
 }

--- a/packages/create-payload-app/src/lib/generate-secret.ts
+++ b/packages/create-payload-app/src/lib/generate-secret.ts
@@ -1,5 +1,5 @@
-import { randomBytes } from 'crypto'
+import { randomBytes } from "crypto"
 
 export function generateSecret(): string {
-  return randomBytes(32).toString('hex').slice(0, 24)
+  return randomBytes(32).toString("hex")
 }


### PR DESCRIPTION
This PR increases the default secret's entropy from 96 bits (4 bits per hex character * 24 characters) to 256 bits (32 bytes converted to hex characters).

This change is recommended to take advantage of 256 bit encryption.