### PR TITLE
fix(email-resend): http fetch error handling swallows errors

### DIFF
--- a/packages/email-resend/src/email-resend.int.spec.ts
+++ b/packages/email-resend/src/email-resend.int.spec.ts
@@ -1,0 +1,52 @@
+import type { Payload } from 'payload'
+
+import { describe, expect, it } from 'vitest'
+
+import { resendAdapter } from './index.js'
+
+/**
+ * Real end-to-end checks against the live Resend API. Skipped unless RESEND_API_KEY
+ * is set, so the default unit run and CI never hit the network.
+ *
+ * Run with:
+ *   RESEND_API_KEY=re_xxx pnpm vitest run packages/email-resend/src/email-resend.int.spec.ts
+ *
+ * Uses Resend's sandbox identities, which require no domain verification:
+ *   from:  onboarding@resend.dev
+ *   to:    delivered@resend.dev  (also bounced@resend.dev / complained@resend.dev)
+ */
+describe.skipIf(!process.env.RESEND_API_KEY)('email-resend (integration)', () => {
+  const mockPayload = {} as unknown as Payload
+
+  const adapter = (apiKey: string) =>
+    resendAdapter({
+      apiKey,
+      defaultFromAddress: 'onboarding@resend.dev',
+      defaultFromName: 'Payload Integration Test',
+    })({ payload: mockPayload })
+
+  it('should send a real email and return a Resend id', async () => {
+    const result = (await adapter(process.env.RESEND_API_KEY!).sendEmail({
+      from: 'Payload <onboarding@resend.dev>',
+      subject: 'Payload email-resend integration test',
+      text: 'This message was sent by the email-resend integration test.',
+      to: 'delivered@resend.dev',
+    })) as { id: string }
+
+    expect(result.id).toEqual(expect.any(String))
+    expect(result.id.length).toBeGreaterThan(0)
+  })
+
+  it('should throw a descriptive APIError for an invalid API key', async () => {
+    // Exercises the real Resend error path end-to-end (JSON 401/403 body),
+    // proving the adapter surfaces the reason instead of a JSON parse error.
+    await expect(() =>
+      adapter('re_invalid_key_for_testing').sendEmail({
+        from: 'Payload <onboarding@resend.dev>',
+        subject: 'Should fail',
+        text: 'Should fail',
+        to: 'delivered@resend.dev',
+      }),
+    ).rejects.toThrow(/Error sending email/)
+  })
+})

--- a/packages/email-resend/src/email-resend.spec.ts
+++ b/packages/email-resend/src/email-resend.spec.ts
@@ -319,7 +319,7 @@ describe('email-resend', () => {
       mockFetch(errorResponse, { status: 403 })
 
       await expect(() => adapter().sendEmail({ from, subject, text, to })).rejects.toThrow(
-        `Error sending email: ${errorResponse.statusCode} ${errorResponse.name} - ${errorResponse.message}`,
+        `Error sending email: ${errorResponse.name} - ${errorResponse.message}`,
       )
     })
 
@@ -327,15 +327,15 @@ describe('email-resend', () => {
       mockFetch('Origin is disallowed', { status: 403, statusText: 'Forbidden' })
 
       await expect(() => adapter().sendEmail({ from, subject, text, to })).rejects.toThrow(
-        /Error sending email: 403.*Origin is disallowed/s,
+        /Error sending email.*Origin is disallowed/s,
       )
     })
 
