### PR TITLE
fix(ui): persist nav open state and honor preference at sidebar widths

### DIFF
--- a/packages/ui/src/elements/AppHeader/index.tsx
+++ b/packages/ui/src/elements/AppHeader/index.tsx
@@ -1,4 +1,6 @@
 'use client'
+import { useWindowInfo } from '@faceless-ui/window-info'
+import { PREFERENCE_KEYS } from 'payload/shared'
 import React, { useEffect, useRef, useState } from 'react'
 
 import type { UserMenuSettingsGroup } from '../UserMenu/SettingsMenu/index.js'
@@ -11,6 +13,7 @@ import { useActions } from '../../providers/Actions/index.js'
 import { useConfig } from '../../providers/Config/index.js'
 import { useEmbed } from '../../providers/Embed/index.js'
 import { useLocale } from '../../providers/Locale/index.js'
+import { usePreferences } from '../../providers/Preferences/index.js'
 import { useTranslation } from '../../providers/Translation/index.js'
 import { Button } from '../Button/index.js'
 import { Localizer } from '../Localizer/index.js'
@@ -34,6 +37,12 @@ export function AppHeader({ CustomAvatar, CustomLogoutButton, settingsItemGroups
   const { Actions } = useActions()
 
   const { navOpen, setNavOpen } = useNav()
+
+  const {
+    breakpoints: { m: midBreak, s: smallBreak },
+  } = useWindowInfo()
+
+  const { setPreference } = usePreferences()
 
   const {
     config: { localization },
@@ -78,7 +87,14 @@ export function AppHeader({ CustomAvatar, CustomLogoutButton, settingsItemGroups
                 buttonStyle="ghost"
                 className={`${baseClass}__sidebar-toggle`}
                 icon={<SidebarIcon />}
-                onClick={() => setNavOpen(!navOpen)}
+                onClick={() => {
+                  setNavOpen(!navOpen)
+
+                  // only persist the preference on widths where the nav is a sidebar (not a modal)
+                  if (midBreak === false && smallBreak === false) {
+                    void setPreference(PREFERENCE_KEYS.NAV, { open: !navOpen }, true)
+                  }
+                }}
                 type="button"
               />
               <div className={`${baseClass}__step-nav-wrapper`}>

--- a/packages/ui/src/elements/Nav/context.tsx
+++ b/packages/ui/src/elements/Nav/context.tsx
@@ -43,7 +43,7 @@ export const NavProvider: React.FC<{
   initialIsOpen?: boolean
 }> = ({ children, initialIsOpen }) => {
   const {
-    breakpoints: { l: largeBreak, m: midBreak, s: smallBreak },
+    breakpoints: { m: midBreak, s: smallBreak },
   } = useWindowInfo()
 
   const pathname = usePathname()
@@ -60,8 +60,9 @@ export const NavProvider: React.FC<{
   const [hydrated, setHydrated] = React.useState(false)
 
   // on load check the user's preference and set "initial" state
+  // read the preference on every width where the nav is a sidebar (not a modal)
   useEffect(() => {
-    if (largeBreak === false) {
+    if (midBreak === false && smallBreak === false) {
       const setNavFromPreferences = async () => {
         const preferredState = await getNavPreference(getPreference)
         setNavOpen(preferredState)
@@ -69,7 +70,7 @@ export const NavProvider: React.FC<{
 
       void setNavFromPreferences()
     }
-  }, [largeBreak, getPreference, setNavOpen])
+  }, [midBreak, smallBreak, getPreference, setNavOpen])
 
   // on smaller screens where the nav is a modal
   // close the nav when the user navigates away
@@ -95,11 +96,11 @@ export const NavProvider: React.FC<{
   // close the nav when the user resizes down to mobile
   // the sidebar is a modal on mobile
   useEffect(() => {
-    if (largeBreak === true || midBreak === true || smallBreak === true) {
+    if (midBreak === true || smallBreak === true) {
       setNavOpen(false)
     }
     setHydrated(true)
-  }, [largeBreak, midBreak, smallBreak])
+  }, [midBreak, smallBreak])
 
   // when the component unmounts, clear all body scroll locks
   useEffect(() => {

--- a/test/admin/e2e/general/e2e.spec.ts
+++ b/test/admin/e2e/general/e2e.spec.ts
@@ -653,6 +653,31 @@ describe('General', () => {
       await expect(link).toBeHidden()
     })
 
+    test('nav — should be open by default at sidebar widths and persist the toggle preference', async () => {
+      // 1280px is within the sidebar width range (1025px - 1440px) where the nav is not a modal
+      await page.setViewportSize({ height: 720, width: 1280 })
+
+      await page.goto(postsUrl.admin)
+      await expect(page.locator('.template-default--nav-hydrated')).toBeVisible()
+
+      // the nav should be open by default, without requiring a toggle click
+      await expect(page.locator('.template-default.template-default--nav-open')).toBeVisible()
+
+      // close the nav, then reload: the preference should be persisted and the nav stays closed
+      await page.locator('.app-header__sidebar-toggle').click()
+      await expect(page.locator('.template-default.template-default--nav-open')).toBeHidden()
+      await page.reload()
+      await expect(page.locator('.template-default--nav-hydrated')).toBeVisible()
+      await expect(page.locator('.template-default.template-default--nav-open')).toBeHidden()
+
+      // reopen the nav, then reload: the preference should be persisted and the nav stays open
+      await page.locator('.app-header__sidebar-toggle').click()
+      await expect(page.locator('.template-default.template-default--nav-open')).toBeVisible()
+      await page.reload()
+      await expect(page.locator('.template-default--nav-hydrated')).toBeVisible()
+      await expect(page.locator('.template-default.template-default--nav-open')).toBeVisible()
+    })
+
     test('should disable active nav item', async () => {
       await page.goto(postsUrl.list)
       await openNav(page)


### PR DESCRIPTION
## What?

The admin nav was force-closed at viewports ≤1440px (`l` breakpoint) even though that range renders the nav as a sidebar, not a modal. The stored nav preference was only **read** above 1440px, and toggling the nav never **wrote** the preference at all (the v3 `NavToggler` that handled this was removed in #17212).

Fixes #17531

## Why?

On any project whose desktop breakpoint is 1440px, the sidebar was never open on first load, the user's saved preference was ignored, and "remember my choice" did not exist. The unconditional close effect used the `l` breakpoint, but the comment/behaviour is about modal widths only.

## How?

- `packages/ui/src/elements/Nav/context.tsx`:
  - Read the nav preference on **every sidebar width** (not just >1440px). Gate changed from `largeBreak === false` to `midBreak === false && smallBreak === false`.
  - Only force-close the nav on the genuinely modal widths: `midBreak === true || smallBreak === true`. The `l` breakpoint (1440px) is no longer treated as a modal width.
- `packages/ui/src/elements/AppHeader/index.tsx`:
  - The sidebar toggle now persists the preference via `setPreference(PREFERENCE_KEYS.NAV, { open }, true)` (same pattern the v3 `NavToggler` used, `merge: true` preserves nav-group prefs), gated to sidebar widths only so programmatic/modal closes are not persisted.

## Tests

- Added an e2e regression test in `test/admin/e2e/general/e2e.spec.ts` (`nav — should be open by default at sidebar widths and persist the toggle preference`) at 1280px: asserts nav is open by default, and that closing/reopening + reload persists.
- Existing `openNav`/`closeNav` e2e helpers already handle both default states, so the viewport change does not break the surrounding tests.
- ESLint: no new issues from these changes. Typecheck (`tsc -p packages/ui/tsconfig.json --noEmit`): 0 errors.