### PR TITLE
feat: support slug fields nested within groups, arrays and blocks

### DIFF
--- a/docs/fields/slug.mdx
+++ b/docs/fields/slug.mdx
@@ -35,10 +35,10 @@ export const ExampleCollection: CollectionConfig = {
 
 The Slug Field defaults `required`, `unique`, and `index` to `true`, and renders in the `sidebar`. In addition to the standard [field options](./overview#field-options), it exposes:
 
-| Option      | Description                                                                                                                         |
-| ----------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| `useAsSlug` | Optional. The name of the top-level field to generate the slug from (e.g. `'title'`). This field must exist in the same collection. |
-| `slugify`   | Optional. Override the default slugify function. [More details](#custom-slugify-function).                                          |
+| Option      | Description                                                                                                                                        |
+| ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `useAsSlug` | Optional. The name of the field to generate the slug from (e.g. `'title'`). It must be a sibling of the slug field. [More details](#nested-slugs). |
+| `slugify`   | Optional. Override the default slugify function. [More details](#custom-slugify-function).                                                         |
 
 Because `slug` is a standard named field, customize it with the usual field properties directly — `label`, `localized`, `required`, `unique` (set `false` to drop the unique index, e.g. for a per-tenant compound index), `index`, `defaultValue`, and `admin` (including `admin.position`).
 
@@ -52,6 +52,29 @@ The slug is static: it fills once while empty and is preserved thereafter, so ed
 - Generated values are deduped against existing documents so two never claim the same slug.
 
 Because the slug is guaranteed to exist on create, [autosave-enabled](../versions/autosave) documents get a stable slug on the initial draft — before a title is typed — which live preview needs to load the document by its slug.
+
+### Nested Slugs
+
+A Slug Field can live inside a Group, Array, Block, or Tab. `useAsSlug` names a sibling of the slug, so each array row or block generates from its own source field:
+
+```ts
+{
+  name: 'sections',
+  type: 'array',
+  fields: [
+    { name: 'heading', type: 'text' },
+    { name: 'slug', type: 'slug', useAsSlug: 'heading' }, // highlight-line
+  ],
+}
+```
+
+Uniqueness is a document-level concept, so a nested slug behaves differently from a root-level one:
+
+- `unique` and `required` default to `false` rather than `true`.
+- Generated values are not deduped against other documents — two rows, in the same document or in different ones, may hold the same slug.
+- There is no `<singular>-<N>` fallback. A row with no source value keeps an empty slug until one is provided.
+
+To generate from a field that is not a sibling — the document title, for instance — use a [custom slugify function](#custom-slugify-function), which receives the full document `data`.
 
 ### Localization
 
@@ -88,8 +111,9 @@ export const MyCollection: CollectionConfig = {
 
 The following args are provided to the custom `slugify` function:
 
-| Argument         | Type             | Description                                      |
-| ---------------- | ---------------- | ------------------------------------------------ |
-| `valueToSlugify` | `string`         | The value of the field specified in `useAsSlug`. |
-| `data`           | `object`         | The full document data being saved.              |
-| `req`            | `PayloadRequest` | The Payload request object.                      |
+| Argument         | Type             | Description                                                                                                                       |
+| ---------------- | ---------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `valueToSlugify` | `string`         | The value of the field specified in `useAsSlug`.                                                                                  |
+| `data`           | `object`         | The full document data being saved.                                                                                               |
+| `siblingData`    | `object`         | The data adjacent to the slug — the group, array row or block it lives in. Same as `data` for a slug at the root of the document. |
+| `req`            | `PayloadRequest` | The Payload request object.                                                                                                       |

--- a/packages/payload/src/admin/functions/index.ts
+++ b/packages/payload/src/admin/functions/index.ts
@@ -15,6 +15,7 @@ import type {
 import type { PayloadRequest, Sort, Where } from '../../types/index.js'
 import type { ColumnsFromURL } from '../../utilities/transformColumnPreferences.js'
 import type { ComponentRenderer } from '../adapters/render.js'
+import type { ClientComponentProps } from '../forms/Field.js'
 
 export type InitReqResult = {
   cookies: Map<string, string>
@@ -144,5 +145,14 @@ export type SlugifyServerFunctionArgs = {
    * Active admin locale, so a localized slug's fallback is deduped within the right locale.
    */
   locale?: Locale['code']
+  /**
+   * Data path of the slug field, e.g. `slug` or `myArray.0.slug`. Tells the handler whether the slug
+   * sits at the root of the document, which is what uniqueness is scoped to.
+   */
   path?: FieldPaths['path']
+  /**
+   * Schema path of the slug field, used to look its config up — and with it, any custom `slugify`.
+   * A data path cannot address the schema, since row indexes have no equivalent there.
+   */
+  schemaPath?: ClientComponentProps['schemaPath']
 } & Omit<Parameters<Slugify>[0], 'req'>

--- a/packages/payload/src/fields/baseFields/slug/fillEmptyLocalizedSlugs.ts
+++ b/packages/payload/src/fields/baseFields/slug/fillEmptyLocalizedSlugs.ts
@@ -48,7 +48,8 @@ export const fillEmptyLocalizedSlugs = async ({
 
     const slugify = (valueToSlugify: unknown) =>
       customSlugify
-        ? customSlugify({ data, req, valueToSlugify })
+        ? // siblingData is the same as data here because this runs at the operation level, not the field level
+          customSlugify({ data, req, siblingData: data, valueToSlugify })
         : defaultSlugify(valueToSlugify as string)
 
     // The source value for a given locale: a non-localized source is shared across all locales, a

--- a/packages/payload/src/fields/baseFields/slug/generateSlug.ts
+++ b/packages/payload/src/fields/baseFields/slug/generateSlug.ts
@@ -30,14 +30,38 @@ type Args = {
  * Generated values dedupe against existing slugs; a localized slug is unique per-locale, so its
  * dedupe and fallback are scoped to the locale being written. Globals have no collection to dedupe
  * against, so their slug is left as-is.
+ *
+ * `useAsSlug` names a *sibling* of the slug, so a slug nested in a group, array row or block derives
+ * from that same level rather than from the root of the document.
  */
 export const generateSlug =
   ({ name, localized, slugify: customSlugify, useAsSlug }: Args): FieldHook =>
-  async ({ collection, context, data, operation, originalDoc, req, value }) => {
+  async ({
+    collection,
+    context,
+    data,
+    operation,
+    originalDoc,
+    path,
+    previousSiblingDoc,
+    req,
+    siblingData,
+    value,
+  }) => {
     const slugify = (valueToSlugify: unknown) =>
       customSlugify
-        ? customSlugify({ data: (data ?? {}) as TypeWithID, req, valueToSlugify })
+        ? customSlugify({
+            data: (data ?? {}) as TypeWithID,
+            req,
+            siblingData: siblingData ?? {},
+            valueToSlugify,
+          })
         : defaultSlugify(valueToSlugify as string)
+
+    // Every uniqueness query below runs against a collection-wide field, which only addresses a slug
+    // at the root of the document — a nested path has no such field to query. A nested slug is scoped
+    // to its own row or group, so it is neither deduped nor given a fallback.
+    const isTopLevelField = path.length === 1
 
     // A localized slug is unique only within its locale, so every uniqueness query below is scoped
     // to the locale being written.
@@ -46,11 +70,11 @@ export const generateSlug =
     // A duplicated document:
     //  - Takes a fresh `<singular>-<N>` fallback — not the original's slug, not a source-derived one
     //  - Skips the explicit-collision check below (see generateSlugBeforeDuplicate).
-    if (collection && consumeSlugDuplicateFallback(context, name)) {
+    if (collection && isTopLevelField && consumeSlugDuplicateFallback(context, name)) {
       return await getSlugFallbackValue({ collection, field: name, locale, req, slugify })
     }
 
-    const storedSlug = originalDoc?.[name]
+    const storedSlug = previousSiblingDoc?.[name]
 
     const storedSlugHasValue = hasValue(storedSlug)
 
@@ -71,6 +95,7 @@ export const generateSlug =
 
         if (
           collection &&
+          isTopLevelField &&
           (await fieldValueExists({
             id: originalDoc?.id,
             collection: collection.slug,
@@ -99,11 +124,11 @@ export const generateSlug =
     // Derive an empty slug from its source, when present.
     // Dedupe so two documents don't both claim it if they have the same source value.
     // Globals have no collection to dedupe against.
-    const source = useAsSlug ? data?.[useAsSlug] : undefined
+    const source = useAsSlug ? siblingData?.[useAsSlug] : undefined
     const derived = source ? await slugify(source) : undefined
 
     if (hasValue(derived)) {
-      if (!collection) {
+      if (!collection || !isTopLevelField) {
         return derived
       }
 
@@ -123,7 +148,7 @@ export const generateSlug =
       return storedSlug
     }
 
-    if (!collection) {
+    if (!collection || !isTopLevelField) {
       return undefined
     }
 

--- a/packages/payload/src/fields/baseFields/slug/types.ts
+++ b/packages/payload/src/fields/baseFields/slug/types.ts
@@ -2,9 +2,10 @@ import type { TextFieldClientProps } from '../../../admin/types.js'
 import type { TypeWithID } from '../../../collections/config/types.js'
 import type { PayloadRequest } from '../../../types/index.js'
 
-export type Slugify<T extends TypeWithID = any> = (args: {
+export type Slugify<T extends TypeWithID = any, TSiblingData = any> = (args: {
   data: T
   req: PayloadRequest
+  siblingData: TSiblingData
   valueToSlugify?: any
 }) => Promise<string | undefined> | string | undefined
 

--- a/packages/payload/src/fields/config/sanitize.ts
+++ b/packages/payload/src/fields/config/sanitize.ts
@@ -283,13 +283,15 @@ export const sanitizeField = ({
 
     // Required by default so the admin marks the slug as required. The value is always populated by
     // the field hooks (source or id fallback), and validations.slug permits empty so the fallback
-    // isn't blocked before it runs.
+    // isn't blocked before it runs. A nested slug has no fallback to fill it, so it is left optional
+    // rather than blocking the save of a row that has no source value yet.
     if (typeof field.required === 'undefined') {
-      field.required = true
+      field.required = isTopLevelField
     }
 
+    // Uniqueness is a root-level concept here
     if (typeof field.unique === 'undefined') {
-      field.unique = true
+      field.unique = isTopLevelField
     }
 
     if (typeof field.index === 'undefined') {

--- a/packages/ui/src/fields/Slug/index.tsx
+++ b/packages/ui/src/fields/Slug/index.tsx
@@ -27,12 +27,13 @@ const baseClass = 'slug-field-component'
 type SlugFieldProps = {
   readonly field: SlugFieldClient
   readonly path?: string
+  readonly schemaPath?: string
 }
 
 /**
  * @experimental This component is experimental and may change or be removed in the future. Use at your own risk.
  */
-const SlugFieldComponent: React.FC<SlugFieldProps> = ({ field, path }) => {
+const SlugFieldComponent: React.FC<SlugFieldProps> = ({ field, path, schemaPath }) => {
   const { admin, label, required, useAsSlug } = field
   const { description, placeholder, readOnly: readOnlyFromProps } = admin || {}
 
@@ -51,7 +52,7 @@ const SlugFieldComponent: React.FC<SlugFieldProps> = ({ field, path }) => {
     value,
   } = useField<string>({ path: path || field.name })
 
-  const { getData, getDataByPath } = useForm()
+  const { getData, getSiblingData } = useForm()
 
   const [isLocked, setIsLocked] = useState(true)
 
@@ -63,7 +64,8 @@ const SlugFieldComponent: React.FC<SlugFieldProps> = ({ field, path }) => {
     async (e: React.MouseEvent<Element>) => {
       e.preventDefault()
 
-      const valueToSlugify = useAsSlug ? getDataByPath(useAsSlug) : undefined
+      const siblingData = getSiblingData(fieldPath)
+      const valueToSlugify = useAsSlug ? siblingData?.[useAsSlug] : undefined
 
       let formattedSlug: null | string | undefined
 
@@ -75,6 +77,8 @@ const SlugFieldComponent: React.FC<SlugFieldProps> = ({ field, path }) => {
           globalSlug,
           locale,
           path: fieldPath,
+          schemaPath,
+          siblingData,
           valueToSlugify,
         })
       } catch (_err) {
@@ -101,12 +105,13 @@ const SlugFieldComponent: React.FC<SlugFieldProps> = ({ field, path }) => {
       useAsSlug,
       getData,
       slugify,
-      getDataByPath,
+      getSiblingData,
       id,
       collectionSlug,
       globalSlug,
       locale,
       fieldPath,
+      schemaPath,
       t,
     ],
   )
@@ -137,7 +142,11 @@ const SlugFieldComponent: React.FC<SlugFieldProps> = ({ field, path }) => {
         .filter(Boolean)
         .join(' ')}
     >
-      <FieldLabel htmlFor={`field-${fieldPath}`} label={label} required={required} />
+      <FieldLabel
+        htmlFor={`field-${fieldPath?.replace(/\./g, '__')}`}
+        label={label}
+        required={required}
+      />
       <div className={`${baseClass}__wrap`}>
         <FieldError path={fieldPath} showError={showError} />
 

--- a/packages/ui/src/utilities/slugify.ts
+++ b/packages/ui/src/utilities/slugify.ts
@@ -2,7 +2,6 @@ import type { Slugify } from 'payload/shared'
 
 import {
   executeAccess,
-  getFieldByPath,
   getSlugFallbackValue,
   getUniqueFieldValue,
   hasDraftsEnabled,
@@ -11,6 +10,8 @@ import {
   UnauthorizedError,
 } from 'payload'
 import { slugify as defaultSlugify } from 'payload/shared'
+
+import { getSchemaMap } from './getSchemaMap.js'
 
 /**
  * This server function is directly related to the {@link https://payloadcms.com/docs/fields/slug | Slug Field}.
@@ -27,44 +28,52 @@ export const slugifyHandler: ServerFunction<
   SlugifyServerFunctionArgs,
   Promise<ReturnType<Slugify>>
 > = async (args) => {
-  const { id, collectionSlug, data, globalSlug, locale, path, req, valueToSlugify } = args
+  const {
+    id,
+    collectionSlug,
+    data,
+    globalSlug,
+    locale,
+    path,
+    req,
+    schemaPath,
+    siblingData,
+    valueToSlugify,
+  } = args
 
   if (!req.user) {
     throw new UnauthorizedError()
   }
 
-  const docConfig = collectionSlug
-    ? req.payload.collections[collectionSlug]?.config
-    : globalSlug
-      ? req.payload.config.globals.find((g) => g.slug === globalSlug)
-      : null
-
-  if (!docConfig) {
-    throw new Error()
-  }
-
-  const { field } = getFieldByPath({
+  const field = getSchemaMap({
+    collectionSlug,
     config: req.payload.config,
-    fields: docConfig.flattenedFields,
-    path,
-  })
+    globalSlug,
+    i18n: req.i18n,
+  }).get(schemaPath ?? '')
 
   const customSlugify = (
-    typeof field?.custom?.slugify === 'function' ? field.custom.slugify : undefined
+    field && 'custom' in field && typeof field.custom?.slugify === 'function'
+      ? field.custom.slugify
+      : undefined
   ) as Slugify
 
   const slugify = (valueToSlugify: unknown) =>
     customSlugify
-      ? customSlugify({ data, req, valueToSlugify })
+      ? customSlugify({ data, req, siblingData, valueToSlugify })
       : defaultSlugify(valueToSlugify as string)
 
   const result = await slugify(valueToSlugify)
 
   const collectionConfig = collectionSlug ? req.payload.collections[collectionSlug]?.config : null
 
+  const slugField = field && 'type' in field && field.type === 'slug' ? field : undefined
+
   // Uniqueness dedupe only applies to a collection's slug field. Globals have no collection to
   // dedupe against, so their result is returned as-is.
-  if (!collectionConfig || !field || field.type !== 'slug' || !('name' in field)) {
+  const isTopLevelField = !path?.includes('.')
+
+  if (!collectionConfig || !isTopLevelField || !slugField) {
     return result
   }
 
@@ -83,7 +92,7 @@ export const slugifyHandler: ServerFunction<
   // A localized slug is unique per-locale, so scope the probe to the current locale — otherwise it
   // dedupes against the default locale and can hand back a colliding value. The client passes the
   // active admin locale; fall back to the request's own locale.
-  const localeToScope = field.localized ? (locale ?? req.locale ?? undefined) : undefined
+  const localeToScope = slugField.localized ? (locale ?? req.locale ?? undefined) : undefined
 
   // The current doc is excluded so a regenerate can reuse its own value rather than bump past it.
   const excludeId = typeof id === 'string' || typeof id === 'number' ? id : undefined
@@ -95,7 +104,7 @@ export const slugifyHandler: ServerFunction<
       id: excludeId,
       collection: collectionConfig.slug,
       draftsEnabled: hasDraftsEnabled(collectionConfig),
-      field: field.name,
+      field: slugField.name,
       locale: localeToScope,
       req,
       value: result,
@@ -105,7 +114,7 @@ export const slugifyHandler: ServerFunction<
   return getSlugFallbackValue({
     id: excludeId,
     collection: collectionConfig,
-    field: field.name,
+    field: slugField.name,
     locale: localeToScope,
     req,
     slugify,

--- a/test/fields/collections/SlugField/e2e.spec.ts
+++ b/test/fields/collections/SlugField/e2e.spec.ts
@@ -8,6 +8,7 @@ import type { PayloadTestSDK } from '../../../__helpers/shared/sdk/index.js'
 import type { Config } from '../../payload-types.js'
 
 import { checkFocusIndicators } from '../../../__helpers/e2e/checkFocusIndicators.js'
+import { addArrayRow } from '../../../__helpers/e2e/fields/array/index.js'
 import { changeLocale, saveDocAndAssert } from '../../../__helpers/e2e/helpers.js'
 import { runAxeScan } from '../../../__helpers/e2e/runAxeScan.js'
 import { AdminUrlUtil } from '../../../__helpers/shared/adminUrlUtil.js'
@@ -167,6 +168,51 @@ describe('SlugField', () => {
       await saveDocAndAssert(page)
 
       await expect(page.locator('#field-localizedSlug')).toHaveValue('title-in-spanish')
+    })
+  })
+
+  describe('nested slugs', () => {
+    test('should generate slug from a sibling field within a group', async () => {
+      await page.goto(url.create)
+      await page.locator('#field-title').fill('Test nested title')
+      await page.locator('#field-group__nestedTitle').fill('Nested title')
+
+      await saveDocAndAssert(page)
+
+      await expect(page.locator('#field-group__nestedSlug')).toHaveValue('nested-title')
+    })
+
+    test('should generate slug from a sibling field within an array row', async () => {
+      await page.goto(url.create)
+      await page.locator('#field-title').fill('Test array title')
+
+      await addArrayRow(page, { fieldName: 'items' })
+      await page.locator('#field-items__0__itemTitle').fill('First item')
+
+      await addArrayRow(page, { fieldName: 'items' })
+      await page.locator('#field-items__1__itemTitle').fill('Second item')
+
+      await saveDocAndAssert(page)
+
+      await expect(page.locator('#field-items__0__itemSlug')).toHaveValue('FIRST ITEM')
+      await expect(page.locator('#field-items__1__itemSlug')).toHaveValue('SECOND ITEM')
+    })
+
+    test('should generate nested slug on demand from client side', async () => {
+      await page.goto(url.create)
+      await page.locator('#field-title').fill('Test nested title client side')
+
+      await addArrayRow(page, { fieldName: 'items' })
+      await page.locator('#field-items__0__itemTitle').fill('First item')
+
+      await saveDocAndAssert(page)
+
+      await page.locator('#field-items__0__itemTitle').fill('This should have regenerated')
+      await regenerateSlug('items__0__itemSlug')
+
+      await expect(page.locator('#field-items__0__itemSlug')).toHaveValue(
+        'THIS SHOULD HAVE REGENERATED',
+      )
     })
   })
 

--- a/test/fields/collections/SlugField/index.ts
+++ b/test/fields/collections/SlugField/index.ts
@@ -56,6 +56,37 @@ const SlugField: CollectionConfig = {
       required: false,
     },
     {
+      name: 'group',
+      type: 'group',
+      fields: [
+        {
+          name: 'nestedTitle',
+          type: 'text',
+        },
+        {
+          name: 'nestedSlug',
+          type: 'slug',
+          useAsSlug: 'nestedTitle',
+        },
+      ],
+    },
+    {
+      name: 'items',
+      type: 'array',
+      fields: [
+        {
+          name: 'itemTitle',
+          type: 'text',
+        },
+        {
+          name: 'itemSlug',
+          type: 'slug',
+          slugify: ({ valueToSlugify }) => valueToSlugify?.toUpperCase(),
+          useAsSlug: 'itemTitle',
+        },
+      ],
+    },
+    {
       type: 'text',
       name: 'test',
       admin: {

--- a/test/fields/int.spec.ts
+++ b/test/fields/int.spec.ts
@@ -838,6 +838,84 @@ describe('Fields', () => {
         expect(afterPublish.slug).toBe('draft-one')
       })
     })
+
+    describe('nested', () => {
+      it('should generate a slug from a sibling field within a group', async () => {
+        const doc = await payload.create({
+          collection: 'slug-fields',
+          data: {
+            group: { nestedTitle: 'Nested Group Title' },
+            title: 'Nested slug within a group',
+          },
+        })
+        created.push(doc.id)
+
+        expect(doc.group?.nestedSlug).toBe('nested-group-title')
+      })
+
+      it('should generate a slug for each array row from its own sibling field', async () => {
+        const doc = await payload.create({
+          collection: 'slug-fields',
+          data: {
+            items: [{ itemTitle: 'First Item' }, { itemTitle: 'Second Item' }],
+            title: 'Nested slug within an array',
+          },
+        })
+        created.push(doc.id)
+
+        expect(doc.items?.[0]?.itemSlug).toBe('FIRST ITEM')
+        expect(doc.items?.[1]?.itemSlug).toBe('SECOND ITEM')
+      })
+
+      it('should let two documents share the same nested slug', async () => {
+        const first = await payload.create({
+          collection: 'slug-fields',
+          data: {
+            group: { nestedTitle: 'Shared Title' },
+            title: 'First shared nested slug',
+          },
+        })
+        created.push(first.id)
+
+        const second = await payload.create({
+          collection: 'slug-fields',
+          data: {
+            group: { nestedTitle: 'Shared Title' },
+            title: 'Second shared nested slug',
+          },
+        })
+        created.push(second.id)
+
+        expect(first.group?.nestedSlug).toBe('shared-title')
+        expect(second.group?.nestedSlug).toBe('shared-title')
+      })
+
+      it('should leave a nested slug empty when it has no source value', async () => {
+        const doc = await payload.create({
+          collection: 'slug-fields',
+          data: {
+            items: [{ itemTitle: '' }],
+            title: 'Nested slug without a source',
+          },
+        })
+        created.push(doc.id)
+
+        expect(doc.items?.[0]?.itemSlug).toBeFalsy()
+      })
+
+      it('should keep a user-provided nested slug', async () => {
+        const doc = await payload.create({
+          collection: 'slug-fields',
+          data: {
+            group: { nestedSlug: 'custom-nested-slug', nestedTitle: 'Nested Group Title' },
+            title: 'Custom nested slug',
+          },
+        })
+        created.push(doc.id)
+
+        expect(doc.group?.nestedSlug).toBe('custom-nested-slug')
+      })
+    })
   })
 
   describe('text', () => {


### PR DESCRIPTION
## Which branch should this PR target?

**`main`** — Payload v4 development. New features, enhancements, and v4 bug fixes go here.

### What?

The slug field only generates correctly at the top level of a document. `useAsSlug` is documented as naming a sibling field, but the hook reads the document root, so a slug nested in a group, array row or block derives from the wrong level or from nothing.

### How?

`useAsSlug` now resolves against the slug field's siblings, and the stored value is read from `previousSiblingDoc` instead of `originalDoc`. At the top level `siblingData` and `data` are the same object, so nothing changes for existing configs.

eg.
```ts
{
  name: 'sections',
  type: 'array',
  fields: [
    { name: 'heading', type: 'text' },
    { name: 'slug', type: 'slug', useAsSlug: 'heading' },
  ],
}
```

Each row generates its own slug from its own heading, both on save and from the Generate button. The field config lookup now goes through the schema map (keyed by schema path), which fixes the crash and handles blocks.

Custom slugify functions now also get siblingData. To generate from a field that is not a sibling, use a custom slugify as it receives the full document data.

Uniqueness is root-only: every uniqueness path addresses a collection-wide field by name, which a nested slug does not have. So a nested slug defaults unique and required to false, and skips dedupe, the collision check and the <singular>-N fallback.

###  Breaking changes

- A slug nested in a group with useAsSlug pointing at a top-level field will stop resolving.
- A nested slug now defaults unique and required to false instead of true — an existing nested slug loses its unique index.
- Nested slugs are no longer deduped and get no <singular>-N fallback.

Builds on #17458. 
Supersedes #14783.