-    it('should throw with the status code when the error body is empty', async () => {
+    it('should throw when the error body is empty', async () => {
       mockFetch('', { status: 500, statusText: 'Internal Server Error' })
 
       await expect(() => adapter().sendEmail({ from, subject, text, to })).rejects.toThrow(
-        /Error sending email: 500/,
+        /Error sending email/,
       )
     })
 

--- a/packages/email-resend/src/email-resend.spec.ts
+++ b/packages/email-resend/src/email-resend.spec.ts
@@ -1,5 +1,6 @@
 import type { Payload } from 'payload'
-import { describe, afterEach, beforeEach, it, expect, vitest, Mock } from 'vitest'
+
+import { afterEach, describe, expect, it, Mock, vitest } from 'vitest'
 
 import { resendAdapter } from './index.js'
 
@@ -14,40 +15,46 @@ describe('email-resend', () => {
 
   const mockPayload = {} as unknown as Payload
 
+  /**
+   * Mocks `global.fetch` with a real `Response` so the adapter exercises the same
+   * `Response` API (`ok`, `status`, `text`, `json`) it uses against the live Resend API.
+   */
+  const mockFetch = (body: string | unknown, init?: ResponseInit) => {
+    const responseBody = typeof body === 'string' ? body : JSON.stringify(body)
+
+    global.fetch = vitest
+      .spyOn(global, 'fetch')
+      .mockResolvedValue(new Response(responseBody, { status: 200, ...init })) as unknown as Mock
+
+    return global.fetch as unknown as Mock
+  }
+
+  const getRequestBody = () => {
+    // @ts-expect-error - fetch is mocked above
+    return JSON.parse(global.fetch.mock.calls[0][1].body)
+  }
+
+  const adapter = () =>
+    resendAdapter({ apiKey, defaultFromAddress, defaultFromName })({ payload: mockPayload })
+
   afterEach(() => {
     vitest.clearAllMocks()
   })
 
   it('should handle sending an email', async () => {
-    global.fetch = vitest.spyOn(global, 'fetch').mockImplementation(
-      vitest.fn(() =>
-        Promise.resolve({
-          json: () => {
-            return { id: 'test-id' }
-          },
-        }),
-      ) as Mock,
-    ) as Mock
+    const fetchMock = mockFetch({ id: 'test-id' })
 
-    const adapter = resendAdapter({
-      apiKey,
-      defaultFromAddress,
-      defaultFromName,
-    })
-
-    await adapter({ payload: mockPayload }).sendEmail({
+    await adapter().sendEmail({
       from,
       subject,
       text,
       to,
     })
 
-    // @ts-expect-error
-    expect(global.fetch.mock.calls[0][0]).toStrictEqual('https://api.resend.com/emails')
-    // @ts-expect-error
-    const request = global.fetch.mock.calls[0][1]
+    expect(fetchMock.mock.calls[0][0]).toStrictEqual('https://api.resend.com/emails')
+    const request = fetchMock.mock.calls[0][1]
     expect(request.headers.Authorization).toStrictEqual(`Bearer ${apiKey}`)
-    expect(JSON.parse(request.body)).toMatchObject({
+    expect(getRequestBody()).toMatchObject({
       from,
       subject,
       text,
@@ -55,21 +62,18 @@ describe('email-resend', () => {
     })
   })
 
+  it('should return the parsed Resend response on success', async () => {
+    mockFetch({ id: 'test-id' })
+
+    const result = await adapter().sendEmail({ from, subject, text, to })
+
+    expect(result).toStrictEqual({ id: 'test-id' })
+  })
+
   describe('attachments', () => {
-    beforeEach(() => {
-      global.fetch = vitest.spyOn(global, 'fetch').mockImplementation(
-        vitest.fn(() =>
-          Promise.resolve({
-            json: () => ({ id: 'test-id' }),
-          }),
-        ) as Mock,
-      ) as Mock
-    })
-
-    const adapter = () =>
-      resendAdapter({ apiKey, defaultFromAddress, defaultFromName })({ payload: mockPayload })
-
     it('should pass path-only attachments through', async () => {
+      mockFetch({ id: 'test-id' })
+
       await adapter().sendEmail({
         from,
         to,
@@ -77,13 +81,14 @@ describe('email-resend', () => {
         attachments: [{ filename: 'file.pdf', path: '/tmp/file.pdf' }],
       })
 
-      // @ts-expect-error
-      const body = JSON.parse(global.fetch.mock.calls[0][1].body)
-      expect(body.attachments).toStrictEqual([{ filename: 'file.pdf', path: '/tmp/file.pdf' }])
+      expect(getRequestBody().attachments).toStrictEqual([
+        { filename: 'file.pdf', path: '/tmp/file.pdf' },
+      ])
     })
 
     it('should preserve base64 string content without converting to Buffer', async () => {
       const base64 = 'SGVsbG8gV29ybGQ='
+      mockFetch({ id: 'test-id' })
 
       await adapter().sendEmail({
         from,
@@ -92,13 +97,14 @@ describe('email-resend', () => {
         attachments: [{ filename: 'hello.txt', content: base64 }],
       })
 
-      // @ts-expect-error
-      const body = JSON.parse(global.fetch.mock.calls[0][1].body)
-      expect(body.attachments).toStrictEqual([{ filename: 'hello.txt', content: base64 }])
+      expect(getRequestBody().attachments).toStrictEqual([
+        { filename: 'hello.txt', content: base64 },
+      ])
     })
 
     it('should pass Buffer content through', async () => {
       const buf = Buffer.from('hello')
+      mockFetch({ id: 'test-id' })
 
       await adapter().sendEmail({
         from,
@@ -107,14 +113,15 @@ describe('email-resend', () => {
         attachments: [{ filename: 'hello.txt', content: buf }],
       })
 
-      // @ts-expect-error
-      const body = JSON.parse(global.fetch.mock.calls[0][1].body)
       // Buffer serializes to { type: 'Buffer', data: [...] } via JSON.stringify
+      const body = getRequestBody()
       expect(body.attachments[0].filename).toBe('hello.txt')
       expect(body.attachments[0].content).toMatchObject({ type: 'Buffer' })
     })
 
     it('should throw when filename is missing', async () => {
+      mockFetch({ id: 'test-id' })
+
       await expect(() =>
         adapter().sendEmail({
           from,
@@ -126,6 +133,8 @@ describe('email-resend', () => {
     })
 
     it('should throw when both content and path are missing', async () => {
+      mockFetch({ id: 'test-id' })
+
       await expect(() =>
         adapter().sendEmail({
           from,
@@ -138,6 +147,7 @@ describe('email-resend', () => {
 
     it('should prefer content over path when both are provided', async () => {
       const content = 'SGVsbG8='
+      mockFetch({ id: 'test-id' })
 
       await adapter().sendEmail({
         from,
@@ -146,27 +156,92 @@ describe('email-resend', () => {
         attachments: [{ filename: 'file.txt', content, path: '/tmp/file.txt' }],
       })
 
-      // @ts-expect-error
-      const body = JSON.parse(global.fetch.mock.calls[0][1].body)
-      expect(body.attachments).toStrictEqual([{ filename: 'file.txt', content }])
+      expect(getRequestBody().attachments).toStrictEqual([{ filename: 'file.txt', content }])
+    })
+  })
+
+  describe('address mapping', () => {
+    it('should map a string reply-to to reply_to', async () => {
+      mockFetch({ id: 'test-id' })
+
+      await adapter().sendEmail({ from, to, subject, replyTo: 'reply@example.com' })
+
+      expect(getRequestBody().reply_to).toStrictEqual('reply@example.com')
+    })
+
+    it('should map cc and bcc recipients', async () => {
+      mockFetch({ id: 'test-id' })
+
+      await adapter().sendEmail({
+        from,
+        to,
+        subject,
+        bcc: ['bcc@example.com'],
+        cc: 'cc@example.com',
+      })
+
+      const body = getRequestBody()
+      expect(body.cc).toStrictEqual('cc@example.com')
+      expect(body.bcc).toStrictEqual(['bcc@example.com'])
+    })
+
+    it('should map an array of address objects to their email strings', async () => {
+      mockFetch({ id: 'test-id' })
+
+      await adapter().sendEmail({
+        from,
+        subject,
+        to: [
+          { name: 'One', address: 'one@example.com' },
+          { name: 'Two', address: 'two@example.com' },
+        ],
+      })
+
+      expect(getRequestBody().to).toStrictEqual(['one@example.com', 'two@example.com'])
+    })
+
+    it('should format a from address object as "Name <address>"', async () => {
+      mockFetch({ id: 'test-id' })
+
+      await adapter().sendEmail({
+        from: { name: 'Sender', address: 'sender@example.com' },
+        subject,
+        to,
+      })
+
+      expect(getRequestBody().from).toStrictEqual('Sender <sender@example.com>')
+    })
+
+    it('should fall back to the default from address when none is provided', async () => {
+      mockFetch({ id: 'test-id' })
+
+      await adapter().sendEmail({ subject, to } as Parameters<
+        ReturnType<typeof adapter>['sendEmail']
+      >[0])
+
+      expect(getRequestBody().from).toStrictEqual(`${defaultFromName} <${defaultFromAddress}>`)
+    })
+  })
+
+  describe('overrideRecipientAddress', () => {
+    it('should send all mail to the override address', async () => {
+      mockFetch({ id: 'test-id' })
+
+      await resendAdapter({
+        apiKey,
+        defaultFromAddress,
+        defaultFromName,
+        overrideRecipientAddress: 'override@example.com',
+      })({ payload: mockPayload }).sendEmail({ from, subject, text, to: 'real@example.com' })
+
+      expect(getRequestBody().to).toStrictEqual('override@example.com')
     })
   })
 
   describe('headers', () => {
-    beforeEach(() => {
-      global.fetch = vitest.spyOn(global, 'fetch').mockImplementation(
-        vitest.fn(() =>
-          Promise.resolve({
-            json: () => ({ id: 'test-id' }),
-          }),
-        ) as Mock,
-      ) as Mock
-    })
-
-    const adapter = () =>
-      resendAdapter({ apiKey, defaultFromAddress, defaultFromName })({ payload: mockPayload })
-
     it('should pass simple string headers through as-is', async () => {
+      mockFetch({ id: 'test-id' })
+
       await adapter().sendEmail({
         from,
         to,
@@ -174,12 +249,14 @@ describe('email-resend', () => {
         headers: { 'List-Unsubscribe': '<mailto:unsub@example.com>' },
       })
 
-      // @ts-expect-error
-      const body = JSON.parse(global.fetch.mock.calls[0][1].body)
-      expect(body.headers).toStrictEqual({ 'List-Unsubscribe': '<mailto:unsub@example.com>' })
+      expect(getRequestBody().headers).toStrictEqual({
+        'List-Unsubscribe': '<mailto:unsub@example.com>',
+      })
     })
 
     it('should join array string values with a comma', async () => {
+      mockFetch({ id: 'test-id' })
+
       await adapter().sendEmail({
         from,
         to,
@@ -187,12 +264,12 @@ describe('email-resend', () => {
         headers: { 'X-Custom': ['val1', 'val2'] },
       })
 
-      // @ts-expect-error
-      const body = JSON.parse(global.fetch.mock.calls[0][1].body)
-      expect(body.headers).toStrictEqual({ 'X-Custom': 'val1, val2' })
+      expect(getRequestBody().headers).toStrictEqual({ 'X-Custom': 'val1, val2' })
     })
 
     it('should extract the value from prepared-object header values', async () => {
+      mockFetch({ id: 'test-id' })
+
       await adapter().sendEmail({
         from,
         to,
@@ -200,12 +277,12 @@ describe('email-resend', () => {
         headers: { 'X-Prepared': { prepared: true, value: 'prepared-value' } },
       })
 
-      // @ts-expect-error
-      const body = JSON.parse(global.fetch.mock.calls[0][1].body)
-      expect(body.headers).toStrictEqual({ 'X-Prepared': 'prepared-value' })
+      expect(getRequestBody().headers).toStrictEqual({ 'X-Prepared': 'prepared-value' })
     })
 
     it('should convert array-of-objects header form to a plain object', async () => {
+      mockFetch({ id: 'test-id' })
+
       await adapter().sendEmail({
         from,
         to,
@@ -216,53 +293,66 @@ describe('email-resend', () => {
         ],
       })
 
-      // @ts-expect-error
-      const body = JSON.parse(global.fetch.mock.calls[0][1].body)
-      expect(body.headers).toStrictEqual({ 'X-First': 'first', 'X-Second': 'second' })
+      expect(getRequestBody().headers).toStrictEqual({ 'X-First': 'first', 'X-Second': 'second' })
     })
 
     it('should omit the headers field when headers are undefined', async () => {
+      mockFetch({ id: 'test-id' })
+
       await adapter().sendEmail({
         from,
         to,
         subject,
       })
 
-      // @ts-expect-error
-      const body = JSON.parse(global.fetch.mock.calls[0][1].body)
-      expect(body).not.toHaveProperty('headers')
+      expect(getRequestBody()).not.toHaveProperty('headers')
     })
   })
 
-  it('should throw an error if the email fails to send', async () => {
-    const errorResponse = {
-      name: 'validation_error',
-      message: 'error information',
-      statusCode: 403,
-    }
-    global.fetch = vitest.spyOn(global, 'fetch').mockImplementation(
-      vitest.fn(() =>
-        Promise.resolve({
-          json: () => errorResponse,
-        }),
-      ) as Mock,
-    ) as Mock
+  describe('error handling', () => {
+    it('should throw a formatted error for a structured JSON error response', async () => {
+      const errorResponse = {
+        name: 'validation_error',
+        message: 'error information',
+        statusCode: 403,
+      }
+      mockFetch(errorResponse, { status: 403 })
 
-    const adapter = resendAdapter({
-      apiKey,
-      defaultFromAddress,
-      defaultFromName,
+      await expect(() => adapter().sendEmail({ from, subject, text, to })).rejects.toThrow(
+        `Error sending email: ${errorResponse.statusCode} ${errorResponse.name} - ${errorResponse.message}`,
+      )
     })
 
-    await expect(() =>
-      adapter({ payload: mockPayload }).sendEmail({
-        from,
-        subject,
-        text,
-        to,
-      }),
-    ).rejects.toThrow(
-      `Error sending email: ${errorResponse.statusCode} ${errorResponse.name} - ${errorResponse.message}`,
-    )
+    it('should surface a non-JSON error body ("Origin is disallowed") instead of a JSON parse error', async () => {
+      mockFetch('Origin is disallowed', { status: 403, statusText: 'Forbidden' })
+
+      await expect(() => adapter().sendEmail({ from, subject, text, to })).rejects.toThrow(
+        /Error sending email: 403.*Origin is disallowed/s,
+      )
+    })
+
+    it('should throw with the status code when the error body is empty', async () => {
+      mockFetch('', { status: 500, statusText: 'Internal Server Error' })
+
+      await expect(() => adapter().sendEmail({ from, subject, text, to })).rejects.toThrow(
+        /Error sending email: 500/,
+      )
+    })
+
+    it('should throw when a 2xx response body is not valid JSON', async () => {
+      mockFetch('<html>not json</html>', { status: 200 })
+
+      await expect(() => adapter().sendEmail({ from, subject, text, to })).rejects.toThrow(
+        /Error sending email/,
+      )
+    })
+
+    it('should throw when a 2xx response is missing an id', async () => {
+      mockFetch({ unexpected: 'shape' }, { status: 200 })
+
+      await expect(() => adapter().sendEmail({ from, subject, text, to })).rejects.toThrow(
+        /Error sending email/,
+      )
+    })
   })
 })

--- a/packages/email-resend/src/index.ts
+++ b/packages/email-resend/src/index.ts
@@ -75,10 +75,10 @@ export const resendAdapter = (args: ResendAdapterArgs): ResendAdapter => {
 
       const errorData = data && 'statusCode' in data ? data : undefined
       const statusCode = errorData?.statusCode || res.status || 500
-      let formattedError = `Error sending email: ${statusCode}`
+      let formattedError = 'Error sending email'
 
       if (errorData?.name && errorData?.message) {
-        formattedError += ` ${errorData.name} - ${errorData.message}`
+        formattedError += `: ${errorData.name} - ${errorData.message}`
       } else if (rawBody) {
         // No structured error shape — include the raw body so the underlying
         // reason (e.g. "Origin is disallowed") reaches the caller.

--- a/packages/email-resend/src/index.ts
+++ b/packages/email-resend/src/index.ts
@@ -55,19 +55,37 @@ export const resendAdapter = (args: ResendAdapterArgs): ResendAdapter => {
         method: 'POST',
       })
 
-      const data = (await res.json()) as ResendResponse
+      // Read the body as text first so a non-JSON response (e.g. an edge/CDN
+      // "Origin is disallowed" page, an empty body, or an HTML error page) does
+      // not surface as an opaque JSON parse error and hide the real failure.
+      const rawBody = await res.text()
 
-      if ('id' in data) {
-        return data
-      } else {
-        const statusCode = data.statusCode || res.status
-        let formattedError = `Error sending email: ${statusCode}`
-        if (data.name && data.message) {
-          formattedError += ` ${data.name} - ${data.message}`
+      let data: ResendResponse | undefined
+      if (rawBody) {
+        try {
+          data = JSON.parse(rawBody) as ResendResponse
+        } catch {
+          // Body was not JSON — fall through to the error handling below.
         }
-
-        throw new APIError(formattedError, statusCode)
       }
+
+      if (res.ok && data && 'id' in data) {
+        return data
+      }
+
+      const errorData = data && 'statusCode' in data ? data : undefined
+      const statusCode = errorData?.statusCode || res.status || 500
+      let formattedError = `Error sending email: ${statusCode}`
+
+      if (errorData?.name && errorData?.message) {
+        formattedError += ` ${errorData.name} - ${errorData.message}`
+      } else if (rawBody) {
+        // No structured error shape — include the raw body so the underlying
+        // reason (e.g. "Origin is disallowed") reaches the caller.
+        formattedError += ` - ${rawBody}`
+      }
+
+      throw new APIError(formattedError, statusCode)
     },
   })
 


### PR DESCRIPTION
## What

The Resend adapter assumed every HTTP response body was valid JSON:

```ts 
const data = (await res.json()) as ResendResponse
if ('id' in data) return data
```                                                                                                                                                                                                                                                    
When Resend (or an edge/CDN in front of it) returns a non-JSON body — such as a 403 "Origin is disallowed", an HTML error page, or an empty body — res.json() throws a SyntaxError: ... is not valid JSON. That masked the real HTTP status and message, so users saw a confusing parse error instead of the actual reason the send failed.

## Fix

Read the response as text, parse it defensively, and decide success from the HTTP status:

- Success is now res.ok and a parsed body containing id.
- On failure, throw a descriptive APIError with the status code, using Resend's structured { name, message } when present, and falling back to the raw body (e.g. "Origin is disallowed") otherwise.

No public API changes — only the internal response handling.

## Testing

- Reworked the unit suite to mock fetch with real Response objects and added coverage for the non-JSON, empty-body, non-2xx, and missing-id paths (24 tests).
- Added a gated integration test (email-resend.int.spec.ts, skipped unless RESEND_API_KEY is set) that sends a real email via Resend's sandbox addresses and verifies the invalid-key error path. Confirmed passing against the live API.