### PR TITLE
ci: gate mongodb test healthcheck on a writable primary

### DIFF
--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -94,6 +94,12 @@ services:
       - ./__helpers/shared/db/mongodb/keyfile:/etc/mongodb/keyfile:ro
       - ./__helpers/shared/db/mongodb/docker-compose-entrypoint.sh:/docker-compose-entrypoint.sh:ro
     entrypoint: ['/bin/bash', '/docker-compose-entrypoint.sh']
+    # Gate on a writable PRIMARY, not just `ping`. `ping` succeeds as soon as mongod
+    # accepts connections — including during the replica-set election gap after the
+    # entrypoint's auth restart — so `up -d --wait` (and compose `service_healthy`)
+    # would report ready while transactions are still rejected with "Only servers in a
+    # sharded cluster can start a new transaction". `quit(1)` on a non-primary keeps the
+    # container unhealthy until an election completes.
     healthcheck:
       test:
         [
@@ -106,7 +112,7 @@ services:
           '--authenticationDatabase',
           'admin',
           '--eval',
-          "db.adminCommand('ping')",
+          'db.hello().isWritablePrimary || quit(1)',
         ]
       interval: 2s
       timeout: 5s


### PR DESCRIPTION
## Problem

Intermittent e2e failures across suites (most visibly on the slower `tanstack-start` variant) with this root error:

```
MongoServerError: Only servers in a sharded cluster can start a new transaction
  at the active transaction number
```

It cascades: the transaction aborts → the write (e.g. autosave) fails → the Server Components render throws → the page never renders → follow-on assertions fail with "Test ended" / "element not found". Seen recently on [run 31960129016](https://github.com/payloadcms/payload/actions/runs/31960129016/job/95197400154) (`versions [tanstack-start]`), earlier on `localization [tanstack-start]`, and confirmed **pre-existing on `main`** (the exact error string appears 6–18× per run across several recent main tanstack-start jobs).

## Root cause

The `mongodb` test service (`test/docker-compose.yml`) is a single-member replica set (`rs0`) initialized by a custom entrypoint whose final step restarts `mongod` with auth. Its healthcheck ran `db.adminCommand('ping')`, which succeeds the instant mongod accepts connections — **including during the replica-set election gap right after that auth restart**, before a writable PRIMARY exists.

CI starts the service with `docker compose … --profile mongodb up -d --wait` (`.github/actions/start-services/action.yml`). `--wait` only blocks until the container is `healthy`, so it returned during the election gap and tests began issuing transactions against a node that couldn't start them.

## Fix

Gate the healthcheck on a writable primary instead of a bare ping:

```yaml
--eval  'db.hello().isWritablePrimary || quit(1)'
```

`quit(1)` keeps the container unhealthy (and `--wait` blocking) until an election completes. One-line change plus an explanatory comment; no application or test-code changes.

## Verification (local, Docker)

- Exit-code semantics: PRIMARY → `true`, exit 0 (healthy); non-primary → `quit(1)`, exit 1 (unhealthy).
- Fresh first-run (`down -v` then `up -d --wait`): `--wait` returned Healthy in ~12s, and at that moment `rs.status().myState === 1` (PRIMARY) and `db.hello().isWritablePrimary === true`.
- A start→commit **transaction succeeded immediately** after `--wait` returned — the exact operation that was being rejected in CI.

## Notes

- Local reproduction of the *failure* is timing-dependent (the election gap rarely opens on fast machines); best confirmed by rerunning the previously-flaky tanstack-start e2e jobs (`versions`, `localization`) and checking that the `Only servers in a sharded cluster…` error count drops to 0.
- The `directConnection=true&replicaSet=rs0` connection string and the internal `mongodb:27017` RS member host are left as-is; they weren't the trigger and changing them is riskier. Flagging for follow-up if the flake persists.
- Separate from the breadcrumb deflake in #17810.

🤖 Generated with [Claude Code](https://claude.com/claude-code)