### PR TITLE
fix(plugin-nested-docs): guard against circular parent relationships

### DIFF
--- a/packages/plugin-nested-docs/src/hooks/resaveChildren.ts
+++ b/packages/plugin-nested-docs/src/hooks/resaveChildren.ts
@@ -64,6 +64,25 @@ export const resaveChildren =
     })
 
     if (sortedChildren.length) {
+      // Resaving a child re-runs this hook for that child. A cyclic parent relationship would
+      // otherwise bounce updates between the documents forever, so skip any document that is
+      // already being resaved further up the current chain.
+      const resavingDocIDs =
+        (req.context.nestedDocsResavingDocIDs as Set<string>) || new Set<string>()
+      req.context.nestedDocsResavingDocIDs = resavingDocIDs
+
+      const docKey = `${collection.slug}:${String(doc.id)}`
+
+      if (resavingDocIDs.has(docKey)) {
+        req.payload.logger.warn(
+          `Nested Docs plugin detected a circular parent relationship in the "${collection.slug}" collection. Skipped re-saving the children of the document with ID ${String(doc.id)}.`,
+        )
+
+        return undefined
+      }
+
+      resavingDocIDs.add(docKey)
+
       try {
         for (const child of sortedChildren) {
           const isDraft = child._status !== 'published'
@@ -97,6 +116,8 @@ export const resaveChildren =
             400,
           )
         }
+      } finally {
+        resavingDocIDs.delete(docKey)
       }
     }
 

--- a/packages/plugin-nested-docs/src/utilities/getParents.ts
+++ b/packages/plugin-nested-docs/src/utilities/getParents.ts
@@ -2,16 +2,30 @@ import type { CollectionConfig, Document, PayloadRequest } from 'payload'
 
 import type { NestedDocsPluginConfig } from '../types.js'
 
