### PR TITLE
chore(templates): remove .npmrc and .yarnrc to resolve Docker build failures

### DIFF
--- a/templates/_template/.yarnrc
+++ b/templates/_template/.yarnrc
@@ -1,1 +1,0 @@
---install.ignore-engines true

--- a/templates/blank-tanstack/.npmrc
+++ b/templates/blank-tanstack/.npmrc
@@ -1,1 +1,0 @@
-legacy-peer-deps=true

--- a/templates/blank-tanstack/.yarnrc
+++ b/templates/blank-tanstack/.yarnrc
@@ -1,1 +1,0 @@
---install.ignore-engines true

--- a/templates/blank/.npmrc
+++ b/templates/blank/.npmrc
@@ -1,1 +1,0 @@
-legacy-peer-deps=true

--- a/templates/blank/.yarnrc
+++ b/templates/blank/.yarnrc
@@ -1,1 +1,0 @@
---install.ignore-engines true

--- a/templates/ecommerce/.npmrc
+++ b/templates/ecommerce/.npmrc
@@ -1,2 +1,0 @@
-legacy-peer-deps=true
-enable-pre-post-scripts=true

--- a/templates/website/.npmrc
+++ b/templates/website/.npmrc
@@ -1,2 +1,0 @@
-legacy-peer-deps=true
-enable-pre-post-scripts=true

--- a/templates/with-cloudflare-d1/.npmrc
+++ b/templates/with-cloudflare-d1/.npmrc
@@ -1,1 +1,0 @@
-legacy-peer-deps=true

--- a/templates/with-cloudflare-d1/.yarnrc
+++ b/templates/with-cloudflare-d1/.yarnrc
@@ -1,1 +1,0 @@
---install.ignore-engines true

--- a/templates/with-postgres/.yarnrc
+++ b/templates/with-postgres/.yarnrc
@@ -1,1 +1,0 @@
---install.ignore-engines true

--- a/templates/with-vercel-mongodb/.yarnrc
+++ b/templates/with-vercel-mongodb/.yarnrc
@@ -1,1 +1,0 @@
---install.ignore-engines true

--- a/templates/with-vercel-postgres/.yarnrc
+++ b/templates/with-vercel-postgres/.yarnrc
@@ -1,1 +1,0 @@
---install.ignore-engines true

--- a/templates/with-vercel-website/.npmrc
+++ b/templates/with-vercel-website/.npmrc
@@ -1,2 +1,0 @@
-legacy-peer-deps=true
-enable-pre-post-scripts=true


### PR DESCRIPTION
### Description
Removes `.npmrc` and `.yarnrc` files across templates. These configurations forced `--legacy-peer-deps`, which is obsolete on modern Node/npm configurations. 

Furthermore, keeping these runcom files breaks Docker deployments because the standard `Dockerfile` doesn't (and shouldn't) execute `COPY .npmrc .` due to security risks involving accidental exposure of sensitive registry tokens. Removing them simplifies environment configuration and prevents build container crashes.

Fixes #17106 