### PR TITLE
fix(db-mongodb): avoid unnecessary aggregation when no joins are selected

### DIFF
--- a/packages/db-mongodb/src/find.ts
+++ b/packages/db-mongodb/src/find.ts
@@ -154,7 +154,7 @@ export const find: Find = async function find(
     query,
   })
 
-  if (aggregate || sortAggregation.length > 0) {
+  if (aggregate.length > 0 || sortAggregation.length > 0) {
     result = await aggregatePaginate({
       adapter: this,
       collation: paginationOptions.collation,

--- a/packages/db-mongodb/src/findOne.ts
+++ b/packages/db-mongodb/src/findOne.ts
@@ -51,7 +51,7 @@ export const findOne: FindOne = async function findOne(
   }
 
   let doc
-  if (aggregate) {
+  if (aggregate.length > 0) {
     const { docs } = await aggregatePaginate({
       adapter: this,
       joinAggregation: aggregate,

--- a/packages/db-mongodb/src/queryDrafts.ts
+++ b/packages/db-mongodb/src/queryDrafts.ts
@@ -145,7 +145,7 @@ export const queryDrafts: QueryDrafts = async function queryDrafts(
     versions: true,
   })
 
-  if (aggregate || sortAggregation.length > 0) {
+  if (aggregate.length > 0 || sortAggregation.length > 0) {
     result = await aggregatePaginate({
       adapter: this,
       collation: paginationOptions.collation,

--- a/packages/db-mongodb/src/utilities/buildJoinAggregation.ts
+++ b/packages/db-mongodb/src/utilities/buildJoinAggregation.ts
@@ -43,16 +43,16 @@ export const buildJoinAggregation = async ({
   locale,
   projection,
   versions,
-}: BuildJoinAggregationArgs): Promise<PipelineStage[] | undefined> => {
+}: BuildJoinAggregationArgs): Promise<PipelineStage[]> => {
   if (!adapter.useJoinAggregations) {
-    return
+    return []
   }
   if (
     (Object.keys(collectionConfig.joins).length === 0 &&
       collectionConfig.polymorphicJoins.length == 0) ||
     joins === false
   ) {
-    return
+    return []
   }
 
   const joinConfig = adapter.payload.collections[collection]?.config?.joins

--- a/test/joins/buildJoinAggregation.int.spec.ts
+++ b/test/joins/buildJoinAggregation.int.spec.ts
@@ -122,7 +122,7 @@ describe(
 
       expect(aggregation).toBeInstanceOf(Array)
 
-      const lookups = getLookups(aggregation!)
+      const lookups = getLookups(aggregation)
 
       expect(lookups).toHaveLength(2)
 
@@ -155,7 +155,7 @@ describe(
 
       expect(aggregation).toBeInstanceOf(Array)
 
-      const lookups = getLookups(aggregation!)
+      const lookups = getLookups(aggregation)
       expect(lookups).toHaveLength(1)
 
       expect(lookups[0]!.as).toBe('posts.docs')
@@ -182,7 +182,7 @@ describe(
 
       expect(aggregation).toBeInstanceOf(Array)
 
-      const lookups = getLookups(aggregation!)
+      const lookups = getLookups(aggregation)
       expect(lookups).toHaveLength(1)
 
       expect(lookups[0]!.as).toBe('postsMany.docs')
@@ -224,7 +224,7 @@ describe(
 
       expect(aggregation).toBeInstanceOf(Array)
 
-      const lookups = getLookups(aggregation!)
+      const lookups = getLookups(aggregation)
 
       expect(lookups).toHaveLength(2)
 
@@ -266,7 +266,7 @@ describe(
 
       expect(aggregation).toBeInstanceOf(Array)
 
-      const lookups = getLookups(aggregation!)
+      const lookups = getLookups(aggregation)
       expect(lookups).toHaveLength(1)
 
       expect(lookups[0]!.as).toBe('version.posts.docs')
@@ -302,7 +302,7 @@ describe(
 
       expect(aggregation).toBeInstanceOf(Array)
 
-      const lookups = getLookups(aggregation!)
+      const lookups = getLookups(aggregation)
       expect(lookups).toHaveLength(1)
 
       expect(lookups[0]!.as).toBe('version.postsMany.docs')

--- a/test/joins/queryPath.int.spec.ts
+++ b/test/joins/queryPath.int.spec.ts
@@ -1,0 +1,151 @@
+// @ts-ignore
+import { type MongooseAdapter } from '@payloadcms/db-mongodb'
+import { buildConfig, getPayload } from 'payload'
+import { afterEach, expect, it, vi } from 'vitest'
+
+import { describe } from '../__helpers/int/vitest.js'
+
+describe(
+  'mongodb read path selection',
+  { db: (adapter) => adapter === 'mongodb' || adapter === 'mongodb-atlas' },
+  () => {
+    const createdIDs: (number | string)[] = []
+
+    const getPayloadInstance = async () =>
+      await getPayload({
+        key: '_joinsQueryPath',
+        config: await buildConfig({
+          secret: '______',
+          db: await import('../databaseAdapter.js').then((mod) => mod.databaseAdapter),
+          collections: [
+            {
+              slug: 'categories',
+              fields: [
+                { name: 'title', type: 'text' },
+                {
+                  name: 'posts',
+                  type: 'join',
+                  collection: 'posts',
+                  on: 'category',
+                },
+              ],
+              versions: false,
+            },
+            {
+              slug: 'posts',
+              fields: [
+                {
+                  name: 'category',
+                  type: 'relationship',
+                  relationTo: 'categories',
+                },
+              ],
+              versions: false,
+            },
+          ],
+        }),
+      })
+
+    const seedCategory = async () => {
+      const payload = await getPayloadInstance()
+
+      const category = await payload.create({
+        collection: 'categories',
+        // @ts-expect-error not generated
+        data: { title: 'a' },
+      })
+      createdIDs.push(category.id)
+
+      return {
+        adapter: payload.db as unknown as MongooseAdapter,
+        category,
+        payload,
+      }
+    }
+
+    afterEach(async () => {
+      vi.restoreAllMocks()
+
+      const payload = await getPayloadInstance()
+
+      for (const id of createdIDs) {
+        await payload.delete({ collection: 'categories', id })
+      }
+
+      createdIDs.length = 0
+    })
+
+    it('should use Model.paginate when a select excludes every join field', async () => {
+      const { adapter, payload } = await seedCategory()
+      const Model = adapter.collections.categories!
+
+      const aggregateSpy = vi.spyOn(Model, 'aggregate')
+      const paginateSpy = vi.spyOn(Model, 'paginate')
+
+      await payload.find({
+        collection: 'categories',
+        limit: 20,
+        // @ts-expect-error not generated
+        select: { title: true },
+        where: { title: { equals: 'a' } },
+      })
+
+      expect(aggregateSpy).not.toHaveBeenCalled()
+      expect(paginateSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('should use Model.paginate when every join is disabled individually', async () => {
+      const { adapter, payload } = await seedCategory()
+      const Model = adapter.collections.categories!
+
+      const aggregateSpy = vi.spyOn(Model, 'aggregate')
+      const paginateSpy = vi.spyOn(Model, 'paginate')
+
+      await payload.find({
+        collection: 'categories',
+        // @ts-expect-error not generated
+        joins: { posts: false },
+        limit: 20,
+        where: { title: { equals: 'a' } },
+      })
+
+      expect(aggregateSpy).not.toHaveBeenCalled()
+      expect(paginateSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('should use Model.findOne for findByID when a select excludes every join field', async () => {
+      const { adapter, category, payload } = await seedCategory()
+      const Model = adapter.collections.categories!
+
+      const aggregateSpy = vi.spyOn(Model, 'aggregate')
+      const findOneSpy = vi.spyOn(Model, 'findOne')
+
+      await payload.findByID({
+        collection: 'categories',
+        id: category.id,
+        // @ts-expect-error not generated
+        select: { title: true },
+      })
+
+      expect(aggregateSpy).not.toHaveBeenCalled()
+      expect(findOneSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('should still use Model.aggregate when a join field is actually selected', async () => {
+      const { adapter, payload } = await seedCategory()
+      const Model = adapter.collections.categories!
+
+      const aggregateSpy = vi.spyOn(Model, 'aggregate')
+      const paginateSpy = vi.spyOn(Model, 'paginate')
+
+      await payload.find({
+        collection: 'categories',
+        limit: 20,
+        where: { title: { equals: 'a' } },
+      })
+
+      expect(aggregateSpy).toHaveBeenCalledTimes(1)
+      expect(paginateSpy).not.toHaveBeenCalled()
+    })
+  },
+)


### PR DESCRIPTION
Backport of https://github.com/payloadcms/payload/pull/17745 to 3.x.

### What?

`find`, `findOne` and `queryDrafts` in `@payloadcms/db-mongodb` run a MongoDB aggregation even when the join pipeline they just built is empty — no `$lookup` stages in it at all. The effect is that any collection with a join field stops using `Model.paginate` / `Model.findOne` on reads whose `select` doesn't include the join, and goes through `Model.aggregate` instead for no benefit.

This PR routes those queries back to the non-aggregation path.

### Why?

`buildJoinAggregation` returned `PipelineStage[] | undefined`. It returns `undefined` from its two early exits (join aggregations disabled; no joins configured, or `joins === false`), but when it runs to completion with every configured join skipped, it returns an empty array.

Joins get skipped on two entirely normal inputs, and both guards exist in both the polymorphic and the regular join loop:

- a `select` that omits the join field — `projection && !projection[projectionPath]`
- per-join `joins: { <name>: false }`

`[]` is truthy, so `if (aggregate)` at all three call sites took the aggregation branch anyway.

### How?

`buildJoinAggregation` now always returns an array (`Promise<PipelineStage[]>`), and the three call sites gate on `aggregate.length > 0`, symmetric with the `sortAggregation.length > 0` check sitting next to them.

Fixing it at the type level rather than with `aggregate?.length` at each call site is deliberate: nothing ever consumed the `undefined`/`[]` distinction — all three post-query `resolveJoins` branches read `this.useJoinAggregations` directly — and on a non-nullable array `if (aggregate)` is visibly always-true, so the original mistake can't be rewritten. The function isn't exported from the package, so the signature change isn't a public API break.
