### PR TITLE
test: surface captured output for int suites that produce no test report

### DIFF
--- a/test/runTestsWithSummary.ts
+++ b/test/runTestsWithSummary.ts
@@ -69,6 +69,8 @@ const TEST_SUITES = [
 ]
 
 interface SuiteResult {
+  /** Captured output for a suite that produced no parseable test report. */
+  diagnostic?: string
   duration: number
   failed: boolean
   name: string
@@ -82,6 +84,8 @@ const contentAPISuiteTimeout = 120000
 // no JSON report, so the suite is recorded as 0/<collected>.
 const vitestExecMaxBuffer = 64 * 1024 * 1024
 const vitestBinary = './node_modules/.bin/vitest'
+const diagnosticMaxLines = 40
+const diagnosticMaxChars = 4000
 
 function getVitestEnv(options?: { unsetPayloadDatabase?: boolean }): NodeJS.ProcessEnv {
   const env = {
@@ -184,6 +188,32 @@ function parseTestResults(output: string): { passed: number; total: number } {
   } catch (e) {
     return { passed: 0, total: 0 }
   }
+}
+
+/**
+ * A suite that reports 0 passing usually died before the JSON reporter flushed,
+ * so the counts alone say nothing about why. Keep the tail of what it printed so
+ * the summary can surface an actionable error instead of a bare `0/<total>`.
+ */
+function extractDiagnostic(output: string): string | undefined {
+  const trimmed = output.trim()
+  if (!trimmed) {
+    return undefined
+  }
+
+  // Drop the JSON report if one was emitted; the interesting output precedes it.
+  const reportIndex = trimmed.lastIndexOf('{"numTotalTestSuites"')
+  const withoutReport = (reportIndex === -1 ? trimmed : trimmed.slice(0, reportIndex)).trim()
+  if (!withoutReport) {
+    return undefined
+  }
+
+  const lines = withoutReport.split('\n').slice(-diagnosticMaxLines)
+  const diagnostic = lines.join('\n')
+
+  return diagnostic.length > diagnosticMaxChars
+    ? `...\n${diagnostic.slice(-diagnosticMaxChars)}`
+    : diagnostic
 }
 
 function parseCollectedTests(output: string): number {
@@ -391,6 +421,10 @@ function runTestSuite(suiteName: string): SuiteResult {
     if (result.total === 0) {
       result.total = getStaticTestCount(suiteName)
     }
+
+    if (result.passed === 0) {
+      result.diagnostic = extractDiagnostic(output)
+    }
   } catch (error: unknown) {
     // Try to parse failure output from both stdout and stderr
     let errorOutput = ''
@@ -422,6 +456,10 @@ function runTestSuite(suiteName: string): SuiteResult {
     }
     if (result.total === 0) {
       result.total = getStaticTestCount(suiteName)
+    }
+
+    if (result.passed === 0) {
+      result.diagnostic = extractDiagnostic(errorOutput)
     }
   }
 
@@ -519,6 +557,24 @@ function main() {
       const icon = r.passed === 0 ? '❌' : '⚠️'
       console.log(`   ${icon} ${r.name} (${r.passed}/${r.total})`)
     })
+
+    const suitesWithoutReport = results.filter((r) => r.passed === 0 && r.diagnostic)
+
+    if (suitesWithoutReport.length > 0) {
+      console.log('\n' + '='.repeat(80))
+      console.log('🔎 Suites that produced no test report')
+      console.log(
+        'These reported 0 passing because no JSON report was parsed, not because every test failed.',
+      )
+      console.log('='.repeat(80))
+
+      for (const r of suitesWithoutReport) {
+        console.log(`\n--- ${r.name} (${r.passed}/${r.total}) ---`)
+        console.log(r.diagnostic)
+      }
+      console.log()
+    }
+
     process.exit(1)
   } else {
     console.log('✅ All test suites passed!')


### PR DESCRIPTION
When a suite in `test:int:summary` dies before vitest's JSON reporter flushes, `parseTestResults` finds no `numTotalTests` and returns 0, then the total falls back to a static count. You end up with a bare `0/26` and no idea why. The runner already collects the child's stdout and stderr into `errorOutput`, but only scrapes counts from it and throws the rest away, so nothing ever gets printed.

This keeps the tail of that output (last 40 lines / 4000 chars, JSON report stripped) and prints it under a "Suites that produced no test report" section at the end of the summary. Only for suites with 0 passing, so a normal run is unchanged.

We hit this on the Figma side chasing suites that report `0/N` in CI but pass when run individually. [#17764](https://github.com/payloadcms/payload/pull/17764) fixed one cause (`execSync` maxBuffer truncation on chatty suites), but `form-state` and `tags` still report `0/26` and `0/9` with no way to tell whether it's a crash, a timeout, or a setup failure. `storage-azure` is a third case where the suite just can't reach its Azurite emulator, which this would make obvious instead of looking like 4 failing tests.