### PR TITLE
fix(drizzle): ignore empty in/not_in operands instead of passing them to typed columns

### DIFF
--- a/packages/drizzle/src/queries/sanitizeQueryValue.spec.ts
+++ b/packages/drizzle/src/queries/sanitizeQueryValue.spec.ts
@@ -1,0 +1,79 @@
+import type { Field } from 'payload'
+
+import { describe, expect, it } from 'vitest'
+
+import type { DrizzleAdapter } from '../types.js'
+
+import { sanitizeQueryValue } from './sanitizeQueryValue.js'
+
+/**
+ * `getTableColumnFromPath` synthesizes these two shapes for the `id` path - a number field
+ * on every non-UUID adapter, a text field on a UUID one - so they are what an `id` query is
+ * actually sanitized against.
+ */
+const numericIDField = { name: 'id', type: 'number' } as unknown as Field
+const uuidIDField = { name: 'id', type: 'text' } as unknown as Field
+
+const uuid = '3f2504e0-4f89-11d3-9a0c-0305e82c3301'
+
+const sanitize = (operator: string, val: unknown) =>
+  sanitizeQueryValue({
+    adapter: { idType: 'serial' } as unknown as DrizzleAdapter,
+    field: numericIDField,
+    isUUID: false,
+    operator,
+    relationOrPath: 'id',
+    val,
+  })
+
+const sanitizeUUID = (operator: string, val: unknown) =>
+  sanitizeQueryValue({
+    adapter: { idType: 'uuid' } as unknown as DrizzleAdapter,
+    field: uuidIDField,
+    isUUID: true,
+    operator,
+    relationOrPath: 'id',
+    val,
+  })
+
+describe('sanitizeQueryValue', () => {
+  describe('in / not_in operands on a numeric column', () => {
+    it('drops an empty operand from a not_in list', () => {
+      expect(sanitize('not_in', ['']).value).toEqual([])
+    })
+
+    it('drops an empty operand from an in list', () => {
+      expect(sanitize('in', ['']).value).toEqual([])
+    })
+
+    it('keeps the numeric operands alongside a dropped empty one', () => {
+      expect(sanitize('not_in', ['', '5']).value).toEqual([5])
+    })
+
+    it('coerces an array of numeric strings to numbers', () => {
+      expect(sanitize('in', ['5', '6']).value).toEqual([5, 6])
+    })
+
+    it('coerces a comma-delineated string, dropping its blank entries', () => {
+      expect(sanitize('not_in', '5,,6').value).toEqual([5, 6])
+    })
+
+    it('drops an operand that is not numeric at all', () => {
+      expect(sanitize('in', ['5', 'abc']).value).toEqual([5])
+    })
+  })
+
+  describe('in / not_in operands on a uuid column', () => {
+    it('drops an empty operand from a not_in list', () => {
+      expect(sanitizeUUID('not_in', ['']).value).toEqual([])
+    })
+
+    it('keeps a valid uuid alongside a dropped empty one', () => {
+      expect(sanitizeUUID('not_in', ['', uuid]).value).toEqual([uuid])
+    })
+
+    it('drops an operand that is not a valid uuid', () => {
+      expect(sanitizeUUID('in', [uuid, 'not-a-uuid']).value).toEqual([uuid])
+    })
+  })
+})

