### PR TITLE
refactor(plugin-mcp): better access control defaults for api keys collection

### DIFF
--- a/docs/plugins/mcp.mdx
+++ b/docs/plugins/mcp.mdx
@@ -524,18 +524,13 @@ mcpPlugin({
 
 ## API Key Access to MCP
 
-Payload adds an API Key collection for managing MCP credentials and capabilities. A user who can
-create or update documents in this collection can choose the user associated with a key and the
-MCP capabilities enabled for it. Requests authenticated with that key then act as the associated
-user. Unless you add additional restrictions, this means a key manager can issue credentials that
-act as any user in the configured user collection.
+Payload adds an API Key collection for managing MCP credentials and capabilities. By default, a
+signed-in user from the configured user collection can create and manage only their own keys. The
+owner is assigned automatically and cannot be changed.
 
-For that reason, access should normally be limited to administrators who are trusted to issue
-credentials on behalf of other users. Payload does not define what an administrator is in your
-application, so access must be manually defined with `overrideApiKeyCollection`.
-
-To manage keys through the Admin Panel or APIs, use `overrideApiKeyCollection` to explicitly grant
-access to your application's administrators:
+Requests authenticated with a key act as its owner. To let administrators issue and manage keys
+for other users, override both the collection access and the `user` field access with
+`overrideApiKeyCollection`:
 
 ```ts
 import type { PayloadRequest } from 'payload'
@@ -549,22 +544,27 @@ const isAdmin = ({ req }: { req: PayloadRequest }) =>
   )
 
 mcpPlugin({
-  overrideApiKeyCollection: (collection) => ({
-    ...collection,
-    access: {
+  overrideApiKeyCollection: (collection) => {
+    collection.access = {
       create: isAdmin,
       delete: isAdmin,
       read: isAdmin,
       unlock: isAdmin,
       update: isAdmin,
-    },
-  }),
+    }
+    collection.fields = collection.fields.map((field) =>
+      'name' in field && field.name === 'user'
+        ? { ...field, access: { create: isAdmin, update: isAdmin } }
+        : field,
+    )
+    return collection
+  },
   // ... other options
 })
 ```
 
-Replace `isAdmin` with the role or permission check used by your application. Once access is
-configured, administrators can:
+Replace `isAdmin` with the permission check used by your application. Only grant this access to
+users trusted to issue credentials that act as another user. Once configured, administrators can:
 
 - Create user associated API keys for MCP clients
 - `Allow` or `disallow` endpoint traffic in real-time

--- a/docs/plugins/mcp.mdx
+++ b/docs/plugins/mcp.mdx
@@ -121,6 +121,12 @@ export default config
 | `mcp.serverOptions.serverInfo.name`    | `string`            | The name of the MCP server (default: 'Payload MCP Server').                                    |
 | `mcp.serverOptions.serverInfo.version` | `string`            | The version of the MCP server (default: '1.0.0').                                              |
 
+<Banner type="warning">
+  The generated API Key collection denies Admin Panel, REST, and GraphQL access
+  by default. Access must be manually defined with `overrideApiKeyCollection`
+  before you are able to see the MCP API Keys collection in the admin panel.
+</Banner>
+
 ## How Access Control Works with MCP
 
 <Banner type="warning">
@@ -145,9 +151,9 @@ mcpPlugin({
 
 **Step 2 — Allow in the API Key**
 
-In your Payload admin panel, navigate to **MCP → API Keys**, create a new key, and
-toggle the individual capabilities on for each collection, global, tool, prompt, and
-resource you want that key to be able to use.
+After manually configuring access to the API Key collection as described below, navigate to
+**MCP → API Keys** in the Payload admin panel. Create a key and toggle the individual
+capabilities for each collection, global, tool, prompt, and resource you want that key to use.
 
 All MCP requests must include a valid API key as a Bearer token — requests without
 one are rejected immediately. Here is a complete example of an MCP `tools/list` request
@@ -518,13 +524,53 @@ mcpPlugin({
 
 ## API Key Access to MCP
 
-Payload adds an API key collection that allows admins to manage MCP capabilities. Admins can:
+Payload adds an API Key collection for managing MCP credentials and capabilities. A user who can
+create or update documents in this collection can choose the user associated with a key and the
+MCP capabilities enabled for it. Requests authenticated with that key then act as the associated
+user. Unless you add additional restrictions, this means a key manager can issue credentials that
+act as any user in the configured user collection.
+
+For that reason, access should normally be limited to administrators who are trusted to issue
+credentials on behalf of other users. Payload does not define what an administrator is in your
+application, so access must be manually defined with `overrideApiKeyCollection`.
+
+To manage keys through the Admin Panel or APIs, use `overrideApiKeyCollection` to explicitly grant
+access to your application's administrators:
+
+```ts
+import type { PayloadRequest } from 'payload'
+
+const isAdmin = ({ req }: { req: PayloadRequest }) =>
+  Boolean(
+    req.user &&
+      req.user.collection === 'users' &&
+      'role' in req.user &&
+      req.user.role === 'admin',
+  )
+
+mcpPlugin({
+  overrideApiKeyCollection: (collection) => ({
+    ...collection,
+    access: {
+      create: isAdmin,
+      delete: isAdmin,
+      read: isAdmin,
+      unlock: isAdmin,
+      update: isAdmin,
+    },
+  }),
+  // ... other options
+})
+```
+
+Replace `isAdmin` with the role or permission check used by your application. Once access is
+configured, administrators can:
 
 - Create user associated API keys for MCP clients
 - `Allow` or `disallow` endpoint traffic in real-time
 - `Allow` or `disallow` tools, resources, and prompts
 
-You can customize the API Key collection using the `overrideApiKeyCollection` option:
+The same callback can also customize the API Key collection:
 
 ```ts
 mcpPlugin({

--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -973,7 +973,7 @@ export class BasePayload {
         }
 
         // 2. if api key enabled, push api key strategy into the array
-        if (collection.auth?.useAPIKey) {
+        if (collection.auth?.useAPIKey && collection.slug !== 'payload-mcp-api-keys') {
           authStrategies.push({
             name: `${collection.slug}-api-key`,
             authenticate: APIKeyAuthentication(collection),

--- a/packages/plugin-mcp/src/collections/createApiKeysCollection.ts
+++ b/packages/plugin-mcp/src/collections/createApiKeysCollection.ts
@@ -55,6 +55,12 @@ export const createAPIKeysCollection = (
 
   const userCollection = pluginOptions.userCollection
 
+  const isAuthenticated = ({ req }: { req: PayloadRequest }): boolean =>
+    Boolean(req.user && req.user.collection === userCollection)
+
+  const restrictToOwnKeys = ({ req }: { req: PayloadRequest }): boolean | Where =>
+    req.user && req.user.collection === userCollection ? { user: { equals: req.user.id } } : false
+
   return {
     slug: 'payload-mcp-api-keys',
     access: {
@@ -92,7 +98,8 @@ export const createAPIKeysCollection = (
         admin: {
           description: 'The user that the API key is associated with.',
         },
-        defaultValue: ({ req }: { req: PayloadRequest }) => req?.user?.id,
+        defaultValue: ({ req }: { req: PayloadRequest }) =>
+          req.user && req.user.collection === userCollection ? req.user.id : undefined,
         relationTo: userCollection as CollectionSlug,
         required: true,
       },
@@ -390,10 +397,3 @@ export const createAPIKeysCollection = (
     },
   }
 }
-
-const isAuthenticated = ({ req }: { req: PayloadRequest }): boolean => Boolean(req.user)
-
-// Constrain reads and mutations to the caller's own keys. Returns a query constraint
-// for authenticated users and denies everyone else.
-const restrictToOwnKeys = ({ req }: { req: PayloadRequest }): boolean | Where =>
-  req.user ? { user: { equals: req.user.id } } : false

--- a/packages/plugin-mcp/src/collections/createApiKeysCollection.ts
+++ b/packages/plugin-mcp/src/collections/createApiKeysCollection.ts
@@ -57,6 +57,13 @@ export const createAPIKeysCollection = (
 
   return {
     slug: 'payload-mcp-api-keys',
+    access: {
+      create: () => false,
+      delete: () => false,
+      read: () => false,
+      unlock: () => false,
+      update: () => false,
+    },
     admin: {
       description:
         'API keys control which collections, resources, tools, and prompts MCP clients can access',

--- a/packages/plugin-mcp/src/collections/createApiKeysCollection.ts
+++ b/packages/plugin-mcp/src/collections/createApiKeysCollection.ts
@@ -1,4 +1,4 @@
-import type { CollectionConfig, CollectionSlug } from 'payload'
+import type { CollectionConfig, CollectionSlug, PayloadRequest, Where } from 'payload'
 
 import type { MCPPluginConfig } from '../types.js'
 
@@ -58,11 +58,14 @@ export const createAPIKeysCollection = (
   return {
     slug: 'payload-mcp-api-keys',
     access: {
-      create: () => false,
-      delete: () => false,
-      read: () => false,
-      unlock: () => false,
-      update: () => false,
+      // Fail-safe default: any authenticated user may manage only their OWN keys.
+      // Cross-user key issuance is disabled by default (see the `user` field below)
+      // and must be granted explicitly via `overrideApiKeyCollection`.
+      create: isAuthenticated,
+      delete: restrictToOwnKeys,
+      read: restrictToOwnKeys,
+      unlock: restrictToOwnKeys,
+      update: restrictToOwnKeys,
     },
     admin: {
       description:
@@ -78,9 +81,18 @@ export const createAPIKeysCollection = (
       {
         name: 'user',
         type: 'relationship',
+        access: {
+          // Bind new keys to the creating user and prevent re-binding on update.
+          // A key acts as its associated user, so allowing arbitrary assignment lets
+          // any key manager impersonate anyone. Grant these via `overrideApiKeyCollection`
+          // to let trusted administrators issue keys on behalf of other users.
+          create: () => false,
+          update: () => false,
+        },
         admin: {
           description: 'The user that the API key is associated with.',
         },
+        defaultValue: ({ req }: { req: PayloadRequest }) => req?.user?.id,
         relationTo: userCollection as CollectionSlug,
         required: true,
       },
@@ -378,3 +390,10 @@ export const createAPIKeysCollection = (
     },
   }
 }
+
+const isAuthenticated = ({ req }: { req: PayloadRequest }): boolean => Boolean(req.user)
+
+// Constrain reads and mutations to the caller's own keys. Returns a query constraint
+// for authenticated users and denies everyone else.
+const restrictToOwnKeys = ({ req }: { req: PayloadRequest }): boolean | Where =>
+  req.user ? { user: { equals: req.user.id } } : false

--- a/packages/plugin-mcp/src/endpoints/mcp.ts
+++ b/packages/plugin-mcp/src/endpoints/mcp.ts
@@ -1,91 +1,26 @@
-import crypto from 'crypto'
-import { type PayloadHandler, type TypedUser, UnauthorizedError, type Where } from 'payload'
+import type { PayloadHandler } from 'payload'
 
-import type { MCPAccessSettings, MCPPluginConfig } from '../types.js'
+import type { MCPPluginConfig } from '../types.js'
 
 import { createRequestFromPayloadRequest } from '../mcp/createRequest.js'
-import { getMCPHandler } from '../mcp/getMcpHandler.js'
+import { getMcpHandler } from '../mcp/getMcpHandler.js'
+import { resolveAccessSettings } from './resolveAccessSettings.js'
+import { withRestoredWebGlobals } from './withRestoredWebGlobals.js'
 
 export const initializeMCPHandler = (pluginOptions: MCPPluginConfig) => {
   const mcpHandler: PayloadHandler = async (req) => {
-    const { payload } = req
-    const MCPOptions = pluginOptions.mcp || {}
-    const MCPHandlerOptions = MCPOptions.handlerOptions || {}
-    const useVerboseLogs = MCPHandlerOptions.verboseLogs ?? false
+    const useVerboseLogs = pluginOptions.mcp?.handlerOptions?.verboseLogs ?? false
 
     req.payloadAPI = 'MCP' as const
 
-    const getDefaultMcpAccessSettings = async (overrideApiKey?: null | string) => {
-      const authorization = req.headers.get('Authorization')
-      const apiKey =
-        overrideApiKey ??
-        (authorization?.startsWith('Bearer ') ? authorization.replace('Bearer ', '').trim() : null)
+    const mcpAccessSettings = await resolveAccessSettings({ pluginOptions, req, useVerboseLogs })
+    req.user = mcpAccessSettings.user
 
-      if (apiKey === null) {
-        throw new UnauthorizedError()
-      }
-
-      const sha256APIKeyIndex = crypto
-        .createHmac('sha256', payload.secret)
-        .update(apiKey || '')
-        .digest('hex')
-
-      const where: Where = {
-        apiKeyIndex: {
-          equals: sha256APIKeyIndex,
-        },
-      }
-
-      const { docs } = await payload.find({
-        collection: 'payload-mcp-api-keys',
-        depth: 1,
-        limit: 1,
-        pagination: false,
-        where,
-      })
-
-      if (docs.length === 0) {
-        throw new UnauthorizedError()
-      }
-
-      if (useVerboseLogs) {
-        payload.logger.info('[payload-mcp] API Key is valid')
-      }
-
-      const user = docs[0]?.user as TypedUser
-      user.collection = pluginOptions.userCollection as string
-      user._strategy = 'mcp-api-key' as const
-
-      return docs[0] as unknown as MCPAccessSettings
-    }
-
-    const mcpAccessSettings = pluginOptions.overrideAuth
-      ? await pluginOptions.overrideAuth(req, getDefaultMcpAccessSettings)
-      : await getDefaultMcpAccessSettings()
-
-    // @modelcontextprotocol/sdk's StreamableHTTPServerTransport uses @hono/node-server's
-    // getRequestListener, which replaces global.Request and global.Response with Hono
-    // custom classes. Unfortunately, we cannot pass overrideGlobalObjects: false because the option is
-    // consumed inside the SDK transport and is not exposed to callers.
-    // Save originals here and restore after the handler resolves so that Next.js
-    // instanceof Response checks on subsequent route handlers keep working.
-    const globals = globalThis as Record<string, unknown>
-    const originalResponse = globals['Response']
-    const originalRequest = globals['Request']
-
-    const handler = getMCPHandler(pluginOptions, mcpAccessSettings, req)
-    const request = createRequestFromPayloadRequest(req)
-
-    try {
+    return await withRestoredWebGlobals(async () => {
+      const handler = getMcpHandler(pluginOptions, mcpAccessSettings, req)
+      const request = createRequestFromPayloadRequest(req)
       return await handler(request)
-    } finally {
-      if (globals['Response'] !== originalResponse) {
-        Object.defineProperty(globalThis, 'Response', { value: originalResponse })
-      }
-      if (globals['Request'] !== originalRequest) {
-        Object.defineProperty(globalThis, 'Request', { value: originalRequest })
-      }
-    }
+    })
   }
   return mcpHandler
 }

--- a/packages/plugin-mcp/src/endpoints/mcp.ts
+++ b/packages/plugin-mcp/src/endpoints/mcp.ts
@@ -16,10 +16,10 @@ export const initializeMCPHandler = (pluginOptions: MCPPluginConfig) => {
     req.payloadAPI = 'MCP' as const
 
     const getDefaultMcpAccessSettings = async (overrideApiKey?: null | string) => {
+      const authorization = req.headers.get('Authorization')
       const apiKey =
-        (overrideApiKey ?? req.headers.get('Authorization')?.startsWith('Bearer '))
-          ? req.headers.get('Authorization')?.replace('Bearer ', '').trim()
-          : null
+        overrideApiKey ??
+        (authorization?.startsWith('Bearer ') ? authorization.replace('Bearer ', '').trim() : null)
 
       if (apiKey === null) {
         throw new UnauthorizedError()

--- a/packages/plugin-mcp/src/endpoints/resolveAccessSettings.ts
+++ b/packages/plugin-mcp/src/endpoints/resolveAccessSettings.ts
@@ -1,0 +1,74 @@
+import crypto from 'crypto'
+import { type PayloadRequest, type TypedUser, UnauthorizedError, type Where } from 'payload'
+
+import type { MCPAccessSettings, MCPPluginConfig } from '../types.js'
+
+type ResolveAccessSettingsArgs = {
+  pluginOptions: MCPPluginConfig
+  req: PayloadRequest
+  useVerboseLogs: boolean
+}
+
+const createDefaultAccessSettingsResolver = ({
+  pluginOptions,
+  req,
+  useVerboseLogs,
+}: ResolveAccessSettingsArgs) => {
+  return async (overrideApiKey?: null | string): Promise<MCPAccessSettings> => {
+    const authorization = req.headers.get('Authorization')
+    const apiKey =
+      overrideApiKey ??
+      (authorization?.startsWith('Bearer ') ? authorization.replace('Bearer ', '').trim() : null)
+
+    if (apiKey === null) {
+      throw new UnauthorizedError()
+    }
+
+    const sha256APIKeyIndex = crypto
+      .createHmac('sha256', req.payload.secret)
+      .update(apiKey || '')
+      .digest('hex')
+    const where: Where = {
+      apiKeyIndex: {
+        equals: sha256APIKeyIndex,
+      },
+    }
+    const { docs } = await req.payload.find({
+      collection: 'payload-mcp-api-keys',
+      depth: 1,
+      limit: 1,
+      pagination: false,
+      where,
+    })
+    const apiKeyDoc = docs[0]
+
+    if (!apiKeyDoc) {
+      throw new UnauthorizedError()
+    }
+
+    if (useVerboseLogs) {
+      req.payload.logger.info('[payload-mcp] API Key is valid')
+    }
+
+    const user = apiKeyDoc.user as TypedUser
+
+    if (!user || typeof user !== 'object' || !('id' in user)) {
+      throw new UnauthorizedError()
+    }
+
+    user.collection = pluginOptions.userCollection as string
+    user._strategy = 'mcp-api-key' as const
+
+    return apiKeyDoc as unknown as MCPAccessSettings
+  }
+}
+
+export const resolveAccessSettings = async (
+  args: ResolveAccessSettingsArgs,
+): Promise<MCPAccessSettings> => {
+  const getDefaultMcpAccessSettings = createDefaultAccessSettingsResolver(args)
+
+  return args.pluginOptions.overrideAuth
+    ? await args.pluginOptions.overrideAuth(args.req, getDefaultMcpAccessSettings)
+    : await getDefaultMcpAccessSettings()
+}

--- a/packages/plugin-mcp/src/endpoints/withRestoredWebGlobals.ts
+++ b/packages/plugin-mcp/src/endpoints/withRestoredWebGlobals.ts
@@ -1,0 +1,19 @@
+/**
+ * Restores globals replaced by @hono/node-server while handling an MCP request.
+ */
+export const withRestoredWebGlobals = async <T>(handler: () => Promise<T>): Promise<T> => {
+  const globals = globalThis as Record<string, unknown>
+  const originalRequest = globals['Request']
+  const originalResponse = globals['Response']
+
+  try {
+    return await handler()
+  } finally {
+    if (globals['Response'] !== originalResponse) {
+      Object.defineProperty(globalThis, 'Response', { value: originalResponse })
+    }
+    if (globals['Request'] !== originalRequest) {
+      Object.defineProperty(globalThis, 'Request', { value: originalRequest })
+    }
+  }
+}

--- a/packages/plugin-mcp/src/mcp/getMcpHandler.ts
+++ b/packages/plugin-mcp/src/mcp/getMcpHandler.ts
@@ -2,7 +2,7 @@ import type { JSONSchema4 } from 'json-schema'
 
 import { createMcpHandler } from 'mcp-handler'
 import { join } from 'path'
-import { APIError, configToJSONSchema, type PayloadRequest, type TypedUser } from 'payload'
+import { APIError, configToJSONSchema, type PayloadRequest } from 'payload'
 
 import type { MCPAccessSettings, MCPPluginConfig } from '../types.js'
 
@@ -43,7 +43,7 @@ import { createJobTool } from './tools/job/create.js'
 import { runJobTool } from './tools/job/run.js'
 import { updateJobTool } from './tools/job/update.js'
 
-export const getMCPHandler = (
+export const getMcpHandler = (
   pluginOptions: MCPPluginConfig,
   mcpAccessSettings: MCPAccessSettings,
   req: PayloadRequest,
@@ -78,32 +78,25 @@ export const getMCPHandler = (
   const user = mcpAccessSettings.user
 
   // MCP Server and Handler Options
-  const MCPOptions = pluginOptions.mcp || {}
-  const customMCPTools = MCPOptions.tools || []
-  const customMCPPrompts = MCPOptions.prompts || []
-  const customMCPResources = MCPOptions.resources || []
-  const MCPHandlerOptions = MCPOptions.handlerOptions || {}
-  const serverOptions = MCPOptions.serverOptions || {}
-  const useVerboseLogs = MCPHandlerOptions.verboseLogs ?? false
+  const mcpOptions = pluginOptions.mcp || {}
+  const customTools = mcpOptions.tools || []
+  const customPrompts = mcpOptions.prompts || []
+  const customResources = mcpOptions.resources || []
+  const mcpHandlerOptions = mcpOptions.handlerOptions || {}
+  const serverOptions = mcpOptions.serverOptions || {}
+  const useVerboseLogs = mcpHandlerOptions.verboseLogs ?? false
 
   // Experimental MCP Tool Requirements
   const isDevelopment = process.env.NODE_ENV === 'development'
   const experimentalTools: NonNullable<MCPPluginConfig['experimental']>['tools'] =
-    pluginOptions?.experimental?.tools || {}
+    pluginOptions.experimental?.tools || {}
   const collectionsPluginConfig = pluginOptions.collections || {}
   const globalsPluginConfig = pluginOptions.globals || {}
   const collectionsDirPath =
-    experimentalTools && experimentalTools.collections?.collectionsDirPath
-      ? experimentalTools.collections.collectionsDirPath
-      : join(process.cwd(), 'src/collections')
+    experimentalTools.collections?.collectionsDirPath || join(process.cwd(), 'src/collections')
   const configFilePath =
-    experimentalTools && experimentalTools.config?.configFilePath
-      ? experimentalTools.config.configFilePath
-      : join(process.cwd(), 'src/payload.config.ts')
-  const jobsDirPath =
-    experimentalTools && experimentalTools.jobs?.jobsDirPath
-      ? experimentalTools.jobs.jobsDirPath
-      : join(process.cwd(), 'src/jobs')
+    experimentalTools.config?.configFilePath || join(process.cwd(), 'src/payload.config.ts')
+  const jobsDirPath = experimentalTools.jobs?.jobsDirPath || join(process.cwd(), 'src/jobs')
 
   try {
     return createMcpHandler(
@@ -274,7 +267,7 @@ export const getMCPHandler = (
         })
 
         // Custom tools
-        customMCPTools.forEach((tool) => {
+        customTools.forEach((tool) => {
           const camelCasedToolName = toCamelCase(tool.name)
           const isToolEnabled = mcpAccessSettings['payload-mcp-tool']?.[camelCasedToolName] ?? false
 
@@ -296,7 +289,7 @@ export const getMCPHandler = (
         })
 
         // Custom prompts
-        customMCPPrompts.forEach((prompt) => {
+        customPrompts.forEach((prompt) => {
           const camelCasedPromptName = toCamelCase(prompt.name)
           const isPromptEnabled =
             mcpAccessSettings['payload-mcp-prompt']?.[camelCasedPromptName] ?? false
@@ -320,7 +313,7 @@ export const getMCPHandler = (
         })
 
         // Custom resources
-        customMCPResources.forEach((resource) => {
+        customResources.forEach((resource) => {
           const camelCasedResourceName = toCamelCase(resource.name)
           const isResourceEnabled =
             mcpAccessSettings['payload-mcp-resource']?.[camelCasedResourceName] ?? false
@@ -492,7 +485,11 @@ export const getMCPHandler = (
           )
         }
 
-        if (mcpAccessSettings.auth?.resetPassword && experimentalTools.auth?.enabled) {
+        if (
+          mcpAccessSettings.auth?.resetPassword &&
+          experimentalTools.auth?.enabled &&
+          isDevelopment
+        ) {
           registerTool(
             mcpAccessSettings.auth.resetPassword,
             'Reset Password',
@@ -502,7 +499,11 @@ export const getMCPHandler = (
           )
         }
 
-        if (mcpAccessSettings.auth?.forgotPassword && experimentalTools.auth?.enabled) {
+        if (
+          mcpAccessSettings.auth?.forgotPassword &&
+          experimentalTools.auth?.enabled &&
+          isDevelopment
+        ) {
           registerTool(
             mcpAccessSettings.auth.forgotPassword,
             'Forgot Password',
@@ -512,7 +513,7 @@ export const getMCPHandler = (
           )
         }
 
-        if (mcpAccessSettings.auth?.unlock && experimentalTools.auth?.enabled) {
+        if (mcpAccessSettings.auth?.unlock && experimentalTools.auth?.enabled && isDevelopment) {
           registerTool(
             mcpAccessSettings.auth.unlock,
             'Unlock',
@@ -531,11 +532,11 @@ export const getMCPHandler = (
         serverInfo: serverOptions.serverInfo,
       },
       {
-        basePath: MCPHandlerOptions.basePath || payload.config.routes?.api || '/api',
-        disableSse: MCPHandlerOptions.disableSse ?? true,
-        maxDuration: MCPHandlerOptions.maxDuration || 60,
-        onEvent: MCPHandlerOptions.onEvent,
-        redisUrl: MCPHandlerOptions.redisUrl,
+        basePath: mcpHandlerOptions.basePath || payload.config.routes?.api || '/api',
+        disableSse: mcpHandlerOptions.disableSse ?? true,
+        maxDuration: mcpHandlerOptions.maxDuration || 60,
+        onEvent: mcpHandlerOptions.onEvent,
+        redisUrl: mcpHandlerOptions.redisUrl,
         verboseLogs: useVerboseLogs,
       },
     )

--- a/packages/plugin-mcp/src/mcp/tools/auth/login.ts
+++ b/packages/plugin-mcp/src/mcp/tools/auth/login.ts
@@ -4,14 +4,7 @@ import type { PayloadRequest } from 'payload'
 import { toolSchemas } from '../schemas.js'
 
 export const loginTool = (server: McpServer, req: PayloadRequest, verboseLogs: boolean) => {
-  const tool = async (
-    collection: string,
-    email: string,
-    password: string,
-    depth: number = 0,
-    overrideAccess: boolean = false,
-    showHiddenFields: boolean = false,
-  ) => {
+  const tool = async (collection: string, email: string, password: string, depth: number = 0) => {
     const payload = req.payload
 
     if (verboseLogs) {
@@ -28,8 +21,7 @@ export const loginTool = (server: McpServer, req: PayloadRequest, verboseLogs: b
           password,
         },
         depth,
-        overrideAccess,
-        showHiddenFields,
+        overrideAccess: false,
       })
 
       if (verboseLogs) {
@@ -65,8 +57,8 @@ export const loginTool = (server: McpServer, req: PayloadRequest, verboseLogs: b
       description: toolSchemas.login.description,
       inputSchema: toolSchemas.login.parameters.shape,
     },
-    async ({ collection, depth, email, overrideAccess, password, showHiddenFields }) => {
-      return await tool(collection, email, password, depth, overrideAccess, showHiddenFields)
+    async ({ collection, depth, email, password }) => {
+      return await tool(collection, email, password, depth)
     },
   )
 }

--- a/packages/plugin-mcp/src/mcp/tools/global/find.ts
+++ b/packages/plugin-mcp/src/mcp/tools/global/find.ts
@@ -37,6 +37,8 @@ export const findGlobalTool = (
       const findOptions: Parameters<typeof payload.findGlobal>[0] = {
         slug: globalSlug,
         depth,
+        overrideAccess: false,
+        req,
         user,
       }
 

--- a/packages/plugin-mcp/src/mcp/tools/global/update.ts
+++ b/packages/plugin-mcp/src/mcp/tools/global/update.ts
@@ -94,6 +94,8 @@ export const updateGlobalTool = (
         data: parsedData,
         depth,
         draft,
+        overrideAccess: false,
+        req,
         user,
       }
 

--- a/packages/plugin-mcp/src/mcp/tools/job/run.ts
+++ b/packages/plugin-mcp/src/mcp/tools/job/run.ts
@@ -23,6 +23,8 @@ export const runJob = async (
     // Actually run the job using Payload's job queue
     const jobQueueOptions: Record<string, unknown> = {
       input,
+      overrideAccess: false,
+      req,
       task: jobSlug,
     }
 

--- a/packages/plugin-mcp/src/mcp/tools/resource/update.ts
+++ b/packages/plugin-mcp/src/mcp/tools/resource/update.ts
@@ -30,8 +30,6 @@ export const updateResourceTool = (
     draft: boolean = false,
     depth: number = 0,
     overrideLock: boolean = true,
-    filePath?: string,
-    overwriteExistingFiles: boolean = false,
     locale?: string,
     fallbackLocale?: string,
     select?: string,
@@ -152,8 +150,6 @@ export const updateResourceTool = (
           overrideLock,
           req,
           user,
-          ...(filePath && { filePath }),
-          ...(overwriteExistingFiles && { overwriteExistingFiles }),
           ...(locale && { locale }),
           ...(fallbackLocale && { fallbackLocale }),
           ...(selectClause && { select: selectClause }),
@@ -203,8 +199,6 @@ ${JSON.stringify(result)}
           req,
           user,
           where: whereClause,
-          ...(filePath && { filePath }),
-          ...(overwriteExistingFiles && { overwriteExistingFiles }),
           ...(locale && { locale }),
           ...(fallbackLocale && { fallbackLocale }),
           ...(selectClause && { select: selectClause }),
@@ -313,7 +307,6 @@ ${JSON.stringify(errors)}
         .string()
         .optional()
         .describe('Optional: fallback locale code to use when requested locale is not available'),
-      filePath: z.string().optional().describe('File path for file uploads'),
       locale: z
         .string()
         .optional()
@@ -325,11 +318,6 @@ ${JSON.stringify(errors)}
         .optional()
         .default(true)
         .describe('Whether to override document locks'),
-      overwriteExistingFiles: z
-        .boolean()
-        .optional()
-        .default(false)
-        .describe('Whether to overwrite existing files'),
       select: z
         .string()
         .optional()
@@ -354,10 +342,8 @@ ${JSON.stringify(errors)}
           depth,
           draft,
           fallbackLocale,
-          filePath,
           locale,
           overrideLock,
-          overwriteExistingFiles,
           select,
           where,
           ...fieldData
@@ -371,8 +357,6 @@ ${JSON.stringify(errors)}
           draft as boolean,
           depth as number,
           overrideLock as boolean,
-          filePath as string | undefined,
-          overwriteExistingFiles as boolean,
           locale as string | undefined,
           fallbackLocale as string | undefined,
           select as string | undefined,

--- a/packages/plugin-mcp/src/mcp/tools/schemas.ts
+++ b/packages/plugin-mcp/src/mcp/tools/schemas.ts
@@ -155,7 +155,6 @@ export const toolSchemas = {
         .string()
         .optional()
         .describe('Optional: fallback locale code to use when requested locale is not available'),
-      filePath: z.string().optional().describe('Optional: absolute file path for file uploads'),
       locale: z
         .string()
         .optional()
@@ -167,11 +166,6 @@ export const toolSchemas = {
         .optional()
         .default(true)
         .describe('Whether to override document locks'),
-      overwriteExistingFiles: z
-        .boolean()
-        .optional()
-        .default(false)
-        .describe('Whether to overwrite existing files'),
       select: z
         .string()
         .optional()
@@ -396,17 +390,7 @@ export const toolSchemas = {
         .default(0)
         .describe('Depth of population for relationships'),
       email: z.string().email().describe('The user email address'),
-      overrideAccess: z
-        .boolean()
-        .optional()
-        .default(false)
-        .describe('Whether to override access controls'),
       password: z.string().describe('The user password'),
-      showHiddenFields: z
-        .boolean()
-        .optional()
-        .default(false)
-        .describe('Whether to show hidden fields in the response'),
     }),
   },
 

--- a/test/plugin-mcp/config.ts
+++ b/test/plugin-mcp/config.ts
@@ -124,6 +124,13 @@ export default buildConfigWithDefaults({
       //   } as MCPAccessSettings
       // },
       overrideApiKeyCollection: (collection) => {
+        collection.access = {
+          create: ({ req }) => Boolean(req.user),
+          delete: ({ req }) => Boolean(req.user),
+          read: ({ req }) => Boolean(req.user),
+          unlock: ({ req }) => Boolean(req.user),
+          update: ({ req }) => Boolean(req.user),
+        }
         collection.fields.push({
           name: 'override',
           type: 'text',


### PR DESCRIPTION
This change gives the generated MCP API Key collection safer defaults. Signed-in users from the
configured user collection can manage only their own keys. Key owners are assigned automatically
and cannot be changed.

Existing MCP keys continue to work, and users can continue managing their own keys. Applications
only need additional configuration if trusted users must manage keys for someone else.

## Configuration

Override both collection access and the owner field for users trusted to issue credentials for
other users:

```ts
import type { PayloadRequest } from 'payload'

const isAdmin = ({ req }: { req: PayloadRequest }) =>
  Boolean(
    req.user && req.user.collection === 'users' && 'role' in req.user && req.user.role === 'admin',
  )

mcpPlugin({
  overrideApiKeyCollection: (collection) => {
    collection.access = {
      create: isAdmin,
      delete: isAdmin,
      read: isAdmin,
      unlock: isAdmin,
      update: isAdmin,
    }
    collection.fields = collection.fields.map((field) =>
      'name' in field && field.name === 'user'
        ? { ...field, access: { create: isAdmin, update: isAdmin } }
        : field,
    )
    return collection
  },
})
```

Replace `isAdmin` with your application's permission check.