### PR TITLE
refactor: remove strictDraftTypes flag, make strict draft types the default

### DIFF
--- a/packages/payload/src/auth/operations/registerFirstUser.ts
+++ b/packages/payload/src/auth/operations/registerFirstUser.ts
@@ -4,7 +4,7 @@ import type {
   DataFromCollectionSlug,
   RequiredDataFromCollectionSlug,
 } from '../../collections/config/types.js'
-import type { AuthCollectionSlug } from '../../index.js'
+import type { AuthCollectionSlug, CollectionSlug } from '../../index.js'
 import type { PayloadRequest, SelectType } from '../../types/index.js'
 
 import { Forbidden } from '../../errors/index.js'
@@ -78,9 +78,12 @@ export const registerFirstUserOperation = async <TSlug extends AuthCollectionSlu
     // Register first user
     // /////////////////////////////////////
 
-    const result = await payload.create<TSlug, SelectType>({
-      collection: slug as TSlug,
-      data,
+    // Widened to `CollectionSlug` so the strict `Options` conditional in `create` resolves
+    // to its wide-slug branch. A naked TSlug generic keeps the conditional deferred and
+    // TypeScript can't route this call to a specific branch.
+    const result = await payload.create<CollectionSlug, SelectType>({
+      collection: slug,
+      data: data as RequiredDataFromCollectionSlug<CollectionSlug>,
       overrideAccess: true,
       req,
     })

--- a/packages/payload/src/collections/config/types.ts
+++ b/packages/payload/src/collections/config/types.ts
@@ -93,31 +93,30 @@ export type CollectionsWithoutDrafts = {
 }[CollectionSlug]
 
 /**
- * Conditionally allows or forbids the `draft` property based on collection configuration.
- * When `strictDraftTypes` is enabled, the `draft` property is forbidden on collections without drafts.
+ * Allows or forbids the `draft` property based on collection configuration.
+ * The `draft` property is forbidden on collections without drafts.
+ *
+ * The conditional lives inside the object so the return shape is always `{ draft?: X }`.
+ * That keeps `Pick<FindOptions, 'select'>` and other indexed accesses stable when
+ * `FindOptions` is composed via intersection with this helper.
+ *
+ * The `CollectionSlug extends TSlug` check catches the wide/generic case where TSlug is the
+ * full slug union (internal calls) and returns `boolean` so those calls don't get locked
+ * out. A narrowed TSlug distributes through the second branch and gets `never` when it
+ * lacks drafts.
  */
-export type DraftFlagFromCollectionSlug<TSlug extends CollectionSlug> = GeneratedTypes extends {
-  strictDraftTypes: true
+export type DraftFlagFromCollectionSlug<TSlug extends CollectionSlug> = {
+  /**
+   * Whether the document(s) should be queried from the versions table/collection or not. [More](https://payloadcms.com/docs/versions/drafts#draft-api)
+   *
+   * Typed as `never` when the collection has no drafts, so passing `draft` fails at compile time.
+   */
+  draft?: CollectionSlug extends TSlug
+    ? boolean
+    : [TSlug] extends [CollectionsWithoutDrafts]
+      ? never
+      : boolean
 }
-  ? TSlug extends CollectionsWithoutDrafts
-    ? {
-        /**
-         * The `draft` property is not allowed because this collection does not have `versions.drafts` enabled.
-         */
-        draft?: never
-      }
-    : {
-        /**
-         * Whether the document(s) should be queried from the versions table/collection or not. [More](https://payloadcms.com/docs/versions/drafts#draft-api)
-         */
-        draft?: boolean
-      }
-  : {
-      /**
-       * Whether the document(s) should be queried from the versions table/collection or not. [More](https://payloadcms.com/docs/versions/drafts#draft-api)
-       */
-      draft?: boolean
-    }
 
 export type AuthOperationsFromCollectionSlug<TSlug extends CollectionSlug> =
   TypedAuthOperations[TSlug]

--- a/packages/payload/src/collections/operations/local/create.ts
+++ b/packages/payload/src/collections/operations/local/create.ts
@@ -19,7 +19,6 @@ import {
   type CollectionSlug,
   deepCopyObjectSimple,
   type FindOptions,
-  type GeneratedTypes,
   type Payload,
   type RequestContext,
   type TypedLocale,
@@ -114,73 +113,50 @@ type BaseOptions<TSlug extends CollectionSlug, TSelect extends SelectType> = {
 export type Options<
   TSlug extends CollectionSlug,
   TSelect extends SelectType,
-> = GeneratedTypes extends { strictDraftTypes: true }
-  ? CollectionsWithoutDrafts extends TSlug
+> = CollectionSlug extends TSlug
+  ? {
+      /**
+       * The data for the document to create.
+       */
+      data: RequiredDataFromCollectionSlug<TSlug>
+      /**
+       * Create a **draft** document. [More](https://payloadcms.com/docs/versions/drafts#draft-api)
+       */
+      draft?: boolean
+    } & BaseOptions<TSlug, TSelect>
+  : TSlug extends CollectionsWithoutDrafts
     ? {
+        data: RequiredDataFromCollectionSlug<TSlug>
         /**
-         * The data for the document to create.
+         * The `draft` property is not allowed because this collection does not have `versions.drafts` enabled.
          */
-        data: DataFromCollectionSlug<TSlug>
-        /**
-         * Create a **draft** document. [More](https://payloadcms.com/docs/versions/drafts#draft-api)
-         */
-        draft?: boolean
+        draft?: never
       } & BaseOptions<TSlug, TSelect>
-    : TSlug extends CollectionsWithoutDrafts
-      ? {
-          data: RequiredDataFromCollectionSlug<TSlug>
-          /**
-           * The `draft` property is not allowed because this collection does not have `versions.drafts` enabled.
-           */
-          draft?: never
-        } & BaseOptions<TSlug, TSelect>
-      : (
-          | {
-              /**
-               * The data for the document to create.
-               */
-              data: RequiredDataFromCollectionSlug<TSlug>
-              /**
-               * Create a **draft** document. [More](https://payloadcms.com/docs/versions/drafts#draft-api)
-               * Omit this property or set to `false` to create a published document.
-               */
-              draft?: false
-            }
-          | {
-              /**
-               * The data for the document to create.
-               * When creating a draft, required fields are optional as validation is skipped by default.
-               */
-              data: DraftDataFromCollectionSlug<TSlug>
-              /**
-               * Create a **draft** document. [More](https://payloadcms.com/docs/versions/drafts#draft-api)
-               */
-              draft: true
-            }
-        ) &
-          BaseOptions<TSlug, TSelect>
-  :
-      | ({
-          /**
-           * The data for the document to create.
-           */
-          data: RequiredDataFromCollectionSlug<TSlug>
-          /**
-           * Create a **draft** document. [More](https://payloadcms.com/docs/versions/drafts#draft-api)
-           */
-          draft?: false
-        } & BaseOptions<TSlug, TSelect>)
-      | ({
-          /**
-           * The data for the document to create.
-           * When creating a draft, required fields are optional as validation is skipped by default.
-           */
-          data: DraftDataFromCollectionSlug<TSlug>
-          /**
-           * Create a **draft** document. [More](https://payloadcms.com/docs/versions/drafts#draft-api)
-           */
-          draft: true
-        } & BaseOptions<TSlug, TSelect>)
+    : (
+        | {
+            /**
+             * The data for the document to create.
+             */
+            data: RequiredDataFromCollectionSlug<TSlug>
+            /**
+             * Create a **draft** document. [More](https://payloadcms.com/docs/versions/drafts#draft-api)
+             * Omit this property or set to `false` to create a published document.
+             */
+            draft?: false
+          }
+        | {
+            /**
+             * The data for the document to create.
+             * When creating a draft, required fields are optional as validation is skipped by default.
+             */
+            data: DraftDataFromCollectionSlug<TSlug>
+            /**
+             * Create a **draft** document. [More](https://payloadcms.com/docs/versions/drafts#draft-api)
+             */
+            draft: true
+          }
+      ) &
+        BaseOptions<TSlug, TSelect>
 
 export async function createLocal<
   TSlug extends CollectionSlug,

--- a/packages/payload/src/collections/operations/local/find.ts
+++ b/packages/payload/src/collections/operations/local/find.ts
@@ -3,7 +3,6 @@ import type {
   CollectionSlug,
   JoinQuery,
   Payload,
-  PayloadTypes,
   RequestContext,
   TypedFallbackLocale,
   TypedLocale,
@@ -197,9 +196,7 @@ export async function findLocal<
 ): Promise<
   PaginatedDocs<
     TDraft extends true
-      ? PayloadTypes extends { strictDraftTypes: true }
-        ? DraftTransformCollectionWithSelect<TSlug, TSelect>
-        : TransformCollectionWithSelect<TSlug, TSelect>
+      ? DraftTransformCollectionWithSelect<TSlug, TSelect>
       : TransformCollectionWithSelect<TSlug, TSelect>
   >
 > {

--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -1340,16 +1340,6 @@ type RootTypeScriptConfig = {
       jsonSchema: JSONSchema4
     }) => JSONSchema4
   >
-
-  /**
-   * Enable strict type safety for draft operations. When enabled, the `draft` parameter is forbidden
-   * on collections without drafts, and query results with `draft: true` type required fields as optional.
-   * This prevents invalid draft usage at compile time and ensures type correctness across all Local API operations.
-   *
-   * @default false
-   * @todo Remove in v4. Strict draft types will become the default behavior.
-   */
-  strictDraftTypes?: boolean
 }
 
 /**

--- a/packages/payload/src/globals/config/types.ts
+++ b/packages/payload/src/globals/config/types.ts
@@ -46,31 +46,25 @@ export type GlobalsWithoutDrafts = {
 }[GlobalSlug]
 
 /**
- * Conditionally allows or forbids the `draft` property based on global configuration.
- * When `strictDraftTypes` is enabled, the `draft` property is forbidden on globals without drafts.
+ * Allows or forbids the `draft` property based on global configuration.
+ * The `draft` property is forbidden on globals without drafts.
+ *
+ * The conditional lives inside the object so the return shape is always `{ draft?: X }`.
+ * That keeps `Pick<FindOptions, 'select'>` and other indexed accesses stable when
+ * intersected with this helper.
  */
-export type DraftFlagFromGlobalSlug<TSlug extends GlobalSlug> = GeneratedTypes extends {
-  strictDraftTypes: true
+export type DraftFlagFromGlobalSlug<TSlug extends GlobalSlug> = {
+  /**
+   * Whether the global should be queried from the versions table/collection or not. [More](https://payloadcms.com/docs/versions/drafts#draft-api)
+   *
+   * Typed as `never` when the global has no drafts, so passing `draft` fails at compile time.
+   */
+  draft?: GlobalSlug extends TSlug
+    ? boolean
+    : [TSlug] extends [GlobalsWithoutDrafts]
+      ? never
+      : boolean
 }
-  ? TSlug extends GlobalsWithoutDrafts
-    ? {
-        /**
-         * The `draft` property is not allowed because this global does not have `versions.drafts` enabled.
-         */
-        draft?: never
-      }
-    : {
-        /**
-         * Whether the global should be queried from the versions table/collection or not. [More](https://payloadcms.com/docs/versions/drafts#draft-api)
-         */
-        draft?: boolean
-      }
-  : {
-      /**
-       * Whether the global should be queried from the versions table/collection or not. [More](https://payloadcms.com/docs/versions/drafts#draft-api)
-       */
-      draft?: boolean
-    }
 
 export type BeforeValidateHook = (args: {
   context: RequestContext

--- a/packages/payload/src/index.ts
+++ b/packages/payload/src/index.ts
@@ -594,9 +594,7 @@ export class BasePayload {
   ): Promise<
     PaginatedDocs<
       TDraft extends true
-        ? PayloadTypes extends { strictDraftTypes: true }
-          ? DraftTransformCollectionWithSelect<TSlug, TSelect>
-          : TransformCollectionWithSelect<TSlug, TSelect>
+        ? DraftTransformCollectionWithSelect<TSlug, TSelect>
         : TransformCollectionWithSelect<TSlug, TSelect>
     >
   > => {

--- a/packages/payload/src/utilities/configToJSONSchema.ts
+++ b/packages/payload/src/utilities/configToJSONSchema.ts
@@ -1664,14 +1664,6 @@ export function configToJSONSchema(
             globalsInput: generateEntityInputSchemas(config.globals || []),
           }
         : {}),
-      ...(config.typescript?.strictDraftTypes
-        ? {
-            strictDraftTypes: {
-              type: 'boolean',
-              const: true,
-            },
-          }
-        : {}),
       user: generateAuthEntitySchemas(config.collections),
     },
     required: [
@@ -1683,7 +1675,6 @@ export function configToJSONSchema(
       'collectionsJoins',
       'globalsSelect',
       ...(generateInputTypes ? ['collectionsInput', 'globalsInput'] : []),
-      ...(config.typescript?.strictDraftTypes ? ['strictDraftTypes'] : []),
       'globals',
       'auth',
       'db',

--- a/test/types/config.ts
+++ b/test/types/config.ts
@@ -213,7 +213,10 @@ export default buildConfigWithDefaults({
               RelationshipFeature(),
               BlocksFeature({
                 blocks: [
-                  { slug: 'cta', fields: [{ name: 'link', type: 'relationship', relationTo: 'pages' }] },
+                  {
+                    slug: 'cta',
+                    fields: [{ name: 'link', type: 'relationship', relationTo: 'pages' }],
+                  },
                 ],
               }),
             ],
@@ -277,7 +280,6 @@ export default buildConfigWithDefaults({
   typescript: {
     generateInputTypes: true,
     outputFile: path.resolve(dirname, 'payload-types.ts'),
-    strictDraftTypes: true,
     postProcess: [
       ({ compiledTypes }) => {
         const genericType = `export type TestPluginGeneric<T> = { value: T };`

--- a/test/types/payload-types.ts
+++ b/test/types/payload-types.ts
@@ -276,7 +276,6 @@ export interface Config {
     menu: MenuInput;
     settings: SettingInput;
   };
-  strictDraftTypes: true;
   user: FallbackUser | User;
   jobs: {
     tasks: unknown;

--- a/test/types/types.spec.ts
+++ b/test/types/types.spec.ts
@@ -1495,9 +1495,9 @@ describe('Types testing', () => {
     })
   })
 
-  describe('strictDraftTypes flag', () => {
+  describe('strict draft types', () => {
     describe('query operations', () => {
-      test('draft find query returns optional required fields when flag is enabled', async () => {
+      test('draft find query returns optional required fields', async () => {
         const result = await payload.find({
           collection: 'draft-posts',
           draft: true,
@@ -1505,7 +1505,7 @@ describe('Types testing', () => {
 
         const doc = result.docs[0]!
 
-        // With strictDraftTypes enabled, user-defined required fields should be optional in draft queries
+        // User-defined required fields should be optional in draft queries
         expect(doc.description).type.toBe<string | undefined>()
         expect(doc.title).type.toBe<string | undefined>()
 


### PR DESCRIPTION
## Summary

- Removes the `typescript.strictDraftTypes` config option; strict draft typing is now always on (completes the v4 TODO on `packages/payload/src/config/types.ts`).
- `draft` is now `never` on collections and globals without drafts, and draft-mode `find`/`findByID` results type required user fields as optional.
- Internal call in `registerFirstUser` widens its slug to `CollectionSlug` since the strict `Options` conditional stays deferred for a naked generic `TSlug` and can't be routed by TS to a specific branch.

## Test plan

- [x] `pnpm --filter payload build` succeeds
- [x] `pnpm run build` (all 45 core packages) succeeds
- [x] `pnpm run test:types` — 212/212 pass across all 9 tstyche projects (`types`, `untyped`, `queues`, `database`, `lexical`, `plugin-mcp`, `image-size-options/*`, `storage-r2`)
- [ ] CI e2e / integration