### PR TITLE
style(editorconfig): define root property in root .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,5 @@
+root = true
+
 [*]
 end_of_line = lf
 charset = utf-8


### PR DESCRIPTION
## Description
Adds `root = true` to `.editorconfig` to prevent IDEs from searching parent directories for configuration rules.