### PR TITLE
fix(templates): enable node:fs for uploads and update GraphQL known-issue reference

### DIFF
--- a/templates/with-cloudflare-d1/README.md
+++ b/templates/with-cloudflare-d1/README.md
@@ -106,7 +106,7 @@ Cloudflare Workers runs in an [isolated environment that cannot access private I
 
 ### GraphQL
 
-We are currently waiting on some issues with GraphQL to be [fixed upstream in Workers](https://github.com/cloudflare/workerd/issues/5175) so full support for GraphQL is not currently guaranteed when deployed.
+GraphQL queries and mutations fail on Workers with `Unexpected input type`. The root cause is the vendored `graphql-query-complexity` validation rule crashing under workerd (the previously referenced workerd#5175 is closed and unrelated). Tracked in [payloadcms/payload#17771](https://github.com/payloadcms/payload/issues/17771) — a working workaround (a custom GraphQL route that omits the complexity rule) is documented there. The REST API is unaffected.
 
 ### Worker size limits
 

--- a/templates/with-cloudflare-d1/README.md
+++ b/templates/with-cloudflare-d1/README.md
@@ -108,6 +108,10 @@ Cloudflare Workers runs in an [isolated environment that cannot access private I
 
 GraphQL queries and mutations fail on Workers with `Unexpected input type`. The root cause is the vendored `graphql-query-complexity` validation rule crashing under workerd (the previously referenced workerd#5175 is closed and unrelated). Tracked in [payloadcms/payload#17771](https://github.com/payloadcms/payload/issues/17771) — a working workaround (a custom GraphQL route that omits the complexity rule) is documented there. The REST API is unaffected.
 
+### Uploads / node:fs
+
+Payload's uploads code imports `node:fs/promises` at module top level. The template's `compatibility_date` must be >= 2025-09-01 so workerd enables the native `node:fs` module — below that date, uploads fail at module load (or hit unenv's "not implemented" `fs.mkdir`).
+
 ### Worker size limits
 
 We currently recommend deploying this template to the Paid Workers plan due to bundle [size limits](https://developers.cloudflare.com/workers/platform/limits/#worker-size) of 3mb. We're actively trying to reduce our bundle footprint over time to better meet this metric.

--- a/templates/with-cloudflare-d1/wrangler.jsonc
+++ b/templates/with-cloudflare-d1/wrangler.jsonc
@@ -2,7 +2,7 @@
   "$schema": "node_modules/wrangler/config-schema.json",
   "main": ".open-next/worker.js",
   "name": "my-app",
-  "compatibility_date": "2025-08-15",
+  "compatibility_date": "2025-09-15", // >= 2025-09-01 enables node:fs — payload uploads import fs/promises at module top level
   "compatibility_flags": [
     // Enable Node.js API
     // see https://developers.cloudflare.com/workers/configuration/compatibility-flags/#nodejs-compatibility-flag


### PR DESCRIPTION
## Summary

Two fixes for the `with-cloudflare-d1` template on Cloudflare Workers, both verified by dogfooding the exact template stack (Payload 3.82.1, local workerd):

### 1. `compatibility_date` → 2025-09-15 (code fix)

Payload's uploads code imports `node:fs/promises` at **module top level** (`generateFileData.ts`, `checkFileRestrictions.ts`, `getFileByPath.ts`, …). With the template's `2025-08-15` date, workerd does not provide the native `node:fs` module — uploads fail at module load or hit unenv's "not implemented" `fs.mkdir`. `>= 2025-09-01` enables native `node:fs`; the template now pins `2025-09-15` with a comment documenting the constraint.

### 2. GraphQL known-issue reference (docs)

The "Known issues → GraphQL" section pointed at [workerd#5175](https://github.com/cloudflare/workerd/issues/5175), which is **closed and unrelated** (it was about `Request#clone`). The actual GraphQL failure on Workers has a precise root cause — the vendored `graphql-query-complexity` validation rule crashes under workerd with `Unexpected input type` — tracked in [payloadcms/payload#17771](https://github.com/payloadcms/payload/issues/17771), where a working workaround is documented. Added a note about the node:fs upload constraint alongside it.

## Verification

- Upload + read-back verified byte-exact on the template stack under local workerd after the compat date bump (R2 storage, multipart)
- GraphQL query/mutation, error masking, and GET-405 verified with a scripted 25-check API coverage suite
- Node vs workerd bisection for the GraphQL failure is documented in #17771

## Scope

- `templates/with-cloudflare-d1/wrangler.jsonc` — 1-line compat date + comment
- `templates/with-cloudflare-d1/README.md` — known-issues updates
