### PR TITLE
perf!: remove DeepRequired from sanitized global config types

### DIFF
--- a/docs/migration-guide/v4.mdx
+++ b/docs/migration-guide/v4.mdx
@@ -258,6 +258,20 @@ const presets = payload.config.queryPresets?.constraints
 
 Properties filled during sanitization, including `auth.jwtOrder`, root routes, GraphQL defaults, TypeScript output settings, and admin dashboard defaults, remain required. `Config.auth.jwtOrder` is now optional for incoming configs because Payload supplies its documented default. The unused `SanitizedConfig.paths` property was also removed because it is not present at runtime.
 
+### Sanitized global config types now match runtime defaults
+
+`SanitizedGlobalConfig` no longer uses `DeepRequired`. This reduces TypeScript checker work and preserves optionality for values global sanitization does not populate, such as `access.readVersions`, `admin.components`, `graphQL`, `lockDocuments`, and `typescript`.
+
+Code that consumes these properties may now need to handle `undefined`:
+
+```ts
+if (global.access.readVersions) await global.access.readVersions(args)
+const views = global.admin.components?.views
+const interfaceName = global.typescript?.interface
+```
+
+Properties filled during sanitization, including `_sanitized`, `admin`, `custom`, `label`, standard access functions, hook arrays, endpoints, and flattened fields, remain required. Use `GlobalConfig` for input and `SanitizedGlobalConfig` after sanitization.
+
 ### User types consolidated into `User` and `AuthenticatedUser`
 
 Payload's user types have been consolidated so each one has a clear job. This completes a cleanup already planned in 3.x: `UntypedUser` was deprecated for removal in 4.0, and `TypedUser` was marked to be renamed to `User` in 4.0.

--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -268,13 +268,6 @@ export type OGImageConfig = {
   width?: number | string
 }
 
-/**
- * @todo find a way to remove the deep clone here.
- * It can probably be removed after the `DeepRequired` from `GlobalConfig` to
- * `SanitizedGlobalConfig` is removed.
- */
-type DeepClone<T> = T extends object ? { [K in keyof T]: DeepClone<T[K]> } : T
-
 export type MetaConfig = {
   /**
    * When `static`, a pre-made image will be used for all pages.
@@ -288,7 +281,7 @@ export type MetaConfig = {
    * @example `" - Custom CMS"`
    */
   titleSuffix?: string
-} & DeepClone<Metadata>
+} & Metadata
 
 export type ServerOnlyLivePreviewProperties = keyof Pick<RootLivePreviewConfig, 'url'>
 

--- a/packages/payload/src/globals/config/sanitize.spec.ts
+++ b/packages/payload/src/globals/config/sanitize.spec.ts
@@ -9,7 +9,62 @@ const minimalConfig = {
   globals: [],
 } as any
 