+const getVisitableID = (doc: Record<string, unknown>): string | undefined =>
+  typeof doc.id === 'string' || typeof doc.id === 'number' ? String(doc.id) : undefined
+
 export const getParents = async (
   req: PayloadRequest,
   pluginConfig: Pick<NestedDocsPluginConfig, 'generateLabel' | 'generateURL' | 'parentFieldSlug'>,
   collection: CollectionConfig,
   doc: Record<string, unknown>,
   docs: Array<Record<string, unknown>> = [],
+  /**
+   * IDs of the documents already traversed, used to stop the traversal when a document points at
+   * an ancestor of itself. Populated by the recursive calls - callers should not pass this.
+   */
+  visitedIDs: Set<string> = new Set(),
 ): Promise<Document[]> => {
   const parentSlug = pluginConfig?.parentFieldSlug || 'parent'
   const parent = doc[parentSlug]
   let retrievedParent: null | Record<string, unknown> = null
+
+  const docID = getVisitableID(doc)
+
+  if (docID) {
+    visitedIDs.add(docID)
+  }
 
   if (parent) {
     // If not auto-populated, and we have an ID
@@ -31,11 +45,29 @@ export const getParents = async (
     }
 
     if (retrievedParent) {
+      const retrievedParentID = getVisitableID(retrievedParent)
+
+      // Without this the traversal of a circular hierarchy never terminates, querying the database
+      // once per iteration until the request runs out of memory. `parentFilterOptions` rejects
+      // cycles created through the API, but they can still reach the database through migrations,
+      // direct adapter writes, or a parent field that overrides the plugin's `filterOptions`.
+      if (retrievedParentID && visitedIDs.has(retrievedParentID)) {
+        req.payload.logger.warn(
+          `Nested Docs plugin detected a circular parent relationship in the "${collection.slug}" collection. Breadcrumb traversal stopped at the document with ID ${retrievedParentID}.`,
+        )
+
+        return docs
+      }
+
       if (retrievedParent[parentSlug]) {
-        return getParents(req, pluginConfig, collection, retrievedParent, [
+        return getParents(
+          req,
+          pluginConfig,
+          collection,
           retrievedParent,
-          ...docs,
-        ])
+          [retrievedParent, ...docs],
+          visitedIDs,
+        )
       }
 
       return [retrievedParent, ...docs]

--- a/test/plugin-nested-docs/collections/Regions.ts
+++ b/test/plugin-nested-docs/collections/Regions.ts
@@ -1,0 +1,28 @@
+import type { CollectionConfig } from 'payload'
+
+import { createParentField } from '@payloadcms/plugin-nested-docs'
+
+import { regionsSlug } from '../shared.js'
+
+// A parent field that declares its own `filterOptions` opts out of the cycle guard the plugin
+// would otherwise apply, so circular hierarchies can be saved through the API
+export const Regions: CollectionConfig = {
+  slug: regionsSlug,
+  access: {
+    read: () => true,
+  },
+  admin: {
+    useAsTitle: 'name',
+  },
+  fields: [
+    {
+      name: 'name',
+      type: 'text',
+      required: true,
+    },
+    createParentField(regionsSlug, {
+      filterOptions: () => true,
+    }),
+  ],
+  versions: false,
+}

--- a/test/plugin-nested-docs/config.ts
+++ b/test/plugin-nested-docs/config.ts
@@ -8,8 +8,10 @@ import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
 import { devUser } from '../credentials.js'
 import { Categories } from './collections/Categories.js'
 import { Pages } from './collections/Pages.js'
+import { Regions } from './collections/Regions.js'
 import { Users } from './collections/Users.js'
 import { seed } from './seed/index.js'
+import { regionsSlug } from './shared.js'
 
 export default buildConfigWithDefaults({
   admin: {
@@ -17,7 +19,7 @@ export default buildConfigWithDefaults({
       baseDir: path.resolve(dirname),
     },
   },
-  collections: [Pages, Categories, Users],
+  collections: [Pages, Categories, Regions, Users],
   localization: {
     defaultLocale: 'en',
     fallback: true,
@@ -39,6 +41,9 @@ export default buildConfigWithDefaults({
       collections: ['pages'],
       generateLabel: (_, doc) => doc.title as string,
       generateURL: (docs) => docs.reduce((url, doc) => `${url}/${doc.slug}`, ''),
+    }),
+    nestedDocsPlugin({
+      collections: [regionsSlug],
     }),
     nestedDocsPlugin({
       breadcrumbsFieldSlug: 'categorization',

--- a/test/plugin-nested-docs/int.spec.ts
+++ b/test/plugin-nested-docs/int.spec.ts
@@ -8,6 +8,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
 import type { Page } from './payload-types.js'
 
 import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
+import { regionsSlug } from './shared.js'
 
 let payload: Payload
 
@@ -496,5 +497,124 @@ describe('@payloadcms/plugin-nested-docs', () => {
       expect(grandchild.categorization[1].label).toStrictEqual('child')
       expect(grandchild.categorization[2].label).toStrictEqual('grandchild')
     })
+  })
+
+  describe('circular parent relationships', () => {
+    const createdCategoryIDs: (number | string)[] = []
+    const createdRegionIDs: (number | string)[] = []
+
+    afterEach(async () => {
+      // Break every parent link first so deleting a document never traverses a circular hierarchy
+      for (const id of [...createdCategoryIDs, ...createdRegionIDs]) {
+        const collection = createdCategoryIDs.includes(id) ? 'categories' : regionsSlug
+        const doc = await payload.findByID({ id, collection, depth: 0 })
+
+        await payload.db.updateOne({
+          id,
+          collection,
+          data: { ...doc, [collection === 'categories' ? 'owner' : 'parent']: null },
+        })
+      }
+
+      for (const id of createdCategoryIDs) {
+        await payload.delete({ id, collection: 'categories' })
+      }
+
+      for (const id of createdRegionIDs) {
+        await payload.delete({ id, collection: regionsSlug })
+      }
+
+      createdCategoryIDs.length = 0
+      createdRegionIDs.length = 0
+    })
+
+    // Writes a parent straight to the database, bypassing hooks and validation, the way a
+    // migration, a seed script or a direct adapter write would
+    const setParentWithoutHooks = async ({
+      id,
+      parentID,
+    }: {
+      id: number | string
+      parentID: number | string
+    }) => {
+      const doc = await payload.findByID({ id, collection: 'categories', depth: 0 })
+
+      await payload.db.updateOne({
+        id,
+        collection: 'categories',
+        data: { ...doc, owner: parentID },
+      })
+    }
+
+    it('should reject a parent that is a descendant of the document', async () => {
+      const parent = await payload.create({ collection: 'categories', data: { name: 'ancestor' } })
+      const child = await payload.create({
+        collection: 'categories',
+        data: { name: 'descendant', owner: parent.id },
+      })
+
+      createdCategoryIDs.push(parent.id, child.id)
+
+      await expect(
+        payload.update({
+          id: parent.id,
+          collection: 'categories',
+          data: { owner: child.id },
+        }),
+      ).rejects.toThrow('The following field is invalid: Owner')
+    })
+
+    it('should stop breadcrumb traversal when a cycle exists in the database', async () => {
+      const first = await payload.create({ collection: 'categories', data: { name: 'first' } })
+      const second = await payload.create({
+        collection: 'categories',
+        data: { name: 'second', owner: first.id },
+      })
+
+      createdCategoryIDs.push(first.id, second.id)
+
+      await setParentWithoutHooks({ id: first.id, parentID: second.id })
+
+      const child = await payload.create({
+        collection: 'categories',
+        data: { name: 'child of cycle', owner: second.id },
+      })
+
+      createdCategoryIDs.push(child.id)
+
+      expect(child.categorization).toHaveLength(3)
+      expect(child.categorization[0].doc).toStrictEqual(first.id)
+      expect(child.categorization[1].doc).toStrictEqual(second.id)
+      expect(child.categorization[2].label).toStrictEqual('child of cycle')
+    }, 30000)
+
+    it('should not loop when a parent field overrides the plugin filterOptions', async () => {
+      const first = await payload.create({ collection: regionsSlug, data: { name: 'north' } })
+      const second = await payload.create({
+        collection: regionsSlug,
+        data: { name: 'south', parent: first.id },
+      })
+
+      createdRegionIDs.push(first.id, second.id)
+
+      // Allowed because the collection replaced the plugin's cycle-detecting filterOptions
+      const updated = await payload.update({
+        id: first.id,
+        collection: regionsSlug,
+        data: { parent: second.id },
+        depth: 0,
+      })
+
+      expect(updated.parent).toStrictEqual(second.id)
+      expect(updated.breadcrumbs).toHaveLength(2)
+      expect(updated.breadcrumbs[0].doc).toStrictEqual(second.id)
+      expect(updated.breadcrumbs[1].doc).toStrictEqual(first.id)
+
+      const child = await payload.findByID({ id: second.id, collection: regionsSlug, depth: 0 })
+
+      expect(child.breadcrumbs).toHaveLength(2)
+      expect(child.breadcrumbs[0].doc).toStrictEqual(first.id)
+      expect(child.breadcrumbs[1].doc).toStrictEqual(second.id)
+    }, 30000)
   })
 })

--- a/test/plugin-nested-docs/payload-types.ts
+++ b/test/plugin-nested-docs/payload-types.ts
@@ -69,8 +69,10 @@ export interface Config {
   collections: {
     pages: Page;
     categories: Category;
+    regions: Region;
     users: User;
     'payload-kv': PayloadKv;
+    'payload-jobs': PayloadJob;
     'payload-locked-documents': PayloadLockedDocument;
     'payload-preferences': PayloadPreference;
     'payload-migrations': PayloadMigration;
@@ -79,8 +81,10 @@ export interface Config {
   collectionsSelect: {
     pages: PagesSelect<false> | PagesSelect<true>;
     categories: CategoriesSelect<false> | CategoriesSelect<true>;
+    regions: RegionsSelect<false> | RegionsSelect<true>;
     users: UsersSelect<false> | UsersSelect<true>;
     'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
+    'payload-jobs': PayloadJobsSelect<false> | PayloadJobsSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
     'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>;
     'payload-migrations': PayloadMigrationsSelect<false> | PayloadMigrationsSelect<true>;
@@ -89,15 +93,27 @@ export interface Config {
     defaultIDType: string;
   };
   fallbackLocale: ('false' | 'none' | 'null') | false | null | ('en' | 'es' | 'de') | ('en' | 'es' | 'de')[];
-  globals: {};
-  globalsSelect: {};
+  globals: {
+    'payload-jobs-stats': PayloadJobsStat;
+  };
+  globalsSelect: {
+    'payload-jobs-stats': PayloadJobsStatsSelect<false> | PayloadJobsStatsSelect<true>;
+  };
   locale: 'en' | 'es' | 'de';
   widgets: {
     collections: CollectionsWidget;
+    'collection-query': CollectionQueryWidget;
+    activity: ActivityWidget;
   };
   user: User;
   jobs: {
-    tasks: unknown;
+    tasks: {
+      schedulePublish: TaskSchedulePublish;
+      inline: {
+        input: unknown;
+        output: unknown;
+      };
+    };
     workflows: unknown;
   };
 }
@@ -169,6 +185,25 @@ export interface Category {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "regions".
+ */
+export interface Region {
+  id: string;
+  name: string;
+  parent?: (string | null) | Region;
+  breadcrumbs?:
+    | {
+        doc?: (string | null) | Region;
+        url?: string | null;
+        label?: string | null;
+        id?: string | null;
+      }[]
+    | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "users".
  */
 export interface User {
@@ -211,6 +246,116 @@ export interface PayloadKv {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "payload-jobs".
+ */
+export interface PayloadJob {
+  id: string;
+  /**
+   * Input data provided to the job
+   */
+  input?:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
+  taskStatus?:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
+  meta?:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
+  completedAt?: string | null;
+  totalTried?: number | null;
+  /**
+   * If hasError is true this job will not be retried
+   */
+  hasError?: boolean | null;
+  /**
+   * If hasError is true, this is the error that caused it
+   */
+  error?:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
+  /**
+   * Task execution log
+   */
+  log?:
+    | {
+        executedAt: string;
+        completedAt: string;
+        taskSlug: 'inline' | 'schedulePublish';
+        taskID: string;
+        input:
+          | {
+              [k: string]: unknown;
+            }
+          | unknown[]
+          | string
+          | number
+          | boolean
+          | null;
+        output?:
+          | {
+              [k: string]: unknown;
+            }
+          | unknown[]
+          | string
+          | number
+          | boolean
+          | null;
+        state: 'failed' | 'succeeded';
+        error?:
+          | {
+              [k: string]: unknown;
+            }
+          | unknown[]
+          | string
+          | number
+          | boolean
+          | null;
+        parent?: {
+          taskSlug?: ('inline' | 'schedulePublish') | null;
+          taskID?: string | null;
+        };
+        id?: string | null;
+      }[]
+    | null;
+  taskSlug?: ('inline' | 'schedulePublish') | null;
+  queue?: string | null;
+  waitUntil?: string | null;
+  processingUntil?: string | null;
+  processingToken?: string | null;
+  /**
+   * Used for concurrency control. Jobs with the same key are subject to exclusive/supersedes rules.
+   */
+  concurrencyKey?: string | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-locked-documents".
  */
 export interface PayloadLockedDocument {
@@ -223,6 +368,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'categories';
         value: string | Category;
+      } | null)
+    | ({
+        relationTo: 'regions';
+        value: string | Region;
       } | null)
     | ({
         relationTo: 'users';
@@ -312,6 +461,24 @@ export interface CategoriesSelect<T extends boolean = true> {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "regions_select".
+ */
+export interface RegionsSelect<T extends boolean = true> {
+  name?: T;
+  parent?: T;
+  breadcrumbs?:
+    | T
+    | {
+        doc?: T;
+        url?: T;
+        label?: T;
+        id?: T;
+      };
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "users_select".
  */
 export interface UsersSelect<T extends boolean = true> {
@@ -339,6 +506,46 @@ export interface UsersSelect<T extends boolean = true> {
 export interface PayloadKvSelect<T extends boolean = true> {
   key?: T;
   data?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "payload-jobs_select".
+ */
+export interface PayloadJobsSelect<T extends boolean = true> {
+  input?: T;
+  taskStatus?: T;
+  meta?: T;
+  completedAt?: T;
+  totalTried?: T;
+  hasError?: T;
+  error?: T;
+  log?:
+    | T
+    | {
+        executedAt?: T;
+        completedAt?: T;
+        taskSlug?: T;
+        taskID?: T;
+        input?: T;
+        output?: T;
+        state?: T;
+        error?: T;
+        parent?:
+          | T
+          | {
+              taskSlug?: T;
+              taskID?: T;
+            };
+        id?: T;
+      };
+  taskSlug?: T;
+  queue?: T;
+  waitUntil?: T;
+  processingUntil?: T;
+  processingToken?: T;
+  concurrencyKey?: T;
+  updatedAt?: T;
+  createdAt?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -374,6 +581,34 @@ export interface PayloadMigrationsSelect<T extends boolean = true> {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "payload-jobs-stats".
+ */
+export interface PayloadJobsStat {
+  id: string;
+  stats?:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
+  updatedAt?: string | null;
+  createdAt?: string | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "payload-jobs-stats_select".
+ */
+export interface PayloadJobsStatsSelect<T extends boolean = true> {
+  stats?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  globalType?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "collections_widget".
  */
 export interface CollectionsWidget {
@@ -381,6 +616,56 @@ export interface CollectionsWidget {
     [k: string]: unknown;
   };
   width: 'full';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "collection-query_widget".
+ */
+export interface CollectionQueryWidget {
+  data?: {
+    title?: string | null;
+    relatedCollection: 'pages' | 'categories' | 'regions' | 'users';
+    where?:
+      | {
+          [k: string]: unknown;
+        }
+      | unknown[]
+      | string
+      | number
+      | boolean
+      | null;
+    sortField?: string | null;
+    sortDirection?: ('asc' | 'desc') | null;
+    limit?: number | null;
+  };
+  width: 'x-small' | 'small' | 'medium' | 'large' | 'x-large' | 'full';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "activity_widget".
+ */
+export interface ActivityWidget {
+  data?: {
+    excludedCollections?: ('pages' | 'categories' | 'regions' | 'users')[] | null;
+  };
+  width: 'x-small' | 'small' | 'medium' | 'large' | 'x-large' | 'full';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "TaskSchedulePublish".
+ */
+export interface TaskSchedulePublish {
+  input: {
+    type?: ('publish' | 'unpublish') | null;
+    locale?: string | null;
+    doc?: {
+      relationTo: 'pages';
+      value: string | Page;
+    } | null;
+    global?: string | null;
+    user?: (string | null) | User;
+  };
+  output?: unknown;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/test/plugin-nested-docs/shared.ts
+++ b/test/plugin-nested-docs/shared.ts
@@ -1,3 +1,5 @@
 export const pagesSlug = 'pages'
 
 export const mediaSlug = 'media'
+
+export const regionsSlug = 'regions'


### PR DESCRIPTION
`getParents` traversed the parent chain with no loop detection, so a document whose ancestor chain contained a cycle recursed until the request exhausted memory. The accumulator copies the breadcrumb array at every level, making the growth quadratic - a cyclic pair takes a Node process to a 4GB heap OOM in roughly 45 seconds, hanging the request and querying the database once per iteration the whole way.

`parentFilterOptions` rejects cycles created through the API, so this is only reachable when a cycle gets into the database another way: a migration, a seed script, a direct adapter write, or a parent field that declares its own `filterOptions` and thereby replaces the plugin's guard.

`getParents` now tracks the IDs it has already visited and stops the traversal when a parent repeats, logging a warning. It truncates rather than throwing so that affected documents stay editable and an editor can clear the parent field to repair the hierarchy.

`resaveChildren` needed the same treatment: re-saving a child re-runs the hook for that child, so a cycle bounces updates between the documents forever once the breadcrumb traversal terminates. It now skips any document already being re-saved further up the current chain, scoped to the request so legitimate repeat re-saves are unaffected.

Adds a `regions` test collection whose parent field overrides `filterOptions`, covering the configuration where a cycle can be created through the public API, alongside coverage for the database-level cycle and for the existing rejection of a descendant parent.

<!--

Thank you for the PR! Please go through the checklist below and make sure you've completed all the steps.

Please review the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository if you haven't already.

## Which branch should this PR target?

- **`main`** — Payload v4 development. New features, enhancements, and v4 bug fixes go here.
- **`3.x`** — Payload v3 maintenance. Bug fixes only. **New features are not accepted against v3.** If this PR adds a feature to v3, please retarget it at `main` (v4) instead.

The following items will ensure that your PR is handled as smoothly as possible:

- PR Title must follow conventional commits format. For example, `feat: my new feature`, `fix(plugin-seo): my fix`.
- Minimal description explained as if explained to someone not immediately familiar with the code.
- Provide before/after screenshots or code diffs if applicable.
- Link any related issues/discussions from GitHub or Discord.
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #

-->
