### PR TITLE
fix(ui): propagate read-only state through tabs

### DIFF
--- a/packages/ui/src/forms/fieldSchemasToFormState/addFieldStatePromise.ts
+++ b/packages/ui/src/forms/fieldSchemasToFormState/addFieldStatePromise.ts
@@ -997,6 +997,7 @@ export const addFieldStatePromise = async (args: AddFieldStatePromiseArgs): Prom
       permissions: parentPermissions,
       preferences,
       previousFormState,
+      readOnly,
       renderAllFields,
       renderFieldFn,
       req,

--- a/packages/ui/src/views/Edit/index.tsx
+++ b/packages/ui/src/views/Edit/index.tsx
@@ -499,6 +499,7 @@ export function DefaultEditView({
         !hasCheckedForStaleDataRef.current &&
         originalUpdatedAtRef.current &&
         operation === 'update' &&
+        !isTrashed &&
         !autosaveEnabled
 
       if (checkForStaleData) {
@@ -517,6 +518,7 @@ export function DefaultEditView({
         globalSlug,
         operation,
         originalUpdatedAt: checkForStaleData ? originalUpdatedAtRef.current : undefined,
+        readOnly: isReadOnlyForIncomingUser || isTrashed,
         renderAllFields: false,
         returnLockStatus: isLockingEnabled,
         schemaPath: schemaPathSegments.join('.'),
@@ -560,10 +562,12 @@ export function DefaultEditView({
       collectionSlug,
       docPermissions,
       globalSlug,
+      isReadOnlyForIncomingUser,
       operation,
       schemaPathSegments,
       handleDocumentLocking,
       autosaveEnabled,
+      isTrashed,
     ],
   )
 

--- a/test/trash/collections/Posts/index.ts
+++ b/test/trash/collections/Posts/index.ts
@@ -7,7 +7,6 @@ export const Posts: CollectionConfig = {
   admin: {
     useAsTitle: 'title',
   },
-  trash: true,
   fields: [
     {
       name: 'title',
@@ -19,7 +18,37 @@ export const Posts: CollectionConfig = {
       type: 'text',
       localized: true,
     },
+    {
+      name: 'showConditionalRichText',
+      type: 'text',
+    },
+    {
+      name: 'richText',
+      type: 'richText',
+    },
+    {
+      type: 'tabs',
+      tabs: [
+        {
+          fields: [
+            {
+              name: 'richTextInTab',
+              type: 'richText',
+            },
+            {
+              name: 'conditionalRichTextInTab',
+              type: 'richText',
+              admin: {
+                condition: ({ showConditionalRichText }) => showConditionalRichText === 'show',
+              },
+            },
+          ],
+          label: 'Tab',
+        },
+      ],
+    },
   ],
+  trash: true,
   versions: {
     drafts: true,
   },

--- a/test/trash/e2e.spec.ts
+++ b/test/trash/e2e.spec.ts
@@ -823,9 +823,65 @@ describe('Trash', () => {
       test('Should render fields as read-only', async ({ page }) => {
         await page.goto(postsUrl.trashEdit(trashedPostDocOne.id))
 
-        // Check that the title field is read-only
         const titleField = page.locator('#field-title')
         await expect(titleField).toBeDisabled()
+
+        const richTextField = page.locator('.rich-text-lexical .ContentEditable__root').first()
+        await expect(richTextField).toHaveAttribute('contenteditable', 'false')
+
+        const richTextInTabField = page.locator(
+          '.tabs-field__tab .rich-text-lexical .ContentEditable__root',
+        )
+        await expect(richTextInTabField).toHaveAttribute('contenteditable', 'false')
+      })
+
+      test('should render rich text fields inside tabs as read-only', async ({ page }) => {
+        const trashedPostWithConditionalRichText = await createTrashedPostDoc({
+          showConditionalRichText: 'show',
+          title: 'Trashed Post With Conditional Rich Text',
+        })
+
+        await page.goto(postsUrl.trashEdit(trashedPostWithConditionalRichText.id))
+
+        const richTextRoot = page.locator(
+          '.rich-text-lexical[data-field-path="richText"] .ContentEditable__root',
+        )
+        const richTextInTabRoot = page.locator(
+          '.rich-text-lexical[data-field-path="richTextInTab"] .ContentEditable__root',
+        )
+        const conditionalRichTextInTabRoot = page.locator(
+          '.rich-text-lexical[data-field-path="conditionalRichTextInTab"] .ContentEditable__root',
+        )
+
+        await expect(conditionalRichTextInTabRoot).toHaveAttribute('contenteditable', 'false')
+        await expect(richTextInTabRoot).toHaveAttribute('contenteditable', 'false')
+        await expect(richTextRoot).toHaveAttribute('contenteditable', 'false')
+        await conditionalRichTextInTabRoot.click()
+        await page.keyboard.type('should not be entered')
+        await expect(conditionalRichTextInTabRoot).not.toContainText('should not be entered')
+      })
+
+      test('should keep server-rendered rich text fields read-only after form state updates', async ({
+        page,
+      }) => {
+        await page.goto(postsUrl.trashEdit(trashedPostDocOne.id))
+
+        const trigger = page.locator('#field-showConditionalRichText')
+        const conditionalRichTextRoot = page.locator(
+          '.rich-text-lexical[data-field-path="conditionalRichTextInTab"] .ContentEditable__root',
+        )
+
+        await expect(conditionalRichTextRoot).toHaveCount(0)
+        // Force a form-state update to verify fields added by the server remain read-only.
+        await trigger.evaluate((element: HTMLInputElement) => {
+          element.disabled = false
+        })
+        await trigger.fill('show')
+
+        await expect(conditionalRichTextRoot).toHaveAttribute('contenteditable', 'false')
+        await conditionalRichTextRoot.click()
+        await page.keyboard.type('should not be entered')
+        await expect(conditionalRichTextRoot).not.toContainText('should not be entered')
       })
 
       test('Should allow viewing of the Versions tab view from trash edit view', async ({

--- a/test/trash/payload-types.ts
+++ b/test/trash/payload-types.ts
@@ -60,6 +60,41 @@ export type SupportedTimezones =
   | 'Pacific/Noumea'
   | 'Pacific/Auckland'
   | 'Pacific/Fiji';
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "LexicalNodes_64B39A02".
+ */
+export type LexicalNodes_64B39A02 =
+  | SerializedTextNode
+  | SerializedTabNode
+  | SerializedLineBreakNode
+  | SerializedParagraphNode<LexicalNodes_64B39A02>
+  | SerializedHorizontalRuleNode
+  | {
+      type: 'upload';
+      /**
+       * Lexical's internal serialization version for this node type.
+       */
+      version: number;
+      [k: string]: unknown;
+    }
+  | SerializedQuoteNode<LexicalNodes_64B39A02>
+  | SerializedRelationshipNode<
+      | 'pages'
+      | 'posts'
+      | 'restricted-collection'
+      | 'differentiated-trash-collection'
+      | 'users'
+      | 'payload-kv'
+      | 'payload-locked-documents'
+      | 'payload-preferences'
+      | 'payload-migrations'
+    >
+  | SerializedAutoLinkNode<LexicalNodes_64B39A02, LexicalLinkFields>
+  | SerializedLinkNode<LexicalNodes_64B39A02, LexicalLinkFields>
+  | SerializedListNode<LexicalNodes_64B39A02>
+  | SerializedListItemNode<LexicalNodes_64B39A02>
+  | SerializedHeadingNode<LexicalNodes_64B39A02>;
 
 export interface Config {
   auth: {
@@ -98,6 +133,8 @@ export interface Config {
   locale: 'en' | 'es';
   widgets: {
     collections: CollectionsWidget;
+    'collection-query': CollectionQueryWidget;
+    activity: ActivityWidget;
   };
   user: User;
   jobs: {
@@ -144,6 +181,10 @@ export interface Post {
   id: string;
   title: string;
   localizedField?: string | null;
+  showConditionalRichText?: string | null;
+  richText?: LexicalRichText<LexicalNodes_64B39A02> | null;
+  richTextInTab?: LexicalRichText<LexicalNodes_64B39A02> | null;
+  conditionalRichTextInTab?: LexicalRichText<LexicalNodes_64B39A02> | null;
   updatedAt: string;
   createdAt: string;
   deletedAt?: string | null;
@@ -306,6 +347,10 @@ export interface PagesSelect<T extends boolean = true> {
 export interface PostsSelect<T extends boolean = true> {
   title?: T;
   localizedField?: T;
+  showConditionalRichText?: T;
+  richText?: T;
+  richTextInTab?: T;
+  conditionalRichTextInTab?: T;
   updatedAt?: T;
   createdAt?: T;
   deletedAt?: T;
@@ -410,10 +455,179 @@ export interface CollectionsWidget {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "collection-query_widget".
+ */
+export interface CollectionQueryWidget {
+  data?: {
+    title?: string | null;
+    relatedCollection: 'pages' | 'posts' | 'restricted-collection' | 'differentiated-trash-collection' | 'users';
+    where?:
+      | {
+          [k: string]: unknown;
+        }
+      | unknown[]
+      | string
+      | number
+      | boolean
+      | null;
+    sortField?: string | null;
+    sortDirection?: ('asc' | 'desc') | null;
+    limit?: number | null;
+  };
+  width: 'x-small' | 'small' | 'medium' | 'large' | 'x-large' | 'full';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "activity_widget".
+ */
+export interface ActivityWidget {
+  data?: {
+    excludedCollections?:
+      | ('pages' | 'posts' | 'restricted-collection' | 'differentiated-trash-collection' | 'users')[]
+      | null;
+  };
+  width: 'x-small' | 'small' | 'medium' | 'large' | 'x-large' | 'full';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "auth".
  */
 export interface Auth {
   [k: string]: unknown;
+}
+
+/** @internal Core Lexical types — see @payloadcms/richtext-lexical. */
+export type LexicalElementFormat = 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+export type LexicalElementDirection = ('ltr' | 'rtl') | null;
+
+export interface SerializedLexicalElementBase<TChildren> {
+  children: TChildren[];
+  direction: LexicalElementDirection;
+  format: LexicalElementFormat;
+  indent: number;
+  textFormat?: number;
+  textStyle?: string;
+  version: number;
+}
+
+export type LexicalTextMode = 'normal' | 'token' | 'segmented';
+
+export interface SerializedTextNode {
+  type: 'text';
+  detail: number;
+  format: number;
+  mode: LexicalTextMode;
+  style: string;
+  text: string;
+  version: number;
+}
+
+export interface SerializedTabNode {
+  type: 'tab';
+  detail: number;
+  format: number;
+  mode: LexicalTextMode;
+  style: string;
+  text: string;
+  version: number;
+}
+
+export interface SerializedLineBreakNode {
+  type: 'linebreak';
+  version: number;
+}
+
+export interface SerializedParagraphNode<TChildren> extends SerializedLexicalElementBase<TChildren> {
+  type: 'paragraph';
+  textFormat: number;
+  textStyle: string;
+}
+
+export interface SerializedHorizontalRuleNode {
+  type: 'horizontalrule';
+  version: number;
+}
+
+export type SerializedUploadNode<TSlugs extends keyof Config['collections'], TFields = { [k: string]: unknown }> = {
+  type: 'upload';
+  format: LexicalElementFormat;
+  id: string;
+  version: number;
+  fields: TFields;
+} & {
+  [TSlug in TSlugs]: {
+    relationTo: TSlug;
+    value: Config['collections'][TSlug]['id'] | Config['collections'][TSlug];
+  };
+}[TSlugs];
+
+export interface SerializedQuoteNode<TChildren> extends SerializedLexicalElementBase<TChildren> {
+  type: 'quote';
+}
+
+export type SerializedRelationshipNode<TSlugs extends keyof Config['collections']> = {
+  type: 'relationship';
+  format: LexicalElementFormat;
+  version: number;
+} & {
+  [TSlug in TSlugs]: {
+    relationTo: TSlug;
+    value: Config['collections'][TSlug]['id'] | Config['collections'][TSlug];
+  };
+}[TSlugs];
+
+export interface LexicalLinkFields {
+  [k: string]: unknown;
+  doc?: {
+    relationTo: string;
+    value: Config['db']['defaultIDType'] | { [k: string]: unknown; id: Config['db']['defaultIDType'] };
+  } | null;
+  linkType: 'custom' | 'internal';
+  newTab: boolean;
+  url?: string;
+}
+export interface SerializedLinkNode<TChildren, TFields = LexicalLinkFields> extends SerializedLexicalElementBase<TChildren> {
+  type: 'link';
+  fields: TFields;
+  id?: string;
+}
+export interface SerializedAutoLinkNode<TChildren, TFields = LexicalLinkFields> extends SerializedLexicalElementBase<TChildren> {
+  type: 'autolink';
+  fields: TFields;
+}
+
+export interface SerializedListNode<TChildren> extends SerializedLexicalElementBase<TChildren> {
+  type: 'list';
+  checked?: boolean;
+  listType: 'number' | 'bullet' | 'check';
+  start: number;
+  tag: 'ul' | 'ol';
+}
+
+export interface SerializedListItemNode<TChildren> extends SerializedLexicalElementBase<TChildren> {
+  type: 'listitem';
+  checked?: boolean;
+  value: number;
+}
+
+export interface SerializedHeadingNode<
+  TChildren,
+  TTag extends 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6',
+> extends SerializedLexicalElementBase<TChildren> {
+  type: 'heading';
+  tag: TTag;
+}
+
+/** Shape of a Lexical `richText` field. */
+export interface LexicalRichText<TNode> {
+  root: {
+    children: TNode[];
+    direction: LexicalElementDirection;
+    format: LexicalElementFormat;
+    indent: number;
+    type: 'root';
+    version: number;
+  };
 }
 
 


### PR DESCRIPTION
Rich text fields nested inside `tabs` now remain read-only on trashed documents and when viewing locked documents in read-only mode.

1. The `tabs` form-state branch did not forward `readOnly` to its child fields.
2. Subsequent form-state requests did not preserve the client’s current read-only state.

Propagates `readOnly` through both paths and adds regression coverage for initial rendering and conditional server-rendered fields.

Fixes #17789
