### PR TITLE
fix(drizzle): generate the locale enum with its actual db name

### DIFF
--- a/packages/drizzle/src/utilities/createSchemaGenerator.ts
+++ b/packages/drizzle/src/utilities/createSchemaGenerator.ts
@@ -83,18 +83,20 @@ export const createSchemaGenerator = ({
     const enumFn = this.schemaName ? `db_schema.enum` : enumImport
 
     const enumsList: string[] = []
-    const addEnum = (name: string, options: string[]) => {
+    const addEnum = (name: string, options: string[], dbName: string = name) => {
       if (enumsList.some((each) => each === name)) {
         return
       }
       enumsList.push(name)
       enumDeclarations.push(
-        `export const ${name} = ${enumFn}('${name}', [${options.map((option) => `'${option}'`).join(', ')}])`,
+        `export const ${name} = ${enumFn}('${dbName}', [${options.map((option) => `'${option}'`).join(', ')}])`,
       )
     }
 
     if (this.payload.config.localization && enumImport) {
-      addEnum('enum__locales', this.payload.config.localization.localeCodes)
+      // The adapter creates this type as '_locales'; 'enum__locales' is only the key in
+      // the enums map. See postgres/init.ts.
+      addEnum('enum__locales', this.payload.config.localization.localeCodes, '_locales')
     }
 
     const tableFn = this.schemaName ? `db_schema.table` : tableImport

--- a/test/relationships/payload-generated-schema.ts
+++ b/test/relationships/payload-generated-schema.ts
@@ -23,7 +23,7 @@ import {
   pgEnum,
 } from '@payloadcms/db-postgres/drizzle/pg-core'
 import { sql, relations } from '@payloadcms/db-postgres/drizzle'
-export const enum__locales = pgEnum('enum__locales', ['en', 'de'])
+export const enum__locales = pgEnum('_locales', ['en', 'de'])
 export const enum_movie_reviews_visibility = pgEnum('enum_movie_reviews_visibility', [
   'followers',
   'public',


### PR DESCRIPTION
Fixes #17736.

### What

`generate:db-schema` declared the locale enum as `pgEnum('enum__locales', …)`, but the adapter creates that type in Postgres as `_locales` — `enum__locales` is only the key in the adapter's `enums` map:

https://github.com/payloadcms/payload/blob/main/packages/drizzle/src/postgres/init.ts#L22-L27

So every `_locale` column in a generated schema referenced a type that does not exist in the database. Under `push: false` the generated file is never executed, so nothing surfaced it.

### How

`addEnum()` already assumed `name === db name`, and that holds for its only other caller — `columnToCodeConverter` passes `column.enumName`, which is a real type name. Rather than change that contract, this adds an optional `dbName` defaulting to `name`, so only the locale call site behaves differently.

The exported const keeps the name `enum__locales`, because [`columnToCodeConverter.ts#L17`](https://github.com/payloadcms/payload/blob/main/packages/drizzle/src/postgres/columnToCodeConverter.ts#L17) emits `enum__locales(…)` as the column builder. Only the first argument to `pgEnum` changes.

### Fixture

`test/relationships/payload-generated-schema.ts` is the one committed fixture that contained the old name; it is updated here. The other two generated-schema fixtures under `test/` are not localized and contain no locale enum.

That one-line fixture change is exactly what regenerating produces — the emitted string is deterministic — but I could not run the repo's test suite locally to confirm, so CI is the real check on that file.

### Verifying

Before this change, in any localized Postgres project:

```sql
SELECT DISTINCT udt_name FROM information_schema.columns
WHERE table_schema = 'public' AND column_name = '_locale';
-- _locales

SELECT typname FROM pg_type WHERE typname = 'enum__locales';
-- 0 rows
```

while the generated schema declared `enum__locales`.
