### PR TITLE
fix(ui): group field not forwarding forceRender to nested fields

### DIFF
--- a/packages/ui/src/fields/Group/index.tsx
+++ b/packages/ui/src/fields/Group/index.tsx
@@ -29,6 +29,7 @@ export const GroupFieldComponent: GroupFieldClientComponent = (props) => {
   const {
     field,
     field: { admin: { className, description, hideGutter } = {}, fields, label },
+    forceRender,
     indexPath,
     parentPath,
     parentSchemaPath,
@@ -111,6 +112,7 @@ export const GroupFieldComponent: GroupFieldClientComponent = (props) => {
           {groupHasName(field) ? (
             <RenderFields
               fields={fields}
+              forceRender={forceRender}
               parentIndexPath=""
               parentPath={path}
               parentSchemaPath={schemaPath}
@@ -120,6 +122,7 @@ export const GroupFieldComponent: GroupFieldClientComponent = (props) => {
           ) : (
             <RenderFields
               fields={fields}
+              forceRender={forceRender}
               parentIndexPath={indexPath}
               parentPath={parentPath}
               parentSchemaPath={parentSchemaPath}

--- a/test/fields/collections/Array/e2e.spec.ts
+++ b/test/fields/collections/Array/e2e.spec.ts
@@ -465,6 +465,32 @@ describe('Array', () => {
     await expect(page.locator(`#field-collapsedArray__0__text`)).toBeVisible()
   })
 
+  test(
+    'should render conditional fields inside a single group when an initially-collapsed array row is expanded for the first time',
+    async () => {
+      await page.goto(url.create)
+
+      const row = page.locator('#collapsedGroupWithCondition-row-0')
+      await expect(row).toBeVisible()
+
+      const toggler = row.locator('button.collapsible__toggle')
+      await expect(toggler).toHaveClass(/collapsible__toggle--collapsed/)
+
+      await toggleBlockOrArrayRow({
+        fieldName: 'collapsedGroupWithCondition',
+        page,
+        rowIndex: 0,
+        targetState: 'open',
+      })
+
+      // The conditional text field, nested inside the array row's single group field,
+      // must render immediately on the first expand rather than only after a second toggle
+      await expect(
+        page.locator('#field-collapsedGroupWithCondition__0__group__text'),
+      ).toBeVisible()
+    },
+  )
+
   describe('sortable arrays', () => {
     test('should have disabled admin sorting', async () => {
       await loadCreatePage()

--- a/test/fields/collections/Array/index.ts
+++ b/test/fields/collections/Array/index.ts
@@ -98,6 +98,41 @@ const ArrayFields: CollectionConfig = {
       type: 'array',
     },
     {
+      name: 'collapsedGroupWithCondition',
+      admin: {
+        initCollapsed: true,
+      },
+      defaultValue: [
+        {
+          group: {
+            text: 'conditional text',
+            toggle: true,
+          },
+        },
+      ],
+      fields: [
+        {
+          name: 'group',
+          fields: [
+            {
+              name: 'toggle',
+              defaultValue: true,
+              type: 'checkbox',
+            },
+            {
+              name: 'text',
+              admin: {
+                condition: (_, siblingData) => Boolean(siblingData?.toggle),
+              },
+              type: 'text',
+            },
+          ],
+          type: 'group',
+        },
+      ],
+      type: 'array',
+    },
+    {
       name: 'localized',
       defaultValue: arrayDefaultValue,
       fields: [


### PR DESCRIPTION
## Which branch should this PR target?

`main` (v4 development) — the bug reproduces on the current `main` UI code as well as v3.

### What?

The `Group` field component never forwarded its `forceRender` prop down to the `RenderFields` calls it renders internally for its own sub-fields. Sibling iterable field types (`Row`, `Tabs`) already correctly forward `forceRender`.

### Why?

Fixes #15613 — "Array with a single group containing conditional fields does not render on first collapsible expand".

Top-level document fields are always rendered with `forceRender` (see `DocumentFields`), which flows down through `Array` → `ArrayRow` → the row's own fields. When an array row contains a single `Group` field, that `forceRender` reached the `Group` component but was silently dropped instead of being passed to the `RenderFields` call for the group's own child fields.

Without `forceRender`, those child fields fall back to lazy, `IntersectionObserver`-gated rendering (`RenderIfInViewport`). While an array row is collapsed, its content lives inside an ancestor with `display: none` (set by `AnimateHeight`), so the observer never reports an intersection. On first expand, `AnimateHeight`'s height-animation helper (`usePatchAnimateHeight`) measures `content.scrollHeight` in the same effect flush in which the sibling `display: none` removal hasn't committed to the DOM yet, so it measures `0` and pins the row's container height to `0px`. That keeps the (still not-yet-mounted) conditional fields clipped and unable to ever report an intersection, so they never mount — appearing "empty". Collapsing and expanding again works because, on the previous cycle, the fields (once mounted) stay mounted, so the height measurement is now accurate.

Forwarding `forceRender` through `Group` (matching `Row`/`Tabs`) makes the group's child fields mount immediately alongside the rest of the row's force-rendered content, avoiding the race entirely.

### How?

- `packages/ui/src/fields/Group/index.tsx`: destructure `forceRender` from props and pass it to both `RenderFields` calls (named-group and unnamed-group paths).
- Added a regression test field `collapsedGroupWithCondition` to the Array fields test collection: an `initCollapsed` array with a default row containing a single `group` field with a conditional (`admin.condition`) text field.
- Added an e2e test in `test/fields/collections/Array/e2e.spec.ts` that loads the create page, confirms the row starts collapsed, expands it once, and asserts the conditional field is visible on that very first expand.

### Test status

I was unable to run the test suite in my environment (no disk space available to `pnpm install` the monorepo's dependencies — the working environment had under 3GB free). I've verified the fix by tracing the actual render/measurement code paths (`Group`, `Row`, `Tabs`, `RenderFields`, `RenderIfInViewport`, `useIntersect`, `AnimateHeight`, `usePatchAnimateHeight`) and confirmed `Group` was the only iterable field type not forwarding `forceRender`, which is a clear, minimal, and type-safe fix (`forceRender` is already part of `GroupFieldClientProps` via `ClientFieldBase`). I was not able to execute `pnpm test:e2e` locally to confirm the new test passes — please run it in CI.

Fixes #15613