### PR TITLE
fix(ui): forward forceRender into CollapsibleField's nested RenderFields

### DIFF
--- a/packages/ui/src/fields/Collapsible/index.tsx
+++ b/packages/ui/src/fields/Collapsible/index.tsx
@@ -26,6 +26,7 @@ const CollapsibleFieldComponent: CollapsibleFieldClientComponent = (props) => {
   const {
     field,
     field: { admin: { className, description, initCollapsed = false } = {}, fields, label } = {},
+    forceRender = false,
     indexPath,
     parentPath,
     parentSchemaPath,
@@ -141,6 +142,7 @@ const CollapsibleFieldComponent: CollapsibleFieldClientComponent = (props) => {
         >
           <RenderFields
             fields={fields}
+            forceRender={forceRender}
             parentIndexPath={indexPath}
             parentPath={parentPath}
             parentSchemaPath={parentSchemaPath}

--- a/test/fields/collections/Collapsible/e2e.spec.ts
+++ b/test/fields/collections/Collapsible/e2e.spec.ts
@@ -69,6 +69,28 @@ describe('Collapsibles', () => {
     await expect(collapsedCollapsible).toBeVisible()
   })
 
+  test('should render nested fields inside a collapsible even when document is hidden at mount', async () => {
+    // Simulate document.hidden === true at the point the page first renders.
+    // This reproduces the condition where CollapsibleField previously dropped
+    // the forceRender prop, causing RenderIfInViewport to defer indefinitely
+    // because IntersectionObserver callbacks are suspended for hidden documents.
+    await page.addInitScript(() => {
+      Object.defineProperty(document, 'hidden', { get: () => true, configurable: true })
+      Object.defineProperty(document, 'visibilityState', {
+        get: () => 'hidden',
+        configurable: true,
+      })
+    })
+
+    await page.goto(url.create)
+
+    // The first collapsible (index 0) is open by default and contains a text field.
+    // It must be visible without any scrolling — forceRender bypasses the
+    // IntersectionObserver gate that would otherwise block rendering when hidden.
+    const nestedField = page.locator('#field-collapsible-_index-0').getByRole('textbox').first()
+    await expect(nestedField).toBeVisible()
+  })
+
   test('should render CollapsibleLabel using a function', async () => {
     const label = 'custom row label'
     await page.goto(url.create)


### PR DESCRIPTION
## What

Closes #17473

`CollapsibleField` receives `forceRender` from the field dispatcher (`RenderField.tsx`) but never destructures or forwards it — it's silently dropped before reaching the nested `<RenderFields>` call.

## Why it matters

Without `forceRender`, each nested field is wrapped in `RenderIfInViewport`, which defers rendering until an `IntersectionObserver` reports the element as visible. Browsers suspend `IntersectionObserver` callbacks when `document.hidden` is `true` (backgrounded tabs, embedded webviews, visibility-throttled automation). So `hasRendered` stays `false` indefinitely and the collapsible's children never appear — no error, no warning.

`DocumentFields` explicitly passes `forceRender: true` for a document's own fields (at both the main and sidebar call sites), intending that field trees are never subject to lazy viewport-gated rendering. `Row`, `Tabs`, and `Array` already honor this by forwarding the prop; `Collapsible` was the only container type that didn't.

## Fix

Two lines, mirroring the existing pattern in `Row/index.tsx`:

```diff
+    forceRender = false,
     indexPath,
```

```diff
           <RenderFields
             fields={fields}
+            forceRender={forceRender}
```

## Verification

```bash
# Confirm the prop was absent before
grep -rn "forceRender" node_modules/@payloadcms/ui/dist/fields/Collapsible/
# (no output)

# Confirm Row already does this correctly
grep -n "forceRender" packages/ui/src/fields/Row/index.tsx
# 17:    forceRender = false,
# 34:          forceRender={forceRender}
```