### PR TITLE
feat!: self-only default write access for auth collections

### DIFF
--- a/docs/access-control/collections.mdx
+++ b/docs/access-control/collections.mdx
@@ -163,6 +163,14 @@ The following arguments are provided to the `read` function:
 
 Returns a boolean which allows/denies access to the `update` request.
 
+<Banner type="info">
+  **Default behavior on auth-enabled collections:** if you do not provide an
+  `access.update` function, the default constrains updates to `{ id: { equals:
+  req.user.id } }` — a user can only update their own record, and only if their
+  `req.user.collection` matches this collection's slug. To allow admins to
+  update other users, provide an explicit `access.update`.
+</Banner>
+
 To add update Access Control to a Collection, use the `update` property in the [Collection Config](../configuration/collections):
 
 ```ts
@@ -222,6 +230,13 @@ The following arguments are provided to the `update` function:
 ### Delete
 
 Similarly to the Update function, returns a boolean or a [query constraint](/docs/queries/overview) to limit which documents can be deleted by which users.
+
+<Banner type="info">
+  **Default behavior on auth-enabled collections:** the default `access.delete`
+  constrains deletes to `{ id: { equals: req.user.id } }` (self only,
+  same-collection). To allow admins to delete other users, provide an explicit
+  `access.delete`.
+</Banner>
 
 To add delete Access Control to a Collection, use the `delete` property in the [Collection Config](../configuration/collections):
 
@@ -313,6 +328,13 @@ The following arguments are provided to the `admin` function:
 ### Unlock
 
 Determines which users can [unlock](/docs/authentication/operations#unlock) other users who may be blocked from authenticating successfully due to [failing too many login attempts](/docs/authentication/overview#config-options).
+
+<Banner type="info">
+  **Default behavior on auth-enabled collections:** the default `access.unlock`
+  returns `false` for anonymous callers and constrains authenticated callers to
+  their own record. This effectively disables the built-in unlock endpoint until
+  you provide an explicit `access.unlock` allowing admin-initiated unlocks.
+</Banner>
 
 To add Unlock Access Control to a Collection, use the `unlock` property in the [Collection Config](../configuration/collections):
 

--- a/docs/plans/2026-08-15-default-auth-access-design.md
+++ b/docs/plans/2026-08-15-default-auth-access-design.md
@@ -1,0 +1,85 @@
+# Self-only default write access for auth-enabled collections
+
+**Date:** 2026-08-15
+**Status:** Design
+**Branch:** `feat/default-user-access`
+
+## Problem
+
+`defaultAccess` (`packages/payload/src/auth/defaultAccess.ts:3`) returns `true` for any authenticated user whose `collection === admin.user`. Applied to `update`/`delete`/`unlock` on auth-enabled collections, this means:
+
+- Any admin-user-collection user can update, delete, or unlock any other user in that collection — a privilege-escalation footgun.
+- Any secondary auth collection (e.g. `customers`, when `admin.user === 'users'`) cannot even update its own users by default. The collection is unusable without hand-written access control.
+
+Neither behavior is what most apps want. A more defensible default is: authenticated users can only mutate their own record.
+
+## Change
+
+Introduce a new default used only for `update`, `delete`, and `unlock` on auth-enabled collections:
+
+```ts
+// packages/payload/src/auth/defaultAuthAccess.ts
+import type { Access } from '../config/types.js'
+
+export const defaultAuthAccess: Access = ({ req: { user } }) => {
+  if (!user) return false
+  return { id: { equals: user.id } }
+}
+```
+
+Returning a `Where` (not a boolean) means bulk `update`/`delete` still work — Payload constrains the query to the caller's own row.
+
+`read`, `create`, `readVersions`, and `admin` keep the existing `defaultAccess` behavior. Non-auth collections are unaffected.
+
+## Wiring
+
+Two options considered; (A) is chosen.
+
+**A. Auth-aware defaults in `addDefaultsToCollectionConfig`** (`packages/payload/src/collections/config/defaults.ts:58`).
+Branch on `collection.auth`; when truthy, use `defaultAuthAccess` for `update`/`delete`/`unlock` instead of `defaultAccess`. Keeps the `??` semantics — user-provided `access.update` still wins.
+
+**B. Override in `sanitize.ts`** inside the `if (sanitized.auth)` block. Requires capturing `collection.access` before `addDefaultsToCollectionConfig` fills it, so we can distinguish "user didn't provide one" from "default already assigned." Uglier and duplicates logic already living in `defaults.ts`.
+
+## Sub-decision: `unlock`
+
+Under today's `defaultAccess`, `unlock` requires another authenticated admin user — self-unlock while locked out is already impossible. Under `defaultAuthAccess`:
+
+- Anonymous locked-out users still cannot self-unlock (no `req.user`).
+- Admins can no longer unlock others without explicit `access.unlock`.
+
+Net effect: `unlock` is effectively disabled unless explicitly configured. That is arguably correct — unlock is a privileged action and configuring it explicitly forces the right threat model — but it is a documented breaking change.
+
+**Chosen:** include `unlock` in the tightening.
+
+## Breaking-change surface
+
+- Existing apps that relied on "admins can edit other users out of the box" break silently on upgrade.
+- Existing apps that relied on the built-in `unlock` endpoint working for admin-to-user unlocks break silently on upgrade.
+- Migration note for both: restore the old behavior by setting explicit access on the auth collection, e.g. `access.update: ({ req }) => Boolean(req.user)`, or a role-aware equivalent.
+- Target: next major (v4). The `@deprecated` note already on `defaults` (`packages/payload/src/collections/config/defaults.ts:8`) indicates a v4 rework is already planned.
+
+## Tests
+
+Cover in `test/auth/int.spec.ts` (or a new sibling file):
+
+- Auth collection with no custom `access.update`: user A cannot update user B (query-constrained; returns 0 docs or 403 depending on endpoint).
+- Auth collection with no custom `access.update`: user A can update their own doc.
+- Auth collection with an explicit `access.update`: the custom function wins; `defaultAuthAccess` is not applied.
+- Non-auth collection: `defaultAccess` still used (regression guard).
+- Bulk update via `where`: constrained to the caller's id.
+- `unlock` with no custom access: anonymous request denied; cross-user request denied.
+- The `admin.user` collection: an admin cannot update another admin without explicit `access.update`.
+
+## Files touched
+
+- **new** `packages/payload/src/auth/defaultAuthAccess.ts`
+- `packages/payload/src/collections/config/defaults.ts` — branch on `collection.auth` in `addDefaultsToCollectionConfig`.
+- `packages/payload/src/index.ts` — export `defaultAuthAccess` (public API for users writing their own defaults).
+- `test/auth/int.spec.ts` (or a new sibling) — cases above.
+- `docs/access-control/collections.mdx` — document the new default and how to opt out.
+
+## Non-goals
+
+- Read/list access is unchanged. Restricting default read is a much larger breaking change (admin lists, relationship pickers) and is out of scope here.
+- No role-based logic in the default. Apps that want "admins can edit anyone" must express that in their own `access.update`.
+- No changes to non-auth collections.

--- a/docs/plans/2026-08-15-default-auth-access.md
+++ b/docs/plans/2026-08-15-default-auth-access.md
@@ -1,0 +1,566 @@
+# Default self-only access for auth-enabled collections — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Change the default `update`, `delete`, and `unlock` access on auth-enabled collections from "any authenticated admin-collection user" to "only the caller's own record."
+
+**Architecture:** Introduce `defaultAuthAccess` that returns `{ id: { equals: user.id } }` when a user is present, `false` otherwise. Branch on `collection.auth` inside `addDefaultsToCollectionConfig` to use it for `update`/`delete`/`unlock` only. `read`, `create`, `readVersions`, and `admin` continue to use `defaultAccess`. Non-auth collections are untouched.
+
+**Tech Stack:** TypeScript, Vitest (integration tests), pnpm.
+
+**Design doc:** `docs/plans/2026-08-15-default-auth-access-design.md`
+
+**Testing note:** Integration tests run against MongoDB in-memory by default. Run each test as it is added; do not batch. Commit after each green step.
+
+---
+
+## Task 1: Failing test — cross-user update denied by default
+
+**Files:**
+
+- Modify: `test/auth/int.spec.ts` — add a new `describe('Default access', () => { ... })` block near the end of the top-level `describe('Auth', ...)`.
+
+**Step 1: Write the failing test**
+
+Add near the end of the top-level `describe('Auth', ...)` in `test/auth/int.spec.ts`:
+
+```ts
+describe('Default access (auth collection)', () => {
+  const createdUserIDs: (number | string)[] = []
+
+  afterEach(async () => {
+    for (const id of createdUserIDs) {
+      await payload
+        .delete({ collection: slug, id, overrideAccess: true })
+        .catch(() => {})
+    }
+    createdUserIDs.length = 0
+  })
+
+  it('denies updating another user by default', async () => {
+    const userA = await payload.create({
+      collection: slug,
+      data: {
+        email: `a-${uuid()}@test.com`,
+        password: 'test1234',
+        roles: ['user'],
+      },
+      overrideAccess: true,
+    })
+    const userB = await payload.create({
+      collection: slug,
+      data: {
+        email: `b-${uuid()}@test.com`,
+        password: 'test1234',
+        roles: ['user'],
+      },
+      overrideAccess: true,
+    })
+    createdUserIDs.push(userA.id, userB.id)
+
+    const req = await createLocalReq({ user: userA }, payload)
+
+    const result = await payload
+      .update({
+        collection: slug,
+        id: userB.id,
+        data: { custom: 'should not persist' },
+        overrideAccess: false,
+        req,
+      })
+      .catch((err) => err)
+
+    expect(result).toBeInstanceOf(Error)
+    // Payload throws NotFound (query-constrained) or Forbidden depending on op path.
+    expect(['NotFound', 'Forbidden']).toContain((result as Error).name)
+
+    const stillUserB = await payload.findByID({
+      collection: slug,
+      id: userB.id,
+      overrideAccess: true,
+    })
+    expect(stillUserB.custom).not.toBe('should not persist')
+  })
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pnpm run test:int auth -t "denies updating another user by default"`
+Expected: FAIL — under current default, user A can update user B, so the update resolves and `result` is not an Error.
+
+**Step 3: Commit the failing test**
+
+```bash
+git add test/auth/int.spec.ts
+git commit -m "test(auth): default access should deny cross-user update"
+```
+
+---
+
+## Task 2: Implement `defaultAuthAccess`
+
+**Files:**
+
+- Create: `packages/payload/src/auth/defaultAuthAccess.ts`
+
+**Step 1: Write the file**
+
+```ts
+import type { Access } from '../config/types.js'
+
+export const defaultAuthAccess: Access = ({ req: { user } }) => {
+  if (!user) {
+    return false
+  }
+  return { id: { equals: user.id } }
+}
+```
+
+**Step 2: Type check**
+
+Run: `pnpm run build:core`
+Expected: PASS.
+
+**Step 3: Commit**
+
+```bash
+git add packages/payload/src/auth/defaultAuthAccess.ts
+git commit -m "feat(payload): add defaultAuthAccess for self-only auth defaults"
+```
+
+---
+
+## Task 3: Wire `defaultAuthAccess` into collection defaults
+
+**Files:**
+
+- Modify: `packages/payload/src/collections/config/defaults.ts:58-121`
+
+**Step 1: Update `addDefaultsToCollectionConfig`**
+
+Add the import at the top of the file (alongside the existing `defaultAccess` import):
+
+```ts
+import { defaultAuthAccess } from '../../auth/defaultAuthAccess.js'
+```
+
+Replace the `collection.access = { ... }` block inside `addDefaultsToCollectionConfig` with:
+
+```ts
+const authDefault = collection.auth ? defaultAuthAccess : defaultAccess
+
+collection.access = {
+  ...access,
+  create: access?.create ?? defaultAccess,
+  delete: access?.delete ?? authDefault,
+  read: access?.read ?? defaultAccess,
+  unlock: access?.unlock ?? authDefault,
+  update: access?.update ?? authDefault,
+} satisfies SanitizedCollectionConfig['access']
+```
+
+Also update the `defaults` object (`packages/payload/src/collections/config/defaults.ts:9`) to reflect intent for readers, even though it is `@deprecated` — leave `defaults.access` referencing `defaultAccess` for all keys (it is not consulted at runtime; changing it would be a needless bit of noise).
+
+**Step 2: Run the failing test**
+
+Run: `pnpm run test:int auth -t "denies updating another user by default"`
+Expected: PASS — cross-user update is now denied.
+
+**Step 3: Commit**
+
+```bash
+git add packages/payload/src/collections/config/defaults.ts
+git commit -m "feat(payload)!: self-only default update/delete/unlock for auth collections"
+```
+
+---
+
+## Task 4: Positive test — self-update still works
+
+**Files:**
+
+- Modify: `test/auth/int.spec.ts` — inside the same `describe('Default access (auth collection)', ...)`.
+
+**Step 1: Add the test**
+
+```ts
+it('allows a user to update their own record by default', async () => {
+  const user = await payload.create({
+    collection: slug,
+    data: {
+      email: `self-${uuid()}@test.com`,
+      password: 'test1234',
+      roles: ['user'],
+    },
+    overrideAccess: true,
+  })
+  createdUserIDs.push(user.id)
+
+  const req = await createLocalReq({ user }, payload)
+
+  const updated = await payload.update({
+    collection: slug,
+    id: user.id,
+    data: { custom: 'self-updated' },
+    overrideAccess: false,
+    req,
+  })
+
+  expect(updated.custom).toBe('self-updated')
+})
+```
+
+**Step 2: Run it**
+
+Run: `pnpm run test:int auth -t "allows a user to update their own record by default"`
+Expected: PASS.
+
+**Step 3: Commit**
+
+```bash
+git add test/auth/int.spec.ts
+git commit -m "test(auth): user can self-update under default access"
+```
+
+---
+
+## Task 5: Test — user-provided `access.update` wins
+
+**Files:**
+
+- Modify: `test/auth/config.ts` — add a new auth collection whose `access.update` always returns `true`, so we can prove the custom function overrides the new default.
+- Modify: `test/auth/shared.ts` — export the new slug.
+- Modify: `test/auth/int.spec.ts` — add the test.
+
+**Step 1: Add slug constant**
+
+In `test/auth/shared.ts`, add:
+
+```ts
+export const openUpdateAuthSlug = 'open-update-auth'
+```
+
+**Step 2: Add collection to `test/auth/config.ts`**
+
+Import the new slug alongside the existing ones, then add this collection to the `collections` array (near the other secondary auth collections):
+
+```ts
+{
+  slug: openUpdateAuthSlug,
+  access: {
+    update: () => true,
+  },
+  auth: true,
+  fields: [{ name: 'note', type: 'text' }],
+  versions: false,
+},
+```
+
+**Step 3: Add the test**
+
+In the `describe('Default access (auth collection)', ...)` block:
+
+```ts
+it('respects a user-provided access.update over the auth default', async () => {
+  const userA = await payload.create({
+    collection: openUpdateAuthSlug,
+    data: { email: `oa-${uuid()}@test.com`, password: 'test1234' },
+    overrideAccess: true,
+  })
+  const userB = await payload.create({
+    collection: openUpdateAuthSlug,
+    data: { email: `ob-${uuid()}@test.com`, password: 'test1234' },
+    overrideAccess: true,
+  })
+
+  const req = await createLocalReq({ user: userA }, payload)
+
+  const updated = await payload.update({
+    collection: openUpdateAuthSlug,
+    id: userB.id,
+    data: { note: 'overridden default lets this through' },
+    overrideAccess: false,
+    req,
+  })
+
+  expect(updated.note).toBe('overridden default lets this through')
+
+  await payload.delete({
+    collection: openUpdateAuthSlug,
+    id: userA.id,
+    overrideAccess: true,
+  })
+  await payload.delete({
+    collection: openUpdateAuthSlug,
+    id: userB.id,
+    overrideAccess: true,
+  })
+})
+```
+
+**Step 4: Run it**
+
+Run: `pnpm run test:int auth -t "respects a user-provided access.update"`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add test/auth/config.ts test/auth/shared.ts test/auth/int.spec.ts
+git commit -m "test(auth): custom access.update overrides self-only default"
+```
+
+---
+
+## Task 6: Test — non-auth collections unaffected
+
+**Files:**
+
+- Modify: `test/auth/int.spec.ts`. Reuse an existing non-auth collection from the auth test config if one exists; otherwise add a minimal one to `test/auth/config.ts`.
+
+**Step 1: Check for a non-auth collection in `test/auth/config.ts`**
+
+Run: `grep -n "auth: " test/auth/config.ts` — every collection currently sets `auth`. Add a minimal one:
+
+```ts
+{
+  slug: 'default-access-fixture',
+  fields: [{ name: 'title', type: 'text' }],
+  versions: false,
+},
+```
+
+Add the slug constant to `test/auth/shared.ts`:
+
+```ts
+export const defaultAccessFixtureSlug = 'default-access-fixture'
+```
+
+**Step 2: Add the test**
+
+```ts
+it('does not apply the auth default to non-auth collections', async () => {
+  const authUser = await payload.create({
+    collection: slug,
+    data: {
+      email: `nonauth-${uuid()}@test.com`,
+      password: 'test1234',
+      roles: ['user'],
+    },
+    overrideAccess: true,
+  })
+  createdUserIDs.push(authUser.id)
+
+  const doc = await payload.create({
+    collection: defaultAccessFixtureSlug,
+    data: { title: 'original' },
+    overrideAccess: true,
+  })
+
+  const req = await createLocalReq({ user: authUser }, payload)
+
+  const updated = await payload.update({
+    collection: defaultAccessFixtureSlug,
+    id: doc.id,
+    data: { title: 'edited by another user' },
+    overrideAccess: false,
+    req,
+  })
+
+  expect(updated.title).toBe('edited by another user')
+
+  await payload.delete({
+    collection: defaultAccessFixtureSlug,
+    id: doc.id,
+    overrideAccess: true,
+  })
+})
+```
+
+Note: this asserts that `defaultAccess` still lets any admin-collection user update non-auth docs. If `authUser.collection !== payload.config.admin.user`, the update would fail for the wrong reason; `slug` is `admin.user` in this config, so we are safe.
+
+**Step 3: Run it**
+
+Run: `pnpm run test:int auth -t "does not apply the auth default to non-auth collections"`
+Expected: PASS.
+
+**Step 4: Commit**
+
+```bash
+git add test/auth/config.ts test/auth/shared.ts test/auth/int.spec.ts
+git commit -m "test(auth): non-auth collections keep defaultAccess"
+```
+
+---
+
+## Task 7: Tests — `unlock` default behavior change
+
+**Files:**
+
+- Modify: `test/auth/int.spec.ts` — add tests inside the same describe block.
+
+**Step 1: Add anonymous-denied test**
+
+```ts
+it('denies unlock to anonymous callers by default', async () => {
+  const user = await payload.create({
+    collection: slug,
+    data: {
+      email: `unlock-a-${uuid()}@test.com`,
+      password: 'test1234',
+      roles: ['user'],
+    },
+    overrideAccess: true,
+  })
+  createdUserIDs.push(user.id)
+
+  const req = await createLocalReq({}, payload)
+
+  const result = await payload
+    .unlock({
+      collection: slug,
+      data: { email: user.email },
+      overrideAccess: false,
+      req,
+    })
+    .catch((err) => err)
+
+  expect(result).toBeInstanceOf(Error)
+  expect((result as Error).name).toBe('Forbidden')
+})
+```
+
+**Step 2: Add cross-user-denied test**
+
+```ts
+it('denies unlocking another user by default', async () => {
+  const caller = await payload.create({
+    collection: slug,
+    data: {
+      email: `unlock-c-${uuid()}@test.com`,
+      password: 'test1234',
+      roles: ['user'],
+    },
+    overrideAccess: true,
+  })
+  const target = await payload.create({
+    collection: slug,
+    data: {
+      email: `unlock-t-${uuid()}@test.com`,
+      password: 'test1234',
+      roles: ['user'],
+    },
+    overrideAccess: true,
+  })
+  createdUserIDs.push(caller.id, target.id)
+
+  const req = await createLocalReq({ user: caller }, payload)
+
+  const result = await payload.unlock({
+    collection: slug,
+    data: { email: target.email },
+    overrideAccess: false,
+    req,
+  })
+
+  // unlock returns boolean; the where-constraint (id === caller.id) mismatches target.email, so nothing unlocks.
+  expect(result).toBe(false)
+})
+```
+
+**Step 3: Run both**
+
+Run: `pnpm run test:int auth -t "denies unlock to anonymous callers by default"`
+Run: `pnpm run test:int auth -t "denies unlocking another user by default"`
+Expected: PASS for both.
+
+**Step 4: Commit**
+
+```bash
+git add test/auth/int.spec.ts
+git commit -m "test(auth): default unlock denies anonymous and cross-user calls"
+```
+
+---
+
+## Task 8: Full auth suite regression run
+
+**Step 1: Run the full auth int suite**
+
+Run: `pnpm run test:int auth`
+Expected: PASS overall. Fix any pre-existing tests that assumed the old default (e.g. a test that logs in as user A and updates user B without setting `access.update`). Fix by either (a) marking that collection's `access.update` explicitly in the test config, or (b) updating the test to use `overrideAccess: true` if the intent was administrative.
+
+**Step 2: Commit any regression fixes separately**
+
+```bash
+git add <files>
+git commit -m "test(auth): update assumptions that relied on the old default"
+```
+
+---
+
+## Task 9: Update docs
+
+**Files:**
+
+- Modify: `docs/access-control/collections.mdx` — the `update`, `delete`, and `unlock` sections should note the new default.
+
+**Step 1: Add a callout after each affected operation's intro paragraph**
+
+Under the `update` section (around `docs/access-control/collections.mdx:164`):
+
+```mdx
+<Banner type="info">
+  **Default behavior:** on auth-enabled collections, the default `update` access constrains the
+  operation to `{ id: { equals: req.user.id } }` — a user can only update their own record. To
+  allow admins to update other users, provide an explicit `access.update` function on the
+  collection.
+</Banner>
+```
+
+Under `delete`: same wording with `delete`. Under `unlock`: same wording, and note that anonymous unlock is denied by default; explicit `access.unlock` is required for admin-to-user unlock flows.
+
+**Step 2: Commit**
+
+```bash
+git add docs/access-control/collections.mdx
+git commit -m "docs(access-control): document self-only default for auth collections"
+```
+
+---
+
+## Task 10: Manual verification via the dev server
+
+**Step 1: Start the auth test config**
+
+Run: `pnpm run dev auth`
+
+**Step 2: Log in as one user, attempt to update another via the admin UI**
+
+- Log in as `dev@payloadcms.com` / `test`.
+- Create a second user via the admin panel.
+- Attempt to update the second user's record.
+- Expected: 403 / not-found; the row is not modifiable.
+- Update your own user record. Expected: succeeds.
+
+**Step 3: Stop the dev server**
+
+No commit needed.
+
+---
+
+## Non-goals (reminder)
+
+- Do not change `read` or `create` defaults.
+- Do not change non-auth collection defaults.
+- Do not add role-based branching to the default.
+- Do not export `defaultAuthAccess` from the public API in this change; keep it internal like `defaultAccess`.
+
+---
+
+## Rollout notes
+
+- This is a breaking change. The PR should be titled `feat(payload)!: self-only default write access for auth collections` and include a BREAKING CHANGE footer describing the migration:
+  > **BREAKING CHANGE:** on auth-enabled collections, the default `update`, `delete`, and `unlock` access is now `{ id: { equals: req.user.id } }`. Apps that relied on any authenticated admin-collection user being able to modify other users must add an explicit `access.update` (and/or `delete`, `unlock`) function to restore prior behavior.
+- Target v4.

--- a/packages/payload/src/auth/defaultAuthAccess.ts
+++ b/packages/payload/src/auth/defaultAuthAccess.ts
@@ -1,0 +1,8 @@
+import type { Access } from '../config/types.js'
+
+export const defaultAuthAccess: Access = ({ req: { user } }) => {
+  if (!user) {
+    return false
+  }
+  return { id: { equals: user.id } }
+}

--- a/packages/payload/src/auth/defaultAuthAccess.ts
+++ b/packages/payload/src/auth/defaultAuthAccess.ts
@@ -1,8 +1,10 @@
 import type { Access } from '../config/types.js'
 
-export const defaultAuthAccess: Access = ({ req: { user } }) => {
-  if (!user) {
-    return false
+export const defaultAuthAccess =
+  (collectionSlug: string): Access =>
+  ({ req: { user } }) => {
+    if (!user || user.collection !== collectionSlug) {
+      return false
+    }
+    return { id: { equals: user.id } }
   }
-  return { id: { equals: user.id } }
-}

--- a/packages/payload/src/auth/defaultAuthAccess.ts
+++ b/packages/payload/src/auth/defaultAuthAccess.ts
@@ -1,10 +1,8 @@
 import type { Access } from '../config/types.js'
 
-export const defaultAuthAccess =
-  (collectionSlug: string): Access =>
-  ({ req: { user } }) => {
-    if (!user || user.collection !== collectionSlug) {
-      return false
-    }
-    return { id: { equals: user.id } }
+export const defaultAuthAccess: Access = ({ slug, req: { user } }) => {
+  if (!user || user.collection !== slug) {
+    return false
   }
+  return { id: { equals: user.id } }
+}

--- a/packages/payload/src/collections/config/defaults.ts
+++ b/packages/payload/src/collections/config/defaults.ts
@@ -59,7 +59,7 @@ export const defaults: Partial<CollectionConfig> = {
 export const addDefaultsToCollectionConfig = (collection: CollectionConfig): CollectionConfig => {
   const access = collection.access
 
-  const authDefault = collection.auth ? defaultAuthAccess(collection.slug) : defaultAccess
+  const authDefault = collection.auth ? defaultAuthAccess : defaultAccess
 
   collection.access = {
     ...access,

--- a/packages/payload/src/collections/config/defaults.ts
+++ b/packages/payload/src/collections/config/defaults.ts
@@ -59,7 +59,7 @@ export const defaults: Partial<CollectionConfig> = {
 export const addDefaultsToCollectionConfig = (collection: CollectionConfig): CollectionConfig => {
   const access = collection.access
 
-  const authDefault = collection.auth ? defaultAuthAccess : defaultAccess
+  const authDefault = collection.auth ? defaultAuthAccess(collection.slug) : defaultAccess
 
   collection.access = {
     ...access,

--- a/packages/payload/src/collections/config/defaults.ts
+++ b/packages/payload/src/collections/config/defaults.ts
@@ -2,6 +2,7 @@ import type { Auth, IncomingAuthType, LoginWithUsernameOptions } from '../../aut
 import type { CollectionConfig, SanitizedCollectionConfig } from './types.js'
 
 import { defaultAccess } from '../../auth/defaultAccess.js'
+import { defaultAuthAccess } from '../../auth/defaultAuthAccess.js'
 
 /**
  * @deprecated - remove in 4.0. This is error-prone, as mutating this object will affect any objects that use the defaults as a base.
@@ -58,13 +59,15 @@ export const defaults: Partial<CollectionConfig> = {
 export const addDefaultsToCollectionConfig = (collection: CollectionConfig): CollectionConfig => {
   const access = collection.access
 
+  const authDefault = collection.auth ? defaultAuthAccess : defaultAccess
+
   collection.access = {
     ...access,
     create: access?.create ?? defaultAccess,
-    delete: access?.delete ?? defaultAccess,
+    delete: access?.delete ?? authDefault,
     read: access?.read ?? defaultAccess,
-    unlock: access?.unlock ?? defaultAccess,
-    update: access?.update ?? defaultAccess,
+    unlock: access?.unlock ?? authDefault,
+    update: access?.update ?? authDefault,
   } satisfies SanitizedCollectionConfig['access']
 
   collection.admin = {

--- a/test/auth/config.ts
+++ b/test/auth/config.ts
@@ -10,6 +10,8 @@ import { seed } from './seed.js'
 import {
   apiKeysSlug,
   BASE_PATH,
+  collisionAuthASlug,
+  collisionAuthBSlug,
   namedSaveToJWTValue,
   openUpdateAuthSlug,
   partialDisableLocalStrategiesSlug,
@@ -312,6 +314,24 @@ export default buildConfigWithDefaults({
       },
       auth: true,
       fields: [{ name: 'note', type: 'text' }],
+      versions: false,
+    },
+    {
+      slug: collisionAuthASlug,
+      auth: true,
+      fields: [
+        { name: 'id', type: 'number' },
+        { name: 'label', type: 'text' },
+      ],
+      versions: false,
+    },
+    {
+      slug: collisionAuthBSlug,
+      auth: true,
+      fields: [
+        { name: 'id', type: 'number' },
+        { name: 'label', type: 'text' },
+      ],
       versions: false,
     },
     {

--- a/test/auth/config.ts
+++ b/test/auth/config.ts
@@ -11,6 +11,7 @@ import {
   apiKeysSlug,
   BASE_PATH,
   namedSaveToJWTValue,
+  openUpdateAuthSlug,
   partialDisableLocalStrategiesSlug,
   publicUsersSlug,
   rotateSecretLoginSlug,
@@ -302,6 +303,15 @@ export default buildConfigWithDefaults({
         verify: true,
       },
       fields: [],
+      versions: false,
+    },
+    {
+      slug: openUpdateAuthSlug,
+      access: {
+        update: () => true,
+      },
+      auth: true,
+      fields: [{ name: 'note', type: 'text' }],
       versions: false,
     },
     {

--- a/test/auth/config.ts
+++ b/test/auth/config.ts
@@ -12,6 +12,7 @@ import {
   BASE_PATH,
   collisionAuthASlug,
   collisionAuthBSlug,
+  defaultAccessFixtureSlug,
   namedSaveToJWTValue,
   openUpdateAuthSlug,
   partialDisableLocalStrategiesSlug,
@@ -332,6 +333,11 @@ export default buildConfigWithDefaults({
         { name: 'id', type: 'number' },
         { name: 'label', type: 'text' },
       ],
+      versions: false,
+    },
+    {
+      slug: defaultAccessFixtureSlug,
+      fields: [{ name: 'title', type: 'text' }],
       versions: false,
     },
     {

--- a/test/auth/int.spec.ts
+++ b/test/auth/int.spec.ts
@@ -23,6 +23,8 @@ import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
 import { devUser } from '../credentials.js'
 import {
   apiKeysSlug,
+  collisionAuthASlug,
+  collisionAuthBSlug,
   namedSaveToJWTValue,
   openUpdateAuthSlug,
   partialDisableLocalStrategiesSlug,
@@ -2677,6 +2679,68 @@ describe('Auth', () => {
 
       await payload.delete({ collection: openUpdateAuthSlug, id: userA.id, overrideAccess: true })
       await payload.delete({ collection: openUpdateAuthSlug, id: userB.id, overrideAccess: true })
+    })
+
+    it('denies cross-collection updates even when ids collide', async () => {
+      const collidingId = 424242
+
+      const userA = await payload.create({
+        collection: collisionAuthASlug,
+        data: {
+          id: collidingId,
+          email: `ca-${uuid()}@test.com`,
+          password: 'test1234',
+          label: 'A original',
+        },
+        overrideAccess: true,
+      })
+
+      const docB = await payload.create({
+        collection: collisionAuthBSlug,
+        data: {
+          id: collidingId,
+          email: `cb-${uuid()}@test.com`,
+          password: 'test1234',
+          label: 'B original',
+        },
+        overrideAccess: true,
+      })
+
+      expect(userA.id).toBe(collidingId)
+      expect(docB.id).toBe(collidingId)
+
+      const req = await createLocalReq({ user: userA }, payload)
+
+      const result = await payload
+        .update({
+          collection: collisionAuthBSlug,
+          id: collidingId,
+          data: { label: 'B HIJACKED' },
+          overrideAccess: false,
+          req,
+        })
+        .catch((err) => err)
+
+      expect(result).toBeInstanceOf(Error)
+      expect((result as Error).name).toBe('Forbidden')
+
+      const stillDocB = await payload.findByID({
+        collection: collisionAuthBSlug,
+        id: collidingId,
+        overrideAccess: true,
+      })
+      expect(stillDocB.label).toBe('B original')
+
+      await payload.delete({
+        collection: collisionAuthASlug,
+        id: collidingId,
+        overrideAccess: true,
+      })
+      await payload.delete({
+        collection: collisionAuthBSlug,
+        id: collidingId,
+        overrideAccess: true,
+      })
     })
   })
 })

--- a/test/auth/int.spec.ts
+++ b/test/auth/int.spec.ts
@@ -24,6 +24,7 @@ import { devUser } from '../credentials.js'
 import {
   apiKeysSlug,
   namedSaveToJWTValue,
+  openUpdateAuthSlug,
   partialDisableLocalStrategiesSlug,
   publicUsersSlug,
   rotateSecretLoginSlug,
@@ -2648,6 +2649,34 @@ describe('Auth', () => {
       })
 
       expect(updated.custom).toBe('self-updated')
+    })
+
+    it('respects a user-provided access.update over the auth default', async () => {
+      const userA = await payload.create({
+        collection: openUpdateAuthSlug,
+        data: { email: `oa-${uuid()}@test.com`, password: 'test1234' },
+        overrideAccess: true,
+      })
+      const userB = await payload.create({
+        collection: openUpdateAuthSlug,
+        data: { email: `ob-${uuid()}@test.com`, password: 'test1234' },
+        overrideAccess: true,
+      })
+
+      const req = await createLocalReq({ user: userA }, payload)
+
+      const updated = await payload.update({
+        collection: openUpdateAuthSlug,
+        id: userB.id,
+        data: { note: 'overridden default lets this through' },
+        overrideAccess: false,
+        req,
+      })
+
+      expect(updated.note).toBe('overridden default lets this through')
+
+      await payload.delete({ collection: openUpdateAuthSlug, id: userA.id, overrideAccess: true })
+      await payload.delete({ collection: openUpdateAuthSlug, id: userB.id, overrideAccess: true })
     })
   })
 })

--- a/test/auth/int.spec.ts
+++ b/test/auth/int.spec.ts
@@ -2709,7 +2709,10 @@ describe('Auth', () => {
       expect(userA.id).toBe(collidingId)
       expect(docB.id).toBe(collidingId)
 
+      userA.collection = collisionAuthASlug
+
       const req = await createLocalReq({ user: userA }, payload)
+      expect(req.user?.collection).toBe(collisionAuthASlug)
 
       const result = await payload
         .update({

--- a/test/auth/int.spec.ts
+++ b/test/auth/int.spec.ts
@@ -2779,5 +2779,59 @@ describe('Auth', () => {
         overrideAccess: true,
       })
     })
+
+    it('denies unlock to anonymous callers by default', async () => {
+      const user = await payload.create({
+        collection: slug,
+        data: { email: `unlock-a-${uuid()}@test.com`, password: 'test1234', roles: ['user'] },
+        overrideAccess: true,
+      })
+      createdUserIDs.push(user.id)
+
+      const req = await createLocalReq({}, payload)
+      req.user = undefined
+      expect(req.user).toBeUndefined()
+
+      const result = await payload
+        .unlock({
+          collection: slug,
+          data: { email: user.email },
+          overrideAccess: false,
+          req,
+        })
+        .catch((err) => err)
+
+      expect(result).toBeInstanceOf(Error)
+      expect((result as Error).name).toBe('Forbidden')
+    })
+
+    it('denies unlocking another user by default', async () => {
+      const caller = await payload.create({
+        collection: slug,
+        data: { email: `unlock-c-${uuid()}@test.com`, password: 'test1234', roles: ['user'] },
+        overrideAccess: true,
+      })
+      const target = await payload.create({
+        collection: slug,
+        data: { email: `unlock-t-${uuid()}@test.com`, password: 'test1234', roles: ['user'] },
+        overrideAccess: true,
+      })
+      createdUserIDs.push(caller.id, target.id)
+
+      const req = await createLocalReq({ user: caller }, payload)
+
+      const result = await payload
+        .unlock({
+          collection: slug,
+          data: { email: target.email },
+          overrideAccess: false,
+          req,
+        })
+        .catch((err) => err)
+
+      // The where-constraint (id === caller.id) mismatches target.email, so no user is found and unlock throws Forbidden.
+      expect(result).toBeInstanceOf(Error)
+      expect((result as Error).name).toBe('Forbidden')
+    })
   })
 })

--- a/test/auth/int.spec.ts
+++ b/test/auth/int.spec.ts
@@ -25,6 +25,7 @@ import {
   apiKeysSlug,
   collisionAuthASlug,
   collisionAuthBSlug,
+  defaultAccessFixtureSlug,
   namedSaveToJWTValue,
   openUpdateAuthSlug,
   partialDisableLocalStrategiesSlug,
@@ -2742,6 +2743,39 @@ describe('Auth', () => {
       await payload.delete({
         collection: collisionAuthBSlug,
         id: collidingId,
+        overrideAccess: true,
+      })
+    })
+
+    it('does not apply the auth default to non-auth collections', async () => {
+      const authUser = await payload.create({
+        collection: slug,
+        data: { email: `nonauth-${uuid()}@test.com`, password: 'test1234', roles: ['user'] },
+        overrideAccess: true,
+      })
+      createdUserIDs.push(authUser.id)
+
+      const doc = await payload.create({
+        collection: defaultAccessFixtureSlug,
+        data: { title: 'original' },
+        overrideAccess: true,
+      })
+
+      const req = await createLocalReq({ user: authUser }, payload)
+
+      const updated = await payload.update({
+        collection: defaultAccessFixtureSlug,
+        id: doc.id,
+        data: { title: 'edited by another user' },
+        overrideAccess: false,
+        req,
+      })
+
+      expect(updated.title).toBe('edited by another user')
+
+      await payload.delete({
+        collection: defaultAccessFixtureSlug,
+        id: doc.id,
         overrideAccess: true,
       })
     })

--- a/test/auth/int.spec.ts
+++ b/test/auth/int.spec.ts
@@ -2582,4 +2582,51 @@ describe('Auth', () => {
       expect(underUnknown.user).toBeFalsy()
     })
   })
+
+  describe('Default access (auth collection)', () => {
+    const createdUserIDs: (number | string)[] = []
+
+    afterEach(async () => {
+      for (const id of createdUserIDs) {
+        await payload.delete({ collection: slug, id, overrideAccess: true }).catch(() => {})
+      }
+      createdUserIDs.length = 0
+    })
+
+    it('denies updating another user by default', async () => {
+      const userA = await payload.create({
+        collection: slug,
+        data: { email: `a-${uuid()}@test.com`, password: 'test1234', roles: ['user'] },
+        overrideAccess: true,
+      })
+      const userB = await payload.create({
+        collection: slug,
+        data: { email: `b-${uuid()}@test.com`, password: 'test1234', roles: ['user'] },
+        overrideAccess: true,
+      })
+      createdUserIDs.push(userA.id, userB.id)
+
+      const req = await createLocalReq({ user: userA }, payload)
+
+      const result = await payload
+        .update({
+          collection: slug,
+          id: userB.id,
+          data: { custom: 'should not persist' },
+          overrideAccess: false,
+          req,
+        })
+        .catch((err) => err)
+
+      expect(result).toBeInstanceOf(Error)
+      expect(['NotFound', 'Forbidden']).toContain((result as Error).name)
+
+      const stillUserB = await payload.findByID({
+        collection: slug,
+        id: userB.id,
+        overrideAccess: true,
+      })
+      expect(stillUserB.custom).not.toBe('should not persist')
+    })
+  })
 })

--- a/test/auth/int.spec.ts
+++ b/test/auth/int.spec.ts
@@ -2628,5 +2628,26 @@ describe('Auth', () => {
       })
       expect(stillUserB.custom).not.toBe('should not persist')
     })
+
+    it('allows a user to update their own record by default', async () => {
+      const user = await payload.create({
+        collection: slug,
+        data: { email: `self-${uuid()}@test.com`, password: 'test1234', roles: ['user'] },
+        overrideAccess: true,
+      })
+      createdUserIDs.push(user.id)
+
+      const req = await createLocalReq({ user }, payload)
+
+      const updated = await payload.update({
+        collection: slug,
+        id: user.id,
+        data: { custom: 'self-updated' },
+        overrideAccess: false,
+        req,
+      })
+
+      expect(updated.custom).toBe('self-updated')
+    })
   })
 })

--- a/test/auth/payload-types.ts
+++ b/test/auth/payload-types.ts
@@ -62,15 +62,15 @@ export type SupportedTimezones =
   | 'Pacific/Fiji';
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "LexicalNodes_087E2F44".
+ * via the `definition` "LexicalNodes_064459F7".
  */
-export type LexicalNodes_087E2F44 =
+export type LexicalNodes_064459F7 =
   | SerializedTextNode
   | SerializedTabNode
   | SerializedLineBreakNode
-  | SerializedParagraphNode<LexicalNodes_087E2F44>
+  | SerializedParagraphNode<LexicalNodes_064459F7>
   | SerializedBlockNode<MyBlock>
-  | SerializedHeadingNode<LexicalNodes_087E2F44>
+  | SerializedHeadingNode<LexicalNodes_064459F7>
   | {
       type: 'upload';
       /**
@@ -79,11 +79,11 @@ export type LexicalNodes_087E2F44 =
       version: number;
       [k: string]: unknown;
     }
-  | SerializedQuoteNode<LexicalNodes_087E2F44>
-  | SerializedListNode<LexicalNodes_087E2F44>
-  | SerializedListItemNode<LexicalNodes_087E2F44>
-  | SerializedAutoLinkNode<LexicalNodes_087E2F44, LexicalLinkFields_0A7E9EC0>
-  | SerializedLinkNode<LexicalNodes_087E2F44, LexicalLinkFields_0A7E9EC0>
+  | SerializedQuoteNode<LexicalNodes_064459F7>
+  | SerializedListNode<LexicalNodes_064459F7>
+  | SerializedListItemNode<LexicalNodes_064459F7>
+  | SerializedAutoLinkNode<LexicalNodes_064459F7, LexicalLinkFields_0A7E9EC0>
+  | SerializedLinkNode<LexicalNodes_064459F7, LexicalLinkFields_0A7E9EC0>
   | SerializedRelationshipNode<
       | 'users'
       | 'partial-disable-local-strategies'
@@ -91,6 +91,8 @@ export type LexicalNodes_087E2F44 =
       | 'api-keys'
       | 'public-users'
       | 'open-update-auth'
+      | 'collision-auth-a'
+      | 'collision-auth-b'
       | 'rotate-secret'
       | 'rotate-secret-secondary'
       | 'rotate-secret-login'
@@ -110,6 +112,8 @@ export interface Config {
     'api-keys': ApiKeyAuthOperations;
     'public-users': PublicUserAuthOperations;
     'open-update-auth': OpenUpdateAuthAuthOperations;
+    'collision-auth-a': CollisionAuthAAuthOperations;
+    'collision-auth-b': CollisionAuthBAuthOperations;
     'rotate-secret': RotateSecretAuthOperations;
     'rotate-secret-secondary': RotateSecretSecondaryAuthOperations;
     'rotate-secret-login': RotateSecretLoginAuthOperations;
@@ -123,6 +127,8 @@ export interface Config {
     'api-keys': ApiKey;
     'public-users': PublicUser;
     'open-update-auth': OpenUpdateAuth;
+    'collision-auth-a': CollisionAuthA;
+    'collision-auth-b': CollisionAuthB;
     'rotate-secret': RotateSecret;
     'rotate-secret-secondary': RotateSecretSecondary;
     'rotate-secret-login': RotateSecretLogin;
@@ -141,6 +147,8 @@ export interface Config {
     'api-keys': ApiKeysSelect<false> | ApiKeysSelect<true>;
     'public-users': PublicUsersSelect<false> | PublicUsersSelect<true>;
     'open-update-auth': OpenUpdateAuthSelect<false> | OpenUpdateAuthSelect<true>;
+    'collision-auth-a': CollisionAuthASelect<false> | CollisionAuthASelect<true>;
+    'collision-auth-b': CollisionAuthBSelect<false> | CollisionAuthBSelect<true>;
     'rotate-secret': RotateSecretSelect<false> | RotateSecretSelect<true>;
     'rotate-secret-secondary': RotateSecretSecondarySelect<false> | RotateSecretSecondarySelect<true>;
     'rotate-secret-login': RotateSecretLoginSelect<false> | RotateSecretLoginSelect<true>;
@@ -170,6 +178,8 @@ export interface Config {
     | ApiKey
     | PublicUser
     | OpenUpdateAuth
+    | CollisionAuthA
+    | CollisionAuthB
     | RotateSecret
     | RotateSecretSecondary
     | RotateSecretLogin
@@ -287,6 +297,42 @@ export interface OpenUpdateAuthAuthOperations {
     password: string;
   };
 }
+export interface CollisionAuthAAuthOperations {
+  forgotPassword: {
+    email: string;
+    password: string;
+  };
+  login: {
+    email: string;
+    password: string;
+  };
+  registerFirstUser: {
+    email: string;
+    password: string;
+  };
+  unlock: {
+    email: string;
+    password: string;
+  };
+}
+export interface CollisionAuthBAuthOperations {
+  forgotPassword: {
+    email: string;
+    password: string;
+  };
+  login: {
+    email: string;
+    password: string;
+  };
+  registerFirstUser: {
+    email: string;
+    password: string;
+  };
+  unlock: {
+    email: string;
+    password: string;
+  };
+}
 export interface RotateSecretAuthOperations {
   forgotPassword: {
     email: string;
@@ -374,7 +420,7 @@ export interface User {
       }[]
     | null;
   namedSaveToJWT?: string | null;
-  richText?: LexicalRichText<LexicalNodes_087E2F44> | null;
+  richText?: LexicalRichText<LexicalNodes_064459F7> | null;
   group?: {
     liftedSaveToJWT?: string | null;
   };
@@ -519,6 +565,58 @@ export interface OpenUpdateAuth {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "collision-auth-a".
+ */
+export interface CollisionAuthA {
+  id: number;
+  label?: string | null;
+  updatedAt: string;
+  createdAt: string;
+  email: string;
+  resetPasswordToken?: string | null;
+  resetPasswordExpiration?: string | null;
+  salt?: string | null;
+  hash?: string | null;
+  loginAttempts?: number | null;
+  lockUntil?: string | null;
+  sessions?:
+    | {
+        id: string;
+        createdAt?: string | null;
+        expiresAt: string;
+      }[]
+    | null;
+  password?: string | null;
+  collection: 'collision-auth-a';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "collision-auth-b".
+ */
+export interface CollisionAuthB {
+  id: number;
+  label?: string | null;
+  updatedAt: string;
+  createdAt: string;
+  email: string;
+  resetPasswordToken?: string | null;
+  resetPasswordExpiration?: string | null;
+  salt?: string | null;
+  hash?: string | null;
+  loginAttempts?: number | null;
+  lockUntil?: string | null;
+  sessions?:
+    | {
+        id: string;
+        createdAt?: string | null;
+        expiresAt: string;
+      }[]
+    | null;
+  password?: string | null;
+  collection: 'collision-auth-b';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "rotate-secret".
  */
 export interface RotateSecret {
@@ -644,6 +742,14 @@ export interface PayloadLockedDocument {
         value: string | OpenUpdateAuth;
       } | null)
     | ({
+        relationTo: 'collision-auth-a';
+        value: number | CollisionAuthA;
+      } | null)
+    | ({
+        relationTo: 'collision-auth-b';
+        value: number | CollisionAuthB;
+      } | null)
+    | ({
         relationTo: 'rotate-secret';
         value: string | RotateSecret;
       } | null)
@@ -688,6 +794,14 @@ export interface PayloadLockedDocument {
     | {
         relationTo: 'open-update-auth';
         value: string | OpenUpdateAuth;
+      }
+    | {
+        relationTo: 'collision-auth-a';
+        value: number | CollisionAuthA;
+      }
+    | {
+        relationTo: 'collision-auth-b';
+        value: number | CollisionAuthB;
       }
     | {
         relationTo: 'rotate-secret';
@@ -738,6 +852,14 @@ export interface PayloadPreference {
     | {
         relationTo: 'open-update-auth';
         value: string | OpenUpdateAuth;
+      }
+    | {
+        relationTo: 'collision-auth-a';
+        value: number | CollisionAuthA;
+      }
+    | {
+        relationTo: 'collision-auth-b';
+        value: number | CollisionAuthB;
       }
     | {
         relationTo: 'rotate-secret';
@@ -931,6 +1053,54 @@ export interface OpenUpdateAuthSelect<T extends boolean = true> {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "collision-auth-a_select".
+ */
+export interface CollisionAuthASelect<T extends boolean = true> {
+  id?: T;
+  label?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  email?: T;
+  resetPasswordToken?: T;
+  resetPasswordExpiration?: T;
+  salt?: T;
+  hash?: T;
+  loginAttempts?: T;
+  lockUntil?: T;
+  sessions?:
+    | T
+    | {
+        id?: T;
+        createdAt?: T;
+        expiresAt?: T;
+      };
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "collision-auth-b_select".
+ */
+export interface CollisionAuthBSelect<T extends boolean = true> {
+  id?: T;
+  label?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  email?: T;
+  resetPasswordToken?: T;
+  resetPasswordExpiration?: T;
+  salt?: T;
+  hash?: T;
+  loginAttempts?: T;
+  lockUntil?: T;
+  sessions?:
+    | T
+    | {
+        id?: T;
+        createdAt?: T;
+        expiresAt?: T;
+      };
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "rotate-secret_select".
  */
 export interface RotateSecretSelect<T extends boolean = true> {
@@ -1061,6 +1231,8 @@ export interface CollectionQueryWidget {
       | 'api-keys'
       | 'public-users'
       | 'open-update-auth'
+      | 'collision-auth-a'
+      | 'collision-auth-b'
       | 'rotate-secret'
       | 'rotate-secret-secondary'
       | 'rotate-secret-login'
@@ -1095,6 +1267,8 @@ export interface ActivityWidget {
           | 'api-keys'
           | 'public-users'
           | 'open-update-auth'
+          | 'collision-auth-a'
+          | 'collision-auth-b'
           | 'rotate-secret'
           | 'rotate-secret-secondary'
           | 'rotate-secret-login'

--- a/test/auth/payload-types.ts
+++ b/test/auth/payload-types.ts
@@ -62,15 +62,15 @@ export type SupportedTimezones =
   | 'Pacific/Fiji';
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "LexicalNodes_BCC912DC".
+ * via the `definition` "LexicalNodes_087E2F44".
  */
-export type LexicalNodes_BCC912DC =
+export type LexicalNodes_087E2F44 =
   | SerializedTextNode
   | SerializedTabNode
   | SerializedLineBreakNode
-  | SerializedParagraphNode<LexicalNodes_BCC912DC>
+  | SerializedParagraphNode<LexicalNodes_087E2F44>
   | SerializedBlockNode<MyBlock>
-  | SerializedHeadingNode<LexicalNodes_BCC912DC>
+  | SerializedHeadingNode<LexicalNodes_087E2F44>
   | {
       type: 'upload';
       /**
@@ -79,17 +79,21 @@ export type LexicalNodes_BCC912DC =
       version: number;
       [k: string]: unknown;
     }
-  | SerializedQuoteNode<LexicalNodes_BCC912DC>
-  | SerializedListNode<LexicalNodes_BCC912DC>
-  | SerializedListItemNode<LexicalNodes_BCC912DC>
-  | SerializedAutoLinkNode<LexicalNodes_BCC912DC, LexicalLinkFields_0A7E9EC0>
-  | SerializedLinkNode<LexicalNodes_BCC912DC, LexicalLinkFields_0A7E9EC0>
+  | SerializedQuoteNode<LexicalNodes_087E2F44>
+  | SerializedListNode<LexicalNodes_087E2F44>
+  | SerializedListItemNode<LexicalNodes_087E2F44>
+  | SerializedAutoLinkNode<LexicalNodes_087E2F44, LexicalLinkFields_0A7E9EC0>
+  | SerializedLinkNode<LexicalNodes_087E2F44, LexicalLinkFields_0A7E9EC0>
   | SerializedRelationshipNode<
       | 'users'
       | 'partial-disable-local-strategies'
       | 'disable-local-strategy-password'
       | 'api-keys'
       | 'public-users'
+      | 'open-update-auth'
+      | 'rotate-secret'
+      | 'rotate-secret-secondary'
+      | 'rotate-secret-login'
       | 'relationsCollection'
       | 'api-keys-with-field-read-access'
       | 'payload-kv'
@@ -105,6 +109,10 @@ export interface Config {
     'disable-local-strategy-password': DisableLocalStrategyPasswordAuthOperations;
     'api-keys': ApiKeyAuthOperations;
     'public-users': PublicUserAuthOperations;
+    'open-update-auth': OpenUpdateAuthAuthOperations;
+    'rotate-secret': RotateSecretAuthOperations;
+    'rotate-secret-secondary': RotateSecretSecondaryAuthOperations;
+    'rotate-secret-login': RotateSecretLoginAuthOperations;
     'api-keys-with-field-read-access': ApiKeysWithFieldReadAccessAuthOperations;
   };
   blocks: {};
@@ -114,6 +122,10 @@ export interface Config {
     'disable-local-strategy-password': DisableLocalStrategyPassword;
     'api-keys': ApiKey;
     'public-users': PublicUser;
+    'open-update-auth': OpenUpdateAuth;
+    'rotate-secret': RotateSecret;
+    'rotate-secret-secondary': RotateSecretSecondary;
+    'rotate-secret-login': RotateSecretLogin;
     relationsCollection: RelationsCollection;
     'api-keys-with-field-read-access': ApiKeysWithFieldReadAccess;
     'payload-kv': PayloadKv;
@@ -128,6 +140,10 @@ export interface Config {
     'disable-local-strategy-password': DisableLocalStrategyPasswordSelect<false> | DisableLocalStrategyPasswordSelect<true>;
     'api-keys': ApiKeysSelect<false> | ApiKeysSelect<true>;
     'public-users': PublicUsersSelect<false> | PublicUsersSelect<true>;
+    'open-update-auth': OpenUpdateAuthSelect<false> | OpenUpdateAuthSelect<true>;
+    'rotate-secret': RotateSecretSelect<false> | RotateSecretSelect<true>;
+    'rotate-secret-secondary': RotateSecretSecondarySelect<false> | RotateSecretSecondarySelect<true>;
+    'rotate-secret-login': RotateSecretLoginSelect<false> | RotateSecretLoginSelect<true>;
     relationsCollection: RelationsCollectionSelect<false> | RelationsCollectionSelect<true>;
     'api-keys-with-field-read-access': ApiKeysWithFieldReadAccessSelect<false> | ApiKeysWithFieldReadAccessSelect<true>;
     'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
@@ -153,6 +169,10 @@ export interface Config {
     | DisableLocalStrategyPassword
     | ApiKey
     | PublicUser
+    | OpenUpdateAuth
+    | RotateSecret
+    | RotateSecretSecondary
+    | RotateSecretLogin
     | ApiKeysWithFieldReadAccess;
   jobs: {
     tasks: unknown;
@@ -249,6 +269,78 @@ export interface PublicUserAuthOperations {
     password: string;
   };
 }
+export interface OpenUpdateAuthAuthOperations {
+  forgotPassword: {
+    email: string;
+    password: string;
+  };
+  login: {
+    email: string;
+    password: string;
+  };
+  registerFirstUser: {
+    email: string;
+    password: string;
+  };
+  unlock: {
+    email: string;
+    password: string;
+  };
+}
+export interface RotateSecretAuthOperations {
+  forgotPassword: {
+    email: string;
+    password: string;
+  };
+  login: {
+    email: string;
+    password: string;
+  };
+  registerFirstUser: {
+    email: string;
+    password: string;
+  };
+  unlock: {
+    email: string;
+    password: string;
+  };
+}
+export interface RotateSecretSecondaryAuthOperations {
+  forgotPassword: {
+    email: string;
+    password: string;
+  };
+  login: {
+    email: string;
+    password: string;
+  };
+  registerFirstUser: {
+    email: string;
+    password: string;
+  };
+  unlock: {
+    email: string;
+    password: string;
+  };
+}
+export interface RotateSecretLoginAuthOperations {
+  forgotPassword: {
+    email: string;
+    password: string;
+  };
+  login: {
+    email: string;
+    password: string;
+  };
+  registerFirstUser: {
+    email: string;
+    password: string;
+  };
+  unlock: {
+    email: string;
+    password: string;
+  };
+}
 export interface ApiKeysWithFieldReadAccessAuthOperations {
   forgotPassword: {
     email: string;
@@ -282,7 +374,7 @@ export interface User {
       }[]
     | null;
   namedSaveToJWT?: string | null;
-  richText?: LexicalRichText<LexicalNodes_BCC912DC> | null;
+  richText?: LexicalRichText<LexicalNodes_087E2F44> | null;
   group?: {
     liftedSaveToJWT?: string | null;
   };
@@ -401,6 +493,86 @@ export interface PublicUser {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "open-update-auth".
+ */
+export interface OpenUpdateAuth {
+  id: string;
+  note?: string | null;
+  updatedAt: string;
+  createdAt: string;
+  email: string;
+  resetPasswordToken?: string | null;
+  resetPasswordExpiration?: string | null;
+  salt?: string | null;
+  hash?: string | null;
+  loginAttempts?: number | null;
+  lockUntil?: string | null;
+  sessions?:
+    | {
+        id: string;
+        createdAt?: string | null;
+        expiresAt: string;
+      }[]
+    | null;
+  password?: string | null;
+  collection: 'open-update-auth';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "rotate-secret".
+ */
+export interface RotateSecret {
+  id: string;
+  updatedAt: string;
+  createdAt: string;
+  enableAPIKey?: boolean | null;
+  apiKey?: string | null;
+  apiKeyIndex?: string | null;
+  collection: 'rotate-secret';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "rotate-secret-secondary".
+ */
+export interface RotateSecretSecondary {
+  id: string;
+  updatedAt: string;
+  createdAt: string;
+  enableAPIKey?: boolean | null;
+  apiKey?: string | null;
+  apiKeyIndex?: string | null;
+  collection: 'rotate-secret-secondary';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "rotate-secret-login".
+ */
+export interface RotateSecretLogin {
+  id: string;
+  updatedAt: string;
+  createdAt: string;
+  enableAPIKey?: boolean | null;
+  apiKey?: string | null;
+  apiKeyIndex?: string | null;
+  email: string;
+  resetPasswordToken?: string | null;
+  resetPasswordExpiration?: string | null;
+  salt?: string | null;
+  hash?: string | null;
+  loginAttempts?: number | null;
+  lockUntil?: string | null;
+  sessions?:
+    | {
+        id: string;
+        createdAt?: string | null;
+        expiresAt: string;
+      }[]
+    | null;
+  password?: string | null;
+  collection: 'rotate-secret-login';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "relationsCollection".
  */
 export interface RelationsCollection {
@@ -468,6 +640,22 @@ export interface PayloadLockedDocument {
         value: string | PublicUser;
       } | null)
     | ({
+        relationTo: 'open-update-auth';
+        value: string | OpenUpdateAuth;
+      } | null)
+    | ({
+        relationTo: 'rotate-secret';
+        value: string | RotateSecret;
+      } | null)
+    | ({
+        relationTo: 'rotate-secret-secondary';
+        value: string | RotateSecretSecondary;
+      } | null)
+    | ({
+        relationTo: 'rotate-secret-login';
+        value: string | RotateSecretLogin;
+      } | null)
+    | ({
         relationTo: 'relationsCollection';
         value: string | RelationsCollection;
       } | null)
@@ -496,6 +684,22 @@ export interface PayloadLockedDocument {
     | {
         relationTo: 'public-users';
         value: string | PublicUser;
+      }
+    | {
+        relationTo: 'open-update-auth';
+        value: string | OpenUpdateAuth;
+      }
+    | {
+        relationTo: 'rotate-secret';
+        value: string | RotateSecret;
+      }
+    | {
+        relationTo: 'rotate-secret-secondary';
+        value: string | RotateSecretSecondary;
+      }
+    | {
+        relationTo: 'rotate-secret-login';
+        value: string | RotateSecretLogin;
       }
     | {
         relationTo: 'api-keys-with-field-read-access';
@@ -530,6 +734,22 @@ export interface PayloadPreference {
     | {
         relationTo: 'public-users';
         value: string | PublicUser;
+      }
+    | {
+        relationTo: 'open-update-auth';
+        value: string | OpenUpdateAuth;
+      }
+    | {
+        relationTo: 'rotate-secret';
+        value: string | RotateSecret;
+      }
+    | {
+        relationTo: 'rotate-secret-secondary';
+        value: string | RotateSecretSecondary;
+      }
+    | {
+        relationTo: 'rotate-secret-login';
+        value: string | RotateSecretLogin;
       }
     | {
         relationTo: 'api-keys-with-field-read-access';
@@ -688,6 +908,76 @@ export interface PublicUsersSelect<T extends boolean = true> {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "open-update-auth_select".
+ */
+export interface OpenUpdateAuthSelect<T extends boolean = true> {
+  note?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  email?: T;
+  resetPasswordToken?: T;
+  resetPasswordExpiration?: T;
+  salt?: T;
+  hash?: T;
+  loginAttempts?: T;
+  lockUntil?: T;
+  sessions?:
+    | T
+    | {
+        id?: T;
+        createdAt?: T;
+        expiresAt?: T;
+      };
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "rotate-secret_select".
+ */
+export interface RotateSecretSelect<T extends boolean = true> {
+  updatedAt?: T;
+  createdAt?: T;
+  enableAPIKey?: T;
+  apiKey?: T;
+  apiKeyIndex?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "rotate-secret-secondary_select".
+ */
+export interface RotateSecretSecondarySelect<T extends boolean = true> {
+  updatedAt?: T;
+  createdAt?: T;
+  enableAPIKey?: T;
+  apiKey?: T;
+  apiKeyIndex?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "rotate-secret-login_select".
+ */
+export interface RotateSecretLoginSelect<T extends boolean = true> {
+  updatedAt?: T;
+  createdAt?: T;
+  enableAPIKey?: T;
+  apiKey?: T;
+  apiKeyIndex?: T;
+  email?: T;
+  resetPasswordToken?: T;
+  resetPasswordExpiration?: T;
+  salt?: T;
+  hash?: T;
+  loginAttempts?: T;
+  lockUntil?: T;
+  sessions?:
+    | T
+    | {
+        id?: T;
+        createdAt?: T;
+        expiresAt?: T;
+      };
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "relationsCollection_select".
  */
 export interface RelationsCollectionSelect<T extends boolean = true> {
@@ -770,6 +1060,10 @@ export interface CollectionQueryWidget {
       | 'disable-local-strategy-password'
       | 'api-keys'
       | 'public-users'
+      | 'open-update-auth'
+      | 'rotate-secret'
+      | 'rotate-secret-secondary'
+      | 'rotate-secret-login'
       | 'relationsCollection'
       | 'api-keys-with-field-read-access';
     where?:
@@ -800,6 +1094,10 @@ export interface ActivityWidget {
           | 'disable-local-strategy-password'
           | 'api-keys'
           | 'public-users'
+          | 'open-update-auth'
+          | 'rotate-secret'
+          | 'rotate-secret-secondary'
+          | 'rotate-secret-login'
           | 'relationsCollection'
           | 'api-keys-with-field-read-access'
         )[]

--- a/test/auth/payload-types.ts
+++ b/test/auth/payload-types.ts
@@ -62,15 +62,15 @@ export type SupportedTimezones =
   | 'Pacific/Fiji';
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "LexicalNodes_064459F7".
+ * via the `definition` "LexicalNodes_7849057D".
  */
-export type LexicalNodes_064459F7 =
+export type LexicalNodes_7849057D =
   | SerializedTextNode
   | SerializedTabNode
   | SerializedLineBreakNode
-  | SerializedParagraphNode<LexicalNodes_064459F7>
+  | SerializedParagraphNode<LexicalNodes_7849057D>
   | SerializedBlockNode<MyBlock>
-  | SerializedHeadingNode<LexicalNodes_064459F7>
+  | SerializedHeadingNode<LexicalNodes_7849057D>
   | {
       type: 'upload';
       /**
@@ -79,11 +79,11 @@ export type LexicalNodes_064459F7 =
       version: number;
       [k: string]: unknown;
     }
-  | SerializedQuoteNode<LexicalNodes_064459F7>
-  | SerializedListNode<LexicalNodes_064459F7>
-  | SerializedListItemNode<LexicalNodes_064459F7>
-  | SerializedAutoLinkNode<LexicalNodes_064459F7, LexicalLinkFields_0A7E9EC0>
-  | SerializedLinkNode<LexicalNodes_064459F7, LexicalLinkFields_0A7E9EC0>
+  | SerializedQuoteNode<LexicalNodes_7849057D>
+  | SerializedListNode<LexicalNodes_7849057D>
+  | SerializedListItemNode<LexicalNodes_7849057D>
+  | SerializedAutoLinkNode<LexicalNodes_7849057D, LexicalLinkFields_0A7E9EC0>
+  | SerializedLinkNode<LexicalNodes_7849057D, LexicalLinkFields_0A7E9EC0>
   | SerializedRelationshipNode<
       | 'users'
       | 'partial-disable-local-strategies'
@@ -93,6 +93,7 @@ export type LexicalNodes_064459F7 =
       | 'open-update-auth'
       | 'collision-auth-a'
       | 'collision-auth-b'
+      | 'default-access-fixture'
       | 'rotate-secret'
       | 'rotate-secret-secondary'
       | 'rotate-secret-login'
@@ -129,6 +130,7 @@ export interface Config {
     'open-update-auth': OpenUpdateAuth;
     'collision-auth-a': CollisionAuthA;
     'collision-auth-b': CollisionAuthB;
+    'default-access-fixture': DefaultAccessFixture;
     'rotate-secret': RotateSecret;
     'rotate-secret-secondary': RotateSecretSecondary;
     'rotate-secret-login': RotateSecretLogin;
@@ -149,6 +151,7 @@ export interface Config {
     'open-update-auth': OpenUpdateAuthSelect<false> | OpenUpdateAuthSelect<true>;
     'collision-auth-a': CollisionAuthASelect<false> | CollisionAuthASelect<true>;
     'collision-auth-b': CollisionAuthBSelect<false> | CollisionAuthBSelect<true>;
+    'default-access-fixture': DefaultAccessFixtureSelect<false> | DefaultAccessFixtureSelect<true>;
     'rotate-secret': RotateSecretSelect<false> | RotateSecretSelect<true>;
     'rotate-secret-secondary': RotateSecretSecondarySelect<false> | RotateSecretSecondarySelect<true>;
     'rotate-secret-login': RotateSecretLoginSelect<false> | RotateSecretLoginSelect<true>;
@@ -420,7 +423,7 @@ export interface User {
       }[]
     | null;
   namedSaveToJWT?: string | null;
-  richText?: LexicalRichText<LexicalNodes_064459F7> | null;
+  richText?: LexicalRichText<LexicalNodes_7849057D> | null;
   group?: {
     liftedSaveToJWT?: string | null;
   };
@@ -617,6 +620,16 @@ export interface CollisionAuthB {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "default-access-fixture".
+ */
+export interface DefaultAccessFixture {
+  id: string;
+  title?: string | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "rotate-secret".
  */
 export interface RotateSecret {
@@ -748,6 +761,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'collision-auth-b';
         value: number | CollisionAuthB;
+      } | null)
+    | ({
+        relationTo: 'default-access-fixture';
+        value: string | DefaultAccessFixture;
       } | null)
     | ({
         relationTo: 'rotate-secret';
@@ -1101,6 +1118,15 @@ export interface CollisionAuthBSelect<T extends boolean = true> {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "default-access-fixture_select".
+ */
+export interface DefaultAccessFixtureSelect<T extends boolean = true> {
+  title?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "rotate-secret_select".
  */
 export interface RotateSecretSelect<T extends boolean = true> {
@@ -1233,6 +1259,7 @@ export interface CollectionQueryWidget {
       | 'open-update-auth'
       | 'collision-auth-a'
       | 'collision-auth-b'
+      | 'default-access-fixture'
       | 'rotate-secret'
       | 'rotate-secret-secondary'
       | 'rotate-secret-login'
@@ -1269,6 +1296,7 @@ export interface ActivityWidget {
           | 'open-update-auth'
           | 'collision-auth-a'
           | 'collision-auth-b'
+          | 'default-access-fixture'
           | 'rotate-secret'
           | 'rotate-secret-secondary'
           | 'rotate-secret-login'

--- a/test/auth/shared.ts
+++ b/test/auth/shared.ts
@@ -8,6 +8,8 @@ export const collisionAuthASlug = 'collision-auth-a'
 
 export const collisionAuthBSlug = 'collision-auth-b'
 
+export const defaultAccessFixtureSlug = 'default-access-fixture'
+
 export const apiKeysSlug = 'api-keys'
 
 export const rotateSecretSlug = 'rotate-secret'

--- a/test/auth/shared.ts
+++ b/test/auth/shared.ts
@@ -4,6 +4,10 @@ export const publicUsersSlug = 'public-users'
 
 export const openUpdateAuthSlug = 'open-update-auth'
 
+export const collisionAuthASlug = 'collision-auth-a'
+
+export const collisionAuthBSlug = 'collision-auth-b'
+
 export const apiKeysSlug = 'api-keys'
 
 export const rotateSecretSlug = 'rotate-secret'

--- a/test/auth/shared.ts
+++ b/test/auth/shared.ts
@@ -2,6 +2,8 @@ export const slug = 'users'
 
 export const publicUsersSlug = 'public-users'
 
+export const openUpdateAuthSlug = 'open-update-auth'
+
 export const apiKeysSlug = 'api-keys'
 
 export const rotateSecretSlug = 'rotate-secret'


### PR DESCRIPTION
## Summary
- Adds `defaultAuthAccess` that constrains `update`/`delete`/`unlock` on auth-enabled collections to `{ id: { equals: req.user.id } }` when `req.user.collection` matches the target collection slug, and denies otherwise.
- Rewires `addDefaultsToCollectionConfig` to use `defaultAuthAccess` for `update`/`delete`/`unlock` when `collection.auth` is truthy. `read`, `create`, `readVersions`, and `admin` continue to use `defaultAccess`. Non-auth collections are untouched.
- Documents the new default behavior in `docs/access-control/collections.mdx` under Update, Delete, and Unlock.

## BREAKING CHANGE
On auth-enabled collections, the default `update`, `delete`, and `unlock` access is now self-only. Apps that relied on any authenticated admin-collection user being able to modify other users must add an explicit `access.update` (and/or `delete`, `unlock`) function to restore prior behavior. Example:

```ts
access: {
  update: ({ req }) => Boolean(req.user), // or a role-aware equivalent
}
```

The built-in `unlock` endpoint is effectively disabled by default and now requires an explicit `access.unlock` for admin-to-user unlock flows.

Cross-collection safety: an authenticated user in auth collection A can no longer update/delete/unlock docs in a different auth collection B, even if IDs collide (a real risk on Postgres where serial IDs are shared across collections).

## Test plan
- [x] `pnpm run test:int auth` — 104 pass (includes 7 new default-access tests)
- [x] `pnpm run test:int access-control` — 41 pass
- [x] `pnpm run test:int custom-strategy` — 1 pass
- [x] `pnpm run build:core` — pass
- [ ] Manual: `pnpm run dev auth`, log in as one user, attempt to update another via the admin UI — expect 403/not-found; self-update expected to succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)