### PR TITLE
fix(db-postgres): release the client checked out during connect

### DIFF
--- a/packages/db-postgres/src/connect.ts
+++ b/packages/db-postgres/src/connect.ts
@@ -43,6 +43,12 @@ const connectWithReconnect = async function ({
       // swallow error
     }
   })
+
+  // The client was only checked out to verify connectivity and to attach the
+  // listener above, both of which outlive the checkout. Holding on to it pins one
+  // connection for the lifetime of the pool, so `pool.end()` can never drain -
+  // including after `payload.destroy()`.
+  result.release()
 }
 
 export const connect: Connect = async function connect(

--- a/test/database/int.spec.ts
+++ b/test/database/int.spec.ts
@@ -90,6 +90,27 @@ describe('database', () => {
     await payload.destroy()
   })
 
+  describe(
+    'connection pool',
+    { db: (adapter) => adapter.startsWith('postgres') || adapter === 'supabase' },
+    () => {
+      it('should not leave a client checked out after connecting', async () => {
+        const { pool } = payload.db as unknown as PostgresAdapter
+
+        // Awaiting a query guarantees the pool has been used and that nothing is
+        // in flight while the counts below are read.
+        await payload.count({ collection: 'simple' })
+
+        expect(pool.totalCount).toBeGreaterThan(0)
+
+        // `connect` acquires a client to verify connectivity and to listen for
+        // ECONNRESET. Failing to release it pins that client for the lifetime of
+        // the process, so `pool.end()` never drains after `payload.destroy()`.
+        expect(pool.totalCount - pool.idleCount).toBe(0)
+      })
+    },
+  )
+
   describe('id type', () => {
     it('should sanitize incoming IDs if ID type is number', async () => {
       const created = await restClient


### PR DESCRIPTION
### What?

`@payloadcms/db-postgres` checks out one client from the pool during `connect` and never releases it. This releases it, and adds a regression test asserting the pool has no checked-out clients after connecting.

### Why?

`connectWithReconnect` acquires a client, attaches an `error` listener to it, and returns without calling `release()`:

```ts
// packages/db-postgres/src/connect.ts
result = await pool.connect()
...
result.prependListener('error', (err) => { /* reconnect on ECONNRESET */ })
// returns here — the client is never released
```

A checked-out client is never handed back to the pool, so it is pinned for the lifetime of the process. Two consequences:

1. **`pool.end()` never drains.** It waits for every checked-out client to come back, so it hangs. The reporter of #15674 measured exactly this — one client outstanding before _and_ after `payload.destroy()`, then a `pool.end()` timeout:

   ```text
   after-init            { idle: 8, total: 9, waiting: 0 }
   after-payload-destroy { idle: 8, total: 9, waiting: 0 }
   pool.end timeout      { elapsedMs: 3006, timeoutMs: 3000 }
   ```

2. **One connection is permanently unavailable** for queries, on the primary pool and on every read-replica pool, since `connect` runs `connectWithReconnect` for each of them.

This also matters for `payload jobs:run`, where `payload.destroy()` is called specifically to "close database connections after running jobs so process can exit cleanly" (`packages/payload/src/bin/index.ts`).

**Why not end the pool in `destroy` instead?** That was my first thought, and it is wrong. `reload()` in `packages/payload/src/index.ts` calls `payload.db.destroy()` on every hot reload and then reconnects, and `connect` guards its pool creation with `if (!this.pool)` — so the pool is deliberately reused across hot reloads. Ending it in `destroy` would leave dev with a pool that has been shut down. The leak is in the checkout, so that is where it is fixed.

`await pool.connect()` itself is load-bearing and stays: `connect` relies on the error it throws to detect a missing database and branch into `createDatabase()`. Only the checkout is released; the `error` listener stays attached to the client instance, so the ECONNRESET reconnect path is unchanged.

### How?

One `result.release()` after the listener is attached, plus a test in `test/database/int.spec.ts` asserting `pool.totalCount - pool.idleCount === 0` once the adapter is connected — scoped to the adapters that use `pg.Pool`.

Verified against the Postgres suite (`pnpm test:int:postgres database`):

- Without the fix, the new test fails with `expected 1 to be +0` — one client outstanding, matching the reported measurement exactly.
- With the fix it passes, and the full suite is green: **200 passed, 36 skipped**.

Fixes #15674
Fixes #11727
