### PR TITLE
fix(ui): keep empty filter rows from being dropped on URL round-trip

### DIFF
--- a/packages/ui/src/elements/WhereBuilder/conditionValue.spec.ts
+++ b/packages/ui/src/elements/WhereBuilder/conditionValue.spec.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+
+import { isEmptyConditionValue, isNoOpConditionValueUpdate } from './conditionValue.js'
+
+describe('isEmptyConditionValue', () => {
+  it.each([
+    ['undefined', undefined],
+    ['null', null],
+    ['an empty string', ''],
+  ])('treats %s as empty', (_label, value) => {
+    expect(isEmptyConditionValue(value)).toBe(true)
+  })
+
+  it.each([
+    ['a string', 'option1'],
+    ['zero', 0],
+    ['false', false],
+  ])('treats %s as a real value', (_label, value) => {
+    expect(isEmptyConditionValue(value)).toBe(false)
+  })
+})
+
+describe('isNoOpConditionValueUpdate', () => {
+  it('skips the empty value a row reports back for a stored empty string', () => {
+    // A row loaded from `?where[or][0][and][0][field][equals]=` holds `''`, but renders with
+    // its value coerced to `undefined`, so on mount it reports `undefined` back up. Committing
+    // that writes `{ equals: undefined }`, which `qs.stringify` omits — dropping the whole
+    // condition from the URL and losing the row.
+    expect(
+      isNoOpConditionValueUpdate({ incomingValue: undefined, storedValue: '', type: 'value' }),
+    ).toBe(true)
+  })
+
+  it.each([
+    ['undefined', 'an empty string', undefined, ''],
+    ['null', 'undefined', null, undefined],
+    ['undefined', 'undefined', undefined, undefined],
+  ])(
+    'skips a %s value stored as %s',
+    (_incomingLabel, _storedLabel, incomingValue, storedValue) => {
+      expect(isNoOpConditionValueUpdate({ incomingValue, storedValue, type: 'value' })).toBe(true)
+    },
+  )
+
+  it('commits a value typed into an empty row', () => {
+    expect(
+      isNoOpConditionValueUpdate({ incomingValue: 'option1', storedValue: '', type: 'value' }),
+    ).toBe(false)
+  })
+
+  it('commits a row the user cleared', () => {
+    expect(
+      isNoOpConditionValueUpdate({
+        incomingValue: undefined,
+        storedValue: 'option1',
+        type: 'value',
+      }),
+    ).toBe(false)
+  })
+
+  it.each([['field'], ['operator']] as const)(
+    'commits a %s edit on a row that holds no value',
+    (type) => {
+      expect(isNoOpConditionValueUpdate({ incomingValue: undefined, storedValue: '', type })).toBe(
+        false,
+      )
+    },
+  )
+})

