### PR TITLE
docs(fields.mdx): fix slugifyTitle example issues

### DIFF
--- a/docs/hooks/fields.mdx
+++ b/docs/hooks/fields.mdx
@@ -287,15 +287,14 @@ const slugifyTitle: PostTitleHook = ({
 
   // Generate slug from title if not provided
   if (!siblingData.slug && value) {
-    const slug = value
+    return value
+      .trim()
+      .replace(/ /g, '-')
+      .replace(/[^\w-]+/g, '')
       .toLowerCase()
-      .replace(/[^\w\s-]/g, '')
-      .replace(/\s+/g, '-')
-
-    return slug
   }
 
-  return value
+  return value ?? ''
 }
 
 // Hook for a relationship field


### PR DESCRIPTION
Removed a redundant `const` on return slug and added a fallback empty string to satisfy `value` type.

<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

## Which branch should this PR target?

- **`main`** — Payload v4 development. New features, enhancements, and v4 bug fixes go here.
- **`3.x`** — Payload v3 maintenance. Bug fixes only. **New features are not accepted against v3.** If this PR adds a feature to v3, please retarget it at `main` (v4) instead.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
