### PR TITLE
fix(ui): rich text fields not read-only inside tabs on trashed and locked documents 3.x

### DIFF
--- a/packages/ui/src/forms/fieldSchemasToFormState/addFieldStatePromise.ts
+++ b/packages/ui/src/forms/fieldSchemasToFormState/addFieldStatePromise.ts
@@ -989,6 +989,7 @@ export const addFieldStatePromise = async (args: AddFieldStatePromiseArgs): Prom
       permissions: parentPermissions,
       preferences,
       previousFormState,
+      readOnly,
       renderAllFields,
       renderFieldFn,
       req,

--- a/packages/ui/src/views/Edit/index.tsx
+++ b/packages/ui/src/views/Edit/index.tsx
@@ -497,6 +497,7 @@ export function DefaultEditView({
         !hasCheckedForStaleDataRef.current &&
         originalUpdatedAtRef.current &&
         operation === 'update' &&
+        !isTrashed &&
         !autosaveEnabled
 
       if (checkForStaleData) {

--- a/packages/ui/src/views/Edit/index.tsx
+++ b/packages/ui/src/views/Edit/index.tsx
@@ -515,6 +515,10 @@ export function DefaultEditView({
         globalSlug,
         operation,
         originalUpdatedAt: checkForStaleData ? originalUpdatedAtRef.current : undefined,
+        // Server-rendered fields (e.g. rich text) take their read-only state from form state,
+        // not from the `readOnly` prop threaded through `RenderFields`. Without this, any field
+        // re-rendered by this request would come back editable on a trashed or locked document.
+        readOnly: isTrashed || isReadOnlyForIncomingUser,
         renderAllFields: false,
         returnLockStatus: isLockingEnabled,
         schemaPath: schemaPathSegments.join('.'),
@@ -562,6 +566,8 @@ export function DefaultEditView({
       schemaPathSegments,
       handleDocumentLocking,
       autosaveEnabled,
+      isTrashed,
+      isReadOnlyForIncomingUser,
     ],
   )
 

--- a/packages/ui/src/views/Edit/index.tsx
+++ b/packages/ui/src/views/Edit/index.tsx
@@ -515,9 +515,6 @@ export function DefaultEditView({
         globalSlug,
         operation,
         originalUpdatedAt: checkForStaleData ? originalUpdatedAtRef.current : undefined,
-        // Server-rendered fields (e.g. rich text) take their read-only state from form state,
-        // not from the `readOnly` prop threaded through `RenderFields`. Without this, any field
-        // re-rendered by this request would come back editable on a trashed or locked document.
         readOnly: isTrashed || isReadOnlyForIncomingUser,
         renderAllFields: false,
         returnLockStatus: isLockingEnabled,

--- a/test/trash/collections/Posts/index.ts
+++ b/test/trash/collections/Posts/index.ts
@@ -19,6 +19,24 @@ export const Posts: CollectionConfig = {
       type: 'text',
       localized: true,
     },
+    {
+      name: 'richText',
+      type: 'richText',
+    },
+    {
+      type: 'tabs',
+      tabs: [
+        {
+          label: 'Tab',
+          fields: [
+            {
+              name: 'richTextInTab',
+              type: 'richText',
+            },
+          ],
+        },
+      ],
+    },
   ],
   versions: {
     drafts: true,

--- a/test/trash/e2e.spec.ts
+++ b/test/trash/e2e.spec.ts
@@ -650,9 +650,6 @@ describe('Trash', () => {
       }) => {
         await page.goto(postsUrl.trashEdit(trashedPostDocOne.id))
 
-        // Rich text takes its read-only state from form state rather than from the `readOnly`
-        // prop threaded through `RenderFields`, so fields nested inside a `tabs` field regressed
-        // to being editable while every other field on the document stayed disabled.
         for (const fieldPath of ['richText', 'richTextInTab']) {
           const editor = page.locator(
             `[data-field-path="${fieldPath}"] .ContentEditable__root[data-lexical-editor="true"]`,

--- a/test/trash/e2e.spec.ts
+++ b/test/trash/e2e.spec.ts
@@ -645,6 +645,25 @@ describe('Trash', () => {
         await expect(statusBlock).toContainText('Previously Published')
       })
 
+      test('Should render rich text fields as read-only, including inside tabs', async ({
+        page,
+      }) => {
+        await page.goto(postsUrl.trashEdit(trashedPostDocOne.id))
+
+        // Rich text takes its read-only state from form state rather than from the `readOnly`
+        // prop threaded through `RenderFields`, so fields nested inside a `tabs` field regressed
+        // to being editable while every other field on the document stayed disabled.
+        for (const fieldPath of ['richText', 'richTextInTab']) {
+          const editor = page.locator(
+            `[data-field-path="${fieldPath}"] .ContentEditable__root[data-lexical-editor="true"]`,
+          )
+
+          await expect(editor).toBeVisible()
+          await expect(editor).toHaveAttribute('contenteditable', 'false')
+          await expect(editor).toHaveAttribute('aria-readonly', 'true')
+        }
+      })
+
       test('Should render Permanently Delete and Restore buttons in doc controls', async ({
         page,
       }) => {

--- a/test/trash/payload-types.ts
+++ b/test/trash/payload-types.ts
@@ -144,6 +144,36 @@ export interface Post {
   id: string;
   title: string;
   localizedField?: string | null;
+  richText?: {
+    root: {
+      type: string;
+      children: {
+        type: any;
+        version: number;
+        [k: string]: unknown;
+      }[];
+      direction: ('ltr' | 'rtl') | null;
+      format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+      indent: number;
+      version: number;
+    };
+    [k: string]: unknown;
+  } | null;
+  richTextInTab?: {
+    root: {
+      type: string;
+      children: {
+        type: any;
+        version: number;
+        [k: string]: unknown;
+      }[];
+      direction: ('ltr' | 'rtl') | null;
+      format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+      indent: number;
+      version: number;
+    };
+    [k: string]: unknown;
+  } | null;
   updatedAt: string;
   createdAt: string;
   deletedAt?: string | null;
@@ -306,6 +336,8 @@ export interface PagesSelect<T extends boolean = true> {
 export interface PostsSelect<T extends boolean = true> {
   title?: T;
   localizedField?: T;
+  richText?: T;
+  richTextInTab?: T;
   updatedAt?: T;
   createdAt?: T;
   deletedAt?: T;


### PR DESCRIPTION
### What?

Rich text fields nested inside a `tabs` field stayed editable on trashed documents (and on documents opened read-only after a document lock), while every other field on the same document was correctly disabled.

### Why?

Rich text renders as a server component, so `RenderField` returns the pre-rendered RSC and discards the client-side `readOnly` prop that `RenderFields` threads down. Its read-only state comes solely from the `readOnly` argument passed into `buildFormState` by the document view (`readOnly: isTrashedDoc || isLocked`).

Every branch of `addFieldStatePromise` forwards that value into its children — `array`, `blocks`, `group`, `row`/`collapsible`, `tab` — except the `tabs` branch, which omitted it. Form state for anything under a tabs field was therefore built with `readOnly: undefined`, `renderField` fell back to permissions, and the field was rendered with `readOnly: false`.

Fields that aren't server-rendered were unaffected, because they receive `readOnly` through the client-side `RenderFields` prop chain — which is why this looked arbitrary in practice: on the same page, a rich text field in one block is disabled while one inside a tabbed block is editable.

This is the same class of bug as #13579, which fixed rich text read-only for locked documents but only for fields that are not inside tabs.

### How?

- Forward `readOnly` in the `tabs` branch of `addFieldStatePromise`.
- The edit view's `onChange` never sent `readOnly` with subsequent form-state requests, so any field re-rendered by one of those requests came back editable on a trashed or locked document. It now sends `isTrashed || isReadOnlyForIncomingUser`, mirroring the initial server render. This one is hardening rather than a visible fix: `LexicalProvider` memoizes `initialConfig.editable` and keys the composer on it, so an editor mounted read-only won't flip back on its own — but the form state was wrong, and any other server-rendered custom `Field` that honours prop changes would be affected.

Regression test added to `test/trash`: the collection gets a rich text field and a rich text field inside a `tabs` field, and the trashed-document edit view test asserts both render `contenteditable="false"` / `aria-readonly="true"`. Verified red before the fix and green after, on this branch and on `3.x`.

v3 backport of #17790 — see #17789.
