### PR TITLE
fix: tests erroring on initial seed

### DIFF
--- a/test/fields/seed.ts
+++ b/test/fields/seed.ts
@@ -3,6 +3,7 @@ import type { Payload } from 'payload'
 import { buildEditorState } from '@payloadcms/richtext-lexical'
 import path from 'path'
 import { getFileByPath } from 'payload'
+import { fileURLToPath } from 'url'
 
 import { seedDB } from '../__helpers/shared/clearAndSeed/seed.js'
 import { devUser } from '../credentials.js'
@@ -56,8 +57,13 @@ import {
   usersSlug,
 } from './slugs.js'
 
+const filename = fileURLToPath(import.meta.url)
+const dirname = path.dirname(filename)
+
 const getFieldsDir = () =>
-  path.resolve(process.env.ROOT_DIR ?? path.resolve(process.cwd(), 'test'), 'fields')
+  process.env.PAYLOAD_FRAMEWORK === 'tanstack-start' && process.env.ROOT_DIR
+    ? path.resolve(process.env.ROOT_DIR, 'fields')
+    : dirname
 
 export const seed = async (_payload: Payload) => {
   const fieldsDir = getFieldsDir()

--- a/test/joins/seed.ts
+++ b/test/joins/seed.ts
@@ -2,6 +2,7 @@ import type { Payload } from 'payload'
 
 import path from 'path'
 import { getFileByPath } from 'payload'
+import { fileURLToPath } from 'url'
 
 import { devUser } from '../credentials.js'
 import {
@@ -12,6 +13,9 @@ import {
   postsSlug,
   uploadsSlug,
 } from './shared.js'
+
+const filename = fileURLToPath(import.meta.url)
+const dirname = path.dirname(filename)
 
 export const seed = async (_payload: Payload) => {
   await _payload.create({
@@ -102,10 +106,11 @@ export const seed = async (_payload: Payload) => {
   })
 
   // create an upload with image.png
-  const imageFilePath = path.resolve(
-    process.env.ROOT_DIR ?? path.resolve(process.cwd(), 'test'),
-    'joins/image.png',
-  )
+  const joinsDir =
+    process.env.PAYLOAD_FRAMEWORK === 'tanstack-start' && process.env.ROOT_DIR
+      ? path.resolve(process.env.ROOT_DIR, 'joins')
+      : dirname
+  const imageFilePath = path.resolve(joinsDir, 'image.png')
   const imageFile = await getFileByPath(imageFilePath)
   const { id: uploadedImage } = await _payload.create({
     collection: uploadsSlug,

--- a/test/lexical/collections/Upload/index.ts
+++ b/test/lexical/collections/Upload/index.ts
@@ -5,9 +5,10 @@ import { fileURLToPath } from 'url'
 
 import { uploads2Slug, uploadsSlug } from '../../slugs.js'
 const filename = fileURLToPath(import.meta.url)
-const dirname = process.env.ROOT_DIR
-  ? path.resolve(process.env.ROOT_DIR, 'lexical/collections/Upload')
-  : path.dirname(filename)
+const dirname =
+  process.env.PAYLOAD_FRAMEWORK === 'tanstack-start' && process.env.ROOT_DIR
+    ? path.resolve(process.env.ROOT_DIR, 'lexical/collections/Upload')
+    : path.dirname(filename)
 
 export const Uploads: CollectionConfig = {
   slug: uploadsSlug,

--- a/test/lexical/seed.ts
+++ b/test/lexical/seed.ts
@@ -97,7 +97,10 @@ import { uploadsDoc } from './collections/Upload/shared.js'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
-const lexicalDir = process.env.ROOT_DIR ? path.resolve(process.env.ROOT_DIR, 'lexical') : dirname
+const lexicalDir =
+  process.env.PAYLOAD_FRAMEWORK === 'tanstack-start' && process.env.ROOT_DIR
+    ? path.resolve(process.env.ROOT_DIR, 'lexical')
+    : dirname
 
 export const seed = async (_payload: Payload) => {
   // Create the admin user first so auto-login still works if a later seed step

--- a/test/uploads/config.ts
+++ b/test/uploads/config.ts
@@ -61,9 +61,10 @@ import {
 } from './shared.js'
 
 const filename = fileURLToPath(import.meta.url)
-const dirname = process.env.ROOT_DIR
-  ? path.resolve(process.env.ROOT_DIR, 'uploads')
-  : path.dirname(filename)
+const dirname =
+  process.env.PAYLOAD_FRAMEWORK === 'tanstack-start' && process.env.ROOT_DIR
+    ? path.resolve(process.env.ROOT_DIR, 'uploads')
+    : path.dirname(filename)
 
 export default buildConfigWithDefaults({
   admin: {

--- a/test/uploads/seed.ts
+++ b/test/uploads/seed.ts
@@ -22,7 +22,10 @@ import {
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
-const seedDir = process.env.ROOT_DIR ? path.resolve(process.env.ROOT_DIR, 'uploads') : dirname
+const seedDir =
+  process.env.PAYLOAD_FRAMEWORK === 'tanstack-start' && process.env.ROOT_DIR
+    ? path.resolve(process.env.ROOT_DIR, 'uploads')
+    : dirname
 
 export const seed = async (payload: Payload) => {
   await payload.create({


### PR DESCRIPTION
## Summary

`pnpm run dev` fails to start for the `fields`, `uploads`, `lexical`, and `joins` test suites. Seeding throws `ENOENT` because it looks for fixture files (`payload.jpg`, `image.png`, and others) at the monorepo root instead of inside `test/`.

## Why

A prior change added a `ROOT_DIR` environment variable so TanStack Start dev runs can locate fixtures outside the standard Next.js test directory. Some seed and config files applied this override for every framework, not only TanStack Start. Since `ROOT_DIR` always points at the monorepo root during a plain Next.js run, these files built fixture paths like `<repo-root>/fields/...` instead of `<repo-root>/test/fields/...`.

## How

- Restrict the `ROOT_DIR`-based path in each affected file to `PAYLOAD_FRAMEWORK === 'tanstack-start'`, matching the guard already used in `test/versions/seed.ts` and `test/live-preview/seed/index.ts`.
- Fall back to the file's own directory (derived from `import.meta.url`) for every other framework, including the default Next.js dev server.
- Apply the same guard to `test/fields/seed.ts`, `test/uploads/seed.ts`, `test/uploads/config.ts`, `test/lexical/seed.ts`, `test/lexical/collections/Upload/index.ts`, and `test/joins/seed.ts`.
