### PR TITLE
ci: avoid redundant Playwright dependency installs

### DIFF
--- a/.github/actions/setup-playwright/action.yml
+++ b/.github/actions/setup-playwright/action.yml
@@ -1,0 +1,56 @@
+name: Setup Playwright
+description: Restores Chromium and installs system dependencies only when the browser cannot launch
+
+runs:
+  using: composite
+  steps:
+    - name: Store Playwright's version
+      shell: bash
+      run: |
+        PLAYWRIGHT_VERSION=$(pnpm ls @playwright/test --depth=0 | awk '/@playwright\/test/ {print $2; exit}')
+        echo "Playwright's version: $PLAYWRIGHT_VERSION"
+        echo "PLAYWRIGHT_VERSION=$PLAYWRIGHT_VERSION" >> "$GITHUB_ENV"
+
+    - name: Cache Playwright browsers
+      id: cache-playwright-browsers
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: ~/.cache/ms-playwright
+        key: playwright-browsers-${{ env.PLAYWRIGHT_VERSION }}
+
+    - name: Install Chromium
+      if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
+      shell: bash
+      run: pnpm exec playwright install chromium --no-shell
+
+    - name: Verify Chromium dependencies
+      id: verify-chromium
+      continue-on-error: true
+      shell: bash
+      run: |
+        pnpm exec node -e "const { chromium } = require('@playwright/test'); (async () => { const browser = await chromium.launch({ channel: 'chromium' }); await browser.close() })().catch((error) => { console.error(error); process.exit(1) })"
+
+    - name: Configure apt fallback
+      if: steps.verify-chromium.outcome == 'failure'
+      shell: bash
+      run: |
+        if [ -f /etc/apt/apt-mirrors.txt ]; then
+          sudo sed -i '/azure\.archive\.ubuntu\.com/d' /etc/apt/apt-mirrors.txt
+        fi
+
+        sudo tee /etc/apt/apt.conf.d/99-playwright-ci > /dev/null <<'EOF'
+        Acquire::Retries "3";
+        Acquire::http::Timeout "30";
+        Acquire::https::Timeout "30";
+        EOF
+
+    - name: Install Chromium dependencies
+      if: steps.verify-chromium.outcome == 'failure'
+      shell: bash
+      run: timeout 8m pnpm exec playwright install-deps chromium
+
+    - name: Verify installed Chromium dependencies
+      if: steps.verify-chromium.outcome == 'failure'
+      shell: bash
+      run: |
+        pnpm exec node -e "const { chromium } = require('@playwright/test'); (async () => { const browser = await chromium.launch({ channel: 'chromium' }); await browser.close() })().catch((error) => { console.error(error); process.exit(1) })"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,7 @@ jobs:
               - '.github/workflows/main.yml'
               - '.github/actions/start-services/**'
               - '.github/actions/setup/**'
+              - '.github/actions/setup-playwright/**'
               - 'packages/**'
               - 'test/**'
               - 'pnpm-lock.yaml'
@@ -383,28 +384,8 @@ jobs:
         with:
           database: mongodb
 
-      - name: Store Playwright's Version
-        run: |
-          # `exit` after the first match: v11's `pnpm ls` lists the dep across every workspace
-          # project, and a multi-line value would break the GITHUB_ENV write.
-          PLAYWRIGHT_VERSION=$(pnpm ls @playwright/test --depth=0 | awk '/@playwright\/test/ {print $2; exit}')
-          echo "Playwright's Version: $PLAYWRIGHT_VERSION"
-          echo "PLAYWRIGHT_VERSION=$PLAYWRIGHT_VERSION" >> $GITHUB_ENV
-
-      - name: Cache Playwright Browsers for Playwright's Version
-        id: cache-playwright-browsers
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-browsers-${{ env.PLAYWRIGHT_VERSION }}
-
-      - name: Setup Playwright - Browsers and Dependencies
-        if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
-        run: pnpm exec playwright install --with-deps chromium --no-shell
-
-      - name: Setup Playwright - Dependencies-only
-        if: steps.cache-playwright-browsers.outputs.cache-hit == 'true'
-        run: pnpm exec playwright install-deps chromium
+      - name: Setup Playwright
+        uses: ./.github/actions/setup-playwright
 
       - name: E2E Tests
         # E2E Test Execution Strategy:
@@ -515,28 +496,8 @@ jobs:
           NODE_OPTIONS: --max-old-space-size=8096
           DB_CONNECTION: ${{ steps.db.outputs.POSTGRES_URL || steps.db.outputs.MONGODB_URL }}
 
