### PR TITLE
feat(ui): add warning type to Banner

### DIFF
--- a/.github/workflows/e2e.config.ts
+++ b/.github/workflows/e2e.config.ts
@@ -13,6 +13,7 @@ export default createE2EConfig([
   { file: '_community', shards: 1 },
   { file: 'a11y', shards: 1 },
   { file: 'access-control', shards: 2 },
+  { file: 'admin__e2e__banner', shards: 1 },
   { file: 'admin__e2e__general', shards: 3 },
   { file: 'admin__e2e__list-view', shards: 4 },
   { file: 'admin__e2e__document-view', shards: 3 },

--- a/packages/ui/src/elements/Banner/index.scss
+++ b/packages/ui/src/elements/Banner/index.scss
@@ -26,7 +26,7 @@
     }
 
     &--type-default {
-      &.button--has-action {
+      &.banner--has-action {
         &:hover {
           background: var(--theme-elevation-900);
         }
@@ -45,7 +45,7 @@
         @include color-svg(var(--theme-error-600));
       }
 
-      &.button--has-action {
+      &.banner--has-action {
         &:hover {
           background: var(--theme-error-200);
         }
@@ -60,13 +60,32 @@
       background: var(--theme-success-100);
       color: var(--theme-success-600);
 
-      &.button--has-action {
+      &.banner--has-action {
         &:hover {
           background: var(--theme-success-200);
         }
 
         &:active {
           background: var(--theme-success-200);
+        }
+      }
+    }
+
+    &--type-warning {
+      background: var(--theme-warning-100);
+      color: var(--theme-warning-600);
+
+      svg {
+        @include color-svg(var(--theme-warning-600));
+      }
+
+      &.banner--has-action {
+        &:hover {
+          background: var(--theme-warning-200);
+        }
+
+        &:active {
+          background: var(--theme-warning-300);
         }
       }
     }

--- a/packages/ui/src/elements/Banner/index.scss
+++ b/packages/ui/src/elements/Banner/index.scss
@@ -26,7 +26,14 @@
     }
 
     &--type-default {
+      // The elevation-900/950 backgrounds invert between themes, and elevation-0
+      // inverts with them, so it stays legible in both.
       &.banner--has-action {
+        &:active,
+        &:hover {
+          color: var(--theme-elevation-0);
+        }
+
         &:hover {
           background: var(--theme-elevation-900);
         }
@@ -46,6 +53,15 @@
       }
 
       &.banner--has-action {
+        &:active,
+        &:hover {
+          color: var(--theme-error-800);
+
+          svg {
+            @include color-svg(var(--theme-error-800));
+          }
+        }
+
         &:hover {
           background: var(--theme-error-200);
         }
@@ -61,6 +77,11 @@
       color: var(--theme-success-600);
 
       &.banner--has-action {
+        &:active,
+        &:hover {
+          color: var(--theme-success-800);
+        }
+
         &:hover {
           background: var(--theme-success-200);
         }
@@ -80,6 +101,15 @@
       }
 
       &.banner--has-action {
+        &:active,
+        &:hover {
+          color: var(--theme-warning-800);
+
+          svg {
+            @include color-svg(var(--theme-warning-800));
+          }
+        }
+
         &:hover {
           background: var(--theme-warning-200);
         }

--- a/packages/ui/src/elements/Banner/index.scss
+++ b/packages/ui/src/elements/Banner/index.scss
@@ -92,12 +92,15 @@
       }
     }
 
+    // Warning sits one ramp step deeper than the other types. The -100 background is
+    // close enough to the error type's pink to be hard to tell apart, so -150 pushes
+    // the two further apart. The text moves with it to stay above 4.5:1.
     &--type-warning {
-      background: var(--theme-warning-100);
-      color: var(--theme-warning-600);
+      background: var(--theme-warning-150);
+      color: var(--theme-warning-650);
 
       svg {
-        @include color-svg(var(--theme-warning-600));
+        @include color-svg(var(--theme-warning-650));
       }
 
       &.banner--has-action {
@@ -111,7 +114,7 @@
         }
 
         &:hover {
-          background: var(--theme-warning-200);
+          background: var(--theme-warning-250);
         }
 
         &:active {

--- a/packages/ui/src/elements/Banner/index.tsx
+++ b/packages/ui/src/elements/Banner/index.tsx
@@ -17,7 +17,7 @@ export type Props = Readonly<{
   icon?: React.ReactNode
   onClick?: onClick
   to?: string
-  type?: 'default' | 'error' | 'info' | 'success'
+  type?: 'default' | 'error' | 'info' | 'success' | 'warning'
 }>
 
 export type RenderedTypeProps = {

--- a/test/admin/components/AfterNavLinks/index.tsx
+++ b/test/admin/components/AfterNavLinks/index.tsx
@@ -69,6 +69,14 @@ export const AfterNavLinks: PayloadClientReactComponent<
             Button Styles
           </Link>
         </p>
+        <p className="nav__link" style={{ margin: 0 }}>
+          <Link
+            href={`${adminRoute}/banner-styles`}
+            style={{ color: '#1976d2', textDecoration: 'none' }}
+          >
+            Banner Styles
+          </Link>
+        </p>
         <div id="custom-css" />
       </div>
     </div>

--- a/test/admin/components/AfterNavLinks/index.tsx
+++ b/test/admin/components/AfterNavLinks/index.tsx
@@ -6,6 +6,8 @@ import { useConfig } from '@payloadcms/ui'
 import LinkImport from 'next/link.js'
 import React from 'react'
 
+import { bannerStylesViewPath } from '../../shared.js'
+
 const Link = 'default' in LinkImport ? LinkImport.default : LinkImport
 
 const baseClass = 'after-nav-links'
@@ -71,7 +73,7 @@ export const AfterNavLinks: PayloadClientReactComponent<
         </p>
         <p className="nav__link" style={{ margin: 0 }}>
           <Link
-            href={`${adminRoute}/banner-styles`}
+            href={`${adminRoute}${bannerStylesViewPath}`}
             style={{ color: '#1976d2', textDecoration: 'none' }}
           >
             Banner Styles

--- a/test/admin/components/views/BannerStyles/index.tsx
+++ b/test/admin/components/views/BannerStyles/index.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import { Banner } from '@payloadcms/ui'
+import LinkImport from 'next/link.js'
+import React from 'react'
+
+const Link = 'default' in LinkImport ? LinkImport.default : LinkImport
+
+const bannerTypes = ['default', 'error', 'info', 'success', 'warning'] as const
+
+export const BannerStyles: React.FC = () => {
+  return (
+    <div style={{ padding: 'var(--gutter-h)' }}>
+      <Link href="/admin">Dashboard</Link>
+      <h1 style={{ marginTop: 'var(--base)' }}>Banners</h1>
+
+      <div id="banner-showcase">
+        {bannerTypes.map((type) => (
+          <Banner key={type} type={type}>
+            {type}
+          </Banner>
+        ))}
+      </div>
+
+      <h2 style={{ marginTop: 'calc(var(--base) * 2)' }}>With Action</h2>
+      <div id="banner-showcase-with-action">
+        {bannerTypes.map((type) => (
+          <Banner key={type} onClick={() => undefined} type={type}>
+            {type}
+          </Banner>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/test/admin/components/views/BannerStyles/index.tsx
+++ b/test/admin/components/views/BannerStyles/index.tsx
@@ -12,7 +12,7 @@ export const BannerStyles: React.FC = () => {
   return (
     <div style={{ padding: 'var(--gutter-h)' }}>
       <Link href="/admin">Dashboard</Link>
-      <h1 style={{ marginTop: 'var(--base)' }}>Banners</h1>
+      <h1 style={{ marginBottom: 'var(--base)', marginTop: 'var(--base)' }}>Banners</h1>
 
       <div id="banner-showcase">
         {bannerTypes.map((type) => (
@@ -22,8 +22,13 @@ export const BannerStyles: React.FC = () => {
         ))}
       </div>
 
-      <h2 style={{ marginTop: 'calc(var(--base) * 2)' }}>With Action</h2>
-      <div id="banner-showcase-with-action">
+      <h2 style={{ marginBottom: 'var(--base)', marginTop: 'calc(var(--base) * 2)' }}>
+        With Action
+      </h2>
+      <div
+        id="banner-showcase-with-action"
+        style={{ display: 'flex', flexWrap: 'wrap', gap: 'calc(var(--base) * 0.5)' }}
+      >
         {bannerTypes.map((type) => (
           <Banner key={type} onClick={() => undefined} type={type}>
             {type}

--- a/test/admin/config.ts
+++ b/test/admin/config.ts
@@ -48,6 +48,7 @@ import { GlobalNotInView } from './globals/NotInView.js'
 import { Settings } from './globals/Settings.js'
 import { seed } from './seed.js'
 import {
+  bannerStylesViewPath,
   BASE_PATH,
   customAdminRoutes,
   customNestedViewPath,
@@ -96,7 +97,7 @@ export default buildConfigWithDefaults({
         // Account: CustomAccountView,
         BannerShowcase: {
           Component: '/components/views/BannerStyles/index.js#BannerStyles',
-          path: '/banner-styles',
+          path: bannerStylesViewPath,
         },
         ButtonShowcase: {
           Component: '/components/views/ButtonStyles/index.js#ButtonStyles',

--- a/test/admin/config.ts
+++ b/test/admin/config.ts
@@ -94,6 +94,14 @@ export default buildConfigWithDefaults({
       views: {
         // Dashboard: CustomDashboardView,
         // Account: CustomAccountView,
+        BannerShowcase: {
+          Component: '/components/views/BannerStyles/index.js#BannerStyles',
+          path: '/banner-styles',
+        },
+        ButtonShowcase: {
+          Component: '/components/views/ButtonStyles/index.js#ButtonStyles',
+          path: '/button-styles',
+        },
         collections: {
           Component: '/components/views/CustomView/index.js#CustomView',
           path: '/collections',
@@ -134,10 +142,6 @@ export default buildConfigWithDefaults({
           exact: true,
           path: publicCustomViewPath,
           strict: true,
-        },
-        ButtonShowcase: {
-          Component: '/components/views/ButtonStyles/index.js#ButtonStyles',
-          path: '/button-styles',
         },
       },
     },

--- a/test/admin/e2e/banner/e2e.spec.ts
+++ b/test/admin/e2e/banner/e2e.spec.ts
@@ -27,16 +27,65 @@ const dirname = path.resolve(currentFolder, '../../')
 
 const bannerTypes = ['default', 'error', 'info', 'success', 'warning'] as const
 
+type BannerType = (typeof bannerTypes)[number]
+
+/** Types that define their own colours. `info` inherits the base banner styles. */
+const styledBannerTypes = ['default', 'error', 'success', 'warning'] as const satisfies BannerType[]
+
+/** WCAG 2.1 minimum contrast ratio for normal-sized body text. */
+const MINIMUM_CONTRAST_RATIO = 4.5
+
+const themes = ['light', 'dark'] as const
+
 describe('Banner', () => {
   let page: Page
   let context: BrowserContext
   let serverURL: string
   let adminRoute: string
 
-  const getBackgroundColor = async (type: string): Promise<string> =>
-    page
-      .locator(`#banner-showcase .banner--type-${type}`)
-      .evaluate((el) => window.getComputedStyle(el).backgroundColor)
+  const setTheme = async ({ theme }: { theme: (typeof themes)[number] }): Promise<void> => {
+    await page.evaluate(
+      (nextTheme) => document.documentElement.setAttribute('data-theme', nextTheme),
+      theme,
+    )
+  }
+
+  const getBanner = ({ type, hasAction }: { hasAction?: boolean; type: BannerType }) =>
+    page.locator(`#banner-showcase${hasAction ? '-with-action' : ''} .banner--type-${type}`)
+
+  const getBackgroundColor = async ({ type }: { type: BannerType }): Promise<string> =>
+    getBanner({ type }).evaluate((el) => window.getComputedStyle(el).backgroundColor)
+
+  const getContrastRatio = async ({
+    type,
+    hasAction,
+  }: {
+    hasAction?: boolean
+    type: BannerType
+  }): Promise<number> =>
+    getBanner({ type, hasAction }).evaluate((el) => {
+      const toChannels = (color: string) =>
+        color
+          .match(/\d+(?:\.\d+)?/g)
+          .slice(0, 3)
+          .map(Number)
+
+      const relativeLuminance = (channels: number[]) =>
+        channels
+          .map((channel) => {
+            const ratio = channel / 255
+            return ratio <= 0.03928 ? ratio / 12.92 : Math.pow((ratio + 0.055) / 1.055, 2.4)
+          })
+          .reduce((total, value, index) => total + [0.2126, 0.7152, 0.0722][index] * value, 0)
+
+      const styles = window.getComputedStyle(el)
+      const foreground = relativeLuminance(toChannels(styles.color))
+      const background = relativeLuminance(toChannels(styles.backgroundColor))
+      const [lighter, darker] =
+        foreground > background ? [foreground, background] : [background, foreground]
+
+      return (lighter + 0.05) / (darker + 0.05)
+    })
 
   beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
@@ -68,44 +117,94 @@ describe('Banner', () => {
   })
 
   test('should give the warning type its own background color', async () => {
-    const warningBackground = await getBackgroundColor('warning')
-    const defaultBackground = await getBackgroundColor('default')
+    const warningBackground = await getBackgroundColor({ type: 'warning' })
+    const defaultBackground = await getBackgroundColor({ type: 'default' })
 
     expect(warningBackground).not.toBe(defaultBackground)
   })
 
   test('should style the warning type with the warning theme token', async () => {
-    const warningBackground = await getBackgroundColor('warning')
+    const warningBackground = await getBackgroundColor({ type: 'warning' })
 
     // The token resolves to a hex string, so paint it onto a probe element to
     // normalise it into the rgb() form that getComputedStyle reports.
-    const warningToken = await page
-      .locator('#banner-showcase .banner--type-warning')
-      .evaluate((el) => {
-        const tokenValue = window
-          .getComputedStyle(el)
-          .getPropertyValue('--theme-warning-100')
-          .trim()
-        const probe = document.createElement('div')
+    const warningToken = await getBanner({ type: 'warning' }).evaluate((el) => {
+      const tokenValue = window.getComputedStyle(el).getPropertyValue('--theme-warning-100').trim()
+      const probe = document.createElement('div')
 
-        probe.style.backgroundColor = tokenValue
-        document.body.appendChild(probe)
+      probe.style.backgroundColor = tokenValue
+      document.body.appendChild(probe)
 
-        const normalised = window.getComputedStyle(probe).backgroundColor
+      const normalised = window.getComputedStyle(probe).backgroundColor
 
-        probe.remove()
+      probe.remove()
 
-        return normalised
-      })
+      return normalised
+    })
 
     expect(warningBackground).toBe(warningToken)
   })
 
   test('should keep the warning type distinct from the other styled types', async () => {
-    const styledTypes = ['default', 'error', 'success', 'warning']
+    const backgrounds = await Promise.all(
+      styledBannerTypes.map((type) => getBackgroundColor({ type })),
+    )
 
-    const backgrounds = await Promise.all(styledTypes.map((type) => getBackgroundColor(type)))
-
-    expect(new Set(backgrounds).size).toBe(styledTypes.length)
+    expect(new Set(backgrounds).size).toBe(styledBannerTypes.length)
   })
+
+  test('should darken the warning background on hover when the banner has an action', async () => {
+    const warning = getBanner({ type: 'warning', hasAction: true })
+
+    const restBackground = await warning.evaluate(
+      (el) => window.getComputedStyle(el).backgroundColor,
+    )
+
+    await warning.hover()
+
+    await expect
+      .poll(() => warning.evaluate((el) => window.getComputedStyle(el).backgroundColor))
+      .not.toBe(restBackground)
+  })
+
+  for (const type of styledBannerTypes) {
+    test(`should keep the ${type} type readable at rest in both themes`, async () => {
+      for (const theme of themes) {
+        await setTheme({ theme })
+
+        await expect
+          .poll(() => getContrastRatio({ type }), { message: `${type} at rest in ${theme}` })
+          .toBeGreaterThanOrEqual(MINIMUM_CONTRAST_RATIO)
+      }
+    })
+
+    test(`should keep the ${type} type readable on hover in both themes`, async () => {
+      for (const theme of themes) {
+        await setTheme({ theme })
+        await getBanner({ type, hasAction: true }).hover()
+
+        await expect
+          .poll(() => getContrastRatio({ type, hasAction: true }), {
+            message: `${type} on hover in ${theme}`,
+          })
+          .toBeGreaterThanOrEqual(MINIMUM_CONTRAST_RATIO)
+      }
+    })
+
+    test(`should keep the ${type} type readable while pressed in both themes`, async () => {
+      for (const theme of themes) {
+        await setTheme({ theme })
+        await getBanner({ type, hasAction: true }).hover()
+        await page.mouse.down()
+
+        await expect
+          .poll(() => getContrastRatio({ type, hasAction: true }), {
+            message: `${type} while pressed in ${theme}`,
+          })
+          .toBeGreaterThanOrEqual(MINIMUM_CONTRAST_RATIO)
+
+        await page.mouse.up()
+      }
+    })
+  }
 })

--- a/test/admin/e2e/banner/e2e.spec.ts
+++ b/test/admin/e2e/banner/e2e.spec.ts
@@ -12,6 +12,7 @@ import {
   getRoutes,
   initPageConsoleErrorCatch,
 } from '../../../__helpers/e2e/helpers.js'
+import { runAxeScan } from '../../../__helpers/e2e/runAxeScan.js'
 import { reInitializeDB } from '../../../__helpers/shared/clearAndSeed/reInitializeDB.js'
 import { initPayloadE2ENoConfig } from '../../../__helpers/shared/initPayloadE2ENoConfig.js'
 import { TEST_TIMEOUT_LONG } from '../../../playwright.config.js'
@@ -31,9 +32,6 @@ type BannerType = (typeof bannerTypes)[number]
 
 /** Types that define their own colours. `info` inherits the base banner styles. */
 const styledBannerTypes = ['default', 'error', 'success', 'warning'] as const satisfies BannerType[]
-
-/** WCAG 2.1 minimum contrast ratio for normal-sized body text. */
-const MINIMUM_CONTRAST_RATIO = 4.5
 
 const themes = ['light', 'dark'] as const
 
@@ -61,43 +59,6 @@ describe('Banner', () => {
 
   const getBackgroundColor = async ({ type }: Pick<BannerTarget, 'type'>): Promise<string> =>
     getBanner({ type }).evaluate((el) => window.getComputedStyle(el).backgroundColor)
-
-  /**
-   * Returns the WCAG 2.1 contrast ratio between a banner's text and its background.
-   *
-   * The calculation runs in the browser so it reads the resolved colours, including
-   * any that a `:hover` or `:active` state applies. `getComputedStyle` reports colours
-   * as `rgb()` or `rgba()` strings, so each is reduced to its numeric channels, then
-   * converted to a relative luminance with the sRGB gamma curve. The ratio is
-   * `(lighter + 0.05) / (darker + 0.05)`, so the result reads the same whichever of
-   * the two colours is lighter.
-   *
-   * @returns A ratio from 1 (identical colours) to 21 (black against white).
-   */
-  const getContrastRatio = async ({ type, hasAction }: BannerTarget): Promise<number> =>
-    getBanner({ type, hasAction }).evaluate((el) => {
-      const toChannels = (color: string) =>
-        color
-          .match(/\d+(?:\.\d+)?/g)
-          .slice(0, 3)
-          .map(Number)
-
-      const relativeLuminance = (channels: number[]) =>
-        channels
-          .map((channel) => {
-            const ratio = channel / 255
-            return ratio <= 0.03928 ? ratio / 12.92 : Math.pow((ratio + 0.055) / 1.055, 2.4)
-          })
-          .reduce((total, value, index) => total + [0.2126, 0.7152, 0.0722][index] * value, 0)
-
-      const styles = window.getComputedStyle(el)
-      const foreground = relativeLuminance(toChannels(styles.color))
-      const background = relativeLuminance(toChannels(styles.backgroundColor))
-      const [lighter, darker] =
-        foreground > background ? [foreground, background] : [background, foreground]
-
-      return (lighter + 0.05) / (darker + 0.05)
-    })
 
   beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
@@ -179,43 +140,53 @@ describe('Banner', () => {
       .not.toBe(restBackground)
   })
 
-  for (const type of styledBannerTypes) {
-    test(`should keep the ${type} type readable at rest in both themes`, async () => {
-      for (const theme of themes) {
-        await setTheme({ theme })
+  for (const theme of themes) {
+    test(`should have no accessibility violations at rest in the ${theme} theme`, async () => {
+      await setTheme({ theme })
 
-        await expect
-          .poll(() => getContrastRatio({ type }), { message: `${type} at rest in ${theme}` })
-          .toBeGreaterThanOrEqual(MINIMUM_CONTRAST_RATIO)
-      }
+      const results = await runAxeScan({
+        include: ['#banner-showcase'],
+        page,
+        testInfo: test.info(),
+      })
+
+      expect(results.violations).toEqual([])
     })
 
-    test(`should keep the ${type} type readable on hover in both themes`, async () => {
-      for (const theme of themes) {
-        await setTheme({ theme })
+    // Axe reads the resolved styles of the current DOM, so hovering or pressing a
+    // banner first means the scan reports the colours of that state.
+    test(`should have no accessibility violations while a banner is hovered in the ${theme} theme`, async () => {
+      await setTheme({ theme })
+
+      for (const type of styledBannerTypes) {
         await getBanner({ type, hasAction: true }).hover()
 
-        await expect
-          .poll(() => getContrastRatio({ type, hasAction: true }), {
-            message: `${type} on hover in ${theme}`,
-          })
-          .toBeGreaterThanOrEqual(MINIMUM_CONTRAST_RATIO)
+        const results = await runAxeScan({
+          include: [`#banner-showcase-with-action .banner--type-${type}`],
+          page,
+          testInfo: test.info(),
+        })
+
+        expect(results.violations, `${type} hovered in ${theme}`).toEqual([])
       }
     })
 
-    test(`should keep the ${type} type readable while pressed in both themes`, async () => {
-      for (const theme of themes) {
-        await setTheme({ theme })
+    test(`should have no accessibility violations while a banner is pressed in the ${theme} theme`, async () => {
+      await setTheme({ theme })
+
+      for (const type of styledBannerTypes) {
         await getBanner({ type, hasAction: true }).hover()
         await page.mouse.down()
 
-        await expect
-          .poll(() => getContrastRatio({ type, hasAction: true }), {
-            message: `${type} while pressed in ${theme}`,
-          })
-          .toBeGreaterThanOrEqual(MINIMUM_CONTRAST_RATIO)
+        const results = await runAxeScan({
+          include: [`#banner-showcase-with-action .banner--type-${type}`],
+          page,
+          testInfo: test.info(),
+        })
 
         await page.mouse.up()
+
+        expect(results.violations, `${type} pressed in ${theme}`).toEqual([])
       }
     })
   }

--- a/test/admin/e2e/banner/e2e.spec.ts
+++ b/test/admin/e2e/banner/e2e.spec.ts
@@ -35,6 +35,12 @@ const styledBannerTypes = ['default', 'error', 'success', 'warning'] as const sa
 
 const themes = ['light', 'dark'] as const
 
+/**
+ * The token the warning type uses for its resting background. It sits one step
+ * deeper than the other types so the warning colour reads apart from the error one.
+ */
+const WARNING_BACKGROUND_TOKEN = '--theme-warning-150'
+
 type BannerTarget = {
   /** Selects the actionable showcase row, whose banners carry `banner--has-action`. */
   hasAction?: boolean
@@ -101,8 +107,8 @@ describe('Banner', () => {
 
     // The token resolves to a hex string, so paint it onto a probe element to
     // normalise it into the rgb() form that getComputedStyle reports.
-    const warningToken = await getBanner({ type: 'warning' }).evaluate((el) => {
-      const tokenValue = window.getComputedStyle(el).getPropertyValue('--theme-warning-100').trim()
+    const warningToken = await getBanner({ type: 'warning' }).evaluate((el, token) => {
+      const tokenValue = window.getComputedStyle(el).getPropertyValue(token).trim()
       const probe = document.createElement('div')
 
       probe.style.backgroundColor = tokenValue
@@ -113,7 +119,7 @@ describe('Banner', () => {
       probe.remove()
 
       return normalised
-    })
+    }, WARNING_BACKGROUND_TOKEN)
 
     expect(warningBackground).toBe(warningToken)
   })

--- a/test/admin/e2e/banner/e2e.spec.ts
+++ b/test/admin/e2e/banner/e2e.spec.ts
@@ -37,6 +37,12 @@ const MINIMUM_CONTRAST_RATIO = 4.5
 
 const themes = ['light', 'dark'] as const
 
+type BannerTarget = {
+  /** Selects the actionable showcase row, whose banners carry `banner--has-action`. */
+  hasAction?: boolean
+  type: BannerType
+}
+
 describe('Banner', () => {
   let page: Page
   let context: BrowserContext
@@ -50,19 +56,25 @@ describe('Banner', () => {
     )
   }
 
-  const getBanner = ({ type, hasAction }: { hasAction?: boolean; type: BannerType }) =>
+  const getBanner = ({ type, hasAction }: BannerTarget) =>
     page.locator(`#banner-showcase${hasAction ? '-with-action' : ''} .banner--type-${type}`)
 
-  const getBackgroundColor = async ({ type }: { type: BannerType }): Promise<string> =>
+  const getBackgroundColor = async ({ type }: Pick<BannerTarget, 'type'>): Promise<string> =>
     getBanner({ type }).evaluate((el) => window.getComputedStyle(el).backgroundColor)
 
-  const getContrastRatio = async ({
-    type,
-    hasAction,
-  }: {
-    hasAction?: boolean
-    type: BannerType
-  }): Promise<number> =>
+  /**
+   * Returns the WCAG 2.1 contrast ratio between a banner's text and its background.
+   *
+   * The calculation runs in the browser so it reads the resolved colours, including
+   * any that a `:hover` or `:active` state applies. `getComputedStyle` reports colours
+   * as `rgb()` or `rgba()` strings, so each is reduced to its numeric channels, then
+   * converted to a relative luminance with the sRGB gamma curve. The ratio is
+   * `(lighter + 0.05) / (darker + 0.05)`, so the result reads the same whichever of
+   * the two colours is lighter.
+   *
+   * @returns A ratio from 1 (identical colours) to 21 (black against white).
+   */
+  const getContrastRatio = async ({ type, hasAction }: BannerTarget): Promise<number> =>
     getBanner({ type, hasAction }).evaluate((el) => {
       const toChannels = (color: string) =>
         color

--- a/test/admin/e2e/banner/e2e.spec.ts
+++ b/test/admin/e2e/banner/e2e.spec.ts
@@ -1,0 +1,111 @@
+import type { BrowserContext, Page } from '@playwright/test'
+
+import { expect, test } from '@playwright/test'
+import path from 'path'
+import { formatAdminURL } from 'payload/shared'
+import { fileURLToPath } from 'url'
+
+import type { Config } from '../../payload-types.js'
+
+import {
+  ensureCompilationIsDone,
+  getRoutes,
+  initPageConsoleErrorCatch,
+} from '../../../__helpers/e2e/helpers.js'
+import { reInitializeDB } from '../../../__helpers/shared/clearAndSeed/reInitializeDB.js'
+import { initPayloadE2ENoConfig } from '../../../__helpers/shared/initPayloadE2ENoConfig.js'
+import { TEST_TIMEOUT_LONG } from '../../../playwright.config.js'
+import { BASE_PATH, customAdminRoutes } from '../../shared.js'
+
+process.env.NEXT_BASE_PATH = BASE_PATH
+
+const { beforeAll, beforeEach, describe } = test
+
+const filename = fileURLToPath(import.meta.url)
+const currentFolder = path.dirname(filename)
+const dirname = path.resolve(currentFolder, '../../')
+
+const bannerTypes = ['default', 'error', 'info', 'success', 'warning'] as const
+
+describe('Banner', () => {
+  let page: Page
+  let context: BrowserContext
+  let serverURL: string
+  let adminRoute: string
+
+  const getBackgroundColor = async (type: string): Promise<string> =>
+    page
+      .locator(`#banner-showcase .banner--type-${type}`)
+      .evaluate((el) => window.getComputedStyle(el).backgroundColor)
+
+  beforeAll(async ({ browser }, testInfo) => {
+    testInfo.setTimeout(TEST_TIMEOUT_LONG)
+
+    process.env.SEED_IN_CONFIG_ONINIT = 'false'
+    ;({ serverURL } = await initPayloadE2ENoConfig<Config>({ dirname, prebuild: false }))
+
+    context = await browser.newContext()
+    page = await context.newPage()
+    initPageConsoleErrorCatch(page)
+
+    await ensureCompilationIsDone({ customAdminRoutes, page, serverURL })
+
+    adminRoute = getRoutes({ customAdminRoutes }).routes.admin
+  })
+
+  beforeEach(async () => {
+    await reInitializeDB({ serverURL, snapshotKey: 'adminTests' })
+
+    await ensureCompilationIsDone({ customAdminRoutes, page, serverURL })
+
+    await page.goto(formatAdminURL({ adminRoute, path: '/banner-styles', serverURL }))
+  })
+
+  test('should render a banner for every supported type', async () => {
+    for (const type of bannerTypes) {
+      await expect(page.locator(`#banner-showcase .banner--type-${type}`)).toBeVisible()
+    }
+  })
+
+  test('should give the warning type its own background color', async () => {
+    const warningBackground = await getBackgroundColor('warning')
+    const defaultBackground = await getBackgroundColor('default')
+
+    expect(warningBackground).not.toBe(defaultBackground)
+  })
+
+  test('should style the warning type with the warning theme token', async () => {
+    const warningBackground = await getBackgroundColor('warning')
+
+    // The token resolves to a hex string, so paint it onto a probe element to
+    // normalise it into the rgb() form that getComputedStyle reports.
+    const warningToken = await page
+      .locator('#banner-showcase .banner--type-warning')
+      .evaluate((el) => {
+        const tokenValue = window
+          .getComputedStyle(el)
+          .getPropertyValue('--theme-warning-100')
+          .trim()
+        const probe = document.createElement('div')
+
+        probe.style.backgroundColor = tokenValue
+        document.body.appendChild(probe)
+
+        const normalised = window.getComputedStyle(probe).backgroundColor
+
+        probe.remove()
+
+        return normalised
+      })
+
+    expect(warningBackground).toBe(warningToken)
+  })
+
+  test('should keep the warning type distinct from the other styled types', async () => {
+    const styledTypes = ['default', 'error', 'success', 'warning']
+
+    const backgrounds = await Promise.all(styledTypes.map((type) => getBackgroundColor(type)))
+
+    expect(new Set(backgrounds).size).toBe(styledTypes.length)
+  })
+})

--- a/test/admin/e2e/banner/e2e.spec.ts
+++ b/test/admin/e2e/banner/e2e.spec.ts
@@ -16,7 +16,7 @@ import { runAxeScan } from '../../../__helpers/e2e/runAxeScan.js'
 import { reInitializeDB } from '../../../__helpers/shared/clearAndSeed/reInitializeDB.js'
 import { initPayloadE2ENoConfig } from '../../../__helpers/shared/initPayloadE2ENoConfig.js'
 import { TEST_TIMEOUT_LONG } from '../../../playwright.config.js'
-import { BASE_PATH, customAdminRoutes } from '../../shared.js'
+import { bannerStylesViewPath, BASE_PATH, customAdminRoutes } from '../../shared.js'
 
 process.env.NEXT_BASE_PATH = BASE_PATH
 
@@ -86,7 +86,7 @@ describe('Banner', () => {
 
     await ensureCompilationIsDone({ customAdminRoutes, page, serverURL })
 
-    await page.goto(formatAdminURL({ adminRoute, path: '/banner-styles', serverURL }))
+    await page.goto(formatAdminURL({ adminRoute, path: bannerStylesViewPath, serverURL }))
   })
 
   test('should render a banner for every supported type', async () => {

--- a/test/admin/shared.ts
+++ b/test/admin/shared.ts
@@ -12,6 +12,8 @@ export const publicCustomViewPath = '/public-custom-view'
 
 export const protectedCustomNestedViewPath = `${publicCustomViewPath}/protected-nested-view`
 
+export const bannerStylesViewPath = '/banner-styles'
+
 export const customParamViewPathBase = '/custom-param'
 
 export const customParamViewPath = `${customParamViewPathBase}/:id`


### PR DESCRIPTION
## Summary

The `Banner` component on 3.x supports `default`, `error`, `info`, and `success`. It has no warning appearance, although a full `--theme-warning-*` token family already exists. This change adds a `warning` type, styles it with those tokens, and corrects a selector fault that had left the interactive states of every type inert.

Note: This change already exists for [4.x](https://github.com/payloadcms/payload/blob/90d179ee630e9a38bea968b676c5e687b776c445/packages/ui/src/elements/Banner/index.tsx#L21)

## Why the change grew past the type union

The hover and active rules for `default`, `error`, and `success` were nested under `.button--has-action`. The component only ever emits `.banner--has-action`, so those six rules had matched nothing since the component moved to its current path in December 2023. No first-party Banner passes `to` or `onClick`, so no built-in banner was clickable and the fault stayed invisible.

Correcting the selector activates those rules for the first time. Measured against WCAG 1.4.3, all four types then failed:

| state                    | light           | dark            |
| ------------------------ | --------------- | --------------- |
| `default` hover          | 1.38:1          | 1.19:1          |
| `error` hover / active   | 3.80:1 / 2.86:1 | 3.81:1 / 2.83:1 |
| `success` hover / active | 3.69:1          | 3.82:1          |
| `warning` hover / active | 3.71:1 / 2.80:1 | 3.74:1 / 2.78:1 |

`default` was the worst case: `--theme-elevation-900` inverts between themes, so its hover state resolved to near-black text on near-black in light mode and white on white in dark. Shipping the selector fix without the colour corrections would introduce four inaccessible interactive states, so the two belong together.

```tsx
// Before: 'warning' is a type error
<Banner type="warning">Check this value</Banner>

// After: supported
<Banner type="warning">Check this value</Banner>
```

The type union changes from:

```ts
type?: 'default' | 'error' | 'info' | 'success'
```

to:

```ts
type?: 'default' | 'error' | 'info' | 'success' | 'warning'
```

Dark Mode: 

<img width="1605" height="381" alt="image" src="https://github.com/user-attachments/assets/11251a49-ce9e-4fcd-bc49-3bb0c397b877" />

Light Mode:

<img width="3188" height="742" alt="image" src="https://github.com/user-attachments/assets/af70ed65-3040-4b65-92c4-7c50cf1c7965" />


## Validation

A new e2e suite covers the Banner component, which had none before. It asserts that every type renders, that `warning` resolves to its background token, and that the styled types stay visually distinct.

The suite is registered in `.github/workflows/e2e.config.ts` as `admin__e2e__banner`. Without an entry there the runner never selects the folder and the tests would not run in CI.