### PR TITLE
fix: hide hierarchy virtual path fields from the admin panel

### DIFF
--- a/packages/payload/src/hierarchy/addHierarchyToCollection.ts
+++ b/packages/payload/src/hierarchy/addHierarchyToCollection.ts
@@ -30,8 +30,8 @@ export const addHierarchyToCollection = ({
       name: slugPathFieldName,
       type: 'text',
       admin: {
+        hidden: true,
         readOnly: true,
-        // hidden: true,
       },
       index: true,
       label: 'Slug Path',
@@ -41,8 +41,8 @@ export const addHierarchyToCollection = ({
       name: titlePathFieldName,
       type: 'text',
       admin: {
+        hidden: true,
         readOnly: true,
-        // hidden: true,
       },
       index: true,
       label: 'Title Path',

--- a/test/hierarchy/int.spec.ts
+++ b/test/hierarchy/int.spec.ts
@@ -40,6 +40,16 @@ describe('Hierarchy', () => {
       expect(titlePathField.virtual).toBe(true)
     })
 
+    it('should hide virtual path fields from the admin panel', () => {
+      const organizationsCollection = payload.collections.organizations.config
+
+      const slugPathField = organizationsCollection.fields.find((f) => f.name === '_h_slugPath')
+      const titlePathField = organizationsCollection.fields.find((f) => f.name === '_h_titlePath')
+
+      expect(slugPathField.admin.hidden).toBe(true)
+      expect(titlePathField.admin.hidden).toBe(true)
+    })
+
     it('should have sanitized hierarchy config', () => {
       const organizationsCollection = payload.collections.organizations.config
 


### PR DESCRIPTION
## What?

Hides the hierarchy virtual path fields (`_h_slugPath` and `_h_titlePath`) from the admin panel again. `admin.hidden` was commented out on both field definitions, so they rendered as read-only text inputs in the edit view of every hierarchy-enabled collection.

## Why?

These fields are computed in the `afterRead` hook and are not editable. Showing them adds two empty read-only inputs to the edit view with no value to the user.

## How?

- Restore `admin.hidden: true` on both generated fields in `addHierarchyToCollection`.
- Add a regression test in `test/hierarchy/int.spec.ts` that asserts both fields are hidden on the sanitized collection config.
