### PR TITLE
fix(ui): render named group child fields when permissions.fields is empty (Closes #17812)

### DIFF
--- a/packages/ui/src/fields/Group/index.tsx
+++ b/packages/ui/src/fields/Group/index.tsx
@@ -29,6 +29,7 @@ export const GroupFieldComponent: GroupFieldClientComponent = (props) => {
   const {
     field,
     field: { admin: { className, description, hideGutter } = {}, fields, label },
+    forceRender,
     indexPath,
     parentPath,
     parentSchemaPath,
@@ -111,10 +112,17 @@ export const GroupFieldComponent: GroupFieldClientComponent = (props) => {
           {groupHasName(field) ? (
             <RenderFields
               fields={fields}
+              forceRender={forceRender}
               parentIndexPath=""
               parentPath={path}
               parentSchemaPath={schemaPath}
-              permissions={permissions === true ? permissions : permissions?.fields}
+              permissions={
+                permissions === true
+                  ? permissions
+                  : Object.keys(permissions?.fields ?? {}).length > 0
+                    ? permissions.fields
+                    : permissions
+              }
               readOnly={readOnly}
             />
           ) : (


### PR DESCRIPTION
Same fix as #17813 but for the `main` branch.

## Description

When a named `group` field renders its children, it passes `permissions?.fields` to the inner `RenderFields` component. If `permissions.fields` is empty or missing, the inner `RenderFields` receives `undefined` or `{}` as permissions, causing `getFieldPermissions` to return `read: false` for all child fields — producing an empty `.render-fields` container.

## Changes

1. **Permissions fallback**: When `permissions.fields` is empty or missing, fall back to the group's own permissions object.
2. **forceRender propagation**: Added missing `forceRender` prop to the inner `RenderFields`.

Closes #17812