### PR TITLE
test: resolve suite fixture paths independently of ROOT_DIR

### DIFF
--- a/test/__helpers/shared/getTestSuiteDir.int.spec.ts
+++ b/test/__helpers/shared/getTestSuiteDir.int.spec.ts
@@ -1,0 +1,47 @@
+import path from 'path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { getTestSuiteDir } from './getTestSuiteDir.js'
+
+describe('getTestSuiteDir', () => {
+  const fallbackDir = '/repo/test/fields'
+  const originalFramework = process.env.PAYLOAD_FRAMEWORK
+  const originalRootDir = process.env.ROOT_DIR
+
+  afterEach(() => {
+    process.env.PAYLOAD_FRAMEWORK = originalFramework
+    process.env.ROOT_DIR = originalRootDir
+  })
+
+  it('should resolve from ROOT_DIR for tanstack start runs', () => {
+    process.env.PAYLOAD_FRAMEWORK = 'tanstack-start'
+    process.env.ROOT_DIR = '/repo/test'
+
+    expect(getTestSuiteDir({ fallbackDir, suitePath: 'fields' })).toBe(
+      path.resolve('/repo/test', 'fields'),
+    )
+  })
+
+  it('should ignore ROOT_DIR for next runs, which point it at the monorepo root', () => {
+    delete process.env.PAYLOAD_FRAMEWORK
+    process.env.ROOT_DIR = '/repo'
+
+    expect(getTestSuiteDir({ fallbackDir, suitePath: 'fields' })).toBe(fallbackDir)
+  })
+
+  it('should use the fallback directory when ROOT_DIR is not set', () => {
+    process.env.PAYLOAD_FRAMEWORK = 'tanstack-start'
+    delete process.env.ROOT_DIR
+
+    expect(getTestSuiteDir({ fallbackDir, suitePath: 'fields' })).toBe(fallbackDir)
+  })
+
+  it('should resolve nested suite paths', () => {
+    process.env.PAYLOAD_FRAMEWORK = 'tanstack-start'
+    process.env.ROOT_DIR = '/repo/test'
+
+    expect(getTestSuiteDir({ fallbackDir, suitePath: 'lexical/collections/Upload' })).toBe(
+      path.resolve('/repo/test', 'lexical/collections/Upload'),
+    )
+  })
+})

--- a/test/__helpers/shared/getTestSuiteDir.ts
+++ b/test/__helpers/shared/getTestSuiteDir.ts
@@ -1,0 +1,26 @@
+import path from 'path'
+
+/**
+ * Resolves a directory inside `test/` that a suite reads runtime assets from.
+ *
+ * TanStack Start bundles suite files, so `import.meta.url` no longer points at the source
+ * folder. Those runs resolve from `ROOT_DIR`, which the TanStack adapters set to `test/`.
+ * Every other run keeps its own directory, because the Next dev server sets `ROOT_DIR` to
+ * the monorepo root.
+ *
+ * @param fallbackDir Directory to use when `ROOT_DIR` cannot be trusted, usually the caller's own `dirname`.
+ * @param suitePath Path of the directory relative to `test/`, e.g. `fields` or `lexical/collections/Upload`.
+ */
+export function getTestSuiteDir({
+  fallbackDir,
+  suitePath,
+}: {
+  fallbackDir: string
+  suitePath: string
+}): string {
+  if (process.env.PAYLOAD_FRAMEWORK === 'tanstack-start' && process.env.ROOT_DIR) {
+    return path.resolve(process.env.ROOT_DIR, suitePath)
+  }
+
+  return fallbackDir
+}

--- a/test/fields/seed.ts
+++ b/test/fields/seed.ts
@@ -414,6 +414,9 @@ export async function clearAndSeedEverything(_payload: Payload) {
     collectionSlugs,
     seedFunction: seed,
     snapshotKey: 'fieldsTest',
-    uploadsDir: path.resolve(getFieldsDir(), './collections/Upload/uploads'),
+    uploadsDir: path.resolve(
+      getTestSuiteDir({ fallbackDir: dirname, suitePath: 'fields' }),
+      './collections/Upload/uploads',
+    ),
   })
 }

--- a/test/fields/seed.ts
+++ b/test/fields/seed.ts
@@ -3,8 +3,10 @@ import type { Payload } from 'payload'
 import { buildEditorState } from '@payloadcms/richtext-lexical'
 import path from 'path'
 import { getFileByPath } from 'payload'
+import { fileURLToPath } from 'url'
 
 import { seedDB } from '../__helpers/shared/clearAndSeed/seed.js'
+import { getTestSuiteDir } from '../__helpers/shared/getTestSuiteDir.js'
 import { devUser } from '../credentials.js'
 import { arrayDoc } from './collections/Array/shared.js'
 import { blocksDoc } from './collections/Blocks/shared.js'
