### PR TITLE
fix(ui): render named group child fields when permissions.fields is empty (Closes #17812)

### DIFF
--- a/packages/ui/src/fields/Group/index.tsx
+++ b/packages/ui/src/fields/Group/index.tsx
@@ -29,6 +29,7 @@ export const GroupFieldComponent: GroupFieldClientComponent = (props) => {
   const {
     field,
     field: { admin: { className, description, hideGutter } = {}, fields, label },
+    forceRender,
     indexPath,
     parentPath,
     parentSchemaPath,
@@ -111,11 +112,18 @@ export const GroupFieldComponent: GroupFieldClientComponent = (props) => {
           {groupHasName(field) ? (
             <RenderFields
               fields={fields}
+              forceRender={forceRender}
               margins="small"
               parentIndexPath=""
               parentPath={path}
               parentSchemaPath={schemaPath}
-              permissions={permissions === true ? permissions : permissions?.fields}
+              permissions={
+                permissions === true
+                  ? permissions
+                  : Object.keys(permissions?.fields ?? {}).length > 0
+                    ? permissions.fields
+                    : permissions
+              }
               readOnly={readOnly}
             />
           ) : (


### PR DESCRIPTION
## Description

When a named `group` field renders its children, it passes `permissions?.fields` to the inner `RenderFields` component. If `permissions.fields` is empty or missing (e.g., when `/api/access` returns an empty fields object), the inner `RenderFields` receives `undefined` or `{}` as permissions. This causes `getFieldPermissions` to return `read: false` for all child fields, which are then filtered out by `RenderFields` — producing an empty `.render-fields` container.

**Root cause**: `GroupField` was the only container component that didn't fall back to the parent permissions object when `permissions.fields` was empty. Other containers (`Row`, `Tabs`, `Collapsible`) pass `permissions` directly, which includes `read: true` and allows child fields to render.

## Changes

1. **Permissions fallback**: When `permissions.fields` is empty or missing, fall back to the group's own permissions object instead of passing `undefined`. This aligns with how `Blocks` (BlockRow) handles the same scenario.

2. **forceRender propagation**: Added `forceRender` to the props destructure and passed it to the inner `RenderFields`. This was already done by `Row` and `Tabs` but was missing in `GroupField`.

## How to reproduce

See the minimal reproduction in the issue. Without this fix, named `group` fields render an empty `RenderFields` container — the header is visible but all child fields are missing.

Closes #17812