### PR TITLE
refactor(ui)!: update useLocale to return null

### DIFF
--- a/docs/admin/react-hooks.mdx
+++ b/docs/admin/react-hooks.mdx
@@ -928,7 +928,7 @@ const MyComponent: React.FC = () => {
 
 ## useLocale
 
-In any Custom Component you can get the selected locale object with the `useLocale` hook. `useLocale` gives you the full locale object, consisting of a `label`, `rtl`(right-to-left) property, and then `code`. Here is a simple example:
+In any Custom Component you can get the selected locale object with the `useLocale` hook. `useLocale` gives you the full locale object, consisting of a `label`, `rtl` (right-to-left) property, and `code`. It returns `null` when localization is disabled or configured without any locales. Here is a simple example:
 
 ```tsx
 'use client'
@@ -938,6 +938,10 @@ const Greeting: React.FC = () => {
   // highlight-start
   const locale = useLocale()
   // highlight-end
+
+  if (!locale) {
+    return null
+  }
 
   const trans = {
     en: 'Hello',

--- a/docs/custom-components/overview.mdx
+++ b/docs/custom-components/overview.mdx
@@ -460,7 +460,7 @@ export default async function MyServerComponent({ payload, locale }) {
 }
 ```
 
-The best way to do this within a Client Component is to import the `useLocale` hook from `@payloadcms/ui`:
+The best way to do this within a Client Component is to import the `useLocale` hook from `@payloadcms/ui`. The hook returns `null` when localization is disabled or configured without any locales:
 
 ```tsx
 'use client'
@@ -469,6 +469,10 @@ import { useLocale } from '@payloadcms/ui'
 
 function Greeting() {
   const locale = useLocale() // highlight-line
+
+  if (!locale) {
+    return null
+  }
 
   const trans = {
     en: 'Hello',

--- a/docs/migration-guide/v4.mdx
+++ b/docs/migration-guide/v4.mdx
@@ -481,6 +481,36 @@ If you only used `useDocumentInfo` for `title` / `setDocumentTitle`, drop the im
 
 Run `npx @payloadcms/codemod --transform migrate-document-title-context` to migrate automatically. The codemod splits mixed destructures, removes the `useDocumentInfo` import when no other properties are still used, and preserves any rename aliases (e.g. `{ title: docTitle }`).
 
+### `useLocale` returns `null` without an active locale
+
+The return type of `useLocale` is now `Locale | null`. It returns `null` when localization is disabled or configured without any locales. In Payload 3, the hook was typed as `Locale` and returned an empty object when localization was unavailable.
+
+Custom Client Components that read locale properties directly must handle the nullable value:
+
+```diff
+'use client'
+import { useLocale } from '@payloadcms/ui'
+
+const Greeting: React.FC = () => {
+-  const { code } = useLocale()
++  const locale = useLocale()
++
++  if (!locale) {
++    return null
++  }
++
++  const { code } = locale
+
+  return <span>{code}</span>
+}
+```
+
+When a missing locale is already valid for the receiving API, optional chaining is sufficient:
+
+```ts
+const locale = useLocale()?.code
+```
+
 ### RichText adapter `i18n` property removed
 
 The `i18n` property on `RichTextAdapter` (and its return type from adapter provider functions) has been removed. It was deprecated in v3 in favour of merging translations directly into `config.i18n.translations` inside the adapter provider.

--- a/packages/plugin-form-builder/src/collections/Forms/DynamicPriceSelector.tsx
+++ b/packages/plugin-form-builder/src/collections/Forms/DynamicPriceSelector.tsx
@@ -47,7 +47,7 @@ export const DynamicPriceSelector: TextFieldClientComponent = (props) => {
     return <TextField {...props} />
   }
 
-  const localeCode = typeof locale === 'object' && 'code' in locale ? locale.code : locale
+  const localeCode = locale?.code ?? 'en'
 
   const localLabels = typeof field.label === 'object' ? field.label : { [localeCode]: field.label }
 

--- a/packages/plugin-search/src/Search/ui/ReindexButton/index.client.tsx
+++ b/packages/plugin-search/src/Search/ui/ReindexButton/index.client.tsx
@@ -33,7 +33,7 @@ export const ReindexButtonClient: React.FC<ReindexButtonProps> = ({
     i18n: { t },
   } = useTranslation()
 
-  const locale = useLocale()
+  const localeCode = useLocale()?.code
   const router = useRouter()
 
   const [reindexCollections, setReindexCollections] = useState<string[]>([])
@@ -49,7 +49,7 @@ export const ReindexButtonClient: React.FC<ReindexButtonProps> = ({
       const res = await fetch(
         formatAdminURL({
           apiRoute: config.routes.api,
-          path: `/${searchSlug}/reindex?locale=${locale.code}`,
+          path: `/${searchSlug}/reindex${localeCode ? `?locale=${localeCode}` : ''}`,
         }),
         {
           body: JSON.stringify({
@@ -72,7 +72,7 @@ export const ReindexButtonClient: React.FC<ReindexButtonProps> = ({
     } finally {
       setReindexCollections([])
     }
-  }, [reindexCollections, router, searchSlug, locale, config])
+  }, [reindexCollections, router, searchSlug, localeCode, config])
 
   const handleShowConfirmModal = useCallback(
     (collections: string | string[] = searchCollections) => {
@@ -96,10 +96,10 @@ export const ReindexButtonClient: React.FC<ReindexButtonProps> = ({
       if (typeof label === 'string') {
         return label
       } else {
-        return label && Object.hasOwn(label, locale.code) ? label[locale.code] : slug
+        return label && localeCode && Object.hasOwn(label, localeCode) ? label[localeCode] : slug
       }
     },
-    [collectionLabels, locale.code],
+    [collectionLabels, localeCode],
   )
 
   const pluralizedLabels = useMemo(() => {

--- a/packages/plugin-search/src/Search/ui/ReindexButton/index.client.tsx
+++ b/packages/plugin-search/src/Search/ui/ReindexButton/index.client.tsx
@@ -33,7 +33,8 @@ export const ReindexButtonClient: React.FC<ReindexButtonProps> = ({
     i18n: { t },
   } = useTranslation()
 
-  const localeCode = useLocale()?.code
+  const locale = useLocale()
+  const localeCode = locale?.code
   const router = useRouter()
 
   const [reindexCollections, setReindexCollections] = useState<string[]>([])

--- a/packages/plugin-seo/src/fields/MetaDescription/MetaDescriptionComponent.tsx
+++ b/packages/plugin-seo/src/fields/MetaDescription/MetaDescriptionComponent.tsx
@@ -89,7 +89,7 @@ export const MetaDescriptionComponent: React.FC<MetaDescriptionProps> = (props) 
         hasSavePermission: docInfo.hasSavePermission,
         initialData: docInfo.initialData,
         initialState: reduceToSerializableFields(docInfo.initialState ?? {}),
-        locale: typeof locale === 'object' ? locale?.code : locale,
+        locale: locale?.code,
         title,
       } satisfies Omit<
         Parameters<GenerateDescription>[0],

--- a/packages/plugin-seo/src/fields/MetaImage/MetaImageComponent.tsx
+++ b/packages/plugin-seo/src/fields/MetaImage/MetaImageComponent.tsx
@@ -81,7 +81,7 @@ export const MetaImageComponent: React.FC<MetaImageProps> = (props) => {
         hasSavePermission: docInfo.hasSavePermission,
         initialData: docInfo.initialData,
         initialState: reduceToSerializableFields(docInfo.initialState ?? {}),
-        locale: typeof locale === 'object' ? locale?.code : locale,
+        locale: locale?.code,
         title,
       } satisfies Omit<
         Parameters<GenerateImage>[0],

--- a/packages/plugin-seo/src/fields/MetaTitle/MetaTitleComponent.tsx
+++ b/packages/plugin-seo/src/fields/MetaTitle/MetaTitleComponent.tsx
@@ -90,7 +90,7 @@ export const MetaTitleComponent: React.FC<MetaTitleProps> = (props) => {
         hasSavePermission: docInfo.hasSavePermission,
         initialData: docInfo.initialData,
         initialState: reduceToSerializableFields(docInfo.initialState ?? {}),
-        locale: typeof locale === 'object' ? locale?.code : locale,
+        locale: locale?.code,
         title,
       } satisfies Omit<
         Parameters<GenerateTitle>[0],

--- a/packages/plugin-seo/src/fields/Preview/PreviewComponent.tsx
+++ b/packages/plugin-seo/src/fields/Preview/PreviewComponent.tsx
@@ -73,7 +73,7 @@ export const PreviewComponent: React.FC<PreviewProps> = (props) => {
           hasSavePermission: docInfo.hasSavePermission,
           initialData: docInfo.initialData,
           initialState: reduceToSerializableFields(docInfo.initialState ?? {}),
-          locale: typeof locale === 'object' ? locale?.code : locale,
+          locale: locale?.code,
           title,
         } satisfies Omit<
           Parameters<GenerateURL>[0],

--- a/packages/ui/src/elements/AppHeader/index.tsx
+++ b/packages/ui/src/elements/AppHeader/index.tsx
@@ -117,7 +117,7 @@ export function AppHeader({ CustomAvatar, CustomLogoutButton, settingsItemGroups
                     {...ariaProps}
                   >
                     <div className="localizer__button-content">
-                      {locale.code}
+                      {locale?.code}
                       <ChevronIcon direction={active ? 'up' : 'down'} size={16} />
                     </div>
                   </Button>

--- a/packages/ui/src/elements/Autosave/index.tsx
+++ b/packages/ui/src/elements/Autosave/index.tsx
@@ -61,7 +61,8 @@ export const Autosave: React.FC<Props> = ({ id, collection, global: globalDoc })
   const modified = useFormModified()
   const submitted = useFormSubmitted()
 
-  const locale = useLocale()?.code
+  const currentLocale = useLocale()
+  const locale = currentLocale?.code
   const { t } = useTranslation()
 
   const interval = getAutosaveInterval(docConfig)

--- a/packages/ui/src/elements/Autosave/index.tsx
+++ b/packages/ui/src/elements/Autosave/index.tsx
@@ -61,7 +61,7 @@ export const Autosave: React.FC<Props> = ({ id, collection, global: globalDoc })
   const modified = useFormModified()
   const submitted = useFormSubmitted()
 
-  const { code: locale } = useLocale()
+  const locale = useLocale()?.code
   const { t } = useTranslation()
 
   const interval = getAutosaveInterval(docConfig)

--- a/packages/ui/src/elements/BulkUpload/FormsManager/index.tsx
+++ b/packages/ui/src/elements/BulkUpload/FormsManager/index.tsx
@@ -106,7 +106,8 @@ export function FormsManagerProvider({ children }: FormsManagerProps) {
   const {
     routes: { api },
   } = config
-  const code = useLocale()?.code
+  const locale = useLocale()
+  const code = locale?.code
   const { i18n, t } = useTranslation()
 
   const { getDocumentSlots, getFormState } = useServerFunctions()

--- a/packages/ui/src/elements/BulkUpload/FormsManager/index.tsx
+++ b/packages/ui/src/elements/BulkUpload/FormsManager/index.tsx
@@ -106,7 +106,7 @@ export function FormsManagerProvider({ children }: FormsManagerProps) {
   const {
     routes: { api },
   } = config
-  const { code } = useLocale()
+  const code = useLocale()?.code
   const { i18n, t } = useTranslation()
 
   const { getDocumentSlots, getFormState } = useServerFunctions()

--- a/packages/ui/src/elements/CopyLocaleData/index.tsx
+++ b/packages/ui/src/elements/CopyLocaleData/index.tsx
@@ -32,7 +32,7 @@ export const CopyLocaleData: React.FC = () => {
       routes: { admin },
     },
   } = useConfig()
-  const { code } = useLocale()
+  const code = useLocale()?.code
   const { id, collectionSlug, globalSlug } = useDocumentInfo()
   const { i18n, t } = useTranslation()
   const modified = useFormModified()

--- a/packages/ui/src/elements/CopyLocaleData/index.tsx
+++ b/packages/ui/src/elements/CopyLocaleData/index.tsx
@@ -32,7 +32,8 @@ export const CopyLocaleData: React.FC = () => {
       routes: { admin },
     },
   } = useConfig()
-  const code = useLocale()?.code
+  const locale = useLocale()
+  const code = locale?.code
   const { id, collectionSlug, globalSlug } = useDocumentInfo()
   const { i18n, t } = useTranslation()
   const modified = useFormModified()

--- a/packages/ui/src/elements/DeleteMany/index.tsx
+++ b/packages/ui/src/elements/DeleteMany/index.tsx
@@ -102,7 +102,7 @@ export function DeleteMany({
     },
   } = useConfig()
 
-  const { code: locale } = useLocale()
+  const locale = useLocale()?.code
   const { i18n } = useTranslation()
   const { openModal } = useModal()
 

--- a/packages/ui/src/elements/DeleteMany/index.tsx
+++ b/packages/ui/src/elements/DeleteMany/index.tsx
@@ -102,7 +102,8 @@ export function DeleteMany({
     },
   } = useConfig()
 
-  const locale = useLocale()?.code
+  const currentLocale = useLocale()
+  const locale = currentLocale?.code
   const { i18n } = useTranslation()
   const { openModal } = useModal()
 

--- a/packages/ui/src/elements/DuplicateDocument/index.tsx
+++ b/packages/ui/src/elements/DuplicateDocument/index.tsx
@@ -43,7 +43,7 @@ export const DuplicateDocument: React.FC<Props> = ({
   const router = useRouter()
   const modified = useFormModified()
   const { openModal } = useModal()
-  const { code: localeCode } = useLocale()
+  const localeCode = useLocale()?.code
   const { setModified } = useForm()
   const { startRouteTransition } = useRouteTransition()
 

--- a/packages/ui/src/elements/DuplicateDocument/index.tsx
+++ b/packages/ui/src/elements/DuplicateDocument/index.tsx
@@ -43,7 +43,8 @@ export const DuplicateDocument: React.FC<Props> = ({
   const router = useRouter()
   const modified = useFormModified()
   const { openModal } = useModal()
-  const localeCode = useLocale()?.code
+  const locale = useLocale()
+  const localeCode = locale?.code
   const { setModified } = useForm()
   const { startRouteTransition } = useRouteTransition()
 

--- a/packages/ui/src/elements/EditMany/DrawerContent.tsx
+++ b/packages/ui/src/elements/EditMany/DrawerContent.tsx
@@ -169,7 +169,7 @@ export const EditManyDrawerContent: React.FC<EditManyDrawerContentProps> = (prop
   } = props
 
   const { permissions, user } = useAuth()
-  const { code: locale } = useLocale()
+  const locale = useLocale()?.code
 
   const { closeModal } = useModal()
 

--- a/packages/ui/src/elements/EditMany/DrawerContent.tsx
+++ b/packages/ui/src/elements/EditMany/DrawerContent.tsx
@@ -169,7 +169,8 @@ export const EditManyDrawerContent: React.FC<EditManyDrawerContentProps> = (prop
   } = props
 
   const { permissions, user } = useAuth()
-  const locale = useLocale()?.code
+  const currentLocale = useLocale()
+  const locale = currentLocale?.code
 
   const { closeModal } = useModal()
 

--- a/packages/ui/src/elements/Hierarchy/MoveMany/index.tsx
+++ b/packages/ui/src/elements/Hierarchy/MoveMany/index.tsx
@@ -59,7 +59,7 @@ export function MoveMany({
   selections,
 }: MoveManyProps) {
   const { i18n, t } = useTranslation()
-  const { code: locale } = useLocale()
+  const locale = useLocale()?.code
   const { openModal } = useModal()
   const {
     config: {

--- a/packages/ui/src/elements/Hierarchy/MoveMany/index.tsx
+++ b/packages/ui/src/elements/Hierarchy/MoveMany/index.tsx
@@ -59,7 +59,8 @@ export function MoveMany({
   selections,
 }: MoveManyProps) {
   const { i18n, t } = useTranslation()
-  const locale = useLocale()?.code
+  const currentLocale = useLocale()
+  const locale = currentLocale?.code
   const { openModal } = useModal()
   const {
     config: {

--- a/packages/ui/src/elements/Hierarchy/Search/useHierarchySearch.ts
+++ b/packages/ui/src/elements/Hierarchy/Search/useHierarchySearch.ts
@@ -47,7 +47,7 @@ export const useHierarchySearch = ({
       serverURL,
     },
   } = useConfig()
-  const { code: locale } = useLocale()
+  const locale = useLocale()?.code
 
   const fetchResults = useCallback(
     async ({

--- a/packages/ui/src/elements/Hierarchy/Search/useHierarchySearch.ts
+++ b/packages/ui/src/elements/Hierarchy/Search/useHierarchySearch.ts
@@ -47,7 +47,8 @@ export const useHierarchySearch = ({
       serverURL,
     },
   } = useConfig()
-  const locale = useLocale()?.code
+  const currentLocale = useLocale()
+  const locale = currentLocale?.code
 
   const fetchResults = useCallback(
     async ({

--- a/packages/ui/src/elements/ListHeader/TitleActions/ListEmptyTrashButton.tsx
+++ b/packages/ui/src/elements/ListHeader/TitleActions/ListEmptyTrashButton.tsx
@@ -28,7 +28,8 @@ export function ListEmptyTrashButton({
   hasDeletePermission: boolean
 }) {
   const { i18n, t } = useTranslation()
-  const locale = useLocale()?.code
+  const currentLocale = useLocale()
+  const locale = currentLocale?.code
   const { config } = useConfig()
   const { openModal } = useModal()
   const router = useRouter()

--- a/packages/ui/src/elements/ListHeader/TitleActions/ListEmptyTrashButton.tsx
+++ b/packages/ui/src/elements/ListHeader/TitleActions/ListEmptyTrashButton.tsx
@@ -28,7 +28,7 @@ export function ListEmptyTrashButton({
   hasDeletePermission: boolean
 }) {
   const { i18n, t } = useTranslation()
-  const { code: locale } = useLocale()
+  const locale = useLocale()?.code
   const { config } = useConfig()
   const { openModal } = useModal()
   const router = useRouter()

--- a/packages/ui/src/elements/LivePreview/Window/index.tsx
+++ b/packages/ui/src/elements/LivePreview/Window/index.tsx
@@ -78,7 +78,7 @@ export const LivePreviewWindow: React.FC<EditViewProps> = (props) => {
       data: values,
       externallyUpdatedRelationship: mostRecentUpdate,
       globalSlug,
-      locale: locale.code,
+      locale: locale?.code,
     })
   }, [
     formState,

--- a/packages/ui/src/elements/Localizer/index.tsx
+++ b/packages/ui/src/elements/Localizer/index.tsx
@@ -39,7 +39,7 @@ export const Localizer: React.FC<{
   const { i18n, t } = useTranslation()
   const locale = useLocale()
 
-  if (localization) {
+  if (localization && locale) {
     const { locales } = localization
 
     return (

--- a/packages/ui/src/elements/PublishButton/index.tsx
+++ b/packages/ui/src/elements/PublishButton/index.tsx
@@ -40,7 +40,7 @@ export function PublishButton({
   const { submit } = useForm()
   const modified = useFormModified()
   const editDepth = useEditDepth()
-  const { code: localeCode } = useLocale()
+  const localeCode = useLocale()?.code
   const {
     localization,
     routes: { api },

--- a/packages/ui/src/elements/PublishButton/index.tsx
+++ b/packages/ui/src/elements/PublishButton/index.tsx
@@ -40,7 +40,8 @@ export function PublishButton({
   const { submit } = useForm()
   const modified = useFormModified()
   const editDepth = useEditDepth()
-  const localeCode = useLocale()?.code
+  const locale = useLocale()
+  const localeCode = locale?.code
   const {
     localization,
     routes: { api },

--- a/packages/ui/src/elements/PublishMany/DrawerContent.tsx
+++ b/packages/ui/src/elements/PublishMany/DrawerContent.tsx
@@ -45,7 +45,7 @@ export function PublishManyDrawerContent(props: PublishManyDrawerContentProps) {
     },
   } = useConfig()
 
-  const { code: locale } = useLocale()
+  const locale = useLocale()?.code
 
   const router = useRouter()
   const searchParams = useSearchParams()

--- a/packages/ui/src/elements/PublishMany/DrawerContent.tsx
+++ b/packages/ui/src/elements/PublishMany/DrawerContent.tsx
@@ -45,7 +45,8 @@ export function PublishManyDrawerContent(props: PublishManyDrawerContentProps) {
     },
   } = useConfig()
 
-  const locale = useLocale()?.code
+  const currentLocale = useLocale()
+  const locale = currentLocale?.code
 
   const router = useRouter()
   const searchParams = useSearchParams()

--- a/packages/ui/src/elements/RestoreMany/index.tsx
+++ b/packages/ui/src/elements/RestoreMany/index.tsx
@@ -35,7 +35,8 @@ export const RestoreMany: React.FC<Props> = (props) => {
   const {
     config: { collections, routes, serverURL },
   } = useConfig()
-  const locale = useLocale()?.code
+  const currentLocale = useLocale()
+  const locale = currentLocale?.code
   const router = useRouter()
   const { clearRouteCache } = useRouteCache()
   const searchParams = useSearchParams()

--- a/packages/ui/src/elements/RestoreMany/index.tsx
+++ b/packages/ui/src/elements/RestoreMany/index.tsx
@@ -35,7 +35,7 @@ export const RestoreMany: React.FC<Props> = (props) => {
   const {
     config: { collections, routes, serverURL },
   } = useConfig()
-  const { code: locale } = useLocale()
+  const locale = useLocale()?.code
   const router = useRouter()
   const { clearRouteCache } = useRouteCache()
   const searchParams = useSearchParams()

--- a/packages/ui/src/elements/SaveDraftButton/index.tsx
+++ b/packages/ui/src/elements/SaveDraftButton/index.tsx
@@ -28,7 +28,7 @@ export function SaveDraftButton(props: SaveDraftButtonClientProps) {
     useDocumentInfo()
 
   const modified = useFormModified()
-  const { code: locale } = useLocale()
+  const locale = useLocale()?.code
   const ref = useRef<HTMLButtonElement>(null)
   const editDepth = useEditDepth()
   const { t } = useTranslation()

--- a/packages/ui/src/elements/SaveDraftButton/index.tsx
+++ b/packages/ui/src/elements/SaveDraftButton/index.tsx
@@ -28,7 +28,8 @@ export function SaveDraftButton(props: SaveDraftButtonClientProps) {
     useDocumentInfo()
 
   const modified = useFormModified()
-  const locale = useLocale()?.code
+  const currentLocale = useLocale()
+  const locale = currentLocale?.code
   const ref = useRef<HTMLButtonElement>(null)
   const editDepth = useEditDepth()
   const { t } = useTranslation()

--- a/packages/ui/src/elements/Status/index.tsx
+++ b/packages/ui/src/elements/Status/index.tsx
@@ -39,7 +39,8 @@ export const Status: React.FC = () => {
   } = useConfig()
 
   const { reset: resetForm } = useForm()
-  const locale = useLocale()?.code
+  const currentLocale = useLocale()
+  const locale = currentLocale?.code
   const { i18n, t } = useTranslation()
 
   const revertModalSlug = `confirm-revert-${id}`

--- a/packages/ui/src/elements/Status/index.tsx
+++ b/packages/ui/src/elements/Status/index.tsx
@@ -39,7 +39,7 @@ export const Status: React.FC = () => {
   } = useConfig()
 
   const { reset: resetForm } = useForm()
-  const { code: locale } = useLocale()
+  const locale = useLocale()?.code
   const { i18n, t } = useTranslation()
 
   const revertModalSlug = `confirm-revert-${id}`

--- a/packages/ui/src/elements/Table/OrderableTable.tsx
+++ b/packages/ui/src/elements/Table/OrderableTable.tsx
@@ -41,7 +41,7 @@ export const OrderableTable: React.FC<Props> = ({
 }) => {
   const { config } = useConfig()
   const { data: listQueryData, orderableFieldName, query } = useListQuery()
-  const { code: localeCode } = useLocale()
+  const localeCode = useLocale()?.code
   const { t } = useTranslation()
   // Use the data from ListQueryProvider if available, otherwise use the props
   const serverData = listQueryData?.docs || initialData

--- a/packages/ui/src/elements/Table/OrderableTable.tsx
+++ b/packages/ui/src/elements/Table/OrderableTable.tsx
@@ -41,7 +41,8 @@ export const OrderableTable: React.FC<Props> = ({
 }) => {
   const { config } = useConfig()
   const { data: listQueryData, orderableFieldName, query } = useListQuery()
-  const localeCode = useLocale()?.code
+  const locale = useLocale()
+  const localeCode = locale?.code
   const { t } = useTranslation()
   // Use the data from ListQueryProvider if available, otherwise use the props
   const serverData = listQueryData?.docs || initialData

--- a/packages/ui/src/elements/Table/RelationshipProvider/index.tsx
+++ b/packages/ui/src/elements/Table/RelationshipProvider/index.tsx
@@ -46,7 +46,7 @@ export const RelationshipProvider: React.FC<{ readonly children?: React.ReactNod
   } = useConfig()
 
   const { i18n } = useTranslation()
-  const { code: locale } = useLocale()
+  const locale = useLocale()?.code
   const prevLocale = useRef(locale)
 
   const loadRelationshipDocs = useCallback(

--- a/packages/ui/src/elements/Table/RelationshipProvider/index.tsx
+++ b/packages/ui/src/elements/Table/RelationshipProvider/index.tsx
@@ -46,7 +46,8 @@ export const RelationshipProvider: React.FC<{ readonly children?: React.ReactNod
   } = useConfig()
 
   const { i18n } = useTranslation()
-  const locale = useLocale()?.code
+  const currentLocale = useLocale()
+  const locale = currentLocale?.code
   const prevLocale = useRef(locale)
 
   const loadRelationshipDocs = useCallback(

--- a/packages/ui/src/elements/UnpublishButton/index.tsx
+++ b/packages/ui/src/elements/UnpublishButton/index.tsx
@@ -37,7 +37,9 @@ export function UnpublishButton({
 
   const { config, getEntityConfig } = useConfig()
   const { reset: resetForm } = useForm()
-  const { code: localeCode, label: localeLabel } = useLocale()
+  const locale = useLocale()
+  const localeCode = locale?.code
+  const localeLabel = locale?.label
   const [unpublishAll, setUnpublishAll] = useState(false)
   const unPublishModalSlug = `confirm-un-publish-${id}`
 

--- a/packages/ui/src/elements/UnpublishMany/DrawerContent.tsx
+++ b/packages/ui/src/elements/UnpublishMany/DrawerContent.tsx
@@ -42,7 +42,8 @@ export function UnpublishManyDrawerContent(props: UnpublishManyDrawerContentProp
       routes: { api },
     },
   } = useConfig()
-  const locale = useLocale()?.code
+  const currentLocale = useLocale()
+  const locale = currentLocale?.code
   const { i18n, t } = useTranslation()
   const searchParams = useSearchParams()
   const router = useRouter()

--- a/packages/ui/src/elements/UnpublishMany/DrawerContent.tsx
+++ b/packages/ui/src/elements/UnpublishMany/DrawerContent.tsx
@@ -42,7 +42,7 @@ export function UnpublishManyDrawerContent(props: UnpublishManyDrawerContentProp
       routes: { api },
     },
   } = useConfig()
-  const { code: locale } = useLocale()
+  const locale = useLocale()?.code
   const { i18n, t } = useTranslation()
   const searchParams = useSearchParams()
   const router = useRouter()

--- a/packages/ui/src/elements/WhereBuilder/Condition/Relationship/index.tsx
+++ b/packages/ui/src/elements/WhereBuilder/Condition/Relationship/index.tsx
@@ -106,7 +106,7 @@ export const RelationshipFilter: React.FC<Props> = (props) => {
         const query = {
           depth: 0,
           limit: maxResultsPerRequest,
-          locale: locale.code,
+          locale: locale?.code,
           page: loadedRelationship.nextPage,
           select: {
             [fieldToSearch]: true,

--- a/packages/ui/src/fields/Array/index.tsx
+++ b/packages/ui/src/fields/Array/index.tsx
@@ -86,7 +86,7 @@ export const ArrayFieldComponent: ArrayFieldClientComponent = (props) => {
     setModified,
   } = useForm()
   const submitted = useFormSubmitted()
-  const { code: locale } = useLocale()
+  const locale = useLocale()?.code
   const { i18n, t } = useTranslation()
 
   const {

--- a/packages/ui/src/fields/Array/index.tsx
+++ b/packages/ui/src/fields/Array/index.tsx
@@ -86,7 +86,8 @@ export const ArrayFieldComponent: ArrayFieldClientComponent = (props) => {
     setModified,
   } = useForm()
   const submitted = useFormSubmitted()
-  const locale = useLocale()?.code
+  const currentLocale = useLocale()
+  const locale = currentLocale?.code
   const { i18n, t } = useTranslation()
 
   const {

--- a/packages/ui/src/fields/Blocks/index.tsx
+++ b/packages/ui/src/fields/Blocks/index.tsx
@@ -87,7 +87,7 @@ const BlocksFieldComponent: BlocksFieldClientComponent = (props) => {
     replaceState,
     setModified,
   } = useForm()
-  const { code: locale } = useLocale()
+  const locale = useLocale()?.code
   const {
     config: { localization },
     config,

--- a/packages/ui/src/fields/Blocks/index.tsx
+++ b/packages/ui/src/fields/Blocks/index.tsx
@@ -87,7 +87,8 @@ const BlocksFieldComponent: BlocksFieldClientComponent = (props) => {
     replaceState,
     setModified,
   } = useForm()
-  const locale = useLocale()?.code
+  const currentLocale = useLocale()
+  const locale = currentLocale?.code
   const {
     config: { localization },
     config,

--- a/packages/ui/src/fields/FieldLabel/index.tsx
+++ b/packages/ui/src/fields/FieldLabel/index.tsx
@@ -30,7 +30,9 @@ export const FieldLabel: React.FC<GenericLabelProps> = (props) => {
   const htmlFor = htmlForFromProps || generateFieldID(path, editDepth, uuid)
 
   const { i18n } = useTranslation()
-  const { code, label: localLabel } = useLocale()
+  const locale = useLocale()
+  const code = locale?.code
+  const localLabel = locale?.label
 
   const Element =
     ElementFromProps === 'label' ? (htmlFor ? 'label' : 'span') : ElementFromProps || 'span'
@@ -40,7 +42,7 @@ export const FieldLabel: React.FC<GenericLabelProps> = (props) => {
       <Element className={`field-label${unstyled ? ' unstyled' : ''}`} htmlFor={htmlFor}>
         {getTranslation(label, i18n)}
         {required && !unstyled && <span className="required">*</span>}
-        {localized && !hideLocale && (
+        {localized && !hideLocale && locale && (
           <span className="localized">
             &mdash; {typeof localLabel === 'string' ? localLabel : code}
           </span>

--- a/packages/ui/src/fields/Relationship/Input.tsx
+++ b/packages/ui/src/fields/Relationship/Input.tsx
@@ -87,7 +87,7 @@ export const RelationshipInput: React.FC<RelationshipInputProps> = (props) => {
 
   const { i18n, t } = useTranslation()
   const { permissions } = useAuth()
-  const { code: locale } = useLocale()
+  const locale = useLocale()?.code
 
   const [currentlyOpenRelationship, setCurrentlyOpenRelationship] = useState<
     Parameters<ReactSelectAdapterProps['customProps']['onDocumentOpen']>[0]

--- a/packages/ui/src/fields/Relationship/Input.tsx
+++ b/packages/ui/src/fields/Relationship/Input.tsx
@@ -87,7 +87,8 @@ export const RelationshipInput: React.FC<RelationshipInputProps> = (props) => {
 
   const { i18n, t } = useTranslation()
   const { permissions } = useAuth()
-  const locale = useLocale()?.code
+  const currentLocale = useLocale()
+  const locale = currentLocale?.code
 
   const [currentlyOpenRelationship, setCurrentlyOpenRelationship] = useState<
     Parameters<ReactSelectAdapterProps['customProps']['onDocumentOpen']>[0]

--- a/packages/ui/src/fields/Slug/index.tsx
+++ b/packages/ui/src/fields/Slug/index.tsx
@@ -42,7 +42,7 @@ const SlugFieldComponent: React.FC<SlugFieldProps> = ({ field, path }) => {
 
   const { slugify } = useServerFunctions()
 
-  const { code: locale } = useLocale()
+  const locale = useLocale()?.code
 
   const {
     path: fieldPath,

--- a/packages/ui/src/fields/Slug/index.tsx
+++ b/packages/ui/src/fields/Slug/index.tsx
@@ -42,7 +42,8 @@ const SlugFieldComponent: React.FC<SlugFieldProps> = ({ field, path }) => {
 
   const { slugify } = useServerFunctions()
 
-  const locale = useLocale()?.code
+  const currentLocale = useLocale()
+  const locale = currentLocale?.code
 
   const {
     path: fieldPath,

--- a/packages/ui/src/fields/Upload/Input.spec.ts
+++ b/packages/ui/src/fields/Upload/Input.spec.ts
@@ -1,4 +1,6 @@
 // @vitest-environment jsdom
+import type { Locale } from 'payload'
+
 import React, { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -33,7 +35,7 @@ vi.mock('../../providers/Auth/index.js', () => ({
 }))
 
 vi.mock('../../providers/Locale/index.js', () => ({
-  useLocale: () => ({ code: 'en' }),
+  useLocale: (): Locale | null => ({ code: 'en', label: 'English' }),
 }))
 
 vi.mock('../../providers/Translation/index.js', () => ({

--- a/packages/ui/src/fields/Upload/Input.tsx
+++ b/packages/ui/src/fields/Upload/Input.tsx
@@ -132,7 +132,7 @@ export function UploadInput(props: UploadInputProps) {
     setSelectableCollections,
   } = useBulkUpload()
   const { permissions } = useAuth()
-  const { code } = useLocale()
+  const code = useLocale()?.code
   const { i18n, t } = useTranslation()
 
   // This will be used by the bulk upload to allow you to select only collections you have create permissions for

--- a/packages/ui/src/fields/Upload/Input.tsx
+++ b/packages/ui/src/fields/Upload/Input.tsx
@@ -132,7 +132,8 @@ export function UploadInput(props: UploadInputProps) {
     setSelectableCollections,
   } = useBulkUpload()
   const { permissions } = useAuth()
-  const code = useLocale()?.code
+  const locale = useLocale()
+  const code = locale?.code
   const { i18n, t } = useTranslation()
 
   // This will be used by the bulk upload to allow you to select only collections you have create permissions for

--- a/packages/ui/src/fields/shared/index.tsx
+++ b/packages/ui/src/fields/shared/index.tsx
@@ -16,7 +16,7 @@ export function isFieldRTL({
 }: {
   fieldLocalized?: boolean
   fieldRTL?: boolean
-  locale: Locale
+  locale: Locale | null
   localizationConfig?: SanitizedLocalizationConfig
 }) {
   const hasMultipleLocales =

--- a/packages/ui/src/forms/Form/index.tsx
+++ b/packages/ui/src/forms/Form/index.tsx
@@ -93,7 +93,7 @@ export const Form: React.FC<FormProps> = (props) => {
 
   const documentForm = useDocumentForm()
 
-  const { code: locale } = useLocale()
+  const locale = useLocale()?.code
   const { i18n, t } = useTranslation()
   const { refreshCookie, user } = useAuth()
   const onNonFieldError = useFormErrorHandler()

--- a/packages/ui/src/forms/Form/index.tsx
+++ b/packages/ui/src/forms/Form/index.tsx
@@ -93,7 +93,8 @@ export const Form: React.FC<FormProps> = (props) => {
 
   const documentForm = useDocumentForm()
 
-  const locale = useLocale()?.code
+  const currentLocale = useLocale()
+  const locale = currentLocale?.code
   const { i18n, t } = useTranslation()
   const { refreshCookie, user } = useAuth()
   const onNonFieldError = useFormErrorHandler()

--- a/packages/ui/src/forms/NullifyField/index.tsx
+++ b/packages/ui/src/forms/NullifyField/index.tsx
@@ -25,7 +25,8 @@ export const NullifyLocaleField: React.FC<NullifyLocaleFieldProps> = ({
   path,
   readOnly = false,
 }) => {
-  const currentLocale = useLocale()?.code
+  const locale = useLocale()
+  const currentLocale = locale?.code
   const {
     config: { localization },
   } = useConfig()

--- a/packages/ui/src/forms/NullifyField/index.tsx
+++ b/packages/ui/src/forms/NullifyField/index.tsx
@@ -25,7 +25,7 @@ export const NullifyLocaleField: React.FC<NullifyLocaleFieldProps> = ({
   path,
   readOnly = false,
 }) => {
-  const { code: currentLocale } = useLocale()
+  const currentLocale = useLocale()?.code
   const {
     config: { localization },
   } = useConfig()

--- a/packages/ui/src/hooks/usePayloadAPI.ts
+++ b/packages/ui/src/hooks/usePayloadAPI.ts
@@ -34,7 +34,7 @@ export const usePayloadAPI: UsePayloadAPI = (url, options = {}) => {
   const [params, setParams] = useState(initialParams)
   const [isLoading, setIsLoading] = useState(!initialData)
   const [isError, setIsError] = useState(false)
-  const { code: locale } = useLocale()
+  const locale = useLocale()?.code
   const hasInitialized = useRef(false)
 
   const search = qs.stringify(

--- a/packages/ui/src/hooks/usePayloadAPI.ts
+++ b/packages/ui/src/hooks/usePayloadAPI.ts
@@ -34,7 +34,8 @@ export const usePayloadAPI: UsePayloadAPI = (url, options = {}) => {
   const [params, setParams] = useState(initialParams)
   const [isLoading, setIsLoading] = useState(!initialData)
   const [isError, setIsError] = useState(false)
-  const locale = useLocale()?.code
+  const currentLocale = useLocale()
+  const locale = currentLocale?.code
   const hasInitialized = useRef(false)
 
   const search = qs.stringify(

--- a/packages/ui/src/providers/DocumentInfo/index.tsx
+++ b/packages/ui/src/providers/DocumentInfo/index.tsx
@@ -131,7 +131,7 @@ const DocumentInfo: React.FC<
   )
 
   const { getPreference, setPreference } = usePreferences()
-  const { code: locale } = useLocale()
+  const locale = useLocale()?.code
   const { localeIsLoading } = useLocaleLoading()
 
   const isInitializing = useMemo(

--- a/packages/ui/src/providers/DocumentInfo/index.tsx
+++ b/packages/ui/src/providers/DocumentInfo/index.tsx
@@ -131,7 +131,8 @@ const DocumentInfo: React.FC<
   )
 
   const { getPreference, setPreference } = usePreferences()
-  const locale = useLocale()?.code
+  const currentLocale = useLocale()
+  const locale = currentLocale?.code
   const { localeIsLoading } = useLocaleLoading()
 
   const isInitializing = useMemo(

--- a/packages/ui/src/providers/Locale/index.tsx
+++ b/packages/ui/src/providers/Locale/index.tsx
@@ -11,7 +11,7 @@ import { useConfig } from '../Config/index.js'
 import { useSearchParams } from '../RouterAdapter/index.js'
 import { useRouteTransition } from '../RouteTransition/index.js'
 
-const LocaleContext = createContext({} as Locale)
+const LocaleContext = createContext<Locale | null>(null)
 
 export const LocaleLoadingContext = createContext({
   localeIsLoading: false,
@@ -53,10 +53,9 @@ export const LocaleProvider: React.FC<{ children?: React.ReactNode; locale?: Loc
 
   const localeFromParams = useSearchParams().get('locale')
 
-  const [locale, setLocale] = React.useState<Locale>(() => {
+  const [locale, setLocale] = React.useState<Locale | null>(() => {
     if (!localization || (localization && !localization.locales.length)) {
-      // TODO: return null V4
-      return {} as Locale
+      return null
     }
 
     return (
@@ -69,11 +68,11 @@ export const LocaleProvider: React.FC<{ children?: React.ReactNode; locale?: Loc
 
   const [isLoading, setLocaleIsLoading] = useState(false)
 
-  const prevLocale = useRef<Locale>(locale)
+  const prevLocale = useRef<Locale | null>(locale)
 
   useEffect(() => {
     // Keep fields disabled until the new locale's document state finishes loading.
-    if (locale.code !== prevLocale.current.code && !isTransitioning) {
+    if (locale?.code !== prevLocale.current?.code && !isTransitioning) {
       setLocaleIsLoading(false)
       prevLocale.current = locale
     }
@@ -121,8 +120,4 @@ export const LocaleProvider: React.FC<{ children?: React.ReactNode; locale?: Loc
 
 export const useLocaleLoading = () => use(LocaleLoadingContext)
 
-/**
- * TODO: V4
- * The return type of the `useLocale` hook will change in v4. It will return `null | Locale` instead of `false | {} | Locale`.
- */
-export const useLocale = (): Locale => use(LocaleContext)
+export const useLocale = (): Locale | null => use(LocaleContext)

--- a/packages/ui/src/providers/Selection/index.tsx
+++ b/packages/ui/src/providers/Selection/index.tsx
@@ -70,7 +70,8 @@ export const SelectionProvider: React.FC<Props> = ({ children, docs = [], totalD
   const contextRef = useRef({} as SelectionContext)
   const { user } = useAuth()
 
-  const locale = useLocale()?.code
+  const currentLocale = useLocale()
+  const locale = currentLocale?.code
 
   const [selected, setSelected] = useState<SelectionContext['selected']>(() => {
     const rows = new Map()

--- a/packages/ui/src/providers/Selection/index.tsx
+++ b/packages/ui/src/providers/Selection/index.tsx
@@ -70,7 +70,7 @@ export const SelectionProvider: React.FC<Props> = ({ children, docs = [], totalD
   const contextRef = useRef({} as SelectionContext)
   const { user } = useAuth()
 
-  const { code: locale } = useLocale()
+  const locale = useLocale()?.code
 
   const [selected, setSelected] = useState<SelectionContext['selected']>(() => {
     const rows = new Map()

--- a/packages/ui/src/views/API/index.client.tsx
+++ b/packages/ui/src/views/API/index.client.tsx
@@ -28,7 +28,7 @@ export const APIViewClient: React.FC = () => {
 
   const searchParams = useSearchParams()
   const { i18n, t } = useTranslation()
-  const { code } = useLocale()
+  const code = useLocale()?.code
 
   const {
     config: {

--- a/packages/ui/src/views/API/index.client.tsx
+++ b/packages/ui/src/views/API/index.client.tsx
@@ -28,7 +28,8 @@ export const APIViewClient: React.FC = () => {
 
   const searchParams = useSearchParams()
   const { i18n, t } = useTranslation()
-  const code = useLocale()?.code
+  const currentLocale = useLocale()
+  const code = currentLocale?.code
 
   const {
     config: {

--- a/packages/ui/src/views/Version/Default/SetStepNav.tsx
+++ b/packages/ui/src/views/Version/Default/SetStepNav.tsx
@@ -10,7 +10,6 @@ import { useEffect } from 'react'
 import { useStepNav } from '../../../elements/StepNav/index.js'
 import { useConfig } from '../../../providers/Config/index.js'
 import { useDocumentTitle } from '../../../providers/DocumentTitle/index.js'
-import { useLocale } from '../../../providers/Locale/index.js'
 import { useTranslation } from '../../../providers/Translation/index.js'
 
 export const SetStepNav: React.FC<{
@@ -31,13 +30,11 @@ export const SetStepNav: React.FC<{
   const { config } = useConfig()
   const { setStepNav } = useStepNav()
   const { i18n, t } = useTranslation()
-  const locale = useLocale()
   const { title } = useDocumentTitle()
 
   useEffect(() => {
     const {
       routes: { admin: adminRoute },
-      serverURL,
     } = config
 
     if (collectionConfig) {
@@ -122,7 +119,6 @@ export const SetStepNav: React.FC<{
     setStepNav,
     id,
     isTrashed,
-    locale,
     t,
     i18n,
     collectionConfig,

--- a/packages/ui/src/views/Version/Default/index.tsx
+++ b/packages/ui/src/views/Version/Default/index.tsx
@@ -38,7 +38,8 @@ export const DefaultVersionView: React.FC<DefaultVersionsViewProps> = ({
   versionToStatus,
 }) => {
   const { config, getEntityConfig } = useConfig()
-  const code = useLocale()?.code
+  const locale = useLocale()
+  const code = locale?.code
   const { i18n, t } = useTranslation()
 
   const [locales, setLocales] = useState<SelectablePill[]>([])

--- a/packages/ui/src/views/Version/Default/index.tsx
+++ b/packages/ui/src/views/Version/Default/index.tsx
@@ -38,7 +38,7 @@ export const DefaultVersionView: React.FC<DefaultVersionsViewProps> = ({
   versionToStatus,
 }) => {
   const { config, getEntityConfig } = useConfig()
-  const { code } = useLocale()
+  const code = useLocale()?.code
   const { i18n, t } = useTranslation()
 
   const [locales, setLocales] = useState<SelectablePill[]>([])

--- a/packages/ui/src/views/Versions/VersionPillLabel/VersionPillLabel.tsx
+++ b/packages/ui/src/views/Versions/VersionPillLabel/VersionPillLabel.tsx
@@ -71,7 +71,8 @@ export const VersionPillLabel: React.FC<{
     },
   } = useConfig()
   const { i18n, t } = useTranslation()
-  const currentLocale = useLocale()?.code
+  const activeLocale = useLocale()
+  const currentLocale = activeLocale?.code
 
   const { name, label } = getVersionLabel({
     currentLocale,

--- a/packages/ui/src/views/Versions/VersionPillLabel/VersionPillLabel.tsx
+++ b/packages/ui/src/views/Versions/VersionPillLabel/VersionPillLabel.tsx
@@ -71,7 +71,7 @@ export const VersionPillLabel: React.FC<{
     },
   } = useConfig()
   const { i18n, t } = useTranslation()
-  const { code: currentLocale } = useLocale()
+  const currentLocale = useLocale()?.code
 
   const { name, label } = getVersionLabel({
     currentLocale,


### PR DESCRIPTION
## Summary

- Changes `useLocale` to return `Locale | null`.
- Returns `null` when localization is disabled or configured without any locales, replacing the previous empty-object fallback.
- Updates affected Admin UI consumers to handle the nullable locale safely.
- Adds migration guidance and updates the `useLocale` documentation.

## Breaking change

`useLocale()` can now return `null`. Custom Client Components that access locale properties directly must handle the nullable value.

Components that require an active locale should guard it:

```diff
- const { code } = useLocale()
+ const locale = useLocale()
+
+ if (!locale) {
+   return null
+ }
+
+ const { code } = locale
```

Optional chaining is also sufficient:
```ts
const localeCode = useLocale()?.code
```
## Background
In V3, `useLocale` returned an empty object when localization was unavailable to avoid introducing a breaking change. With V4, we can clean this up and return `null` instead, making the hook’s behavior and type clearer and more predictable.