### PR TITLE
fix(ui): propagate read-only state through tabs 3.x

### DIFF
--- a/packages/ui/src/forms/fieldSchemasToFormState/addFieldStatePromise.ts
+++ b/packages/ui/src/forms/fieldSchemasToFormState/addFieldStatePromise.ts
@@ -989,6 +989,7 @@ export const addFieldStatePromise = async (args: AddFieldStatePromiseArgs): Prom
       permissions: parentPermissions,
       preferences,
       previousFormState,
+      readOnly,
       renderAllFields,
       renderFieldFn,
       req,

--- a/packages/ui/src/views/Edit/index.tsx
+++ b/packages/ui/src/views/Edit/index.tsx
@@ -497,6 +497,7 @@ export function DefaultEditView({
         !hasCheckedForStaleDataRef.current &&
         originalUpdatedAtRef.current &&
         operation === 'update' &&
+        !isTrashed &&
         !autosaveEnabled
 
       if (checkForStaleData) {
@@ -515,6 +516,7 @@ export function DefaultEditView({
         globalSlug,
         operation,
         originalUpdatedAt: checkForStaleData ? originalUpdatedAtRef.current : undefined,
+        readOnly: isReadOnlyForIncomingUser || isTrashed,
         renderAllFields: false,
         returnLockStatus: isLockingEnabled,
         schemaPath: schemaPathSegments.join('.'),
@@ -558,6 +560,8 @@ export function DefaultEditView({
       collectionSlug,
       docPermissions,
       globalSlug,
+      isReadOnlyForIncomingUser,
+      isTrashed,
       operation,
       schemaPathSegments,
       handleDocumentLocking,

--- a/test/trash/collections/Posts/index.ts
+++ b/test/trash/collections/Posts/index.ts
@@ -24,6 +24,15 @@ export const Posts: CollectionConfig = {
       type: 'text',
     },
     {
+      name: 'triggerFormStateUpdate',
+      type: 'ui',
+      admin: {
+        components: {
+          Field: '/components/TriggerFormStateUpdate/index.tsx#TriggerFormStateUpdate',
+        },
+      },
+    },
+    {
       name: 'richText',
       type: 'richText',
     },

--- a/test/trash/collections/Posts/index.ts
+++ b/test/trash/collections/Posts/index.ts
@@ -19,6 +19,35 @@ export const Posts: CollectionConfig = {
       type: 'text',
       localized: true,
     },
+    {
+      name: 'showConditionalRichText',
+      type: 'text',
+    },
+    {
+      name: 'richText',
+      type: 'richText',
+    },
+    {
+      type: 'tabs',
+      tabs: [
+        {
+          label: 'Tab',
+          fields: [
+            {
+              name: 'richTextInTab',
+              type: 'richText',
+            },
+            {
+              name: 'conditionalRichTextInTab',
+              type: 'richText',
+              admin: {
+                condition: ({ showConditionalRichText }) => showConditionalRichText === 'show',
+              },
+            },
+          ],
+        },
+      ],
+    },
   ],
   versions: {
     drafts: true,

--- a/test/trash/components/TriggerFormStateUpdate/index.tsx
+++ b/test/trash/components/TriggerFormStateUpdate/index.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+import { useField } from '@payloadcms/ui'
+
+export const TriggerFormStateUpdate = () => {
+  const { setValue } = useField({ path: 'showConditionalRichText' })
+
+  return (
+    <button id="trigger-form-state-update" onClick={() => setValue('show')} type="button">
+      Trigger form state update
+    </button>
+  )
+}

--- a/test/trash/e2e.spec.ts
+++ b/test/trash/e2e.spec.ts
@@ -651,17 +651,12 @@ describe('Trash', () => {
       }) => {
         await page.goto(postsUrl.trashEdit(trashedPostDocOne.id))
 
-        const trigger = page.locator('#field-showConditionalRichText')
         const conditionalRichTextRoot = page.locator(
           '.rich-text-lexical[data-field-path="conditionalRichTextInTab"] .ContentEditable__root',
         )
 
         await expect(conditionalRichTextRoot).toHaveCount(0)
-        // Force a form-state update to verify fields added by the server remain read-only.
-        await trigger.evaluate((element: HTMLInputElement) => {
-          element.disabled = false
-        })
-        await trigger.fill('show')
+        await page.locator('#trigger-form-state-update').click()
 
         await expect(conditionalRichTextRoot).toHaveAttribute('contenteditable', 'false')
         await conditionalRichTextRoot.click()

--- a/test/trash/e2e.spec.ts
+++ b/test/trash/e2e.spec.ts
@@ -620,6 +620,55 @@ describe('Trash', () => {
         await expect(page.locator('.trash-banner')).toBeVisible()
       })
 
+      test('should render rich text fields inside tabs as read-only', async ({ page }) => {
+        const trashedPostWithConditionalRichText = await createTrashedPostDoc({
+          showConditionalRichText: 'show',
+          title: 'Trashed Post With Conditional Rich Text',
+        })
+
+        await page.goto(postsUrl.trashEdit(trashedPostWithConditionalRichText.id))
+
+        const richTextRoot = page.locator(
+          '.rich-text-lexical[data-field-path="richText"] .ContentEditable__root',
+        )
+        const richTextInTabRoot = page.locator(
+          '.rich-text-lexical[data-field-path="richTextInTab"] .ContentEditable__root',
+        )
+        const conditionalRichTextInTabRoot = page.locator(
+          '.rich-text-lexical[data-field-path="conditionalRichTextInTab"] .ContentEditable__root',
+        )
+
+        await expect(conditionalRichTextInTabRoot).toHaveAttribute('contenteditable', 'false')
+        await expect(richTextInTabRoot).toHaveAttribute('contenteditable', 'false')
+        await expect(richTextRoot).toHaveAttribute('contenteditable', 'false')
+        await conditionalRichTextInTabRoot.click()
+        await page.keyboard.type('should not be entered')
+        await expect(conditionalRichTextInTabRoot).not.toContainText('should not be entered')
+      })
+
+      test('should keep server-rendered rich text fields read-only after form state updates', async ({
+        page,
+      }) => {
+        await page.goto(postsUrl.trashEdit(trashedPostDocOne.id))
+
+        const trigger = page.locator('#field-showConditionalRichText')
+        const conditionalRichTextRoot = page.locator(
+          '.rich-text-lexical[data-field-path="conditionalRichTextInTab"] .ContentEditable__root',
+        )
+
+        await expect(conditionalRichTextRoot).toHaveCount(0)
+        // Force a form-state update to verify fields added by the server remain read-only.
+        await trigger.evaluate((element: HTMLInputElement) => {
+          element.disabled = false
+        })
+        await trigger.fill('show')
+
+        await expect(conditionalRichTextRoot).toHaveAttribute('contenteditable', 'false')
+        await conditionalRichTextRoot.click()
+        await page.keyboard.type('should not be entered')
+        await expect(conditionalRichTextRoot).not.toContainText('should not be entered')
+      })
+
       test('Should navigate back to the trash view using the `trash` breadcrumb', async ({
         page,
       }) => {

--- a/test/trash/payload-types.ts
+++ b/test/trash/payload-types.ts
@@ -144,6 +144,52 @@ export interface Post {
   id: string;
   title: string;
   localizedField?: string | null;
+  showConditionalRichText?: string | null;
+  richText?: {
+    root: {
+      type: string;
+      children: {
+        type: any;
+        version: number;
+        [k: string]: unknown;
+      }[];
+      direction: ('ltr' | 'rtl') | null;
+      format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+      indent: number;
+      version: number;
+    };
+    [k: string]: unknown;
+  } | null;
+  richTextInTab?: {
+    root: {
+      type: string;
+      children: {
+        type: any;
+        version: number;
+        [k: string]: unknown;
+      }[];
+      direction: ('ltr' | 'rtl') | null;
+      format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+      indent: number;
+      version: number;
+    };
+    [k: string]: unknown;
+  } | null;
+  conditionalRichTextInTab?: {
+    root: {
+      type: string;
+      children: {
+        type: any;
+        version: number;
+        [k: string]: unknown;
+      }[];
+      direction: ('ltr' | 'rtl') | null;
+      format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+      indent: number;
+      version: number;
+    };
+    [k: string]: unknown;
+  } | null;
   updatedAt: string;
   createdAt: string;
   deletedAt?: string | null;
@@ -306,6 +352,10 @@ export interface PagesSelect<T extends boolean = true> {
 export interface PostsSelect<T extends boolean = true> {
   title?: T;
   localizedField?: T;
+  showConditionalRichText?: T;
+  richText?: T;
+  richTextInTab?: T;
+  conditionalRichTextInTab?: T;
   updatedAt?: T;
   createdAt?: T;
   deletedAt?: T;


### PR DESCRIPTION
Backport of #17793 to `3.x`

Rich text fields nested inside `tabs` now remain read-only on trashed documents and when viewing locked documents in read-only mode.

1. The `tabs` form-state branch did not forward `readOnly` to its child fields.
2. Subsequent form-state requests did not preserve the client’s current read-only state.

Propagates `readOnly` through both paths and adds regression coverage for initial rendering and conditional server-rendered fields.

Fixes #17789
