### PR TITLE
fix(ui): strip lastRenderedPath from copied form state so pasted rows re-render

### DIFF
--- a/packages/ui/src/elements/ClipboardAction/mergeFormStateFromClipboard.spec.ts
+++ b/packages/ui/src/elements/ClipboardAction/mergeFormStateFromClipboard.spec.ts
@@ -3,7 +3,7 @@ import type { FormState } from 'payload'
 import ObjectIdImport from 'bson-objectid'
 import { describe, expect, it } from 'vitest'
 
-import { mergeFormStateFromClipboard } from './mergeFormStateFromClipboard.js'
+import { mergeFormStateFromClipboard, reduceFormStateByPath } from './mergeFormStateFromClipboard.js'
 import type { ClipboardPasteData } from './types.js'
 
 const ObjectId = (
@@ -548,5 +548,82 @@ describe('mergeFormStateFromClipboard', () => {
       // Check that other fields were preserved
       expect(result['disableSort.0.text'].value).toEqual('row one')
     })
+  })
+})
+
+describe('reduceFormStateByPath', () => {
+  it('should strip lastRenderedPath from fields and rows so pasted content re-renders', () => {
+    const formState: FormState = {
+      layout: {
+        valid: true,
+        value: 1,
+        initialValue: 1,
+        rows: [
+          {
+            id: 'row-1',
+            blockType: 'content',
+            isLoading: false,
+            lastRenderedPath: 'layout.0',
+          },
+        ],
+      },
+      'layout.0.id': {
+        value: 'row-1',
+        valid: true,
+      },
+      'layout.0.richText': {
+        value: 'test content',
+        valid: true,
+        lastRenderedPath: 'layout.0.richText',
+      },
+    }
+
+    const result = reduceFormStateByPath({
+      formState,
+      path: 'layout',
+    })
+
+    // lastRenderedPath must not survive the copy, otherwise pasting back onto the
+    // same path makes the server skip re-rendering and the block body renders blank
+    expect(result.layout.rows![0].lastRenderedPath).toBeUndefined()
+    expect(result['layout.0.richText'].lastRenderedPath).toBeUndefined()
+
+    // The rest of the state is preserved
+    expect(result.layout.rows![0].id).toEqual('row-1')
+    expect(result.layout.rows![0].blockType).toEqual('content')
+    expect(result['layout.0.richText'].value).toEqual('test content')
+    expect(result['layout.0.id'].value).toEqual('row-1')
+  })
+
+  it('should strip lastRenderedPath when copying a single row', () => {
+    const formState: FormState = {
+      'layout.0.nested': {
+        valid: true,
+        value: 1,
+        rows: [
+          {
+            id: 'nested-row-1',
+            isLoading: false,
+            lastRenderedPath: 'layout.0.nested.0',
+          },
+        ],
+      },
+      'layout.0.richText': {
+        value: 'row content',
+        valid: true,
+        lastRenderedPath: 'layout.0.richText',
+      },
+    }
+
+    const result = reduceFormStateByPath({
+      formState,
+      path: 'layout',
+      rowIndex: 0,
+    })
+
+    expect(result['layout.0.richText'].lastRenderedPath).toBeUndefined()
+    expect(result['layout.0.nested'].rows![0].lastRenderedPath).toBeUndefined()
+    expect(result['layout.0.richText'].value).toEqual('row content')
+    expect(result['layout.0.nested'].rows![0].id).toEqual('nested-row-1')
   })
 })

--- a/packages/ui/src/elements/ClipboardAction/mergeFormStateFromClipboard.ts
+++ b/packages/ui/src/elements/ClipboardAction/mergeFormStateFromClipboard.ts
@@ -25,14 +25,14 @@ export function reduceFormStateByPath({
       continue
     }
 
-    const { customComponents: _, validate: __, ...field } = formState[key]
+    const { customComponents: _, lastRenderedPath: __, validate: ___, ...field } = formState[key]
 
     if (Array.isArray(field.rows)) {
       field.rows = field.rows.map((row) => {
         if (!row || typeof row !== 'object') {
           return row
         }
-        const { customComponents: _, ...serializableRow } = row
+        const { customComponents: _, lastRenderedPath: __, ...serializableRow } = row
         return serializableRow
       })
     }


### PR DESCRIPTION
Fixes #17375

When you copy a blocks row and paste it onto the same field path and row index, the block body goes blank until a full page refresh. The data is intact, it's purely a render bug.

@DarioSiroki traced the root cause in the issue and this PR follows his suggested fix, so full credit for the diagnosis goes to him. In short: `reduceFormStateByPath` strips `customComponents` from the copied form state because it isn't serializable, but it keeps `lastRenderedPath`. On paste the server checks `lastRenderedPath !== path` to decide whether a field needs rendering, and since the pasted entries carry the stale value from the clipboard, a same path paste looks already rendered and never gets its components back. The client falls back to `return null`, so the whole block body disappears.

The fix strips `lastRenderedPath` at copy time, both at field level and on row entries, right next to the existing `customComponents` stripping. Pasted content then renders again on the next form state round trip. As Dario notes in the issue, the trade off is that array pastes get one redundant server render even though their `customComponents` survive the merge.

Added two unit tests in `mergeFormStateFromClipboard.spec.ts` covering field level and row level stripping.
