### PR TITLE
fix(ui): show locale badge on localized group field labels (#17639)

### DIFF
--- a/packages/ui/src/fields/Group/index.tsx
+++ b/packages/ui/src/fields/Group/index.tsx
@@ -90,7 +90,7 @@ export const GroupFieldComponent: GroupFieldClientComponent = (props) => {
                         <FieldLabel
                           as="span"
                           label={getTranslation(label, i18n)}
-                          localized={false}
+                          localized={groupHasName(field) ? Boolean(field.localized) : false}
                           path={path}
                           required={false}
                         />

--- a/test/fields/collections/Group/e2e.spec.ts
+++ b/test/fields/collections/Group/e2e.spec.ts
@@ -134,6 +134,26 @@ describe('Group', () => {
     })
   })
 
+  describe('Localized', () => {
+    test('should show locale badge on localized group field label', async () => {
+      await page.goto(url.create)
+
+      const localizedGroupLabel = page.locator(
+        '#field-localizedGroup .group-field__title .localized',
+      )
+
+      await expect(localizedGroupLabel).toBeVisible()
+    })
+
+    test('should not show locale badge on non-localized group field label', async () => {
+      await page.goto(url.create)
+
+      const groupLabel = page.locator('#field-group .group-field__title .localized')
+
+      await expect(groupLabel).toBeHidden()
+    })
+  })
+
   describe.skip('A11y', () => {
     test.fixme('Edit view should have no accessibility violations', async ({}, testInfo) => {
       await page.goto(url.create)


### PR DESCRIPTION
Fixes #17639

## Summary

When a `group` field is `localized`, the admin panel edit view did not show the locale badge next to the group's label — unlike other localized field types (text, select, relationship, etc.) which all render the badge via `FieldLabel`.

Root cause: `GroupFieldComponent` hardcoded `localized={false}` when rendering its `FieldLabel`, regardless of the group field's actual `localized` config.

## Change

`packages/ui/src/fields/Group/index.tsx`: pass the group field's actual localized state to `FieldLabel` (only named groups can be localized, per the `GroupField`/`UnnamedGroupField` types, so this is gated with `groupHasName`).

```diff
-  localized={false}
+  localized={groupHasName(field) ? Boolean(field.localized) : false}
```

## Test plan

Added two Playwright e2e tests in `test/fields/collections/Group/e2e.spec.ts` (the test fixture collection already includes a `localizedGroup` field and a plain non-localized `group` field):

- `should show locale badge on localized group field label` — asserts the `.localized` badge is visible on the localized group's label
- `should not show locale badge on non-localized group field label` — asserts it stays hidden on a non-localized group's label

Note: I was unable to run the e2e suite locally due to disk space exhaustion in my sandbox environment (a shared host at ~100% disk usage from unrelated concurrent work) — `pnpm install` could not complete. The change itself is a one-line, narrowly-scoped fix mirroring the exact pattern already used by every other localized field type, and the added tests follow this directory's existing conventions. Please let CI confirm; happy to iterate on review feedback.