### PR TITLE
docs: document GraphQL select option for field projection

### DIFF
--- a/docs/graphql/overview.mdx
+++ b/docs/graphql/overview.mdx
@@ -117,6 +117,26 @@ User [preferences](../admin/preferences) for the [Admin Panel](../admin/overview
 | `updatePreference` | `update`  |
 | `deletePreference` | `delete`  |
 
+## Select
+
+Collection and global GraphQL queries accept an optional boolean `select` argument. When `select` is `true`, Payload maps your GraphQL selection set to the [Select API](../queries/select) and only queries those fields from the database. This can significantly reduce database load and response size for large documents.
+
+```graphql
+query {
+  Posts(select: true) {
+    docs {
+      id
+      title
+      slug
+    }
+  }
+}
+```
+
+Without `select: true`, GraphQL clients still receive only the fields they request, but Payload may still load the full document from the database. Enable `select` when you want database-level field projection.
+
+To learn more, including how this interacts with hooks and access control, see the [Select documentation](../queries/select#graphql-api).
+
 ## GraphQL Playground
 
 GraphQL Playground is enabled by default for development purposes, but disabled in production. You can enable it in production by passing `graphQL.disablePlaygroundInProduction` a `false` setting in the main Payload Config.

--- a/docs/performance/overview.mdx
+++ b/docs/performance/overview.mdx
@@ -32,6 +32,8 @@ There are several ways to optimize your [Queries](../queries/overview). Many of 
 
 When building queries, combine as many of these options together as possible. This will ensure your queries are as efficient as they can be.
 
+A particularly effective option is the [Select API](../queries/select), which limits which fields are loaded from the database. Use it with the Local and REST APIs via a field map, or pass `select: true` on GraphQL queries so Payload projects only the fields in your selection set.
+
 To learn more, see the [Query Performance](../queries/overview#performance) docs.
 
 ### Optimizing your APIs

--- a/docs/queries/select.mdx
+++ b/docs/queries/select.mdx
@@ -155,6 +155,55 @@ const getPosts = async () => {
   the `/api/globals` endpoint.
 </Banner>
 
+## GraphQL API
+
+In the [GraphQL API](../graphql/overview), `select` is a **boolean** argument on collection and global queries (including version queries). When set to `true`, Payload builds a [Select](./select) projection from your GraphQL selection set and only loads those fields from the database.
+
+Unlike the Local and REST APIs, you do not pass a field map. The fields you request in the GraphQL query become the select projection:
+
+```graphql
+query {
+  # highlight-start
+  Posts(select: true) {
+  # highlight-end
+    docs {
+      id
+      text
+      group {
+        number
+      }
+    }
+  }
+}
+```
+
+The same argument works on singular document queries and globals:
+
+```graphql
+query {
+  Post(id: "123", select: true) {
+    id
+    text
+  }
+}
+
+query {
+  Header(select: true) {
+    title
+  }
+}
+```
+
+Without `select: true`, GraphQL still returns only the fields in your selection set over the wire, but Payload may load the full document from the database. Passing `select: true` applies the Select API at the database level for better performance.
+
+<Banner type="warning">
+  **Important:** Because `select` is applied on the database level, your
+  `beforeRead` and `afterRead` hooks may not receive the full `doc`. To ensure
+  that some fields are always selected for your hooks / access control, use the
+  [entity-level `select`](#entity-level-select-config) function on your
+  Collection or Global config.
+</Banner>
+
 ## defaultPopulate collection config property
 
 The `defaultPopulate` property allows you specify which fields to select when populating the collection from another document.


### PR DESCRIPTION
## Description

Documents the GraphQL `select` boolean argument introduced in #13711 so users know how to enable database-level field projection from GraphQL queries.

- Add a Select section to the GraphQL overview with an example
- Add a GraphQL API section to the Select docs explaining that `select: true` derives the projection from the selection set
- Mention Select (including GraphQL `select: true`) on the Performance overview under querying guidance

Fixes #14465

## Testing

- [x] Docs match GraphQL resolver behavior (`select?: boolean` + selection-set projection)
- [x] Examples align with existing Local/REST Select docs and GraphQL tests