### PR TITLE
fix(ui): send JSON body as application/json when no file upload is present (Fixes #17777)

### DIFF
--- a/packages/ui/src/forms/Form/index.tsx
+++ b/packages/ui/src/forms/Form/index.tsx
@@ -397,10 +397,12 @@ export const Form: React.FC<FormProps> = (props) => {
         let res
 
         if (typeof actionArg === 'string') {
+          const isFormData = formData instanceof FormData
           res = await requests[methodToUse.toLowerCase()](actionArg, {
             body: formData,
             headers: {
               'Accept-Language': i18n.language,
+              ...(isFormData ? {} : { 'Content-Type': 'application/json' }),
             },
           })
         } else if (typeof action === 'function') {
@@ -613,6 +615,13 @@ export const Form: React.FC<FormProps> = (props) => {
 
       if (docConfig && 'upload' in docConfig && docConfig.upload && file) {
         dataToSerialize.file = file
+      }
+
+      // If no file is being uploaded, send the JSON body directly as application/json
+      // instead of wrapping it in multipart/form-data, which triggers false positives
+      // in WAF configurations (e.g., Cloudflare Enterprise)
+      if (!('file' in dataToSerialize)) {
+        return dataToSerialize._payload as string
       }
 
       // nullAsUndefineds is important to allow uploads and relationship fields to clear themselves

--- a/packages/ui/src/forms/Form/types.ts
+++ b/packages/ui/src/forms/Form/types.ts
@@ -76,7 +76,7 @@ export type FormProps = {
   waitForAutocomplete?: boolean
 } & (
   | {
-      action: (formData: FormData) => Promise<void>
+      action: (formData: FormData | string) => Promise<void>
     }
   | {
       action?: string
@@ -139,7 +139,7 @@ export type CreateFormData = (
     data?: Data
     mergeOverrideData?: boolean
   },
-) => FormData | Promise<FormData>
+) => FormData | string | Promise<FormData | string>
 
 export type GetFields = () => FormState
 export type GetField = (path: string) => FormField


### PR DESCRIPTION
## Summary

Fixes #17777 — The admin panel unconditionally sends all PATCH/POST requests (save, autosave, publish, save draft) as `multipart/form-data`, even when the request payload contains only JSON data and no file is being uploaded.

Per HTTP semantics, `multipart/form-data` is intended for requests that include binary file data. When the payload is purely JSON, the request should use `application/json`. Sending JSON-only data wrapped in multipart encoding triggers false positives in standard WAF configurations (e.g., Cloudflare Enterprise).

### Changes

**`packages/ui/src/forms/Form/index.tsx`:**
- `createFormData`: When no file is present in the form data, return the JSON body directly as a string instead of wrapping it in `FormData` with `serialize()` from `object-to-formdata`
- `submit`: Detect whether the body is `FormData` (file upload) or a string (JSON), and set `Content-Type: application/json` header when sending JSON

**`packages/ui/src/forms/Form/types.ts`:**
- Updated `CreateFormData` return type to `FormData | string | Promise<FormData | string>`
- Updated `FormProps` action callback type to accept `FormData | string`

### Verified behavior

- Exact same JSON body sent as `application/json` to the same endpoint: 200 OK
- Same JSON body wrapped in `multipart/form-data` to the same endpoint: 403 blocked by WAF (Cloudflare Enterprise rule 6179ae15870a4bb7b2d480d4843b323c)
- This fix sends the JSON body as `application/json` when no file is present, bypassing the WAF false positive
- File uploads continue to use `multipart/form-data` as before (unaffected)
