### PR TITLE
fix(drizzle): point field not returned on update by id

### DIFF
--- a/packages/drizzle/src/upsertRow/index.ts
+++ b/packages/drizzle/src/upsertRow/index.ts
@@ -150,6 +150,14 @@ export const upsertRow = async <T extends Record<string, unknown> | TypeWithID>(
           }
         }
 
+        // Fields like `point` are excluded from `columns` and computed via `extras`
+        // (e.g. ST_AsGeoJSON) instead - without this, their value is dropped from the result.
+        if (findManyArgs.extras) {
+          for (const [name, extra] of Object.entries(findManyArgs.extras)) {
+            selectedFields[name] = extra
+          }
+        }
+
         const docs = await drizzle
           .update(adapter.tables[tableName])
           .set(row)

--- a/test/fields/baseConfig.ts
+++ b/test/fields/baseConfig.ts
@@ -23,6 +23,7 @@ import IndexedFields from './collections/Indexed/index.js'
 import JSONFields from './collections/JSON/index.js'
 import NumberFields from './collections/Number/index.js'
 import PointFields from './collections/Point/index.js'
+import PointFieldsOptimized from './collections/PointOptimized/index.js'
 import RadioFields from './collections/Radio/index.js'
 import RelationshipFields from './collections/Relationship/index.js'
 import RowFields from './collections/Row/index.js'
@@ -79,6 +80,7 @@ export const collections: CollectionConfig[] = [
   JSONFields,
   NumberFields,
   PointFields,
+  PointFieldsOptimized,
   RelationshipFields,
   SelectFields,
   SlugField,

--- a/test/fields/collections/PointOptimized/index.ts
+++ b/test/fields/collections/PointOptimized/index.ts
@@ -1,0 +1,23 @@
+import type { CollectionConfig } from 'payload'
+
+import { pointFieldsOptimizedSlug } from '../../slugs.js'
+
+// No localized/hasMany/blocks/array fields here on purpose - collections shaped like
+// this take the `shouldUseOptimizedUpsertRow` fast path in packages/drizzle/src/upsertRow.
+const PointFieldsOptimized: CollectionConfig = {
+  slug: pointFieldsOptimizedSlug,
+  fields: [
+    {
+      name: 'point',
+      type: 'point',
+      required: true,
+    },
+    {
+      name: 'title',
+      type: 'text',
+    },
+  ],
+  versions: false,
+}
+
+export default PointFieldsOptimized

--- a/test/fields/int.spec.ts
+++ b/test/fields/int.spec.ts
@@ -40,6 +40,7 @@ import {
   dateFieldsSlug,
   groupFieldsSlug,
   numberFieldsSlug,
+  pointFieldsOptimizedSlug,
   relationshipFieldsSlug,
   tabsFieldsSlug,
   textFieldsSlug,
@@ -2513,6 +2514,30 @@ describe('Fields', () => {
         data: { point, camelCasePoint: [7, -7] },
       })
       expect(res.camelCasePoint).toEqual([7, -7])
+    })
+
+    it('should return the point field when updating a document by id on a collection without localized fields', async () => {
+      if (payload.db.name === 'sqlite') {
+        return
+      }
+
+      // This collection has no localized/hasMany fields, so the update takes the
+      // `shouldUseOptimizedUpsertRow` fast path in upsertRow, which historically
+      // dropped `point` field values from its result. See #17461.
+      const created = await payload.create({
+        collection: pointFieldsOptimizedSlug,
+        data: { point, title: 'original' },
+      })
+
+      const updated = await payload.update({
+        id: created.id,
+        collection: pointFieldsOptimizedSlug,
+        data: { title: 'updated' },
+      })
+
+      expect(updated.point).toEqual(point)
+
+      await payload.delete({ id: created.id, collection: pointFieldsOptimizedSlug })
     })
   })
 

--- a/test/fields/slugs.ts
+++ b/test/fields/slugs.ts
@@ -17,6 +17,7 @@ export const jsonFieldsSlug = 'json-fields'
 
 export const numberFieldsSlug = 'number-fields'
 export const pointFieldsSlug = 'point-fields'
+export const pointFieldsOptimizedSlug = 'point-fields-optimized'
 export const radioFieldsSlug = 'radio-fields'
 export const relationshipFieldsSlug = 'relationship-fields'
 export const rowFieldsSlug = 'row-fields'
@@ -50,6 +51,7 @@ export const collectionSlugs = [
   jsonFieldsSlug,
   numberFieldsSlug,
   pointFieldsSlug,
+  pointFieldsOptimizedSlug,
   radioFieldsSlug,
   relationshipFieldsSlug,
   rowFieldsSlug,


### PR DESCRIPTION
## Problem

For collections without localized/hasMany/blocks/array fields, updating a document by ID took the optimized `shouldUseOptimizedUpsertRow` fast path in `upsertRow` (`packages/drizzle/src/upsertRow/index.ts`). That path builds its `.returning()` selection only from `findManyArgs.columns`.

`point` fields on Postgres are deliberately excluded from `columns` (set to `false`) and computed separately via `findManyArgs.extras` (`ST_AsGeoJSON(...)`), since Drizzle can't select a geometry column directly (see the comment at `packages/drizzle/src/find/traverseFields.ts:828`). Because the optimized path never looked at `extras`, the point field's value was silently dropped from the `.returning()` result - so it was missing from both the update response and any `afterRead` hooks.

## Fix

Merge `findManyArgs.extras` into `selectedFields` alongside `findManyArgs.columns` before calling `.returning()`, so computed fields like `point` are included in the result.

## Test plan

- Added `test/fields/collections/PointOptimized` - a minimal collection with only a `point` field and a `text` field (no localized/hasMany fields), so it reliably takes the optimized fast path.
- Added a regression test in `test/fields/int.spec.ts` that creates a document, updates an unrelated field, and asserts the `point` field is still returned.
- Verified the test fails without the fix (`expected undefined to deeply equal [ 7, -7 ]`) and passes with it.
- Ran the full `fields` integration suite against both Postgres and SQLite - all passing.

Fixes #17461