### PR TITLE
test(plugin-mcp): keep int summary counts when suite stdout is large and remove `verbose` from plugin-mcp int tests

### DIFF
--- a/test/plugin-mcp/config.ts
+++ b/test/plugin-mcp/config.ts
@@ -184,7 +184,6 @@ export default buildConfigWithDefaults({
             version: '1.0.0',
           },
         },
-        verboseLogs: true,
       },
       tools: {
         hiddenTool: defineTool({

--- a/test/runTestsWithSummary.ts
+++ b/test/runTestsWithSummary.ts
@@ -78,6 +78,9 @@ interface SuiteResult {
 
 const isContentAPIMode = process.env.PAYLOAD_DATABASE === 'content-api'
 const contentAPISuiteTimeout = 120000
+// Chatty suites can exceed Node's 1 MiB execSync default; truncated stdout has
+// no JSON report, so the suite is recorded as 0/<collected>.
+const vitestExecMaxBuffer = 64 * 1024 * 1024
 const vitestBinary = './node_modules/.bin/vitest'
 
 function getVitestEnv(options?: { unsetPayloadDatabase?: boolean }): NodeJS.ProcessEnv {
@@ -217,6 +220,7 @@ function getCollectedTestCount(suiteName: string): number {
         cwd: path.join(dirname, '..'),
         encoding: 'utf8',
         env: getVitestEnv({ unsetPayloadDatabase }),
+        maxBuffer: vitestExecMaxBuffer,
         stdio: ['pipe', 'pipe', 'pipe'],
         ...(isContentAPIMode ? { timeout: contentAPISuiteTimeout } : {}),
       })
@@ -371,6 +375,7 @@ function runTestSuite(suiteName: string): SuiteResult {
       cwd: path.join(dirname, '..'),
       encoding: 'utf8',
       env: getVitestEnv(),
+      maxBuffer: vitestExecMaxBuffer,
       stdio: ['pipe', 'pipe', 'pipe'],
       ...(isContentAPIMode ? { timeout: contentAPISuiteTimeout } : {}),
     })


### PR DESCRIPTION
The `test:int:summary` runner shells each suite with `execSync` and Node's default 1 MiB `maxBuffer`. When a suite writes more than that, the Vitest JSON report (emitted at the end of stdout) is truncated away, `parseTestResults` returns `0/0`, and the suite is recorded as `0/<collected>` even though tests ran.

`plugin-mcp` hit this hard: with `verboseLogs: true` it printed ~18k "Tool Registered" lines (~2.3 MiB). Against content-api it was really ~193/223, but the summary showed `0/223`.

This raises `maxBuffer` to 64 MiB and drops `verboseLogs: true` from the plugin-mcp test config (default is off). No other int suite enables `verboseLogs`.