### PR TITLE
fix(drizzle): surface transaction commit failures instead of resolving successfully

### DIFF
--- a/packages/drizzle/src/transactions/beginTransaction.ts
+++ b/packages/drizzle/src/transactions/beginTransaction.ts
@@ -29,26 +29,30 @@ export const beginTransaction: BeginTransaction = async function beginTransactio
     // over many files and we don't want to pass the `tx` around like that,
     // so instead, we "lift" up the `resolve` and `reject` methods
     // and will call them in our respective transaction methods
-    const done = this.drizzle
-      .transaction(async (tx) => {
-        transaction = tx
-        await new Promise<void>((res, rej) => {
-          resolve = () => {
-            res()
-            return done
-          }
-          reject = () => {
-            // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
-            rej()
-            return done
-          }
-          transactionReady()
-        })
-      }, options || this.transactionOptions)
-      .catch((err) => {
-        // Connection failed before callback ran - reject instead of hanging forever
-        transactionFailed(err)
+    const transactionPromise = this.drizzle.transaction(async (tx) => {
+      transaction = tx
+      await new Promise<void>((res, rej) => {
+        resolve = () => {
+          res()
+          // return the raw transaction promise so a failed COMMIT rejects in
+          // commitTransaction instead of being absorbed by the catch below,
+          // which is a no-op once the transaction is ready
+          return transactionPromise
+        }
+        reject = () => {
+          // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
+          rej()
+          return done
+        }
+        transactionReady()
       })
+    }, options || this.transactionOptions)
+
+    // Connection failed before callback ran - reject instead of hanging forever.
+    // Also keeps rollback-path rejections handled.
+    const done = transactionPromise.catch((err) => {
+      transactionFailed(err)
+    })
 
     // Need to wait until the transaction is ready
     // before binding its `resolve` and `reject` methods below

--- a/packages/drizzle/src/transactions/commitTransaction.ts
+++ b/packages/drizzle/src/transactions/commitTransaction.ts
@@ -18,7 +18,13 @@ export const commitTransaction: CommitTransaction = async function commitTransac
 
   try {
     await session.resolve()
-  } catch (_) {
-    await session.reject()
+  } catch (error) {
+    try {
+      await session.reject()
+    } catch (_) {
+      // rollback is best effort once the commit has failed — the commit
+      // error is the one the caller must see
+    }
+    throw error
   }
 }

--- a/test/database/int.spec.ts
+++ b/test/database/int.spec.ts
@@ -15,6 +15,7 @@ import {
   migrateVersionsV1_V2,
 } from '@payloadcms/db-mongodb/migration-utils'
 import { randomUUID } from 'crypto'
+import { sql } from 'drizzle-orm'
 import * as drizzlePg from 'drizzle-orm/pg-core'
 import * as drizzleSqlite from 'drizzle-orm/sqlite-core'
 import fs from 'fs'
@@ -2336,6 +2337,52 @@ describe('database', () => {
           } finally {
             db.drizzle = originalDrizzle
           }
+        },
+      )
+
+      it(
+        'should surface commit failures to the caller instead of resolving (drizzle)',
+        { db: (adapter) => adapter.startsWith('postgres') || adapter === 'supabase' },
+        async () => {
+          const req = {
+            payload,
+            user,
+          } as unknown as PayloadRequest
+
+          await initTransaction(req)
+          const transactionID = req.transactionID as number | string
+          const session = (
+            payload.db as unknown as {
+              sessions: Record<
+                number | string,
+                { db: { execute: (query: unknown) => Promise<unknown> } }
+              >
+            }
+          ).sessions[transactionID]
+
+          const doc = await payload.create({ collection, data: { title }, req })
+
+          // A constraint checked only at COMMIT time makes the commit itself
+          // fail while the connection stays healthy. Created inside the
+          // transaction, so the failed commit also rolls the table away.
+          await session.db.execute(sql`
+            CREATE TABLE commit_failure_probe (
+              id integer PRIMARY KEY,
+              parent integer REFERENCES commit_failure_probe (id) DEFERRABLE INITIALLY DEFERRED
+            )
+          `)
+          await session.db.execute(sql`INSERT INTO commit_failure_probe (id, parent) VALUES (1, 2)`)
+
+          await expect(commitTransaction(req)).rejects.toThrow()
+          await killTransaction(req)
+
+          // The write must not be reported as persisted when the commit failed
+          await expect(() =>
+            payload.findByID({
+              id: doc.id,
+              collection,
+            }),
+          ).rejects.toThrow('Not Found')
         },
       )
 


### PR DESCRIPTION
Mirror of #17726, which targets `3.x`.

### What?

When the database fails at COMMIT time, drizzle-based adapters roll the transaction back and the Local API operation still resolves successfully, returning the full document as if persisted. This affects `db-postgres` and `db-vercel-postgres` out of the box (transactions are on by default there), and AFAIK `db-sqlite` / `db-d1-sqlite` when transactions are enabled via `transactionOptions`.

Two layers are producing this. `commitTransaction` swallows any error thrown by `session.resolve()`:

```ts
try {
  await session.resolve()
} catch (_) {
  await session.reject()
}
```

And since #16220, `session.resolve()` cannot actually reject at all: the `.catch` added there (to stop hangs when the connection fails before the callback runs) also absorbs the transaction promise's rejection after the transaction is ready (`transactionFailed` is a no-op by then) so a failed COMMIT never surfaces anywhere.

The idea behind this PR is to have `resolve()` return the raw transaction promise (keeping the #16220 `.catch` for the pre-ready connection failures it fixes, and for the rollback path), and to rethrow the commit error in `commitTransaction` after attempting the rollback. The rollback becomes best-effort so a dead connection cannot shadow the original commit failure.

Commit failures have never been observable in the SQL adapters (the swallow shipped with the original postgres support in 2023) while `db-mongodb` has always propagated them (see #5904: commit errors propagate, only `endSession()` is best-effort). This aligns the adapters.

### Why?

Hit this in production (healthcare enrollment platform, `@payloadcms/db-vercel-postgres` 3.84.1). A Stripe webhook handler called `payload.create` to record an order after a successful payment. The Postgres connection then fails at COMMIT. `payload.create` resolved successfully with a complete document (id included), the webhook was acknowledged, and the row did not exist. No rejected promise, no error, nothing on the returned document to inspect. So essentially the adapter swallowed the failure, rolled back, and handed back a complete document with an id, so every layer above concluded success: the pipeline logged the order as written, the event was marked processed, the webhook was acknowledged. The system ended up in a state our domain model says cannot exist: someone who has verifiably paid, with no record of the payment. I can't possibly find a way in application code to defend against this.

### How?

Two small changes in `packages/drizzle` (`beginTransaction.ts`, `commitTransaction.ts`) plus a regression test in `test/database/int.spec.ts` that makes the COMMIT itself fail: a `DEFERRABLE INITIALLY DEFERRED` constraint violated inside the transaction, so Postgres raises the error at COMMIT while the connection stays healthy.

Verification on `test/database` with `PAYLOAD_DATABASE=postgres`:

| Variant | Result |
| --- | --- |
| Unpatched | new test fails (`commitTransaction` resolves despite the failed COMMIT) |
| `commitTransaction` change only | still fails |
| Both changes | passes |
| Full suite with the fix | 169 passed, 0 failed, 36 skipped (other-adapter variants) |

(Verification ran on the `3.x` branch; the transactions code is identical here.)