### PR TITLE
fix(plugin-search): surface sync write errors that silently roll back the parent transaction

### DIFF
--- a/packages/plugin-search/src/utilities/syncDocAsSearchIndex.ts
+++ b/packages/plugin-search/src/utilities/syncDocAsSearchIndex.ts
@@ -19,6 +19,32 @@ export const syncDocAsSearchIndex = async ({
   // Determine sync locale
   const syncLocale = locale || req.locale || undefined
 
+  // A failed search-doc write inside the parent operation's transaction has already
+  // aborted that transaction, so the parent (e.g. a publish) will roll back. Swallowing
+  // the error would let the parent operation report success for a write that did not
+  // persist, so the editor sees a silent revert (#17699). Surface it in that case.
+  //
+  // The rethrow is scoped to callers that have not opted into handling sync errors
+  // themselves: the reindex handler passes `onSyncError` and manages its own transaction
+  // and per-collection recovery, so it stays best-effort exactly as before. It is also a
+  // no-op when there is no shared transaction to abort. Each error object is logged once,
+  // so a rethrow re-caught by an outer handler keeps its original, most specific message.
+  const loggedSyncErrors = new WeakSet<object>()
+  const handleSyncError = (err: unknown, msg: string) => {
+    if (typeof err === 'object' && err !== null) {
+      if (!loggedSyncErrors.has(err)) {
+        payload.logger.error({ err, msg })
+        loggedSyncErrors.add(err)
+      }
+    } else {
+      payload.logger.error({ err, msg })
+    }
+
+    if (req.transactionID && !onSyncError) {
+      throw err
+    }
+  }
+
   if (typeof pluginConfig.skipSync === 'function') {
     try {
       const skipSync = await pluginConfig.skipSync({
@@ -158,10 +184,7 @@ export const syncDocAsSearchIndex = async ({
               where: { id: { in: duplicativeDocIDs } },
             })
           } catch (err: unknown) {
-            payload.logger.error({
-              err,
-              msg: `Error deleting duplicative ${searchSlug} documents.`,
-            })
+            handleSyncError(err, `Error deleting duplicative ${searchSlug} documents.`)
           }
         }
 
@@ -180,10 +203,7 @@ export const syncDocAsSearchIndex = async ({
                 req,
               })
             } catch (err: unknown) {
-              payload.logger.error({
-                err,
-                msg: `Error deleting ${searchSlug} document for trashed doc.`,
-              })
+              handleSyncError(err, `Error deleting ${searchSlug} document for trashed doc.`)
             }
           } else {
             if (doSync) {
@@ -201,7 +221,7 @@ export const syncDocAsSearchIndex = async ({
                   req,
                 })
               } catch (err: unknown) {
-                payload.logger.error({ err, msg: `Error updating ${searchSlug} document.` })
+                handleSyncError(err, `Error updating ${searchSlug} document.`)
               }
             }
 
@@ -244,7 +264,7 @@ export const syncDocAsSearchIndex = async ({
                     req,
                   })
                 } catch (err: unknown) {
-                  payload.logger.error({ err, msg: `Error deleting ${searchSlug} document.` })
+                  handleSyncError(err, `Error deleting ${searchSlug} document.`)
                 }
               }
             }
@@ -262,22 +282,22 @@ export const syncDocAsSearchIndex = async ({
               req,
             })
           } catch (err: unknown) {
-            payload.logger.error({ err, msg: `Error creating ${searchSlug} document.` })
+            handleSyncError(err, `Error creating ${searchSlug} document.`)
           }
         }
       } catch (err: unknown) {
-        payload.logger.error({ err, msg: `Error finding ${searchSlug} document.` })
+        handleSyncError(err, `Error finding ${searchSlug} document.`)
       }
     }
   } catch (err: unknown) {
-    payload.logger.error({
-      err,
-      msg: `Error syncing ${searchSlug} document related to ${collection} with id: '${id}'.`,
-    })
-
     if (onSyncError) {
       onSyncError()
     }
+
+    handleSyncError(
+      err,
+      `Error syncing ${searchSlug} document related to ${collection} with id: '${id}'.`,
+    )
   }
 
   return doc