--- a/packages/ui/src/elements/WhereBuilder/conditionValue.spec.ts
+++ b/packages/ui/src/elements/WhereBuilder/conditionValue.spec.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
-import { isEmptyConditionValue, isNoOpConditionValueUpdate } from './conditionValue.js'
+import {
+  getDisplayedConditionValue,
+  isEmptyConditionValue,
+  isNoOpConditionValueUpdate,
+} from './conditionValue.js'
 
 describe('isEmptyConditionValue', () => {
   it.each([
@@ -20,12 +24,27 @@ describe('isEmptyConditionValue', () => {
   })
 })
 
+describe('getDisplayedConditionValue', () => {
+  it.each([
+    ['undefined', undefined],
+    ['null', null],
+  ])('displays %s as no value', (_label, value) => {
+    expect(getDisplayedConditionValue(value)).toBeUndefined()
+  })
+
+  it.each([
+    ['zero', 0],
+    ['false', false],
+    ['an empty string', ''],
+    ['a string', 'option1'],
+  ])('displays %s as itself', (_label, value) => {
+    expect(getDisplayedConditionValue(value)).toBe(value)
+  })
+})
+
 describe('isNoOpConditionValueUpdate', () => {
   it('skips the empty value a row reports back for a stored empty string', () => {
-    // A row loaded from `?where[or][0][and][0][field][equals]=` holds `''`, but renders with
-    // its value coerced to `undefined`, so on mount it reports `undefined` back up. Committing
-    // that writes `{ equals: undefined }`, which `qs.stringify` omits — dropping the whole
-    // condition from the URL and losing the row.
+    // The row this covers comes from a URL such as `?where[or][0][and][0][field][equals]=`.
     expect(
       isNoOpConditionValueUpdate({ incomingValue: undefined, storedValue: '', type: 'value' }),
     ).toBe(true)

--- a/packages/ui/src/elements/WhereBuilder/conditionValue.spec.ts
+++ b/packages/ui/src/elements/WhereBuilder/conditionValue.spec.ts
@@ -11,16 +11,16 @@ describe('isEmptyConditionValue', () => {
     ['undefined', undefined],
     ['null', null],
     ['an empty string', ''],
-  ])('treats %s as empty', (_label, value) => {
-    expect(isEmptyConditionValue(value)).toBe(true)
+  ])('should treat %s as empty', (_label, value) => {
+    expect(isEmptyConditionValue({ value })).toBe(true)
   })
 
   it.each([
     ['a string', 'option1'],
     ['zero', 0],
     ['false', false],
-  ])('treats %s as a real value', (_label, value) => {
-    expect(isEmptyConditionValue(value)).toBe(false)
+  ])('should treat %s as a real value', (_label, value) => {
+    expect(isEmptyConditionValue({ value })).toBe(false)
   })
 })
 
@@ -28,8 +28,8 @@ describe('getDisplayedConditionValue', () => {
   it.each([
     ['undefined', undefined],
     ['null', null],
-  ])('displays %s as no value', (_label, value) => {
-    expect(getDisplayedConditionValue(value)).toBeUndefined()
+  ])('should display %s as no value', (_label, value) => {
+    expect(getDisplayedConditionValue({ value })).toBeUndefined()
   })
 
   it.each([
@@ -37,13 +37,13 @@ describe('getDisplayedConditionValue', () => {
     ['false', false],
     ['an empty string', ''],
     ['a string', 'option1'],
-  ])('displays %s as itself', (_label, value) => {
-    expect(getDisplayedConditionValue(value)).toBe(value)
+  ])('should display %s as itself', (_label, value) => {
+    expect(getDisplayedConditionValue({ value })).toBe(value)
   })
 })
 
 describe('isNoOpConditionValueUpdate', () => {
-  it('skips the empty value a row reports back for a stored empty string', () => {
+  it('should skip the empty value a row reports back for a stored empty string', () => {
     // The row this covers comes from a URL such as `?where[or][0][and][0][field][equals]=`.
     expect(
       isNoOpConditionValueUpdate({ incomingValue: undefined, storedValue: '', type: 'value' }),
@@ -55,19 +55,19 @@ describe('isNoOpConditionValueUpdate', () => {
     ['null', 'undefined', null, undefined],
     ['undefined', 'undefined', undefined, undefined],
   ])(
-    'skips a %s value stored as %s',
+    'should skip a %s value stored as %s',
     (_incomingLabel, _storedLabel, incomingValue, storedValue) => {
       expect(isNoOpConditionValueUpdate({ incomingValue, storedValue, type: 'value' })).toBe(true)
     },
   )
 
-  it('commits a value typed into an empty row', () => {
+  it('should commit a value typed into an empty row', () => {
     expect(
       isNoOpConditionValueUpdate({ incomingValue: 'option1', storedValue: '', type: 'value' }),
     ).toBe(false)
   })
 
-  it('commits a row the user cleared', () => {
+  it('should commit a row the user cleared', () => {
     expect(
       isNoOpConditionValueUpdate({
         incomingValue: undefined,
@@ -78,7 +78,7 @@ describe('isNoOpConditionValueUpdate', () => {
   })
 
   it.each([['field'], ['operator']] as const)(
-    'commits a %s edit on a row that holds no value',
+    'should commit a %s edit on a row that holds no value',
     (type) => {
       expect(isNoOpConditionValueUpdate({ incomingValue: undefined, storedValue: '', type })).toBe(
         false,

--- a/packages/ui/src/elements/WhereBuilder/conditionValue.ts
+++ b/packages/ui/src/elements/WhereBuilder/conditionValue.ts
@@ -1,0 +1,35 @@
+import type { UpdateCondition } from './types.js'
+
+type UpdateType = Parameters<UpdateCondition>[0]['type']
+
+/**
+ * A condition value that means "this row has no value yet". The same emptiness reaches the
+ * where builder in three spellings: `''` from a query string such as `?where[or][0][and][0]
+ * [title][equals]=`, `null` from a cleared ReactSelect, and `undefined` from a row that was
+ * added but never filled in.
+ */
+export const isEmptyConditionValue = (value: unknown): boolean =>
+  value === undefined || value === null || value === ''
+
+/**
+ * Whether a condition edit leaves the row exactly as it was, and so must not be committed.
+ *
+ * A row is rendered with its value coerced to `undefined` when it is empty, so a row loaded
+ * from the URL holding `''` reports `undefined` back up as soon as it mounts. Committing that
+ * stores `{ [operator]: undefined }`, which `qs.stringify` omits when the list view writes the
+ * query back to the URL — so the condition serializes to nothing, the surrounding array closes
+ * the gap, and the row disappears on the next parse.
+ *
+ * Only value edits are covered. A field or operator edit changes the row even while it holds
+ * no value, so those must always be committed.
+ */
+export const isNoOpConditionValueUpdate = ({
+  type,
+  incomingValue,
+  storedValue,
+}: {
+  incomingValue: unknown
+  storedValue: unknown
+  type: UpdateType
+}): boolean =>
+  type === 'value' && isEmptyConditionValue(storedValue) && isEmptyConditionValue(incomingValue)

--- a/packages/ui/src/elements/WhereBuilder/conditionValue.ts
+++ b/packages/ui/src/elements/WhereBuilder/conditionValue.ts
@@ -3,25 +3,26 @@ import type { UpdateCondition } from './types.js'
 type UpdateType = Parameters<UpdateCondition>[0]['type']
 
 /**
- * A condition value that means "this row has no value yet". The same emptiness reaches the
- * where builder in three spellings: `''` from a query string such as `?where[or][0][and][0]
- * [title][equals]=`, `null` from a cleared ReactSelect, and `undefined` from a row that was
- * added but never filled in.
+ * A row that holds no value yet. Empty arrives as `''` from the URL, `null` from a cleared
+ * select, or `undefined` from a row that was added but never filled in.
  */
 export const isEmptyConditionValue = (value: unknown): boolean =>
   value === undefined || value === null || value === ''
 
 /**
- * Whether a condition edit leaves the row exactly as it was, and so must not be committed.
+ * The value a row renders with. Only a missing value becomes `undefined`. `0` and `false` are
+ * real filter values, so they must survive.
+ */
+export const getDisplayedConditionValue = <T>(value: T): T | undefined => value ?? undefined
+
+/**
+ * Whether an edit leaves the row unchanged, and so must not be committed.
  *
- * A row is rendered with its value coerced to `undefined` when it is empty, so a row loaded
- * from the URL holding `''` reports `undefined` back up as soon as it mounts. Committing that
- * stores `{ [operator]: undefined }`, which `qs.stringify` omits when the list view writes the
- * query back to the URL — so the condition serializes to nothing, the surrounding array closes
- * the gap, and the row disappears on the next parse.
+ * An empty row renders blank and reports `undefined` back up as soon as it mounts. Committing
+ * that stores `{ [operator]: undefined }`, which `qs.stringify` drops when the query is written
+ * to the URL — so the row is gone on the next parse.
  *
- * Only value edits are covered. A field or operator edit changes the row even while it holds
- * no value, so those must always be committed.
+ * Field and operator edits change the row even while it holds no value, so they always commit.
  */
 export const isNoOpConditionValueUpdate = ({
   type,

--- a/packages/ui/src/elements/WhereBuilder/conditionValue.ts
+++ b/packages/ui/src/elements/WhereBuilder/conditionValue.ts
@@ -6,14 +6,15 @@ type UpdateType = Parameters<UpdateCondition>[0]['type']
  * A row that holds no value yet. Empty arrives as `''` from the URL, `null` from a cleared
  * select, or `undefined` from a row that was added but never filled in.
  */
-export const isEmptyConditionValue = (value: unknown): boolean =>
+export const isEmptyConditionValue = ({ value }: { value: unknown }): boolean =>
   value === undefined || value === null || value === ''
 
 /**
  * The value a row renders with. Only a missing value becomes `undefined`. `0` and `false` are
  * real filter values, so they must survive.
  */
-export const getDisplayedConditionValue = <T>(value: T): T | undefined => value ?? undefined
+export const getDisplayedConditionValue = <T>({ value }: { value: T }): T | undefined =>
+  value ?? undefined
 
 /**
  * Whether an edit leaves the row unchanged, and so must not be committed.
@@ -33,4 +34,6 @@ export const isNoOpConditionValueUpdate = ({
   storedValue: unknown
   type: UpdateType
 }): boolean =>
-  type === 'value' && isEmptyConditionValue(storedValue) && isEmptyConditionValue(incomingValue)
+  type === 'value' &&
+  isEmptyConditionValue({ value: storedValue }) &&
+  isEmptyConditionValue({ value: incomingValue })

--- a/packages/ui/src/elements/WhereBuilder/index.tsx
+++ b/packages/ui/src/elements/WhereBuilder/index.tsx
@@ -19,6 +19,7 @@ import { useTranslation } from '../../providers/Translation/index.js'
 import { reduceFieldsToOptions } from '../../utilities/reduceFieldsToOptions.js'
 import { Button } from '../Button/index.js'
 import { Condition } from './Condition/index.js'
+import { isEmptyConditionValue, isNoOpConditionValueUpdate } from './conditionValue.js'
 import './index.css'
 import { fieldTypeConditions, getValidFieldOperators } from './field-types.js'
 
@@ -112,7 +113,7 @@ export const WhereBuilder: React.FC<WhereBuilderProps> = (props) => {
       if (conditions.length === 0) {
         // Ignore empty value edits so a cleared row doesn't re-commit itself. Field and
         // operator picks carry empty values too, but must fall through to build the row.
-        if (type === 'value' && (value === undefined || value === null || value === '')) {
+        if (type === 'value' && isEmptyConditionValue(value)) {
           return
         }
 
@@ -137,6 +138,12 @@ export const WhereBuilder: React.FC<WhereBuilderProps> = (props) => {
         // Skip if nothing changed
         const existingValue = existingCondition[String(field.fieldPath)]?.[validOperator]
         if (typeof existingValue !== 'undefined' && existingValue === value) {
+          return
+        }
+
+        if (
+          isNoOpConditionValueUpdate({ type, incomingValue: value, storedValue: existingValue })
+        ) {
           return
         }
 

--- a/packages/ui/src/elements/WhereBuilder/index.tsx
+++ b/packages/ui/src/elements/WhereBuilder/index.tsx
@@ -19,7 +19,11 @@ import { useTranslation } from '../../providers/Translation/index.js'
 import { reduceFieldsToOptions } from '../../utilities/reduceFieldsToOptions.js'
 import { Button } from '../Button/index.js'
 import { Condition } from './Condition/index.js'
-import { isEmptyConditionValue, isNoOpConditionValueUpdate } from './conditionValue.js'
+import {
+  getDisplayedConditionValue,
+  isEmptyConditionValue,
+  isNoOpConditionValueUpdate,
+} from './conditionValue.js'
 import './index.css'
 import { fieldTypeConditions, getValidFieldOperators } from './field-types.js'
 
@@ -111,8 +115,7 @@ export const WhereBuilder: React.FC<WhereBuilderProps> = (props) => {
     ({ type, andIndex, field, operator: incomingOperator, orIndex, value }) => {
       // Virtual first row: conditions not yet committed, build from scratch
       if (conditions.length === 0) {
-        // Ignore empty value edits so a cleared row doesn't re-commit itself. Field and
-        // operator picks carry empty values too, but must fall through to build the row.
+        // Field and operator picks carry empty values too, but must fall through to build the row.
         if (type === 'value' && isEmptyConditionValue(value)) {
           return
         }
@@ -274,7 +277,7 @@ export const WhereBuilder: React.FC<WhereBuilderProps> = (props) => {
                   const operator =
                     (Object.keys(condition?.[fieldPath] || {})?.[0] as Operator) || undefined
 
-                  const value = condition?.[fieldPath]?.[operator] || undefined
+                  const value = getDisplayedConditionValue(condition?.[fieldPath]?.[operator])
 
                   const isFirstCondition = orIndex === 0 && andIndex === 0
                   const join: 'and' | 'or' = andIndex === 0 ? 'or' : 'and'

--- a/packages/ui/src/elements/WhereBuilder/index.tsx
+++ b/packages/ui/src/elements/WhereBuilder/index.tsx
@@ -116,7 +116,7 @@ export const WhereBuilder: React.FC<WhereBuilderProps> = (props) => {
       // Virtual first row: conditions not yet committed, build from scratch
       if (conditions.length === 0) {
         // Field and operator picks carry empty values too, but must fall through to build the row.
-        if (type === 'value' && isEmptyConditionValue(value)) {
+        if (type === 'value' && isEmptyConditionValue({ value })) {
           return
         }
 
@@ -277,7 +277,9 @@ export const WhereBuilder: React.FC<WhereBuilderProps> = (props) => {
                   const operator =
                     (Object.keys(condition?.[fieldPath] || {})?.[0] as Operator) || undefined
 
-                  const value = getDisplayedConditionValue(condition?.[fieldPath]?.[operator])
+                  const value = getDisplayedConditionValue({
+                    value: condition?.[fieldPath]?.[operator],
+                  })
 
                   const isFirstCondition = orIndex === 0 && andIndex === 0
                   const join: 'and' | 'or' = andIndex === 0 ? 'or' : 'and'


### PR DESCRIPTION
## Summary

A filter row that holds no value can disappear from the list view. The row is lost when the query is written to the URL and read back. This makes the `admin__e2e__list-view [tanstack-start]` e2e suite fail on `main`. The where builder now ignores an empty value edit that leaves an empty row unchanged.

## Why

A row loaded from a query string such as `?where[or][0][and][0][title][equals]=` holds an empty string. The where builder renders that row with its value changed to `undefined`. The row reports `undefined` back up as soon as it mounts. The guard compared the two raw values, so the empty string and `undefined` did not match, and the no-op edit was committed.

The committed row holds `{ [operator]: undefined }`. `qs.stringify` omits that value when the list view writes the query to the URL. The condition serializes to nothing, the surrounding array closes the gap, and the row is lost on the next parse.

## Why TanStack Start and not Next.js

The bad commit leaves the URL and local state disagreeing. `qs` drops the row from the URL, but React state still holds `{ [operator]: undefined }` as a real key, so the row stays on screen. It disappears only once the server sends a fresh `query` prop and `syncPropsToURL` overwrites local state from the URL.

`refineListData` calls `router.replace`, which re-runs the TanStack route loader on every filter change, so TanStack reaches that point almost every time. Next.js re-renders the segment far less often, so local state keeps winning. The window is narrower on Next.js, not absent. The defect is in shared code.

## How

- Treat `undefined`, `null`, and an empty string as the same empty condition value.
- Ignore a value edit when the stored value and the incoming value are both empty.
- Keep field edits and operator edits. Those edits change the row even when it holds no value.
- Pass `0` and `false` down to the row instead of coercing them to `undefined`. The row then reports the same value back, the existing equality guard matches, and nothing is committed — so the row survives. These values reach the where builder from a query preset or a programmatic `where`, not from the URL, where every value is a string.

## Validation

- The `admin__e2e__list-view` suite passes on TanStack Start. The placeholder tests pass over repeated runs. `should display placeholder in filter options` is the test that covers this regression.
- The `query-presets` suite passes. That suite hosts the where builder with form state instead of URL state.
- New unit tests cover the empty value rule, the exemption for field and operator edits, and the rendering rule for `0` and `false`.

The failure needs a slower machine than a local workstation. CPU throttling and delayed relationship requests did not reproduce it locally. Instrumentation of the running build confirmed both steps of the cause. Every row reports an empty value on mount, and the new guard stops each of those reports.

## Related work

The same failure occurs on `main`: https://github.com/payloadcms/payload/actions/runs/31384615806

It also occurs on #16742, #17557, and #17674. None of those branches touch the where builder.
