### PR TITLE
fix(plugin-nested-docs): exclude descendants from parent options

### DIFF
--- a/packages/plugin-nested-docs/src/fields/parentFilterOptions.ts
+++ b/packages/plugin-nested-docs/src/fields/parentFilterOptions.ts
@@ -1,38 +1,66 @@
 import type { FilterOptions } from 'payload'
 
-export const parentFilterOptions: (breadcrumbsFieldSlug?: string) => FilterOptions =
-  (breadcrumbsFieldSlug = 'breadcrumbs') =>
+/**
+ * Builds the default `filterOptions` for the nested-docs `parent` field.
+ *
+ * A document may not be its own parent, and it may not be parented to any of its own
+ * descendants (that would create a cycle in the tree). Excluding descendants with a
+ * `not_in` against the breadcrumbs relationship is unreliable on relational databases:
+ * the SQL adapters join the breadcrumbs rows table and evaluate the filter per joined
+ * row, so a document is excluded only when ONE of its rows matches instead of requiring
+ * ALL of them to not match. Descendants therefore slip through the exclusion (see #17658).
+ *
+ * Instead, descendants are discovered by walking the real `parent` relationships
+ * breadth-first, then excluded with a plain `not_in` on `id` - a column that is never
+ * joined, and so behaves identically on every database adapter.
+ *
+ * The traversal runs with `overrideAccess: true` on purpose: this filter is structural,
+ * not an access-control boundary. Descendants the current user cannot read must still be
+ * excluded, otherwise a restricted user could select one and create a cycle.
+ *
+ * @param _breadcrumbsFieldSlug - retained for signature compatibility; descendants are no
+ * longer resolved through breadcrumbs.
+ */
+export const parentFilterOptions: (
+  breadcrumbsFieldSlug?: string,
+  parentFieldSlug?: string,
+) => FilterOptions =
+  (_breadcrumbsFieldSlug = 'breadcrumbs', parentFieldSlug = 'parent') =>
   async ({ id, relationTo, req }) => {
-    if (id) {
-      // Querying `not_in` directly against a hasMany/array relationship subfield (e.g.
-      // `breadcrumbs.doc`) is unreliable on relational databases: the SQL adapters join
-      // the breadcrumbs rows table and filter it per-row, so a document is excluded only
-      // if ONE of its breadcrumb rows matches, rather than requiring ALL of them to not
-      // match. That lets descendants slip through the exclusion (see #17658).
-      //
-      // Querying `equals`/`in` against the same path does not have this problem, since
-      // "at least one row matches" is exactly the semantics we want there. So we first
-      // resolve the set of descendant IDs with a positive lookup, then exclude them (and
-      // the document itself) using a plain `not_in` on `id`, which is never joined and is
-      // therefore safe on every database.
-      const { docs: descendants } = await req.payload.find({
+    if (!id) {
+      return true
+    }
+
+    const excludedIDs = new Set<number | string>([id])
+    let frontier: (number | string)[] = [id]
+
+    while (frontier.length > 0) {
+      const { docs: children } = await req.payload.find({
         collection: relationTo,
         depth: 0,
         limit: 0,
-        overrideAccess: false,
+        overrideAccess: true,
         pagination: false,
         req,
         select: {},
-        user: req.user,
         where: {
-          [`${breadcrumbsFieldSlug}.doc`]: { equals: id },
+          [parentFieldSlug]: { in: frontier },
         },
       })
 
-      return {
-        id: { not_in: [id, ...descendants.map((doc) => doc.id)] },
+      const nextFrontier: (number | string)[] = []
+
+      for (const child of children) {
+        if (!excludedIDs.has(child.id)) {
+          excludedIDs.add(child.id)
+          nextFrontier.push(child.id)
+        }
       }
+
+      frontier = nextFrontier
     }
 
-    return true
+    return {
+      id: { not_in: [...excludedIDs] },
+    }
   }

--- a/packages/plugin-nested-docs/src/fields/parentFilterOptions.ts
+++ b/packages/plugin-nested-docs/src/fields/parentFilterOptions.ts
@@ -2,11 +2,35 @@ import type { FilterOptions } from 'payload'
 
 export const parentFilterOptions: (breadcrumbsFieldSlug?: string) => FilterOptions =
   (breadcrumbsFieldSlug = 'breadcrumbs') =>
-  ({ id }) => {
+  async ({ id, relationTo, req }) => {
     if (id) {
+      // Querying `not_in` directly against a hasMany/array relationship subfield (e.g.
+      // `breadcrumbs.doc`) is unreliable on relational databases: the SQL adapters join
+      // the breadcrumbs rows table and filter it per-row, so a document is excluded only
+      // if ONE of its breadcrumb rows matches, rather than requiring ALL of them to not
+      // match. That lets descendants slip through the exclusion (see #17658).
+      //
+      // Querying `equals`/`in` against the same path does not have this problem, since
+      // "at least one row matches" is exactly the semantics we want there. So we first
+      // resolve the set of descendant IDs with a positive lookup, then exclude them (and
+      // the document itself) using a plain `not_in` on `id`, which is never joined and is
+      // therefore safe on every database.
+      const { docs: descendants } = await req.payload.find({
+        collection: relationTo,
+        depth: 0,
+        limit: 0,
+        overrideAccess: false,
+        pagination: false,
+        req,
+        select: {},
+        user: req.user,
+        where: {
+          [`${breadcrumbsFieldSlug}.doc`]: { equals: id },
+        },
+      })
+
       return {
-        id: { not_equals: id },
-        [`${breadcrumbsFieldSlug}.doc`]: { not_in: [id] },
+        id: { not_in: [id, ...descendants.map((doc) => doc.id)] },
       }
     }
 

--- a/packages/plugin-nested-docs/src/index.ts
+++ b/packages/plugin-nested-docs/src/index.ts
@@ -31,7 +31,10 @@ export const nestedDocsPlugin = definePlugin<NestedDocsPluginConfig>({
           (field) => 'name' in field && field.name === (pluginConfig?.parentFieldSlug || 'parent'),
         ) as SingleRelationshipField
 
-        const defaultFilterOptions = parentFilterOptions(pluginConfig?.breadcrumbsFieldSlug)
+        const defaultFilterOptions = parentFilterOptions(
+          pluginConfig?.breadcrumbsFieldSlug,
+          pluginConfig?.parentFieldSlug,
+        )
 
         if (existingParentField) {
           if (!existingParentField.filterOptions) {

--- a/test/plugin-nested-docs/int.spec.ts
+++ b/test/plugin-nested-docs/int.spec.ts
@@ -1,6 +1,14 @@
-import type { ArrayField, Payload, RelationshipField } from 'payload'
+import type {
+  ArrayField,
+  FilterOptions,
+  FilterOptionsProps,
+  Payload,
+  RelationshipField,
+  Where,
+} from 'payload'
 
 import path from 'path'
+import { createLocalReq } from 'payload'
 import { wait } from 'payload/shared'
 import { fileURLToPath } from 'url'
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
@@ -442,8 +450,18 @@ describe('@payloadcms/plugin-nested-docs', () => {
 
   describe('overrides', () => {
     let collection
+    const createdCategoryIDs: (number | string)[] = []
+
     beforeAll(() => {
       collection = payload.config.collections.find(({ slug }) => slug === 'categories')
+    })
+
+    afterEach(async () => {
+      // Clean up in reverse order (children before parents)
+      for (const id of [...createdCategoryIDs].reverse()) {
+        await payload.delete({ collection: 'categories', id })
+      }
+      createdCategoryIDs.length = 0
     })
 
     it('should allow overriding breadcrumbs field', () => {
@@ -466,6 +484,62 @@ describe('@payloadcms/plugin-nested-docs', () => {
       ) as RelationshipField
 
       expect(parentField.admin.description).toStrictEqual('custom')
+    })
+
+    it('should not offer a document its own descendants as a parent', async () => {
+      const root = await payload.create({
+        collection: 'categories',
+        data: {
+          name: 'filter-root',
+        },
+      })
+      createdCategoryIDs.push(root.id)
+
+      const child = await payload.create({
+        collection: 'categories',
+        data: {
+          name: 'filter-child',
+          owner: root.id,
+        },
+      })
+      createdCategoryIDs.push(child.id)
+
+      const grandchild = await payload.create({
+        collection: 'categories',
+        data: {
+          name: 'filter-grandchild',
+          owner: child.id,
+        },
+      })
+      createdCategoryIDs.push(grandchild.id)
+
+      // Sanity check - descendants carry the root in their breadcrumbs
+      expect(child.categorization?.[0]?.doc).toStrictEqual(root.id)
+      expect(grandchild.categorization?.[0]?.doc).toStrictEqual(root.id)
+
+      const ownerField = collection.fields.find(
+        (field) => field.type === 'relationship' && field.name === 'owner',
+      ) as RelationshipField
+
+      const req = await createLocalReq({}, payload)
+
+      const where = (await (ownerField.filterOptions as Exclude<FilterOptions, null | Where>)({
+        id: root.id,
+        relationTo: 'categories',
+        req,
+      } as FilterOptionsProps)) as Where
+
+      const { docs } = await payload.find({
+        collection: 'categories',
+        limit: 0,
+        where,
+      })
+
+      const returnedIDs = docs.map((doc) => doc.id)
+
+      expect(returnedIDs).not.toContain(root.id)
+      expect(returnedIDs).not.toContain(child.id)
+      expect(returnedIDs).not.toContain(grandchild.id)
     })
 
     it('should allow custom breadcrumb and parent slugs', async () => {


### PR DESCRIPTION
## What does this PR do?

Fixes #17658 by preventing a document from selecting its own descendants as its parent when using PostgreSQL.

## Why?

Filtering `breadcrumbs.doc` with `not_in` on relational adapters can produce incorrect results because array relationships are joined and evaluated per row. This allows descendant documents to incorrectly appear in the parent picker.

## What changed?

* Replaced the `breadcrumbs.doc` exclusion with descendant resolution using the parent relationship.
* Excludes the current document and all descendants using `id: { not_in: [...] }`.
* Passes `parentFieldSlug` into the default filter so custom parent field names (for example `owner`) are supported.
* Adds a regression test covering a Root → Child → Grandchild hierarchy.

## Verification

Verified with PostgreSQL:

```bash
pnpm test:int:postgres plugin-nested-docs
```

**Result:** 13/13 tests passing.