--- a/test/plugin-search-write-errors/config.ts
+++ b/test/plugin-search-write-errors/config.ts
@@ -1,0 +1,41 @@
+import { searchPlugin } from '@payloadcms/plugin-search'
+
+import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
+import { devUser } from '../credentials.js'
+
+export default buildConfigWithDefaults({
+  collections: [
+    {
+      slug: 'users',
+      auth: true,
+      fields: [],
+    },
+    {
+      slug: 'posts',
+      admin: { useAsTitle: 'title' },
+      versions: { drafts: true },
+      fields: [{ name: 'title', type: 'text', required: true }],
+    },
+  ],
+  onInit: async (payload) => {
+    await payload.create({
+      collection: 'users',
+      data: { email: devUser.email, password: devUser.password },
+    })
+  },
+  plugins: [
+    searchPlugin({
+      collections: ['posts'],
+      // beforeSync gives every search doc the same `dedupeKey`. Combined with the
+      // `unique: true` override below, the SECOND published post's search-doc write
+      // hits an E11000 duplicate-key error inside the parent publish transaction.
+      beforeSync: ({ searchDoc }) => ({ ...searchDoc, dedupeKey: 'constant' }),
+      searchOverrides: {
+        fields: ({ defaultFields }) => [
+          ...defaultFields,
+          { name: 'dedupeKey', type: 'text', unique: true },
+        ],
+      },
+    }),
+  ],
+})

--- a/test/plugin-search-write-errors/int.spec.ts
+++ b/test/plugin-search-write-errors/int.spec.ts
@@ -1,0 +1,56 @@
+import type { Payload } from 'payload'
+
+import path from 'path'
+import { fileURLToPath } from 'url'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
+
+let payload: Payload
+
+const filename = fileURLToPath(import.meta.url)
+const dirname = path.dirname(filename)
+
+describe('@payloadcms/plugin-search — search-doc write errors', () => {
+  beforeAll(async () => {
+    ;({ payload } = await initPayloadInt(dirname))
+  })
+
+  afterAll(async () => {
+    if (typeof payload?.destroy === 'function') {
+      await payload.destroy()
+    }
+  })
+
+  it('surfaces a search-doc write failure instead of silently rolling back the publish', async () => {
+    // First published post: its search doc writes fine (dedupeKey = 'constant').
+    await payload.create({
+      collection: 'posts',
+      data: { title: 'first', _status: 'published' },
+    })
+
+    // Second published post: its search doc collides on the unique `dedupeKey`,
+    // raising an E11000 write error inside the shared publish transaction.
+    // plugin-search catches it and only logs it, so create() resolves without
+    // throwing while the aborted transaction rolls this post's publish back.
+    let threw = false
+    try {
+      await payload.create({
+        collection: 'posts',
+        data: { title: 'second', _status: 'published' },
+      })
+    } catch {
+      threw = true
+    }
+
+    const { totalDocs } = await payload.find({
+      collection: 'posts',
+      where: { _status: { equals: 'published' } },
+    })
+
+    // Desired behaviour: the second publish either surfaces a visible error, or
+    // it persists. On current `main` it does neither — create() resolved, but the
+    // row was rolled back, so only the first post survives (silent data loss).
+    expect(threw || totalDocs === 2).toBe(true)
+  })
+})

--- a/test/plugin-search-write-errors/tsconfig.json
+++ b/test/plugin-search-write-errors/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["./**/*.ts", "./**/*.tsx"]
+}


### PR DESCRIPTION
Fixes #17699.

## Problem

`syncDocAsSearchIndex` runs the search-doc `create`/`update`/`delete` calls with the incoming `req`, so they join the parent operation's transaction. Every write is wrapped in a `try/catch` that logs and swallows the error. Under MongoDB, a failed write inside a transaction aborts the whole transaction, so the parent operation (e.g. a publish) rolls back — but because the error was swallowed, `payload.create`/`payload.update` and the REST/GraphQL request resolve as if they succeeded. The editor sees their publish silently revert to the previously published version, with the only signal being a server log line.

## Fix

Errors from the search-doc writes are still logged, but they are now rethrown when both:

- the sync is running inside a shared transaction (`req.transactionID` is set), so a failed write has genuinely aborted the parent operation and reporting success would be wrong; and
- the caller has not opted into handling sync errors itself (`onSyncError` is not provided).

That second condition keeps the change scoped to the document-lifecycle hook path (the publish in the issue). The reindex handler passes its own `onSyncError` and manages its own transaction and per-collection recovery, so it stays best-effort exactly as before. When there is no shared transaction to abort (e.g. adapters running without one), the sync also stays best-effort and only logs.

A small `WeakSet` makes sure each error object is logged once, so an error rethrown out of an inner `catch` and re-caught by an outer one keeps its original, most specific message instead of being relabelled.

## Result

For an indexed collection with a search-doc write failure inside the parent transaction, the parent operation now fails with the error surfaced to the caller instead of resolving successfully and silently reverting. The repro in `test/plugin-search-write-errors` (a second publish that hits a unique-index conflict on the search collection) now either surfaces the error or persists, rather than doing neither.
