### PR TITLE
fix: respect data overrides when duplicating upload collections

### DIFF
--- a/packages/payload/src/uploads/generateFileData.ts
+++ b/packages/payload/src/uploads/generateFileData.ts
@@ -157,7 +157,7 @@ export const generateFileData = async <T>({
     }
 
     return {
-      data: incomingFileData!,
+      data,
       files: [],
     }
   }
@@ -172,7 +172,7 @@ export const generateFileData = async <T>({
     await fs.mkdir(staticPath!, { recursive: true })
   }
 
-  let newData = incomingFileData as T
+  let newData = data
   const filesToSave: FileToSave[] = []
   const fileData: Partial<FileData> = {}
   const fileIsAnimatedType = ['image/avif', 'image/gif', 'image/webp'].includes(file.mimetype)

--- a/test/uploads/int.spec.ts
+++ b/test/uploads/int.spec.ts
@@ -1759,6 +1759,31 @@ describe('Collections - Uploads', () => {
       await payload.delete({ collection: 'media', id: duplicatedDoc.id })
     })
 
+    it('should respect data overrides when duplicating an upload collection doc', async () => {
+      const filePath = path.resolve(dirname, './image.png')
+      const file = await getFileByPath(filePath)
+      file.name = 'file-to-duplicate-override.png'
+
+      const mediaDoc = await payload.create({
+        collection: mediaSlug,
+        data: { alt: 'source-alt' },
+        file,
+      })
+
+      expect(mediaDoc).toBeDefined()
+
+      const duplicatedDoc = await payload.duplicate({
+        collection: mediaSlug,
+        id: mediaDoc.id,
+        data: { alt: 'override-alt' },
+      })
+
+      expect(duplicatedDoc.alt).toBe('override-alt')
+
+      await payload.delete({ collection: mediaSlug, id: mediaDoc.id })
+      await payload.delete({ collection: mediaSlug, id: duplicatedDoc.id })
+    })
+
     it('should not leak req.file between sequential duplicate() calls on a shared req', async () => {
       const filePath1 = path.resolve(dirname, './image.png')
       const file1 = await getFileByPath(filePath1)


### PR DESCRIPTION
## Description

Fixes `payload.duplicate()` silently discarding the caller's `data` overrides on upload collections.

On non-upload collections `data` is respected, so the same call behaved differently depending on whether the collection has `upload` configured. This is a regression from v3.71.0 (commit `d462f9bcf4`, PR #15089).

### Root cause

In `packages/payload/src/uploads/generateFileData.ts`, when `isDuplicating` is true the function built its return value from `originalDoc` (the source document) instead of the incoming `data`:

- `const incomingFileData = isDuplicating ? originalDoc : data`
- `let newData = incomingFileData as T` (previously `let newData = data`)
- early return `return { data: incomingFileData!, files: [] }` (previously `return { data, files: [] }`)

`collections/operations/create.ts` then overwrites `data` wholesale with that value (`data = newFileData`), so the caller's overrides never survive. `incomingFileData` is retained for filename/url extraction (file retrieval), where it is still correct.

### Fix

Restore the incoming `data` as the base for the returned document (the two lines changed in #15089), while keeping `originalDoc` for filename/url lookup.

### Testing

- Added an integration test: `should respect data overrides when duplicating an upload collection doc` (creates media with `alt: 'source-alt'`, duplicates with `data: { alt: 'override-alt' }`, asserts `override-alt`).
- RED before fix: `AssertionError: expected 'source-alt' to be 'override-alt'`
- GREEN after fix: `1 passed`
- Full `test/uploads/int.spec.ts` suite: `111 passed (111)`
- Regression checks for the #15089 behavior: `-t "Duplicate"` (3 passed) and `-t "serverURL"` (3 passed)

Closes #17762
