### PR TITLE
test: deflake trash breadcrumb collapse e2e

### DIFF
--- a/test/trash/e2e.spec.ts
+++ b/test/trash/e2e.spec.ts
@@ -626,7 +626,11 @@ describe('Trash', () => {
       test('Should collapse breadcrumbs into a popup menu when they do not fit the available width', async ({
         page,
       }) => {
-        await page.setViewportSize({ width: 400, height: 800 })
+        // 320px (not 400px) puts the breadcrumbs unambiguously past the available
+        // width. At 400px the expanded breadcrumbs measure within ~1px of the
+        // available space, making the collapse decision a coin-flip in slower CI
+        // environments (e.g. tanstack-start).
+        await page.setViewportSize({ width: 320, height: 800 })
         await page.goto(postsUrl.trashEdit(trashedPostDocOne.id))
 
         const collapsedToggle = page.locator('.step-nav__collapsed-toggle')


### PR DESCRIPTION
## What / Why

`test/trash/e2e.spec.ts` → **"Should collapse breadcrumbs into a popup menu when they do not fit the available width"** is flaky on the `trash [tanstack-start]` CI variant (fails all retries in some runs, passes in others; passes reliably on `next`). Seen on [PR #17806](https://github.com/payloadcms/payload/pull/17806/checks) and [run 31884980215](https://github.com/payloadcms/payload/actions/runs/31884980215), and confirmed intermittent on recent `main` runs too.

## Root cause

The test used a **400px** viewport. At 400px the expanded breadcrumbs (`Dashboard / Posts / Trash / Trashed Post`) measure **~298px** against **~298px** of available space — within 1px. `StepNav`'s overflow check is `needed - available > 1`, so at that exact-fit boundary the collapse decision is effectively a coin-flip:

| Viewport | available | needed | collapses |
| --- | --- | --- | --- |
| **400px** | **298** | **298** | **no ← flaky knife-edge** |
| 360px | 213 | 298 | yes |
| 320px | 213 | 298 | yes |
| 280px | 196 | 298 | yes |

Because the `.app-header__step-nav-wrapper` shrink-wraps to the breadcrumb content, both the collapsed and expanded states are self-stable, so once a run lands "expanded" at the boundary it stays expanded and the toggle never renders. Slower environments (tanstack-start) land on the wrong side of the boundary more often. Reproduced deterministically locally by rendering wide (expanded) then resizing to 400px.

## Fix

Move the test viewport to **320px** (a standard small-mobile width), where the breadcrumbs are unambiguously past the available width (~213px available vs ~298px needed). This makes the collapse deterministic without touching the shared `StepNav` component.

## Verification

- 15/15 consecutive local runs of the target test pass.
- All 7 `-g "breadcrumb"` tests in the trash suite pass.

## Note

The knife-edge is a symptom of a latent measurement quirk in `StepNav`: `available` is read from a container that shrink-wraps to the breadcrumb content, so the measure is content-dependent rather than a stable available-width reference. That only manifests at an exact-fit width and is benign for users (the breadcrumbs genuinely fit), so it's intentionally out of scope here — flagging for the UI team.

🤖 Generated with [Claude Code](https://claude.com/claude-code)