### PR TITLE
fix(plugin-form-builder): include autolink nodes in LinkHTMLConverter

### DIFF
--- a/packages/plugin-form-builder/src/utilities/lexical/converters/link.ts
+++ b/packages/plugin-form-builder/src/utilities/lexical/converters/link.ts
@@ -31,5 +31,5 @@ export const LinkHTMLConverter: HTMLConverter<any> = {
 
     return `<a href="${safeHref}"${node.fields.newTab ? ' rel="noopener noreferrer" target="_blank"' : ''}>${childrenText}</a>`
   },
-  nodeTypes: ['link'],
+  nodeTypes: ['autolink', 'link'],
 }

--- a/test/plugin-form-builder/int.spec.ts
+++ b/test/plugin-form-builder/int.spec.ts
@@ -385,6 +385,76 @@ describe('@payloadcms/plugin-form-builder', () => {
           expect(serializedEmail).toContain(`<tr><td>name</td><td>${mockName}</td></tr>`)
           expect(serializedEmail).toContain(`<tr><td>email</td><td>${mockEmail}</td></tr>`)
         })
+
+        it('serializes automatically detected links', async () => {
+          const url = 'https://example.com'
+          const serializedEmail = await serializeLexical({
+            root: {
+              type: 'root',
+              children: [
+                {
+                  type: 'paragraph',
+                  children: [
+                    {
+                      type: 'text',
+                      detail: 0,
+                      format: 0,
+                      mode: 'normal',
+                      style: '',
+                      text: 'This person used ',
+                      version: 1,
+                    },
+                    {
+                      type: 'autolink',
+                      children: [
+                        {
+                          type: 'text',
+                          detail: 0,
+                          format: 0,
+                          mode: 'normal',
+                          style: '',
+                          text: url,
+                          version: 1,
+                        },
+                      ],
+                      direction: 'ltr',
+                      fields: {
+                        linkType: 'custom',
+                        newTab: false,
+                        url,
+                      },
+                      format: '',
+                      indent: 0,
+                      version: 2,
+                    },
+                    {
+                      type: 'text',
+                      detail: 0,
+                      format: 0,
+                      mode: 'normal',
+                      style: '',
+                      text: ' to sign in',
+                      version: 1,
+                    },
+                  ],
+                  direction: 'ltr',
+                  format: '',
+                  indent: 0,
+                  version: 1,
+                },
+              ],
+              direction: 'ltr',
+              format: '',
+              indent: 0,
+              version: 1,
+            },
+          })
+
+          expect(serializedEmail).toBe(
+            `<p>This person used <a href="${url}">${url}</a> to sign in</p>`,
+          )
+          expect(serializedEmail).not.toContain('unknown node')
+        })
       })
     })
   })


### PR DESCRIPTION
`LinkHTMLConverter` only declared `nodeTypes: ['link']` so Lexical autolink nodes (URLs and emails auto-detected by the editor) were silently skipped during HTML serialisation. Adding 'autolink' to ensure both explicit links and autolinks are converted to <a> tags.

V3 backport here https://github.com/payloadcms/payload/pull/17788