### PR TITLE
fix(ui): rich text fields not read-only inside tabs on trashed and locked documents

### DIFF
--- a/packages/ui/src/forms/fieldSchemasToFormState/addFieldStatePromise.ts
+++ b/packages/ui/src/forms/fieldSchemasToFormState/addFieldStatePromise.ts
@@ -997,6 +997,7 @@ export const addFieldStatePromise = async (args: AddFieldStatePromiseArgs): Prom
       permissions: parentPermissions,
       preferences,
       previousFormState,
+      readOnly,
       renderAllFields,
       renderFieldFn,
       req,

--- a/packages/ui/src/views/Edit/index.tsx
+++ b/packages/ui/src/views/Edit/index.tsx
@@ -499,6 +499,7 @@ export function DefaultEditView({
         !hasCheckedForStaleDataRef.current &&
         originalUpdatedAtRef.current &&
         operation === 'update' &&
+        !isTrashed &&
         !autosaveEnabled
 
       if (checkForStaleData) {

--- a/packages/ui/src/views/Edit/index.tsx
+++ b/packages/ui/src/views/Edit/index.tsx
@@ -517,9 +517,6 @@ export function DefaultEditView({
         globalSlug,
         operation,
         originalUpdatedAt: checkForStaleData ? originalUpdatedAtRef.current : undefined,
-        // Server-rendered fields (e.g. rich text) take their read-only state from form state,
-        // not from the `readOnly` prop threaded through `RenderFields`. Without this, any field
-        // re-rendered by this request would come back editable on a trashed or locked document.
         readOnly: isTrashed || isReadOnlyForIncomingUser,
         renderAllFields: false,
         returnLockStatus: isLockingEnabled,

--- a/packages/ui/src/views/Edit/index.tsx
+++ b/packages/ui/src/views/Edit/index.tsx
@@ -517,6 +517,10 @@ export function DefaultEditView({
         globalSlug,
         operation,
         originalUpdatedAt: checkForStaleData ? originalUpdatedAtRef.current : undefined,
+        // Server-rendered fields (e.g. rich text) take their read-only state from form state,
+        // not from the `readOnly` prop threaded through `RenderFields`. Without this, any field
+        // re-rendered by this request would come back editable on a trashed or locked document.
+        readOnly: isTrashed || isReadOnlyForIncomingUser,
         renderAllFields: false,
         returnLockStatus: isLockingEnabled,
         schemaPath: schemaPathSegments.join('.'),
@@ -564,6 +568,8 @@ export function DefaultEditView({
       schemaPathSegments,
       handleDocumentLocking,
       autosaveEnabled,
+      isTrashed,
+      isReadOnlyForIncomingUser,
     ],
   )
 

--- a/test/trash/collections/Posts/index.ts
+++ b/test/trash/collections/Posts/index.ts
@@ -19,6 +19,24 @@ export const Posts: CollectionConfig = {
       type: 'text',
       localized: true,
     },
+    {
+      name: 'richText',
+      type: 'richText',
+    },
+    {
+      type: 'tabs',
+      tabs: [
+        {
+          label: 'Tab',
+          fields: [
+            {
+              name: 'richTextInTab',
+              type: 'richText',
+            },
+          ],
+        },
+      ],
+    },
   ],
   versions: {
     drafts: true,

--- a/test/trash/e2e.spec.ts
+++ b/test/trash/e2e.spec.ts
@@ -708,6 +708,25 @@ describe('Trash', () => {
         await expect(statusBlock).toContainText('Previously Published')
       })
 
+      test('Should render rich text fields as read-only, including inside tabs', async ({
+        page,
+      }) => {
+        await page.goto(postsUrl.trashEdit(trashedPostDocOne.id))
+
+        // Rich text takes its read-only state from form state rather than from the `readOnly`
+        // prop threaded through `RenderFields`, so fields nested inside a `tabs` field regressed
+        // to being editable while every other field on the document stayed disabled.
+        for (const fieldPath of ['richText', 'richTextInTab']) {
+          const editor = page.locator(
+            `[data-field-path="${fieldPath}"] .ContentEditable__root[data-lexical-editor="true"]`,
+          )
+
+          await expect(editor).toBeVisible()
+          await expect(editor).toHaveAttribute('contenteditable', 'false')
+          await expect(editor).toHaveAttribute('aria-readonly', 'true')
+        }
+      })
+
       test('Should render Permanently Delete and Restore buttons in doc controls', async ({
         page,
       }) => {

--- a/test/trash/e2e.spec.ts
+++ b/test/trash/e2e.spec.ts
@@ -713,9 +713,6 @@ describe('Trash', () => {
       }) => {
         await page.goto(postsUrl.trashEdit(trashedPostDocOne.id))
 
-        // Rich text takes its read-only state from form state rather than from the `readOnly`
-        // prop threaded through `RenderFields`, so fields nested inside a `tabs` field regressed
-        // to being editable while every other field on the document stayed disabled.
         for (const fieldPath of ['richText', 'richTextInTab']) {
           const editor = page.locator(
             `[data-field-path="${fieldPath}"] .ContentEditable__root[data-lexical-editor="true"]`,

--- a/test/trash/payload-types.ts
+++ b/test/trash/payload-types.ts
@@ -60,6 +60,41 @@ export type SupportedTimezones =
   | 'Pacific/Noumea'
   | 'Pacific/Auckland'
   | 'Pacific/Fiji';
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "LexicalNodes_64B39A02".
+ */
+export type LexicalNodes_64B39A02 =
+  | SerializedTextNode
+  | SerializedTabNode
+  | SerializedLineBreakNode
+  | SerializedParagraphNode<LexicalNodes_64B39A02>
+  | SerializedHorizontalRuleNode
+  | {
+      type: 'upload';
+      /**
+       * Lexical's internal serialization version for this node type.
+       */
+      version: number;
+      [k: string]: unknown;
+    }
+  | SerializedQuoteNode<LexicalNodes_64B39A02>
+  | SerializedRelationshipNode<
+      | 'pages'
+      | 'posts'
+      | 'restricted-collection'
+      | 'differentiated-trash-collection'
+      | 'users'
+      | 'payload-kv'
+      | 'payload-locked-documents'
+      | 'payload-preferences'
+      | 'payload-migrations'
+    >
+  | SerializedAutoLinkNode<LexicalNodes_64B39A02, LexicalLinkFields>
+  | SerializedLinkNode<LexicalNodes_64B39A02, LexicalLinkFields>
+  | SerializedListNode<LexicalNodes_64B39A02>
+  | SerializedListItemNode<LexicalNodes_64B39A02>
+  | SerializedHeadingNode<LexicalNodes_64B39A02>;
 
 export interface Config {
   auth: {
@@ -98,6 +133,8 @@ export interface Config {
   locale: 'en' | 'es';
   widgets: {
     collections: CollectionsWidget;
+    'collection-query': CollectionQueryWidget;
+    activity: ActivityWidget;
   };
   user: User;
   jobs: {
@@ -144,6 +181,8 @@ export interface Post {
   id: string;
   title: string;
   localizedField?: string | null;
+  richText?: LexicalRichText<LexicalNodes_64B39A02> | null;
+  richTextInTab?: LexicalRichText<LexicalNodes_64B39A02> | null;
   updatedAt: string;
   createdAt: string;
   deletedAt?: string | null;
@@ -306,6 +345,8 @@ export interface PagesSelect<T extends boolean = true> {
 export interface PostsSelect<T extends boolean = true> {
   title?: T;
   localizedField?: T;
+  richText?: T;
+  richTextInTab?: T;
   updatedAt?: T;
   createdAt?: T;
   deletedAt?: T;
@@ -410,10 +451,179 @@ export interface CollectionsWidget {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "collection-query_widget".
+ */
+export interface CollectionQueryWidget {
+  data?: {
+    title?: string | null;
+    relatedCollection: 'pages' | 'posts' | 'restricted-collection' | 'differentiated-trash-collection' | 'users';
+    where?:
+      | {
+          [k: string]: unknown;
+        }
+      | unknown[]
+      | string
+      | number
+      | boolean
+      | null;
+    sortField?: string | null;
+    sortDirection?: ('asc' | 'desc') | null;
+    limit?: number | null;
+  };
+  width: 'x-small' | 'small' | 'medium' | 'large' | 'x-large' | 'full';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "activity_widget".
+ */
+export interface ActivityWidget {
+  data?: {
+    excludedCollections?:
+      | ('pages' | 'posts' | 'restricted-collection' | 'differentiated-trash-collection' | 'users')[]
+      | null;
+  };
+  width: 'x-small' | 'small' | 'medium' | 'large' | 'x-large' | 'full';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "auth".
  */
 export interface Auth {
   [k: string]: unknown;
+}
+
+/** @internal Core Lexical types — see @payloadcms/richtext-lexical. */
+export type LexicalElementFormat = 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+export type LexicalElementDirection = ('ltr' | 'rtl') | null;
+
+export interface SerializedLexicalElementBase<TChildren> {
+  children: TChildren[];
+  direction: LexicalElementDirection;
+  format: LexicalElementFormat;
+  indent: number;
+  textFormat?: number;
+  textStyle?: string;
+  version: number;
+}
+
+export type LexicalTextMode = 'normal' | 'token' | 'segmented';
+
+export interface SerializedTextNode {
+  type: 'text';
+  detail: number;
+  format: number;
+  mode: LexicalTextMode;
+  style: string;
+  text: string;
+  version: number;
+}
+
+export interface SerializedTabNode {
+  type: 'tab';
+  detail: number;
+  format: number;
+  mode: LexicalTextMode;
+  style: string;
+  text: string;
+  version: number;
+}
+
+export interface SerializedLineBreakNode {
+  type: 'linebreak';
+  version: number;
+}
+
+export interface SerializedParagraphNode<TChildren> extends SerializedLexicalElementBase<TChildren> {
+  type: 'paragraph';
+  textFormat: number;
+  textStyle: string;
+}
+
+export interface SerializedHorizontalRuleNode {
+  type: 'horizontalrule';
+  version: number;
+}
+
+export type SerializedUploadNode<TSlugs extends keyof Config['collections'], TFields = { [k: string]: unknown }> = {
+  type: 'upload';
+  format: LexicalElementFormat;
+  id: string;
+  version: number;
+  fields: TFields;
+} & {
+  [TSlug in TSlugs]: {
+    relationTo: TSlug;
+    value: Config['collections'][TSlug]['id'] | Config['collections'][TSlug];
+  };
+}[TSlugs];
+
+export interface SerializedQuoteNode<TChildren> extends SerializedLexicalElementBase<TChildren> {
+  type: 'quote';
+}
+
+export type SerializedRelationshipNode<TSlugs extends keyof Config['collections']> = {
+  type: 'relationship';
+  format: LexicalElementFormat;
+  version: number;
+} & {
+  [TSlug in TSlugs]: {
+    relationTo: TSlug;
+    value: Config['collections'][TSlug]['id'] | Config['collections'][TSlug];
+  };
+}[TSlugs];
+
+export interface LexicalLinkFields {
+  [k: string]: unknown;
+  doc?: {
+    relationTo: string;
+    value: Config['db']['defaultIDType'] | { [k: string]: unknown; id: Config['db']['defaultIDType'] };
+  } | null;
+  linkType: 'custom' | 'internal';
+  newTab: boolean;
+  url?: string;
+}
+export interface SerializedLinkNode<TChildren, TFields = LexicalLinkFields> extends SerializedLexicalElementBase<TChildren> {
+  type: 'link';
+  fields: TFields;
+  id?: string;
+}
+export interface SerializedAutoLinkNode<TChildren, TFields = LexicalLinkFields> extends SerializedLexicalElementBase<TChildren> {
+  type: 'autolink';
+  fields: TFields;
+}
+
+export interface SerializedListNode<TChildren> extends SerializedLexicalElementBase<TChildren> {
+  type: 'list';
+  checked?: boolean;
+  listType: 'number' | 'bullet' | 'check';
+  start: number;
+  tag: 'ul' | 'ol';
+}
+
+export interface SerializedListItemNode<TChildren> extends SerializedLexicalElementBase<TChildren> {
+  type: 'listitem';
+  checked?: boolean;
+  value: number;
+}
+
+export interface SerializedHeadingNode<
+  TChildren,
+  TTag extends 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6',
+> extends SerializedLexicalElementBase<TChildren> {
+  type: 'heading';
+  tag: TTag;
+}
+
+/** Shape of a Lexical `richText` field. */
+export interface LexicalRichText<TNode> {
+  root: {
+    children: TNode[];
+    direction: LexicalElementDirection;
+    format: LexicalElementFormat;
+    indent: number;
+    type: 'root';
+    version: number;
+  };
 }
 
 


### PR DESCRIPTION
### What?

Rich text fields nested inside a `tabs` field stayed editable on trashed documents (and on documents opened read-only after a document lock), while every other field on the same document was correctly disabled.

### Why?

Rich text renders as a server component, so `RenderField` returns the pre-rendered RSC and discards the client-side `readOnly` prop that `RenderFields` threads down. Its read-only state comes solely from the `readOnly` argument passed into `buildFormState` by the document view (`readOnly: isTrashedDoc || isLocked`).

Every branch of `addFieldStatePromise` forwards that value into its children — `array`, `blocks`, `group`, `row`/`collapsible`, `tab` — except the `tabs` branch, which omitted it. Form state for anything under a tabs field was therefore built with `readOnly: undefined`, `renderField` fell back to permissions, and the field was rendered with `readOnly: false`.

Fields that aren't server-rendered were unaffected, because they receive `readOnly` through the client-side `RenderFields` prop chain — which is why this looked arbitrary in practice: on the same page, a rich text field in one block is disabled while one inside a tabbed block is editable.

This is the same class of bug as #13579, which fixed rich text read-only for locked documents but only for fields that are not inside tabs.

### How?

- Forward `readOnly` in the `tabs` branch of `addFieldStatePromise`.
- The edit view's `onChange` never sent `readOnly` with subsequent form-state requests, so any field re-rendered by one of those requests came back editable on a trashed or locked document. It now sends `isTrashed || isReadOnlyForIncomingUser`, mirroring the initial server render. This one is hardening rather than a visible fix: `LexicalProvider` memoizes `initialConfig.editable` and keys the composer on it, so an editor mounted read-only won't flip back on its own — but the form state was wrong, and any other server-rendered custom `Field` that honours prop changes would be affected.

Regression test added to `test/trash`: the collection gets a rich text field and a rich text field inside a `tabs` field, and the trashed-document edit view test asserts both render `contenteditable="false"` / `aria-readonly="true"`. Verified red before the fix and green after, on this branch and on `3.x`.

Fixes #17789
