### PR TITLE
fix(ui): guard live preview URL against aborted form-state requests in onSave

### DIFF
--- a/packages/ui/src/views/Edit/index.tsx
+++ b/packages/ui/src/views/Edit/index.tsx
@@ -397,11 +397,16 @@ export function DefaultEditView({
           setDocumentIsLocked(false)
         }
 
-        if (isLivePreviewEnabled && typeofLivePreviewURL === 'function') {
+        // Only update the live-preview / preview URLs when the form-state
+        // request was not aborted. When a save is superseded by a newer one,
+        // `getFormState` resolves to `{ state: null }` (without a
+        // `livePreviewURL` / `previewURL` key), and applying that here would
+        // silently close the live preview pane while the user is still typing.
+        if (state && isLivePreviewEnabled && typeofLivePreviewURL === 'function') {
           setLivePreviewURL(livePreviewURL)
         }
 
-        if (isPreviewEnabled) {
+        if (state && isPreviewEnabled) {
           setPreviewURL(previewURL)
         }
 


### PR DESCRIPTION
## Description

Fixes #17779

When a save starts while the previous form-state request is still in-flight, the earlier request is aborted and `getFormState` resolves to `{ state: null }` without a `livePreviewURL` key. The `onSave` callback then destructures `undefined` `livePreviewURL` and calls `setLivePreviewURL(undefined)`, which silently closes the live preview pane while the user is still typing.

The `onChange` callback already guards against this with `if (!result) { return }` — this PR applies the same protection to `onSave` by only updating the live-preview / preview URLs when the form-state request actually succeeded (i.e. `state` is present).

### Changes
- `packages/ui/src/views/Edit/index.tsx`: only call `setLivePreviewURL` / `setPreviewURL` when `state` exists (aborted requests resolve to `{ state: null }`)