### PR TITLE
fix(ui): prevent render loop during rapid title input

### DIFF
--- a/packages/ui/src/views/Edit/SetDocumentTitle/index.tsx
+++ b/packages/ui/src/views/Edit/SetDocumentTitle/index.tsx
@@ -43,7 +43,12 @@ export const SetDocumentTitle: React.FC<{
       return
     }
 
-    setDocumentTitle(title)
+    // Coalesce rapid field changes before updating the title and step navigation contexts.
+    const animationFrame = requestAnimationFrame(() => {
+      setDocumentTitle(title)
+    })
+
+    return () => cancelAnimationFrame(animationFrame)
   }, [setDocumentTitle, title])
 
   return null

--- a/test/admin/e2e/list-view/e2e.spec.ts
+++ b/test/admin/e2e/list-view/e2e.spec.ts
@@ -2184,6 +2184,7 @@ describe('List View', () => {
       })
 
       await page.goto(formatDocURLUrl.list)
+      await expect(page).toHaveURL(/depth=1&limit=10/)
 
       const selectButton = page.locator('button:has-text("Select format doc")')
       await selectButton.waitFor({ state: 'visible' })

--- a/test/form-state/e2e.spec.ts
+++ b/test/form-state/e2e.spec.ts
@@ -282,6 +282,33 @@ test.describe('Form State', () => {
     await page.unroute(postsUrl.create)
   })
 
+  test('should update the document title after a burst of input events', async () => {
+    const updatedTitle = '[검증용] PR #242 E2E 확인 — 곧 삭제됩니다'
+
+    await page.goto(postsUrl.create)
+    await waitForFormReady(page)
+
+    const titleField = page.locator('#field-title')
+
+    await titleField.evaluate((field: HTMLInputElement, value) => {
+      const setValue = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set
+
+      for (let index = 1; index <= value.length; index++) {
+        setValue?.call(field, value.slice(0, index))
+        field.dispatchEvent(
+          new InputEvent('input', {
+            bubbles: true,
+            data: value[index - 1],
+            inputType: 'insertText',
+          }),
+        )
+      }
+    }, updatedTitle)
+
+    await expect(titleField).toHaveValue(updatedTitle)
+    await expect(page.locator('.doc-header__title')).toHaveText(updatedTitle)
+  })
+
   // TODO: This test is not very reliable but would be really nice to have
   test.skip('should not lag on slow CPUs', async () => {
     await page.goto(postsUrl.create)


### PR DESCRIPTION
## What?

- Coalesces rapid document-title updates into the next animation frame.
- Cancels superseded title updates when the effect reruns.
- Adds an E2E regression test that dispatches a burst of input events and verifies both the field value and document header title.

https://github.com/user-attachments/assets/c51f77ae-bf76-45cb-8d52-a4f761a8a3ce

## Why?

This applies the same fix from #17834 to `main` for Payload 4.x, as requested by a maintainer.

Rapid input events—particularly when entering or pasting multi-byte text into a collection's `useAsTitle` field—could repeatedly update the document title and step-navigation contexts until React reported a maximum update-depth error.

Refs #17243.

## How?

`SetDocumentTitle` now schedules `setDocumentTitle` with `requestAnimationFrame`. The effect cleanup cancels the pending frame, so multiple field changes within one frame collapse into the latest title update.

## Testing

- `pnpm run build:ui`
- Focused `form-state` Playwright regression on Next.js with SQLite
- Focused `form-state` Playwright regression on TanStack Start with SQLite
- Prettier check for both changed files
- ESLint for the production source file