--- a/packages/drizzle/src/queries/sanitizeQueryValue.ts
+++ b/packages/drizzle/src/queries/sanitizeQueryValue.ts
@@ -84,16 +84,20 @@ export const sanitizeQueryValue = ({
   if (['all', 'in', 'not_in'].includes(operator)) {
     if (typeof formattedValue === 'string') {
       formattedValue = createArrayFromCommaDelineated(formattedValue)
-
-      if (field.type === 'number') {
-        formattedValue = formattedValue.map((arrayVal) => parseFloat(arrayVal))
-      }
     } else if (typeof formattedValue === 'number') {
       formattedValue = [formattedValue]
     }
 
     if (!Array.isArray(formattedValue)) {
       return null
+    }
+
+    if (field.type === 'number') {
+      formattedValue = formattedValue
+        .map((arrayVal) => parseFloat(arrayVal))
+        .filter((arrayVal) => !Number.isNaN(arrayVal))
+    } else if (isUUID) {
+      formattedValue = formattedValue.filter((arrayVal) => uuidValidate(arrayVal))
     }
   }
 

--- a/test/database/int.spec.ts
+++ b/test/database/int.spec.ts
@@ -117,6 +117,36 @@ describe('database', () => {
       expect(updated.id).toStrictEqual(created.doc.id)
     })
 
+    it(
+      'should ignore an empty id operand in in / not_in queries instead of erroring',
+      { db: 'drizzle' },
+      async () => {
+        const doc = await payload.create({
+          collection: postsSlug,
+          data: { title: 'empty id operand' },
+        })
+
+        // Payload's own relationship field asks for its options with the already-selected
+        // ids excluded, and still sends the parameter when nothing is selected yet:
+        // `?where[and][0][id][not_in][0]=`. That reaches the adapter as an empty-string
+        // operand, which cannot be cast to the id column's type.
+        const excludesNothing = await payload.find({
+          collection: postsSlug,
+          where: { id: { not_in: [''] } },
+        })
+
+        const matchesNothing = await payload.find({
+          collection: postsSlug,
+          where: { id: { in: [''] } },
+        })
+
+        await payload.delete({ collection: postsSlug, id: doc.id })
+
+        expect(excludesNothing.docs.map(({ id }) => id)).toContain(doc.id)
+        expect(matchesNothing.totalDocs).toStrictEqual(0)
+      },
+    )
+
     it('should create with generated ID text from hook', async () => {
       const doc = await payload.create({
         collection: 'custom-ids',


### PR DESCRIPTION
### What?

`sanitizeQueryValue` only coerced `in` / `not_in` / `all` operands when the incoming value was a comma-delineated **string**. When the same value arrives as an **array** — which is what an indexed query string produces — the coercion was skipped entirely, so an operand that cannot be cast to the column's type reached the driver as-is.

This moves the existing numeric coercion below the array normalisation so it applies in both cases, drops operands that are not numbers, and adds the equivalent for `uuid` id columns.

### Why?

Payload's own relationship field asks for its options with the already-selected ids excluded, and it still sends the parameter when nothing is selected yet:

```
GET /api/roles?where[and][0][id][not_in][0]=
```

`qs` parses that into `not_in: ['']`. Because the value is an array, no coercion ran, and the empty string was bound straight to the id column:

```sql
select count(*) from "roles" where "roles"."id" not in ($1)   -- params: ['']
```

```
error: invalid input syntax for type integer: ""
```

The endpoint 500s and the field spins on "Loading…" with nothing surfaced to the user. On a `uuid` adapter the same query fails with `invalid input syntax for type uuid: ""`. Every collection is affected, not only the one where we hit it.

Where it actually shows up is an install whose `users` table is empty while the data to select already exists — the `create-first-user` screen — because that is when nothing is selected yet. Local development rarely reproduces it, since those databases already have users.

Related issues:

- #7909 — the same driver error, from `where[...][id][not_equals]=`. It was closed by removing the empty parameter at that one call site rather than in the adapter, which is why this variant still reproduces.
- #14204 — the `NaN` sibling of the same problem. Not addressed in general here, but `'5,,6'` no longer produces `[5, NaN, 6]`.
- #14257 — same screen, different cause (the client-side permissions guard), closed as expected behaviour. This is not that: the failure here is server-side and happens for any caller, authenticated or not.

### How?

The coercion moved below the `Array.isArray` normalisation and gained a filter:

```ts
if (field.type === 'number') {
  formattedValue = formattedValue
    .map((arrayVal) => parseFloat(arrayVal))
    .filter((arrayVal) => !Number.isNaN(arrayVal))
} else if (isUUID) {
  formattedValue = formattedValue.filter((arrayVal) => uuidValidate(arrayVal))
}
```

Dropping the operand is semantics-preserving rather than lenient: a value that cannot be cast to the column's type can never equal any row, so removing it leaves the result set identical for both operators. Filtering down to an empty list stays correct as well — drizzle compiles `inArray(col, [])` to `false` (matches nothing) and `notInArray(col, [])` to `true` (excludes nothing), which is exactly what an `in` / `not_in` of nothing means.

`isUUID` is only true when the column really is a `PgUUID`, so the uuid filter cannot narrow a plain text id column.

### Tests

- `packages/drizzle/src/queries/sanitizeQueryValue.spec.ts` — new unit spec covering both id types, including that valid operands are left untouched.
- `test/database/int.spec.ts` — one integration test under `describe('id type')`, tagged `{ db: 'drizzle' }`. It asserts the semantics rather than just the absence of a throw: `not_in: ['']` excludes nothing, `in: ['']` matches nothing.

Without this change that integration test fails with the driver error above: `invalid input syntax for type integer: ""` on `postgres`, and `invalid input syntax for type uuid: ""` on `postgres-uuid`.

Verified locally: `test:unit`, `test:types`, `build:core`, and the `database` int suite on `postgres`, `postgres-uuid` and `sqlite`.

---

This targets `main` (v4). The `3.x` branch carries the identical block, so the fix applies there unchanged if you would like a backport.
