### PR TITLE
fix(ui): preserve column visibility during pagination

### DIFF
--- a/packages/ui/src/providers/ListQuery/index.tsx
+++ b/packages/ui/src/providers/ListQuery/index.tsx
@@ -70,7 +70,10 @@ export const ListQueryProvider: React.FC<ListQueryProps> = ({
       if (modifySearchParams) {
         const search = `?${qs.stringify({
           ...newQuery,
-          columns: JSON.stringify(newQuery.columns),
+          columns:
+            typeof newQuery.columns === 'string'
+              ? newQuery.columns
+              : JSON.stringify(newQuery.columns),
           queryByGroup: JSON.stringify(newQuery.queryByGroup),
         })}`
         if (window.location.search !== search) {

--- a/test/admin/e2e/list-view/e2e.spec.ts
+++ b/test/admin/e2e/list-view/e2e.spec.ts
@@ -1175,6 +1175,27 @@ describe('List View', () => {
       await expect(page.locator('table > thead > tr > th:nth-child(2)')).toHaveText('Number')
     })
 
+    test('should retain column visibility after reload and navigating to the next page', async () => {
+      await deleteAllPosts()
+
+      await mapAsync([...Array(6)], async () => {
+        await createPost()
+      })
+
+      await page.goto(postsUrl.list)
+      await setPerPageLimit({ page, limit: 5 })
+
+      await toggleColumn(page, { columnLabel: 'ID', columnName: 'id', targetState: 'off' })
+
+      await page.reload()
+
+      await expect(page.locator('#heading-id')).toBeHidden()
+
+      await goToNextPage(page)
+
+      await expect(page.locator('#heading-id')).toBeHidden()
+    })
+
     test('should inject preferred columns into URL search params on load', async () => {
       await toggleColumn(page, { columnLabel: 'ID', columnName: 'id', targetState: 'off' })
 


### PR DESCRIPTION
### What?

Fixes an issue where collection table column visibility settings are lost after refreshing the browser and then navigating to another pagination page.

### Why?

After a browser refresh, the `columns` query parameter can be represented as a JSON string in the client query state. When pagination changes, this value was JSON-stringified again, resulting in a double-encoded query parameter.

This caused the server to fail to resolve the column preference and fall back to the default columns.

### How?

Avoid JSON-stringifying `columns` when it is already a string.

Added a regression test covering:

- changing column visibility
- refreshing the browser
- navigating to the next page
- verifying that the column visibility is preserved

Fixes #17792