### PR TITLE
fix(ui): translate collection label when matching relationship option groups

### DIFF
--- a/packages/ui/src/fields/Relationship/optionsReducer.ts
+++ b/packages/ui/src/fields/Relationship/optionsReducer.ts
@@ -34,7 +34,7 @@ export const optionsReducer = (state: OptionGroup[], action: Action): OptionGrou
       const loadedIDs = reduceToIDs(state)
       const newOptions = [...state]
       const optionsToAddTo = newOptions.find(
-        (optionGroup) => optionGroup.label === collection.labels.plural,
+        (optionGroup) => optionGroup.label === getTranslation(collection.labels.plural, i18n),
       )
       const newSubOptions = docs.reduce((docSubOptions, doc) => {
         if (
@@ -119,12 +119,12 @@ export const optionsReducer = (state: OptionGroup[], action: Action): OptionGrou
     }
 
     case 'REMOVE': {
-      const { id, collection } = action
+      const { id, collection, i18n } = action
 
       const newOptions = [...state]
 
       const indexOfGroup = newOptions.findIndex(
-        (optionGroup) => optionGroup.label === collection.labels.plural,
+        (optionGroup) => optionGroup.label === getTranslation(collection.labels.plural, i18n),
       )
 
       if (indexOfGroup === -1) {
@@ -153,7 +153,7 @@ export const optionsReducer = (state: OptionGroup[], action: Action): OptionGrou
       })
 
       const foundOptionGroup = newOptions.find(
-        (optionGroup) => optionGroup.label === collection.labels.plural,
+        (optionGroup) => optionGroup.label === getTranslation(collection.labels.plural, i18n),
       )
       const foundOption = foundOptionGroup?.options?.find((option) => option.value === doc.id)
 


### PR DESCRIPTION
Fixes #17758

### What?

Option groups in the relationship field's dropdown are **created** with the translated collection label but **looked up** by the untranslated one:

```ts
// creating — translated
newOptions.push({ label: getTranslation(collection.labels.plural, i18n), options: ... })

// looking up — not translated
newOptions.find((optionGroup) => optionGroup.label === collection.labels.plural)
```

When `labels.plural` is a localization object (`{ en: 'Case Studies', zh: '客户案例' }`), that comparison puts an object against a string, never matches, and every batch of loaded documents appends another group carrying the same heading.

This PR wraps the three lookup sites in `getTranslation`, matching how the group is created — and matching the near-identical reducer under `elements/WhereBuilder/Condition/Relationship/optionsReducer.ts`, which already does this at both of its sites.

### Why?

Users see duplicated group headings in the dropdown, most visibly on polymorphic relationships:

```
Case Studies
  Recognition
Products
  Water Treatment Automation
Case Studies          ← repeat
  Cooling Water Treatment
Products              ← repeat
  PLC Control Cabinets
```

Two less obvious consequences follow from the same mismatch, since `REMOVE` and `UPDATE` also never find their group:

- deleting a document leaves its stale option in the dropdown
- renaming one does not refresh the displayed title

Collections whose labels are plain strings are unaffected — `getTranslation` passes strings through, so the comparison happens to succeed. That is likely why this went unnoticed.

### How?

Four lines in `packages/ui/src/fields/Relationship/optionsReducer.ts`:

- `ADD`, `REMOVE`, `UPDATE` — wrap the lookup in `getTranslation(collection.labels.plural, i18n)`
- `REMOVE` — destructure `i18n` from the action. The `REMOVE` action type in `types.ts` already declares `i18n: I18nClient` and `Input.tsx` already dispatches it; it was simply never read.

`getTranslation` was already imported in this file. No type changes needed.

Verified against 3.86.0 by running the reducer directly with a localized-label collection: before the change, repeated `ADD` dispatches produced one group per dispatch; after it, they merge into a single group across `ADD`, `CLEAR`, and post-`CLEAR` re-`ADD` sequences.
