### PR TITLE
fix(ui): prevent render loop during rapid title input

### DIFF
--- a/packages/ui/src/views/Edit/SetDocumentTitle/index.tsx
+++ b/packages/ui/src/views/Edit/SetDocumentTitle/index.tsx
@@ -43,7 +43,12 @@ export const SetDocumentTitle: React.FC<{
       return
     }
 
-    setDocumentTitle(title)
+    // Coalesce rapid field changes before updating the title and step navigation contexts.
+    const animationFrame = requestAnimationFrame(() => {
+      setDocumentTitle(title)
+    })
+
+    return () => cancelAnimationFrame(animationFrame)
   }, [setDocumentTitle, title])
 
   return null

--- a/test/admin/e2e/list-view/e2e.spec.ts
+++ b/test/admin/e2e/list-view/e2e.spec.ts
@@ -2222,6 +2222,7 @@ describe('List View', () => {
       })
 
       await page.goto(formatDocURLUrl.list)
+      await expect(page).toHaveURL(/depth=1&limit=10/)
 
       const selectButton = page.locator('button:has-text("Select format doc")')
       await selectButton.waitFor({ state: 'visible' })

--- a/test/form-state/e2e.spec.ts
+++ b/test/form-state/e2e.spec.ts
@@ -9,14 +9,6 @@ import { fileURLToPath } from 'url'
 import type { PayloadTestSDK } from '../__helpers/shared/sdk/index.js'
 import type { Config, Post } from './payload-types.js'
 
-import {
-  ensureCompilationIsDone,
-  initPageConsoleErrorCatch,
-  saveDocAndAssert,
-  throttleTest,
-  waitForFormReady,
-} from '../__helpers/e2e/helpers.js'
-import { AdminUrlUtil } from '../__helpers/shared/adminUrlUtil.js'
 import { assertElementStaysVisible } from '../__helpers/e2e/assertElementStaysVisible.js'
 import { assertNetworkRequests } from '../__helpers/e2e/assertNetworkRequests.js'
 import { assertRequestBody } from '../__helpers/e2e/assertRequestBody.js'
@@ -27,7 +19,15 @@ import {
   removeArrayRow,
 } from '../__helpers/e2e/fields/array/index.js'
 import { addBlock } from '../__helpers/e2e/fields/blocks/index.js'
+import {
+  ensureCompilationIsDone,
+  initPageConsoleErrorCatch,
+  saveDocAndAssert,
+  throttleTest,
+  waitForFormReady,
+} from '../__helpers/e2e/helpers.js'
 import { waitForAutoSaveToRunAndComplete } from '../__helpers/e2e/waitForAutoSaveToRunAndComplete.js'
+import { AdminUrlUtil } from '../__helpers/shared/adminUrlUtil.js'
 import { initPayloadE2ENoConfig } from '../__helpers/shared/initPayloadE2ENoConfig.js'
 import { TEST_TIMEOUT, TEST_TIMEOUT_LONG } from '../playwright.config.js'
 import { autosavePostsSlug } from './collections/Autosave/index.js'
@@ -267,6 +267,33 @@ test.describe('Form State', () => {
     ).toHaveValue('2')
 
     await page.unroute(postsUrl.create)
+  })
+
+  test('should update the document title after a burst of input events', async () => {
+    const updatedTitle = '[검증용] PR #242 E2E 확인 — 곧 삭제됩니다'
+
+    await page.goto(postsUrl.create)
+    await waitForFormReady(page)
+
+    const titleField = page.locator('#field-title')
+
+    await titleField.evaluate((field: HTMLInputElement, value) => {
+      const setValue = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set
+
+      for (let index = 1; index <= value.length; index++) {
+        setValue?.call(field, value.slice(0, index))
+        field.dispatchEvent(
+          new InputEvent('input', {
+            bubbles: true,
+            data: value[index - 1],
+            inputType: 'insertText',
+          }),
+        )
+      }
+    }, updatedTitle)
+
+    await expect(titleField).toHaveValue(updatedTitle)
+    await expect(page.locator('.doc-header__title')).toHaveText(updatedTitle)
   })
 
   // TODO: This test is not very reliable but would be really nice to have


### PR DESCRIPTION
## What?

- Coalesce rapid `useAsTitle` field changes before updating the document title context.
- Add an end-to-end regression that dispatches a dense burst of input events and verifies both the complete field value and the rendered document header title.

https://github.com/user-attachments/assets/c51f77ae-bf76-45cb-8d52-a4f761a8a3ce

## Why?

Rapid title changes currently cascade through `SetDocumentTitle`, `DocumentTitleProvider`, and `SetDocumentStepNav`. A sufficiently dense burst exhausts React's nested update limit and crashes the edit view with "Maximum update depth exceeded."

The regression fails against the original implementation and passes when title propagation is limited to the latest value per animation frame. Live title and breadcrumb updates are preserved.

Fixes #17243.

## How?

`SetDocumentTitle` now schedules its context update with `requestAnimationFrame`. Effect cleanup cancels the previous frame, so multiple field changes in the same frame produce one title update using the latest value.

## Testing

- `pnpm run build:ui`
- `pnpm run test:e2e form-state --grep 'should update the document title after a burst' --workers 1`
- Full `form-state` E2E suite: 17 passed, 4 skipped; one existing throttled test timed out and passed on immediate isolated rerun.
- Verified the new regression fails with the original uncoalesced effect and passes with this change.