-describe('sanitizeGlobal — versions default', () => {
+describe('sanitizeGlobal', () => {
+  it('should populate sanitized global defaults for a minimal config', () => {
+    const global: GlobalConfig = {
+      slug: 'header',
+      fields: [],
+    }
+
+    const result = sanitizeGlobal(minimalConfig, global)
+
+    expect(result).toMatchObject({
+      _sanitized: true,
+      access: {
+        read: expect.any(Function),
+        update: expect.any(Function),
+      },
+      admin: {},
+      custom: {},
+      endpoints: expect.any(Array),
+      fields: expect.any(Array),
+      flattenedFields: expect.any(Array),
+      hooks: {
+        afterChange: [],
+        afterRead: [],
+        beforeChange: [],
+        beforeOperation: [],
+        beforeRead: [],
+        beforeValidate: [],
+      },
+      label: 'Header',
+      slug: 'header',
+    })
+    expect(result.access.readVersions).toBeUndefined()
+    expect(result.admin.components).toBeUndefined()
+    expect(result.graphQL).toBeUndefined()
+    expect(result.lockDocuments).toBeUndefined()
+    expect(result.typescript).toBeUndefined()
+  })
+
+  it('should populate a nested default when the property is explicitly undefined', () => {
+    const global: GlobalConfig = {
+      access: {
+        read: undefined,
+      },
+      hooks: {
+        beforeOperation: undefined,
+      },
+      slug: 'header',
+      fields: [],
+    }
+
+    const result = sanitizeGlobal(minimalConfig, global)
+
+    expect(result.access.read).toEqual(expect.any(Function))
+    expect(result.hooks.beforeOperation).toEqual([])
+  })
+
   it('should default versions to true when not specified', () => {
     const global: GlobalConfig = {
       slug: 'header',

--- a/packages/payload/src/globals/config/sanitize.ts
+++ b/packages/payload/src/globals/config/sanitize.ts
@@ -73,6 +73,10 @@ export const sanitizeGlobal = (
     global.hooks.afterRead = []
   }
 
+  if (!global.hooks.beforeOperation) {
+    global.hooks.beforeOperation = []
+  }
+
   // Sanitize fields
   const validRelationships = _validRelationships ?? config.collections?.map((c) => c.slug) ?? []
 

--- a/packages/payload/src/globals/config/types.ts
+++ b/packages/payload/src/globals/config/types.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { GraphQLNonNull, GraphQLObjectType } from 'graphql'
-import type { DeepRequired, IsAny } from 'ts-essentials'
+import type { IsAny } from 'ts-essentials'
 
 import type {
   Access,
@@ -185,17 +185,28 @@ export type GlobalAdminOptions = {
   preview?: GeneratePreviewURL
 }
 
+type GlobalAccess = {
+  read?: Access
+  readVersions?: Access
+  update?: Access
+}
+
+type GlobalHooks = {
+  afterChange?: AfterChangeHook[]
+  afterRead?: AfterReadHook[]
+  beforeChange?: BeforeChangeHook[]
+  beforeOperation?: BeforeOperationHook[]
+  beforeRead?: BeforeReadHook[]
+  beforeValidate?: BeforeValidateHook[]
+}
+
 export type GlobalConfig<TSlug extends GlobalSlug = any> = {
   /**
    * Do not set this property manually. This is set to true during sanitization, to avoid
    * sanitizing the same global multiple times.
    */
   _sanitized?: boolean
-  access?: {
-    read?: Access
-    readVersions?: Access
-    update?: Access
-  }
+  access?: GlobalAccess
   admin?: GlobalAdminOptions
   /** Extension point to add your custom data. Server only. */
   custom?: GlobalCustom
@@ -212,14 +223,7 @@ export type GlobalConfig<TSlug extends GlobalSlug = any> = {
         name?: string
       }
     | false
-  hooks?: {
-    afterChange?: AfterChangeHook[]
-    afterRead?: AfterReadHook[]
-    beforeChange?: BeforeChangeHook[]
-    beforeOperation?: BeforeOperationHook[]
-    beforeRead?: BeforeReadHook[]
-    beforeValidate?: BeforeValidateHook[]
-  }
+  hooks?: GlobalHooks
   label?: LabelFunction | StaticLabel
   /**
    * Enables / Disables the ability to lock documents while editing
@@ -251,14 +255,28 @@ export type GlobalConfig<TSlug extends GlobalSlug = any> = {
 >
 
 export interface SanitizedGlobalConfig
-  extends Omit<DeepRequired<GlobalConfig>, 'endpoints' | 'fields' | 'slug' | 'versions'> {
+  extends Omit<
+      GlobalConfig,
+      | '_sanitized'
+      | 'access'
+      | 'admin'
+      | 'custom'
+      | 'endpoints'
+      | 'hooks'
+      | 'label'
+      | 'slug'
+      | 'versions'
+    >,
+    Required<Pick<GlobalConfig, 'admin' | 'custom' | 'label'>> {
+  _sanitized: true
+  access: Pick<GlobalAccess, 'readVersions'> & Required<Pick<GlobalAccess, 'read' | 'update'>>
   endpoints: Endpoint[] | false
-  fields: Field[]
   /**
    * Fields in the database schema structure
    * Rows / collapsible / tabs w/o name `fields` merged to top, UIs are excluded
    */
   flattenedFields: FlattenedField[]
+  hooks: Required<GlobalHooks>
   slug: GlobalSlug
   versions?: SanitizedGlobalVersions
 }

--- a/packages/ui/src/utilities/formatMetadata.ts
+++ b/packages/ui/src/utilities/formatMetadata.ts
@@ -62,13 +62,7 @@ export const formatMetadata = async (
   args: { serverURL?: string } & MetaConfig,
 ): Promise<MetaConfig> => {
   const { defaultOGImageType, serverURL, titleSuffix, ...rest } = args
-
-  /**
-   * @todo find a way to remove the type assertion here.
-   * It is a result of needing to `DeepCopy` the `MetaConfig` type from Payload.
-   * This is required for the `DeepRequired` from `Config` to `SanitizedConfig`.
-   */
-  const incomingMetadata = rest as MetaConfig
+  const incomingMetadata: MetaConfig = rest
 
   const faviconDark = payloadFaviconDark as { src: string } | string
   const faviconLight = payloadFaviconLight as { src: string } | string

--- a/packages/ui/src/views/Version/generateVersionViewMetadata.ts
+++ b/packages/ui/src/views/Version/generateVersionViewMetadata.ts
@@ -49,8 +49,8 @@ export const generateVersionViewMetadata: GenerateEditViewMetadata = async ({
       ...(config.admin.meta || {}),
       description: t('version:viewingVersionGlobal', { entityLabel }),
       title: `${t('version:version')}${formattedCreatedAt ? ` - ${formattedCreatedAt}` : ''}${entityLabel}`,
-      ...((globalConfig?.admin?.meta || {})),
-      ...((globalConfig?.admin?.components?.views?.edit?.version?.meta || {})),
+      ...(globalConfig?.admin?.meta || {}),
+      ...(globalConfig?.admin?.components?.views?.edit?.version?.meta || {}),
     }
   }
 

--- a/packages/ui/src/views/Version/generateVersionViewMetadata.ts
+++ b/packages/ui/src/views/Version/generateVersionViewMetadata.ts
@@ -49,8 +49,8 @@ export const generateVersionViewMetadata: GenerateEditViewMetadata = async ({
       ...(config.admin.meta || {}),
       description: t('version:viewingVersionGlobal', { entityLabel }),
       title: `${t('version:version')}${formattedCreatedAt ? ` - ${formattedCreatedAt}` : ''}${entityLabel}`,
-      ...((globalConfig?.admin?.meta || {}) as MetaConfig),
-      ...((globalConfig?.admin?.components?.views?.edit?.version?.meta || {}) as MetaConfig),
+      ...((globalConfig?.admin?.meta || {})),
+      ...((globalConfig?.admin?.components?.views?.edit?.version?.meta || {})),
     }
   }
 

--- a/packages/ui/src/views/Versions/generateVersionsViewMetadata.ts
+++ b/packages/ui/src/views/Versions/generateVersionsViewMetadata.ts
@@ -50,8 +50,8 @@ export const generateVersionsViewMetadata: GenerateEditViewMetadata = async ({
       ...(config.admin.meta || {}),
       description: t('version:viewingVersionsGlobal', { entitySlug: globalConfig.slug }),
       title: `${t('version:versions')} - ${entityLabel}`,
-      ...((globalConfig?.admin.meta || {}) as MetaConfig),
-      ...((globalConfig?.admin?.components?.views?.edit?.versions?.meta || {}) as MetaConfig),
+      ...((globalConfig?.admin.meta || {})),
+      ...((globalConfig?.admin?.components?.views?.edit?.versions?.meta || {})),
     }
   }
 


### PR DESCRIPTION
This PR removes `DeepRequired` from `SanitizedGlobalConfig`. It uses shallow `Pick`, `Omit`, and `Required` types so only properties populated during global config sanitization are required.

## Why

`DeepRequired` recursively processes large field, hook, admin, and conditional types, adding unnecessary TypeScript checker work.

It was also inaccurate. `access.readVersions`, `admin.components`, `graphQL`, `lockDocuments`, and `typescript` could be undefined but were typed as required. Meanwhile, `_sanitized`, `admin`, `custom`, `label`, standard access functions, and hook arrays are always present.

Global sanitization now also defaults `hooks.beforeOperation` to an empty array, matching collection sanitization and the required sanitized hook shape.

With the final `DeepRequired` usage removed from sanitized config types, this also removes the `DeepClone<Metadata>` workaround and its paired `formatMetadata` assertion, which were only needed to support it.

## Breaking change

Code using `SanitizedGlobalConfig` may now need to handle `undefined` for properties Payload does not default.

```ts
if (global.access.readVersions) await global.access.readVersions(args)
const views = global.admin.components?.views
const interfaceName = global.typescript?.interface
```