### PR TITLE
fix: prevent findUp infinite loop when given a relative dir

### DIFF
--- a/packages/payload/src/utilities/findUp.spec.ts
+++ b/packages/payload/src/utilities/findUp.spec.ts
@@ -1,0 +1,44 @@
+import path from 'path'
+import { describe, expect, it } from 'vitest'
+
+import { findUp, findUpSync } from './findUp'
+
+const missingFileName = 'this-file-name-should-never-exist.payload-test'
+
+// Relative to the process cwd rather than hardcoded, so these hold no matter
+// where vitest is invoked from.
+const relativeDir = path.relative(process.cwd(), import.meta.dirname) || '.'
+
+describe('findUpSync', () => {
+  // Note this cannot fail fast: the pre-fix behaviour is a synchronous infinite
+  // loop, which blocks the worker thread and prevents any test timeout from
+  // firing. A regression here hangs the run rather than failing an assertion.
+  it('returns null for a relative dir when no match exists', () => {
+    expect(findUpSync({ dir: relativeDir, fileNames: [missingFileName] })).toBeNull()
+    expect(findUpSync({ dir: './', fileNames: [missingFileName] })).toBeNull()
+  })
+
+  it('returns null for an absolute dir when no match exists', () => {
+    expect(findUpSync({ dir: import.meta.dirname, fileNames: [missingFileName] })).toBeNull()
+  })
+
+  it('finds a file in an ancestor of a relative dir', () => {
+    expect(findUpSync({ dir: relativeDir, fileNames: ['package.json'] })).toBe(
+      path.resolve(import.meta.dirname, '../../package.json'),
+    )
+  })
+})
+
+describe('findUp', () => {
+  // The async variant awaits between iterations, so its loop does yield and a
+  // regression here does surface as a timeout.
+  it('returns null for a relative dir when no match exists', { timeout: 10000 }, async () => {
+    await expect(findUp({ dir: relativeDir, fileNames: [missingFileName] })).resolves.toBeNull()
+  })
+
+  it('finds a file in an ancestor of a relative dir', async () => {
+    await expect(findUp({ dir: relativeDir, fileNames: ['package.json'] })).resolves.toBe(
+      path.resolve(import.meta.dirname, '../../package.json'),
+    )
+  })
+})

--- a/packages/payload/src/utilities/findUp.ts
+++ b/packages/payload/src/utilities/findUp.ts
@@ -13,6 +13,10 @@ export function findUpSync({
   dir: string
   fileNames?: string[]
 }): null | string {
+  // A relative dir has no parsed root (`path.parse('./src').root === ''`) and
+  // `path.dirname()` bottoms out at '.', so the root checks below would never be
+  // reached and the walk would never terminate.
+  dir = path.resolve(dir)
   const { root } = path.parse(dir)
 
   while (true) {
@@ -60,6 +64,8 @@ export async function findUp({
   dir: string
   fileNames?: string[]
 }): Promise<null | string> {
+  // See findUpSync above — a relative dir never reaches the parsed root.
+  dir = path.resolve(dir)
   const { root } = path.parse(dir)
 
   while (true) {


### PR DESCRIPTION
### What?

When `dir` is a relative path, `findUpSync()` and `findUp()` loop forever at 100% CPU instead of returning `null`.

This is a follow-up to #12457, which fixed the same infinite loop for absolute paths. That fix added a `dir !== root` guard:

```ts
if (!found && dir !== root) {
  dir = path.dirname(dir) // Move up one directory level.
  continue
}
```

`root` comes from `path.parse(dir).root`, which is `''` for any relative path. `path.dirname()` bottoms out at `'.'`, and `'.'` is never equal to `''`, so neither that guard nor the `if (dir === root) return null` below it can ever fire:

```
dir './'  → access 'payload.config.ts' → ENOENT → dirname → '.'
dir '.'   → access 'payload.config.ts' → ENOENT → dirname → '.'   ← forever
```

### Why?

`findConfig()` in `packages/payload/src/config/find.ts` passes `compilerOptions.rootDir` to `findUpSync()` without resolving it first:

```ts
const srcPath = tsConfig.compilerOptions?.rootDir || path.resolve(process.cwd(), 'src')
```

A relative `rootDir` in tsconfig.json is very common, for example `"rootDir": "./"` or `"rootDir": "./src"`. Any `payload` bin command hangs if the nearest tsconfig sets one. In a monorepo this is easy to hit by accident, for example by running `payload generate:types` from the wrong workspace. In this case, the process hangs until noticed.

Note that this isn't the same as #15553. There, `generate:types` finishes and writes its output but fails to exit but here `findConfig()` never returns, so nothing is written at all.

### How?

Resolve `dir` to an absolute path at the start of both functions, which makes the existing root checks reachable. After the fix the same call returns `null` right away, and callers report the intended error (e.g. "cannot find Payload config. Please create a configuration file...").

### Reproduction

No app or install is needed. Against stock `payload@3.87.1`:

```bash
curl -s -O https://unpkg.com/payload@3.87.1/dist/utilities/findUp.js

cat > driver.mjs <<'EOF'
import { findUpSync } from './findUp.js'
const dir = process.argv[2]
console.log(`calling findUpSync({ dir: ${JSON.stringify(dir)} })`)
console.log('returned:', findUpSync({ dir, fileNames: ['payload.config.ts'] }))
EOF

node driver.mjs './'      # hangs at 100% CPU, never returns
node driver.mjs './src'   # hangs at 100% CPU, never returns
node driver.mjs "$PWD"    # returns null immediately (correct)
```

It also reproduces end to end, in a package whose tsconfig.json sets `"rootDir": "./"`:

```bash
node ./node_modules/payload/bin.js generate:types   # hangs at 100% CPU, never returns
```

### Environment Info

- Payload: 3.84.1. Also verified on 3.87.1, where the code is unchanged.
- Node.js: 24.13.0
- OS: macOS 15. The affected code path has no OS-specific behaviour.

### Test

Adds `packages/payload/src/utilities/findUp.spec.ts`, co-located to match `formatLabels.spec.ts` and `isURLAllowed.spec.ts`. It covers both functions with three cases: the relative dir with no match that used to hang, the absolute dir with no match that #12457 already fixed, and a positive case checking that a relative dir still finds a match in an ancestor.

`pnpm test:unit` passes with 5 tests.

**Note for review:** The old behaviour is a synchronous infinite loop, which blocks the vitest worker thread, so no test timeout can fire. A regression hangs the run instead of failing an assertion.