### PR TITLE
refactor(payload): pass literal operation to buildBeforeOperation

### DIFF
--- a/packages/payload/src/collections/operations/deleteByID.ts
+++ b/packages/payload/src/collections/operations/deleteByID.ts
@@ -55,7 +55,7 @@ export const deleteByIDOperation = async <TSlug extends CollectionSlug, TSelect 
     args = await buildBeforeOperation({
       args,
       collection: args.collection.config,
-      operation: 'delete',
+      operation: 'deleteByID',
       overrideAccess: args.overrideAccess!,
     })
 

--- a/packages/payload/src/collections/operations/find.ts
+++ b/packages/payload/src/collections/operations/find.ts
@@ -74,7 +74,7 @@ export const findOperation = async <
     args = await buildBeforeOperation({
       args,
       collection: args.collection.config,
-      operation: 'read',
+      operation: 'find',
       overrideAccess: args.overrideAccess!,
     })
 

--- a/packages/payload/src/collections/operations/findByID.ts
+++ b/packages/payload/src/collections/operations/findByID.ts
@@ -72,7 +72,7 @@ export const findByIDOperation = async <
     args = await buildBeforeOperation({
       args,
       collection: args.collection.config,
-      operation: 'read',
+      operation: 'findByID',
       overrideAccess: args.overrideAccess!,
     })
 

--- a/packages/payload/src/collections/operations/findDistinct.ts
+++ b/packages/payload/src/collections/operations/findDistinct.ts
@@ -49,7 +49,7 @@ export const findDistinctOperation = async (
     args = await buildBeforeOperation({
       args,
       collection: args.collection.config,
-      operation: 'readDistinct',
+      operation: 'findDistinct',
       overrideAccess: args.overrideAccess!,
     })
 

--- a/packages/payload/src/collections/operations/updateByID.ts
+++ b/packages/payload/src/collections/operations/updateByID.ts
@@ -72,7 +72,7 @@ export const updateByIDOperation = async <
     args = await buildBeforeOperation({
       args,
       collection: args.collection.config,
-      operation: 'update',
+      operation: 'updateByID',
       overrideAccess: args.overrideAccess!,
     })
 

--- a/packages/payload/src/collections/operations/utilities/buildBeforeOperation.ts
+++ b/packages/payload/src/collections/operations/utilities/buildBeforeOperation.ts
@@ -1,80 +1,19 @@
 import type { CollectionSlug } from '../../../index.js'
-import type { BeforeOperationArg, OperationArgs, OperationMap } from './types.js'
+import type { BeforeOperationArg, OperationMap } from './types.js'
 
 import { operationToHookOperation } from './types.js'
-// Specific overloads with TArgs (these take priority over the general overload)
-// Overload for 'read' operation (deprecated, backward compatibility)
 
 /**
- * TODO V4: remove overloads and operations should be the literal operation that was called
- *
- * - `read`: replace with `find` and `findByID` in both operations
- * - `delete`: replace with `deleteByID` in deleteByID operation
- * - `update`: replace with `updateByID` in updateByID operation
- */
-
-/**
- * @deprecated
- *
- * Should use `find` or `findByID`
+ * Runs a collection's `beforeOperation` hooks. `operation` is the literal operation
+ * that was called (e.g. `find`, `findByID`, `findDistinct`, `deleteByID`, `updateByID`).
+ * The args are returned with the same type that was passed in.
  */
 export async function buildBeforeOperation<TOperationGeneric extends CollectionSlug, TArgs>(
   operationArgs: {
     args: TArgs
-    operation: 'read'
+    operation: keyof OperationMap<TOperationGeneric>
   } & Omit<BeforeOperationArg<TOperationGeneric>, 'args' | 'context' | 'operation' | 'req'>,
 ): Promise<TArgs>
-
-/**
- * Overload for 'readDistinct' operation
- *
- * @deprecated - use `findDistinct`
- */
-export async function buildBeforeOperation<TOperationGeneric extends CollectionSlug, TArgs>(
-  operationArgs: {
-    args: TArgs
-    operation: 'readDistinct'
-  } & Omit<BeforeOperationArg<TOperationGeneric>, 'args' | 'context' | 'operation' | 'req'>,
-): Promise<TArgs>
-
-// Overload for 'update' operation (can be called by both update and updateByID)
-export async function buildBeforeOperation<TOperationGeneric extends CollectionSlug, TArgs>(
-  operationArgs: {
-    args: TArgs
-    operation: 'update'
-  } & Omit<BeforeOperationArg<TOperationGeneric>, 'args' | 'context' | 'operation' | 'req'>,
-): Promise<TArgs>
-
-// Overload for 'updateByID' operation
-export async function buildBeforeOperation<TOperationGeneric extends CollectionSlug, TArgs>(
-  operationArgs: {
-    args: TArgs
-    operation: 'updateByID'
-  } & Omit<BeforeOperationArg<TOperationGeneric>, 'args' | 'context' | 'operation' | 'req'>,
-): Promise<TArgs>
-
-export async function buildBeforeOperation<TOperationGeneric extends CollectionSlug, TArgs>(
-  operationArgs: {
-    args: TArgs
-    operation: 'delete'
-  } & Omit<BeforeOperationArg<TOperationGeneric>, 'args' | 'context' | 'operation' | 'req'>,
-): Promise<TArgs>
-
-// Overload for 'deleteByID' operation
-export async function buildBeforeOperation<TOperationGeneric extends CollectionSlug, TArgs>(
-  operationArgs: {
-    args: TArgs
-    operation: 'deleteByID'
-  } & Omit<BeforeOperationArg<TOperationGeneric>, 'args' | 'context' | 'operation' | 'req'>,
-): Promise<TArgs>
-
-// General overload for operations that exist in OperationMap (fallback)
-export async function buildBeforeOperation<
-  TOperationGeneric extends CollectionSlug,
-  O extends keyof OperationMap<TOperationGeneric>,
->(
-  operationArgs: { operation: O } & Omit<BeforeOperationArg<TOperationGeneric>, 'context' | 'req'>,
-): Promise<OperationArgs<TOperationGeneric, O>>
 
 // Implementation
 export async function buildBeforeOperation<TOperationGeneric extends CollectionSlug>(


### PR DESCRIPTION
## What / Why

Resolves the `buildBeforeOperation.ts` TODO to _"remove overloads and operations should be the literal operation that was called"_ — the non-controversial slice of the v4 `beforeOperation` cleanup.

The `find`, `findByID`, `findDistinct`, `deleteByID`, and `updateByID` operations now pass their **literal** operation name to `buildBeforeOperation` instead of coarse aliases (`'read'`, `'readDistinct'`, `'delete'`, `'update'`). With every caller now passing a literal op, the six deprecated per-operation overloads collapse into a single generic passthrough overload.

## Behavior is unchanged

`operationToHookOperation` still maps the internal op to the public hook operation, so user `beforeOperation` hooks continue to receive `'read'`, `'readDistinct'`, `'delete'`, and `'update'` — matching the promise in `docs/migration-guide/v4.mdx` ("The `operation: 'read'` value on the `beforeOperation` hook is unchanged.") and the existing integration tests.

## Deferred follow-up

The remaining TODOs change what value `beforeOperation` hooks receive (a breaking change) and are tracked, with a full checklist, in [PYLD-2687](https://linear.app/figma/issue/PYLD-2687/collection-operations).

## Verification

- `pnpm build:types` (payload `tsc`): 0 errors
- `pnpm test:int hooks -t beforeOperation`: 13 passed (hook still receives `'read'`/`'readDistinct'`/`'delete'`/`'update'`)
- ESLint on changed files: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
