### PR TITLE
fix(gitignore): ignore temporary build artifacts and coverage profiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -375,3 +375,6 @@ test/payload.db
 test/evals/eval-results/report.html
 # Versioned eval run snapshots (local only — used for run comparison in dashboard)
 test/evals/eval-results/runs/
+*.tmp
+.nx/
+profile.cov


### PR DESCRIPTION
## Description
Adds `*.tmp`, `.nx/`, and `profile.cov` to `.gitignore` to prevent tracking temporary files and coverage output.