### PR TITLE
feat(codemod): add rename-experimental-table-feature transform

### DIFF
--- a/packages/codemod/README.md
+++ b/packages/codemod/README.md
@@ -48,6 +48,7 @@ The tool loads your project via [ts-morph](https://ts-morph.com/), using your `t
 - `rename-typescript-schema-to-json-schema` — renames the `typescriptSchema` field-config property to `jsonSchema` (it always accepted JSON Schema, not TypeScript). Skips any object that already defines a `jsonSchema` sibling and surfaces it as a note for manual review.
 - `migrate-build-script` — rewrites the `build` npm script in `package.json` from `next build` to `payload build`, so the Import Map (and types) are generated before the Next.js build. Matches the `next build` invocation only (leaves `next build-storybook` and the like untouched) and is a no-op when `build` is already `payload build`.
 - `migrate-slug-field` — converts the removed experimental `slugField()` helper (imported from `payload`) into the native `{ type: 'slug' }` field, mapping `useAsSlug`/`fieldToUse`, `slugify`, `required`, `localized`, `disableUnique` (→ `unique: false`), and `position` (→ `admin.position`), and dropping the obsolete `checkboxName`. Removes the now-unused `slugField` import. Calls using `overrides` (or other unrecognized options) are left in place with a note for manual migration.
+- `rename-experimental-table-feature` — renames imports of `EXPERIMENTAL_TableFeature` from `@payloadcms/richtext-lexical` to `TableFeature` (the table feature is now stable) and updates all local usages, e.g. `EXPERIMENTAL_TableFeature()` call sites.
 
 ## Contributing
 

--- a/packages/codemod/src/registry.ts
+++ b/packages/codemod/src/registry.ts
@@ -23,6 +23,7 @@ import { removeGroupByTrue } from './transforms/remove-group-by-true/index.js'
 import { removeLocalizeStatusConfig } from './transforms/remove-localize-status-config/index.js'
 import { removePublishSpecificLocale } from './transforms/remove-publish-specific-locale/index.js'
 import { removeVersionsTrue } from './transforms/remove-versions-true/index.js'
+import { renameExperimentalTableFeature } from './transforms/rename-experimental-table-feature/index.js'
 import { renameStorageAdaptersToStorage } from './transforms/rename-storage-adapters-to-storage/index.js'
 import { renameTypescriptSchemaToJsonSchema } from './transforms/rename-typescript-schema-to-json-schema/index.js'
 
@@ -52,4 +53,5 @@ export const transforms: Transform[] = [
   removeVersionsTrue,
   removePublishSpecificLocale,
   renameTypescriptSchemaToJsonSchema,
+  renameExperimentalTableFeature,
 ]

--- a/packages/codemod/src/transforms/rename-experimental-table-feature/alias.input.ts
+++ b/packages/codemod/src/transforms/rename-experimental-table-feature/alias.input.ts
@@ -1,0 +1,3 @@
+import { EXPERIMENTAL_TableFeature as TableFeatureFn } from '@payloadcms/richtext-lexical'
+
+export const features = [TableFeatureFn()]

--- a/packages/codemod/src/transforms/rename-experimental-table-feature/alias.output.ts
+++ b/packages/codemod/src/transforms/rename-experimental-table-feature/alias.output.ts
@@ -1,0 +1,3 @@
+import { TableFeature as TableFeatureFn } from '@payloadcms/richtext-lexical'
+
+export const features = [TableFeatureFn()]

--- a/packages/codemod/src/transforms/rename-experimental-table-feature/basic.input.ts
+++ b/packages/codemod/src/transforms/rename-experimental-table-feature/basic.input.ts
@@ -1,0 +1,20 @@
+import type { CollectionConfig } from 'payload'
+
+import { EXPERIMENTAL_TableFeature, FixedToolbarFeature, lexicalEditor } from '@payloadcms/richtext-lexical'
+
+export const RichText: CollectionConfig = {
+  fields: [
+    {
+      name: 'content',
+      type: 'richText',
+      editor: lexicalEditor({
+        features: ({ defaultFeatures }) => [
+          ...defaultFeatures,
+          FixedToolbarFeature(),
+          EXPERIMENTAL_TableFeature(),
+        ],
+      }),
+    },
+  ],
+  slug: 'richtext',
+}

--- a/packages/codemod/src/transforms/rename-experimental-table-feature/basic.output.ts
+++ b/packages/codemod/src/transforms/rename-experimental-table-feature/basic.output.ts
@@ -1,0 +1,20 @@
+import type { CollectionConfig } from 'payload'
+
+import { TableFeature, FixedToolbarFeature, lexicalEditor } from '@payloadcms/richtext-lexical'
+
+export const RichText: CollectionConfig = {
+  fields: [
+    {
+      name: 'content',
+      type: 'richText',
+      editor: lexicalEditor({
+        features: ({ defaultFeatures }) => [
+          ...defaultFeatures,
+          FixedToolbarFeature(),
+          TableFeature(),
+        ],
+      }),
+    },
+  ],
+  slug: 'richtext',
+}

--- a/packages/codemod/src/transforms/rename-experimental-table-feature/collision.input.ts
+++ b/packages/codemod/src/transforms/rename-experimental-table-feature/collision.input.ts
@@ -1,0 +1,3 @@
+import { EXPERIMENTAL_TableFeature, TableFeature } from '@payloadcms/richtext-lexical'
+
+export const features = [EXPERIMENTAL_TableFeature(), TableFeature()]

--- a/packages/codemod/src/transforms/rename-experimental-table-feature/index.spec.ts
+++ b/packages/codemod/src/transforms/rename-experimental-table-feature/index.spec.ts
@@ -1,0 +1,54 @@
+import { readFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+import { runTransform } from '../../utils/test-helpers.js'
+import { renameExperimentalTableFeature } from './index.js'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const fixture = (name: string) => readFile(join(here, name), 'utf8')
+
+describe('rename-experimental-table-feature', () => {
+  it('renames EXPERIMENTAL_TableFeature to TableFeature and updates call sites', async () => {
+    const input = await fixture('basic.input.ts')
+    const output = await fixture('basic.output.ts')
+
+    const result = await runTransform({ source: input, transform: renameExperimentalTableFeature })
+
+    expect(result).toBe(output)
+  })
+
+  it('is idempotent', async () => {
+    const output = await fixture('basic.output.ts')
+
+    const result = await runTransform({ source: output, transform: renameExperimentalTableFeature })
+
+    expect(result).toBe(output)
+  })
+
+  it('renames the imported name without touching an aliased local binding', async () => {
+    const input = await fixture('alias.input.ts')
+    const output = await fixture('alias.output.ts')
+
+    const result = await runTransform({ source: input, transform: renameExperimentalTableFeature })
+
+    expect(result).toBe(output)
+  })
+
+  it('no-ops on code without EXPERIMENTAL_TableFeature', async () => {
+    const input = await fixture('no-match.input.ts')
+
+    const result = await runTransform({ source: input, transform: renameExperimentalTableFeature })
+
+    expect(result).toBe(input)
+  })
+
+  it('skips the rename when TableFeature is already imported from the same declaration', async () => {
+    const input = await fixture('collision.input.ts')
+
+    const result = await runTransform({ source: input, transform: renameExperimentalTableFeature })
+
+    expect(result).toBe(input)
+  })
+})

--- a/packages/codemod/src/transforms/rename-experimental-table-feature/index.ts
+++ b/packages/codemod/src/transforms/rename-experimental-table-feature/index.ts
@@ -1,0 +1,50 @@
+import type { Transform } from '../../types.js'
+
+const PACKAGE_NAME = '@payloadcms/richtext-lexical'
+const OLD_NAME = 'EXPERIMENTAL_TableFeature'
+const NEW_NAME = 'TableFeature'
+
+export const renameExperimentalTableFeature: Transform = {
+  name: 'rename-experimental-table-feature',
+  apply: ({ project }) => {
+    const filesChanged = new Set<string>()
+
+    for (const file of project.getSourceFiles()) {
+      for (const importDecl of file.getImportDeclarations()) {
+        if (importDecl.getModuleSpecifierValue() !== PACKAGE_NAME) {
+          continue
+        }
+
+        const named = importDecl.getNamedImports()
+        const spec = named.find((specifier) => specifier.getName() === OLD_NAME)
+        if (!spec) {
+          continue
+        }
+
+        // Skip if `TableFeature` is already imported here too, to avoid a collision.
+        const hasNewName = named.some(
+          (specifier) => (specifier.getAliasNode()?.getText() ?? specifier.getName()) === NEW_NAME,
+        )
+        if (hasNewName) {
+          continue
+        }
+
+        if (spec.getAliasNode()) {
+          // Aliased usages (`EXPERIMENTAL_TableFeature as Foo`) only reference the alias,
+          // so the imported name can be swapped without touching call sites.
+          spec.setName(NEW_NAME)
+        } else {
+          // No alias: the imported name is also the local binding, so rename it to update
+          // every call site (e.g. `EXPERIMENTAL_TableFeature()`) in the same pass.
+          spec.getNameNode().rename(NEW_NAME)
+        }
+
+        filesChanged.add(file.getFilePath())
+      }
+    }
+
+    return { filesChanged: [...filesChanged] }
+  },
+  description:
+    'Renames imports of `EXPERIMENTAL_TableFeature` from `@payloadcms/richtext-lexical` to `TableFeature` (the table feature is now stable) and updates all local usages.',
+}

--- a/packages/codemod/src/transforms/rename-experimental-table-feature/no-match.input.ts
+++ b/packages/codemod/src/transforms/rename-experimental-table-feature/no-match.input.ts
@@ -1,0 +1,5 @@
+import { FixedToolbarFeature, lexicalEditor } from '@payloadcms/richtext-lexical'
+
+export const editor = lexicalEditor({
+  features: ({ defaultFeatures }) => [...defaultFeatures, FixedToolbarFeature()],
+})


### PR DESCRIPTION
## Summary
- PR #17555 renamed `EXPERIMENTAL_TableFeature` to `TableFeature` in `@payloadcms/richtext-lexical` but didn't ship a codemod for it
- Adds `rename-experimental-table-feature` to `@payloadcms/codemod`, renaming imports of `EXPERIMENTAL_TableFeature` from `@payloadcms/richtext-lexical` to `TableFeature` and updating all local usages (e.g. `EXPERIMENTAL_TableFeature()` call sites)
- Handles aliased imports and skips when `TableFeature` is already imported from the same declaration to avoid a collision