### PR TITLE
fix(richtext-lexical): fix korean label for horizontal rule

### DIFF
--- a/packages/richtext-lexical/src/features/horizontalRule/server/i18n.ts
+++ b/packages/richtext-lexical/src/features/horizontalRule/server/i18n.ts
@@ -53,7 +53,7 @@ export const i18n: Partial<GenericLanguages> = {
     label: '水平線',
   },
   ko: {
-    label: '수평 규칙',
+    label: '수평선',
   },
   my: {
     label: 'Peraturan Mendatar',


### PR DESCRIPTION
### What?

Fix the Korean translation of `Horizontal Rule` in `@payloadcms/richtext-lexical`.

### Why?

The Korean localization in [i18n.ts](https://github.com/payloadcms/payload/blob/main/packages/richtext-lexical/src/i18n.ts) of `@payloadcms/richtext-lexical` currently translates `Horizontal Rule` as `수평 규칙`.

While `rule` in `Horizontal Rule` is a typographic term referring to a horizontal line or divider, `규칙` in Korean is normally understood as a “rule” in the sense of a regulation or principle. As a result, `수평 규칙` is unnatural and potentially misleading in the editor UI.

Other localizations more directly describe the visual element. For example, Japanese uses `水平線` and Chinese uses `水平线`, both meaning “horizontal line.”

### How?

Change the Korean label from `수평 규칙` to `수평선`, which is a more natural Korean term for a horizontal divider.

### Fixes
 none
