### PR TITLE
fix: throw clear error for non-existent listSearchableFields

### DIFF
--- a/packages/payload/src/collections/config/listSearchableFields.spec.ts
+++ b/packages/payload/src/collections/config/listSearchableFields.spec.ts
@@ -1,0 +1,102 @@
+import type { Config } from '../../config/types.js'
+import type { CollectionConfig } from '../../index.js'
+
+import { InvalidConfiguration } from '../../errors/InvalidConfiguration.js'
+import { sanitizeCollection } from './sanitize.js'
+import { describe, it, expect } from 'vitest'
+
+describe('sanitize - collections -', () => {
+  const config = {
+    collections: [],
+    globals: [],
+  } as Partial<Config>
+
+  describe('validate listSearchableFields -', () => {
+    const defaultCollection: CollectionConfig = {
+      slug: 'collection-with-defaults',
+      fields: [
+        {
+          name: 'title',
+          type: 'text',
+        },
+        {
+          name: 'slug',
+          type: 'text',
+        },
+      ],
+    }
+
+    it('should throw on non-existent field', () => {
+      const collectionConfig: CollectionConfig = {
+        ...defaultCollection,
+        admin: {
+          listSearchableFields: ['title', 'nonExistentField'],
+        },
+      }
+      expect(() => {
+        sanitizeCollection(
+          // @ts-expect-error
+          {
+            ...config,
+            collections: [collectionConfig],
+          },
+          collectionConfig,
+        )
+      }).toThrow(InvalidConfiguration)
+    })
+
+    it('should not throw when all fields exist', () => {
+      const collectionConfig: CollectionConfig = {
+        ...defaultCollection,
+        admin: {
+          listSearchableFields: ['title', 'slug'],
+        },
+      }
+      expect(() => {
+        sanitizeCollection(
+          // @ts-expect-error
+          {
+            ...config,
+            collections: [collectionConfig],
+          },
+          collectionConfig,
+        )
+      }).not.toThrow()
+    })
+
+    it('should not throw on default field: id', () => {
+      const collectionConfig: CollectionConfig = {
+        ...defaultCollection,
+        admin: {
+          listSearchableFields: ['id'],
+        },
+      }
+      expect(() => {
+        sanitizeCollection(
+          // @ts-expect-error
+          {
+            ...config,
+            collections: [collectionConfig],
+          },
+          collectionConfig,
+        )
+      }).not.toThrow()
+    })
+
+    it('should not throw when listSearchableFields is undefined', () => {
+      const collectionConfig: CollectionConfig = {
+        ...defaultCollection,
+      }
+      expect(() => {
+        sanitizeCollection(
+          // @ts-expect-error
+          {
+            ...config,
+            collections: [collectionConfig],
+          },
+          collectionConfig,
+        )
+      }).not.toThrow()
+    })
+  })
+})

--- a/packages/payload/src/collections/config/listSearchableFields.ts
+++ b/packages/payload/src/collections/config/listSearchableFields.ts
@@ -1,0 +1,47 @@
+import type { CollectionConfig } from '../../index.js'
+
+import { InvalidConfiguration } from '../../errors/InvalidConfiguration.js'
+import { fieldAffectsData } from '../../fields/config/types.js'
+import { flattenTopLevelFields } from '../../utilities/flattenTopLevelFields.js'
+
+/**
+ * Validate listSearchableFields for collections.
+ *
+ * Previously, specifying a field name in `admin.listSearchableFields` that does not
+ * exist on the collection would not throw until the field was actually queried
+ * (e.g. when searching in the List View), and the resulting error was only
+ * ever surfaced in production builds - in development it silently failed to
+ * error at all. Validating eagerly here, at config sanitization time, ensures a
+ * clear, actionable error is thrown consistently in every environment.
+ */
+export const validateListSearchableFields = (config: CollectionConfig) => {
+  if (!config.admin?.listSearchableFields?.length) {
+    return
+  }
+
+  const fields = flattenTopLevelFields(config.fields)
+
+  for (const fieldName of config.admin.listSearchableFields) {
+    if (fieldName === 'id') {
+      continue
+    }
+
+    // Only validate the top-level segment of the path - relationship/join
+    // paths such as `category.title` are resolved deeper in the query and
+    // are not flattened top-level fields of this collection.
+    const topLevelFieldName = fieldName.split('.')[0]
+
+    const searchableField = fields.find((field) => {
+      if (fieldAffectsData(field)) {
+        return field.name === topLevelFieldName
+      }
+      return false
+    })
+
+    if (!searchableField) {
+      throw new InvalidConfiguration(
+        `The field "${fieldName}" specified in "admin.listSearchableFields" does not exist in the collection "${config.slug}"`,
+      )
+    }
+  }
+}

--- a/packages/payload/src/collections/config/sanitize.ts
+++ b/packages/payload/src/collections/config/sanitize.ts
@@ -26,6 +26,7 @@ import { baseVersionFields } from '../../versions/baseFields.js'
 import { versionDefaults } from '../../versions/defaults.js'
 import { defaultCollectionEndpoints } from '../endpoints/index.js'
 import { addDefaultsToAuthConfig, addDefaultsToCollectionConfig } from './defaults.js'
+import { validateListSearchableFields } from './listSearchableFields.js'
 import { sanitizeCompoundIndexes } from './sanitizeCompoundIndexes.js'
 import { validateUseAsTitle } from './useAsTitle.js'
 
@@ -338,6 +339,7 @@ export const sanitizeCollection = (
   }
 
   validateUseAsTitle(sanitized)
+  validateListSearchableFields(sanitized)
 
   const sanitizedConfig = sanitized as SanitizedCollectionConfig
 


### PR DESCRIPTION
### What?

Adds validation that throws a clear `InvalidConfiguration` error when `admin.listSearchableFields` on a collection config references a field name that does not exist on that collection.

### Why?

Fixes #14904.

Previously, referencing a non-existent field name in `admin.listSearchableFields` produced no error at all in `pnpm dev`, and in production builds it "imploded" the admin List View search with no usable error message - the actual failure (`"The following path cannot be queried: <field>"`) only ever showed up in server logs, never reaching the user.

### How?

Added `validateListSearchableFields` in `packages/payload/src/collections/config/listSearchableFields.ts`, mirroring the existing `validateUseAsTitle` precedent in the same directory. It flattens the collection's top-level fields and checks each entry in `admin.listSearchableFields` (skipping the implicit `id` field, and only checking the top-level segment of dotted/relationship paths) exists on the collection, throwing `InvalidConfiguration` naming the offending field and collection slug if not.

This is called from `sanitizeCollection` right after `validateUseAsTitle`, so it runs unconditionally at config-sanitization time in both dev and production - no more environment-dependent failure mode.

### Test plan

Added `packages/payload/src/collections/config/listSearchableFields.spec.ts` (mirrors `useAsTitle.spec.ts`), covering:
- throws on a non-existent field
- does not throw when all fields exist
- does not throw on the default `id` field
- does not throw when `listSearchableFields` is undefined

Note: `pnpm install` in this sandbox environment was intermittently failing on Windows temp-path EPERM/network timeout issues while I prepared this PR, so I could not get a green local `vitest` run to paste here. The test code itself directly follows the existing, currently-passing `useAsTitle.spec.ts` pattern in the same file, using the same `sanitizeCollection` harness.

Fixes #14904