-      - name: Store Playwright's Version
-        run: |
-          # `exit` after the first match: v11's `pnpm ls` lists the dep across every workspace
-          # project, and a multi-line value would break the GITHUB_ENV write.
-          PLAYWRIGHT_VERSION=$(pnpm ls @playwright/test --depth=0 | awk '/@playwright\/test/ {print $2; exit}')
-          echo "Playwright's Version: $PLAYWRIGHT_VERSION"
-          echo "PLAYWRIGHT_VERSION=$PLAYWRIGHT_VERSION" >> $GITHUB_ENV
-
-      - name: Cache Playwright Browsers for Playwright's Version
-        id: cache-playwright-browsers
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-browsers-${{ env.PLAYWRIGHT_VERSION }}
-
-      - name: Setup Playwright - Browsers and Dependencies
-        if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
-        run: pnpm exec playwright install --with-deps chromium
-
-      - name: Setup Playwright - Dependencies-only
-        if: steps.cache-playwright-browsers.outputs.cache-hit == 'true'
-        run: pnpm exec playwright install-deps chromium
+      - name: Setup Playwright
+        uses: ./.github/actions/setup-playwright
 
       - name: Runs Template Int Tests
         run: pnpm --filter ${{ matrix.template }} run test:int

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -386,6 +386,7 @@ jobs:
 
       - name: Setup Playwright
         uses: ./.github/actions/setup-playwright
+        timeout-minutes: 10
 
       - name: E2E Tests
         # E2E Test Execution Strategy:
@@ -498,6 +499,7 @@ jobs:
 
       - name: Setup Playwright
         uses: ./.github/actions/setup-playwright
+        timeout-minutes: 10
 
       - name: Runs Template Int Tests
         run: pnpm --filter ${{ matrix.template }} run test:int


### PR DESCRIPTION
Skips Playwright's `install-deps` when Chromium can already launch on GitHub's Ubuntu runner. Each E2E shard currently runs `apt-get update` even when the browser cache hits, multiplying transient Ubuntu mirror failures across 221 jobs and allowing dependency setup to consume the 45-minute job timeout.

Without this change, it's possible for CI to enter into a time-consuming, flakey state. It hangs up on the following until the timeout has elapsed:

```
Run pnpm exec playwright install-deps chromium
Installing dependencies...
Switching to root user to install dependencies...
Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [144 B]
Get:6 https://packages.microsoft.com/repos/azure-cli noble InRelease [3564 B]
Get:7 https://packages.microsoft.com/ubuntu/24.04/prod noble InRelease [3600 B]
Get:8 https://packages.microsoft.com/repos/azure-cli noble/main amd64 Packages [2452 B]
Get:9 https://packages.microsoft.com/ubuntu/24.04/prod noble/main arm64 Packages [288 kB]
Get:10 https://packages.microsoft.com/ubuntu/24.04/prod noble/main amd64 Packages [329 kB]
Get:11 https://packages.microsoft.com/ubuntu/24.04/prod noble/main armhf Packages [12.4 kB]
Get:12 https://dl.google.com/linux/chrome-stable/deb stable InRelease [2548 B]
Get:13 https://dl.google.com/linux/chrome-stable/deb stable/main amd64 Packages [1417 B]
Ign:2 http://azure.archive.ubuntu.com/ubuntu noble InRelease
Ign:3 http://azure.archive.ubuntu.com/ubuntu noble-updates InRelease
Ign:4 http://azure.archive.ubuntu.com/ubuntu noble-backports InRelease
Ign:5 http://azure.archive.ubuntu.com/ubuntu noble-security InRelease
Ign:2 http://azure.archive.ubuntu.com/ubuntu noble InRelease
Ign:3 http://azure.archive.ubuntu.com/ubuntu noble-updates InRelease
Ign:4 http://azure.archive.ubuntu.com/ubuntu noble-backports InRelease
Ign:5 http://azure.archive.ubuntu.com/ubuntu noble-security InRelease
Ign:2 http://azure.archive.ubuntu.com/ubuntu noble InRelease
Ign:3 http://azure.archive.ubuntu.com/ubuntu noble-updates InRelease
Ign:4 http://azure.archive.ubuntu.com/ubuntu noble-backports InRelease
Ign:5 http://azure.archive.ubuntu.com/ubuntu noble-security InRelease
Ign:2 http://azure.archive.ubuntu.com/ubuntu noble InRelease
Ign:3 http://azure.archive.ubuntu.com/ubuntu noble-updates InRelease
Ign:4 http://azure.archive.ubuntu.com/ubuntu noble-backports InRelease
Ign:5 http://azure.archive.ubuntu.com/ubuntu noble-security InRelease
Hit:2 https://archive.ubuntu.com/ubuntu noble InRelease
Get:3 https://archive.ubuntu.com/ubuntu noble-updates InRelease [126 kB]
Get:4 https://archive.ubuntu.com/ubuntu noble-backports InRelease [126 kB]
Ign:14 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 Packages
Get:5 https://archive.ubuntu.com/ubuntu noble-security InRelease [126 kB]
```

The fallback installs system dependencies only after a launch probe fails, bypasses the Azure mirror, bounds APT retries and connection timeouts, and verifies Chromium again. Both E2E and template jobs use the shared local action.