### PR TITLE
fix(ui): degrade gracefully on a malformed block row instead of failing whole form-state

### DIFF
--- a/packages/ui/src/forms/fieldSchemasToFormState/addFieldStatePromise.ts
+++ b/packages/ui/src/forms/fieldSchemasToFormState/addFieldStatePromise.ts
@@ -460,15 +460,31 @@ export const addFieldStatePromise = async (args: AddFieldStatePromiseArgs): Prom
 
         const { promises, rowMetadata } = blocksValue.reduce(
           (acc, row, i: number) => {
-            const blockTypeToMatch: string = row.blockType
+            const blockTypeToMatch: string | undefined = row?.blockType
 
             const block =
-              req.payload.blocks[blockTypeToMatch] ??
-              (field.blocks.find(
-                (blockType) => typeof blockType !== 'string' && blockType.slug === blockTypeToMatch,
-              ) as FlattenedBlock | undefined)
+              blockTypeToMatch == null
+                ? undefined
+                : (req.payload.blocks[blockTypeToMatch] ??
+                  (field.blocks.find(
+                    (blockType) =>
+                      typeof blockType !== 'string' && blockType.slug === blockTypeToMatch,
+                  ) as FlattenedBlock | undefined))
 
             if (!block) {
+              if (blockTypeToMatch == null) {
+                // A block row with no `blockType` - e.g. an `undefined` entry rehydrated
+                // from a gap in the persisted `_order` sequence. Throwing here fails
+                // form-state for the entire document and locks editors out of it, so skip
+                // the malformed row with a warning and keep the rest of the form usable
+                // (see #17508). A genuine unknown-but-named block type still throws below.
+                req.payload.logger.warn(
+                  `Skipping malformed block row at "${schemaPath}.${i}": it has no "blockType". ` +
+                    `This usually indicates corrupt block data such as a gap in the persisted "_order" sequence.`,
+                )
+                return acc
+              }
+
               throw new Error(
                 `Block with type "${row.blockType}" was found in block data, but no block with that type is defined in the config for field with schema path ${schemaPath}.`,
               )


### PR DESCRIPTION
Addresses the read-path half of #17508.

## Problem

When a blocks array is persisted with a gap in its `_order` sequence (Postgres rows at `_order` 1 and 3, none at 2), Payload rehydrates the gap as an `undefined`/blockType-less entry. `addFieldStatePromise` then hits:

```ts
const blockTypeToMatch: string = row.blockType
const block = req.payload.blocks[blockTypeToMatch] ?? field.blocks.find(...)
if (!block) {
  throw new Error(`Block with type "${row.blockType}" was found in block data, but no block with that type is defined ...`)
}
```

`row.blockType` is `undefined`, so `!block` is true and it throws. Because form-state is built for the whole document at once, that single bad row fails the entire edit view — editors are locked out of the document until someone repairs the rows directly in the database.

## Fix

Only the read path, and deliberately narrow: when a block row has **no** `blockType` (the corrupt-data signature — an `undefined` row from an `_order` gap), skip it with a `logger.warn` and keep building the rest of the form, so the document stays editable and the editor can fix it with a normal save. A row whose `blockType` **is** a real string that simply isn't in the config still throws exactly as before, so genuine config mistakes (a removed block type) keep surfacing loudly.

`row?.blockType` also guards the case where the entry rehydrates as a fully `undefined` element rather than an empty object.

This does not touch the write path (problem 1 in the issue — the adapter persisting a gapped `_order`); it's the smaller, safer change that immediately unblocks affected documents.

## Reproduction

Per the issue: create a doc with 3 blocks in a `layout` blocks field on `@payloadcms/db-postgres`, then delete the middle block row in the DB (leaving `_order` 1 and 3, and the same in the `_v_blocks_*` version tables). Before: the edit view fails to load with the `Block with type "undefined" ...` error. After: the malformed row is skipped with a warning and the document opens normally.