@@ -56,11 +58,11 @@ import {
   usersSlug,
 } from './slugs.js'
 
-const getFieldsDir = () =>
-  path.resolve(process.env.ROOT_DIR ?? path.resolve(process.cwd(), 'test'), 'fields')
+const filename = fileURLToPath(import.meta.url)
+const dirname = path.dirname(filename)
 
 export const seed = async (_payload: Payload) => {
-  const fieldsDir = getFieldsDir()
+  const fieldsDir = getTestSuiteDir({ fallbackDir: dirname, suitePath: 'fields' })
   const jpgPath = path.resolve(fieldsDir, './collections/Upload/payload.jpg')
   const jpg480x320Path = path.resolve(fieldsDir, './collections/Upload/payload480x320.jpg')
   const pngPath = path.resolve(fieldsDir, './uploads/payload.png')

--- a/test/joins/seed.ts
+++ b/test/joins/seed.ts
@@ -2,7 +2,9 @@ import type { Payload } from 'payload'
 
 import path from 'path'
 import { getFileByPath } from 'payload'
+import { fileURLToPath } from 'url'
 
+import { getTestSuiteDir } from '../__helpers/shared/getTestSuiteDir.js'
 import { devUser } from '../credentials.js'
 import {
   categoriesJoinRestrictedSlug,
@@ -12,6 +14,10 @@ import {
   postsSlug,
   uploadsSlug,
 } from './shared.js'
+
+const filename = fileURLToPath(import.meta.url)
+const dirname = path.dirname(filename)
+const joinsDir = getTestSuiteDir({ fallbackDir: dirname, suitePath: 'joins' })
 
 export const seed = async (_payload: Payload) => {
   await _payload.create({
@@ -102,10 +108,7 @@ export const seed = async (_payload: Payload) => {
   })
 
   // create an upload with image.png
-  const imageFilePath = path.resolve(
-    process.env.ROOT_DIR ?? path.resolve(process.cwd(), 'test'),
-    'joins/image.png',
-  )
+  const imageFilePath = path.resolve(joinsDir, 'image.png')
   const imageFile = await getFileByPath(imageFilePath)
   const { id: uploadedImage } = await _payload.create({
     collection: uploadsSlug,

--- a/test/lexical/collections/Upload/index.ts
+++ b/test/lexical/collections/Upload/index.ts
@@ -3,11 +3,14 @@ import type { CollectionConfig } from 'payload'
 import path from 'path'
 import { fileURLToPath } from 'url'
 
+import { getTestSuiteDir } from '../../../__helpers/shared/getTestSuiteDir.js'
 import { uploads2Slug, uploadsSlug } from '../../slugs.js'
+
 const filename = fileURLToPath(import.meta.url)
-const dirname = process.env.ROOT_DIR
-  ? path.resolve(process.env.ROOT_DIR, 'lexical/collections/Upload')
-  : path.dirname(filename)
+const dirname = getTestSuiteDir({
+  fallbackDir: path.dirname(filename),
+  suitePath: 'lexical/collections/Upload',
+})
 
 export const Uploads: CollectionConfig = {
   slug: uploadsSlug,

--- a/test/lexical/seed.ts
+++ b/test/lexical/seed.ts
@@ -3,6 +3,7 @@ import type { Payload } from 'payload'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+import { getTestSuiteDir } from '../__helpers/shared/getTestSuiteDir.js'
 import { lexicalDocData } from './collections/Lexical/data.js'
 import { generateLexicalLocalizedRichText } from './collections/LexicalLocalized/generateLexicalRichText.js'
 import { richTextDocData } from './collections/RichText/data.js'
@@ -97,7 +98,7 @@ import { uploadsDoc } from './collections/Upload/shared.js'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
-const lexicalDir = process.env.ROOT_DIR ? path.resolve(process.env.ROOT_DIR, 'lexical') : dirname
+const lexicalDir = getTestSuiteDir({ fallbackDir: dirname, suitePath: 'lexical' })
 
 export const seed = async (_payload: Payload) => {
   // Create the admin user first so auto-login still works if a later seed step

--- a/test/live-preview/seed/index.ts
+++ b/test/live-preview/seed/index.ts
@@ -3,6 +3,7 @@ import type { Config } from 'payload'
 import path from 'path'
 import { fileURLToPath } from 'url'
 
+import { getTestSuiteDir } from '../../__helpers/shared/getTestSuiteDir.js'
 import { removeFiles } from '../../__helpers/shared/removeFiles.js'
 import { devUser } from '../../credentials.js'
 import {
@@ -25,10 +26,7 @@ import { tenant2 } from './tenant-2.js'
 import { trashedPost } from './trashed-post.js'
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
-const seedDir =
-  process.env.PAYLOAD_FRAMEWORK === 'tanstack-start' && process.env.ROOT_DIR
-    ? path.resolve(process.env.ROOT_DIR, 'live-preview/seed')
-    : dirname
+const seedDir = getTestSuiteDir({ fallbackDir: dirname, suitePath: 'live-preview/seed' })
 
 export const seed: Config['onInit'] = async (payload) => {
   const existingUser = await payload.find({

--- a/test/uploads/config.ts
+++ b/test/uploads/config.ts
@@ -1,6 +1,7 @@
 import path from 'path'
 import { fileURLToPath } from 'url'
 
+import { getTestSuiteDir } from '../__helpers/shared/getTestSuiteDir.js'
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
 import { AdminThumbnailFunction } from './collections/AdminThumbnailFunction/index.js'
 import { AdminThumbnailSize } from './collections/AdminThumbnailSize/index.js'
@@ -61,9 +62,7 @@ import {
 } from './shared.js'
 
 const filename = fileURLToPath(import.meta.url)
-const dirname = process.env.ROOT_DIR
-  ? path.resolve(process.env.ROOT_DIR, 'uploads')
-  : path.dirname(filename)
+const dirname = getTestSuiteDir({ fallbackDir: path.dirname(filename), suitePath: 'uploads' })
 
 export default buildConfigWithDefaults({
   admin: {

--- a/test/uploads/seed.ts
+++ b/test/uploads/seed.ts
@@ -4,6 +4,7 @@ import path from 'path'
 import { getFileByPath } from 'payload'
 import { fileURLToPath } from 'url'
 
+import { getTestSuiteDir } from '../__helpers/shared/getTestSuiteDir.js'
 import { devUser } from '../credentials.js'
 import { AdminThumbnailSize } from './collections/AdminThumbnailSize/index.js'
 import {
@@ -22,7 +23,7 @@ import {
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
-const seedDir = process.env.ROOT_DIR ? path.resolve(process.env.ROOT_DIR, 'uploads') : dirname
+const seedDir = getTestSuiteDir({ fallbackDir: dirname, suitePath: 'uploads' })
 
 export const seed = async (payload: Payload) => {
   await payload.create({

--- a/test/versions/seed.ts
+++ b/test/versions/seed.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'url'
 import type { DraftPost } from './payload-types.js'
 
 import { executePromises } from '../__helpers/shared/executePromises.js'
+import { getTestSuiteDir } from '../__helpers/shared/getTestSuiteDir.js'
 import { devUser } from '../credentials.js'
 import { generateLexicalData } from './collections/Diff/generateLexicalData.js'
 import {
@@ -18,10 +19,7 @@ import {
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
-const seedDir =
-  process.env.PAYLOAD_FRAMEWORK === 'tanstack-start' && process.env.ROOT_DIR
-    ? path.resolve(process.env.ROOT_DIR, 'versions')
-    : dirname
+const seedDir = getTestSuiteDir({ fallbackDir: dirname, suitePath: 'versions' })
 
 export async function seed(_payload: Payload, parallel: boolean = false) {
   const blocksField: DraftPost['blocksField'] = [


### PR DESCRIPTION
### Summary

Several test suites could not start with `pnpm run dev <suite>` after #17542. The suites read their fixture files from `ROOT_DIR`, but that variable does not identify the suite directory. This PR resolves fixture paths from the suite files themselves and keeps the TanStack Start behavior that #17542 added.

### Why

`ROOT_DIR` tells the import map generator which app directory Next.js serves. For a Next dev run that directory is the monorepo root, so `path.resolve(ROOT_DIR, 'fields')` produced `<repo>/fields` instead of `<repo>/test/fields`. Payload then failed during `onInit`:

```
Error: ENOENT: no such file or directory, stat '<repo>/fields/collections/Upload/payload.jpg'
    at async getFileByPath (packages/payload/src/uploads/getFileByPath.ts:19)
    at async seed (test/fields/seed.ts:69)
```

CI stayed green because e2e runs use `--prod-server`, which points `ROOT_DIR` at `test/`, and integration tests run without `ROOT_DIR` at all. Only the Next dev server exposes the wrong value.

### How

- Add `getTestSuiteDir`, which returns a path under `ROOT_DIR` only for TanStack Start runs, where suite files are bundled and `import.meta.url` no longer points at the source folder. Every other run resolves from the caller's own directory.
- Apply the helper to `fields`, `uploads`, `lexical`, and `joins`, which were broken.
- Apply the helper to `versions` and `live-preview` as well. Those suites already had the correct condition inline, so the change removes duplication and gives one place to reason about the rule.

### Validation

- `pnpm run dev fields` starts and seeds. The uploads endpoint returns the seeded documents.
- New unit-style test covers the three cases: TanStack Start with `ROOT_DIR`, a Next run with `ROOT_DIR` set to the monorepo root, and no `ROOT_DIR`.
- `test/uploads/int.spec.ts` and `test/joins/int.spec.ts` pass: 184 passed, 1 skipped.

### Related work

Follow-up to #17542.