### PR TITLE
fix(drizzle): return point field value on optimized update by ID

### DIFF
--- a/packages/drizzle/src/upsertRow/index.ts
+++ b/packages/drizzle/src/upsertRow/index.ts
@@ -150,6 +150,17 @@ export const upsertRow = async <T extends Record<string, unknown> | TypeWithID>(
           }
         }
 
+        // Fields such as `point` are resolved via raw SQL expressions (e.g. ST_AsGeoJSON)
+        // rather than plain columns, and are tracked in `findManyArgs.extras`. Without
+        // merging them in here, `.returning()` would either omit them or fall back to
+        // returning every column (including the raw, unconverted value) once selectedFields
+        // is non-empty but missing these keys.
+        if (findManyArgs.extras) {
+          for (const [name, extra] of Object.entries(findManyArgs.extras)) {
+            selectedFields[name] = extra
+          }
+        }
+
         const docs = await drizzle
           .update(adapter.tables[tableName])
           .set(row)

--- a/test/fields/int.spec.ts
+++ b/test/fields/int.spec.ts
@@ -1611,6 +1611,35 @@ describe('Fields', () => {
       expect(doc.group).toMatchObject(group)
     })
 
+    it('should return point field on update by id', async () => {
+      if (payload.db.name === 'sqlite') {
+        return
+      }
+
+      const created = await payload.create({
+        collection: 'point-fields',
+        data: {
+          group,
+          localized,
+          point,
+        },
+      })
+
+      // Update an unrelated field and ensure the point field is still
+      // present in the response - https://github.com/payloadcms/payload/issues/17461
+      const updated = await payload.update({
+        id: created.id,
+        collection: 'point-fields',
+        data: {
+          group,
+        },
+      })
+
+      expect(updated.point).toEqual(point)
+      expect(updated.localized).toEqual(localized)
+      expect(updated.group).toMatchObject(group)
+    })
+
     it('should not create duplicate point when unique', async () => {
       if (payload.db.name === 'sqlite') {
         return


### PR DESCRIPTION
### What?

`point` field values are missing from the response when updating a document by ID via the optimized single-row update path in `@payloadcms/drizzle`.

### Why?

Fixes #17461

`upsertRow`'s "no joins needed" optimization builds the `.returning()` selection only from `findManyArgs.columns`, ignoring `findManyArgs.extras`. The `point` field type is resolved through a raw SQL extra (`ST_AsGeoJSON(...)::jsonb`) rather than a plain column (its raw column is explicitly disabled via `columns[name] = false`, since Drizzle handles PostGIS geometry columns poorly - drizzle-team/drizzle-orm#2526). Because the extra was dropped, `selectedFields` ended up empty for collections whose only "column" entry was the disabled point column, so `.returning(undefined)` fell back to Drizzle's default full-row return - which returns the raw, unconverted geometry value instead of GeoJSON, and gets silently discarded during transform.

### How?

Merge `findManyArgs.extras` into `selectedFields` alongside the existing `findManyArgs.columns` merge, mirroring how the non-optimized path already includes `extras` when re-fetching via `db.query[tableName].findFirst(findManyArgs)`.

Scope: `packages/drizzle` (used by the postgres/sqlite adapters). SQLite point fields already skip this codepath (`if (adapter.name === 'sqlite') break`), so this only affects the postgres/postgis-backed adapters, matching the issue's `db: postgres` label.

Added an int test (`test/fields/int.spec.ts`) that creates a doc with a point field, updates an unrelated field, and asserts the point field is present and correct in the update response.

**Test status:** I traced the root cause through the code (confirmed the exact mechanism, matching the fix suggested in the issue itself) and added a regression test, but could not execute `pnpm test:int:postgres` in this environment - Docker/Postgres was not available locally, so I'm flagging this honestly rather than claiming a run that didn't happen.
