### PR TITLE
fix(plugin-multi-tenant): respect undefined initialValue and userHasAccessToAllTenants on single-tenant auto-select (#17833)

### DIFF
--- a/PR_DESCRIPTION_DRAFT.md
+++ b/PR_DESCRIPTION_DRAFT.md
@@ -1,0 +1,16 @@
+## 📌 Summary
+Fixes #17833
+
+Fixes an issue in `@payloadcms/plugin-multi-tenant` where single-tenant auto-selection overrode the server's intentional "no tenant selected" state on every page mount for users with `userHasAccessToAllTenants`.
+
+---
+
+## 🔍 Root Cause Analysis
+When an installation had exactly one tenant, `TenantSelectionProvider` unconditionally auto-selected the first tenant and wrote the `payload-tenant` cookie, ignoring whether the user had global access (`userHasAccessToAllTenants`) and desired an unselected platform-wide view. On the client, the sync effect and `setTenant` also forced re-selection of the single tenant even when clearing the selection or when `initialValue` was undefined.
+
+---
+
+## 🛠️ Solution
+- In `TenantSelectionProvider` (server component), checked `userHasAccessToAllTenants(user)` before falling back to auto-selecting the single tenant, ensuring users with global access retain `initialValue = undefined` when no tenant cookie is set.
+- In `TenantSelectionProviderClient`, only auto-select the single tenant and set the cookie if `initialValue` is defined, and allow `setTenant({ id: undefined })` to clear tenant selection regardless of tenant count.
+- Added unit tests in `packages/plugin-multi-tenant/src/providers/TenantSelectionProvider/tenantSelection.unit.test.ts`.

--- a/packages/plugin-multi-tenant/src/providers/TenantSelectionProvider/index.client.tsx
+++ b/packages/plugin-multi-tenant/src/providers/TenantSelectionProvider/index.client.tsx
@@ -147,13 +147,8 @@ export const TenantSelectionProviderClient = ({
   const setTenant = React.useCallback<ContextType['setTenant']>(
     ({ id, refresh }) => {
       if (id === undefined) {
-        if (tenantOptions.length > 1 || tenantOptions.length === 0) {
-          // users with multiple tenants can clear the tenant selection
-          setTenantAndCookie({ id: undefined, refresh })
-        } else if (tenantOptions[0]) {
-          // if there is only one tenant, auto-select that tenant
-          setTenantAndCookie({ id: tenantOptions[0].value, refresh: true })
-        }
+        // users can clear the tenant selection
+        setTenantAndCookie({ id: undefined, refresh })
       } else if (!tenantOptions.find((option) => option.value === id)) {
         // if the tenant is invalid, set the first tenant as selected
         setTenantAndCookie({
@@ -186,7 +181,7 @@ export const TenantSelectionProviderClient = ({
       if (result.tenantOptions && userID) {
         setTenantOptions(result.tenantOptions)
 
-        if (result.tenantOptions.length === 1) {
+        if (initialValue && result.tenantOptions.length === 1) {
           setSelectedTenantID(result.tenantOptions[0].value)
           setTenantCookie({ value: String(result.tenantOptions[0].value) })
         }
@@ -194,7 +189,7 @@ export const TenantSelectionProviderClient = ({
     } catch (e) {
       toast.error(`Error fetching tenants`)
     }
-  }, [config.routes.api, tenantsCollectionSlug, userID])
+  }, [config.routes.api, tenantsCollectionSlug, userID, initialValue])
 
   const updateTenants = React.useCallback<ContextType['updateTenants']>(
     ({ id, label }) => {
@@ -234,12 +229,12 @@ export const TenantSelectionProviderClient = ({
         return initialTenantOptions
       })
 
-      if (initialTenantOptions.length === 1 && initialTenantOptions[0]) {
+      if (initialValue && initialTenantOptions.length === 1 && initialTenantOptions[0]) {
         setSelectedTenantID(initialTenantOptions[0].value)
         setTenantCookie({ value: String(initialTenantOptions[0].value) })
       }
     }
-  }, [initialTenantOptions])
+  }, [initialTenantOptions, initialValue])
 
   React.useEffect(() => {
     if (userChanged || (initialValue && String(initialValue) !== getTenantCookie())) {

--- a/packages/plugin-multi-tenant/src/providers/TenantSelectionProvider/index.tsx
+++ b/packages/plugin-multi-tenant/src/providers/TenantSelectionProvider/index.tsx
@@ -58,10 +58,17 @@ export const TenantSelectionProvider = async ({
   }
 
   /**
-   * If the there was no cookie or the cookie was an invalid tenantID set intialValue
+   * If there was no cookie or the cookie was an invalid tenantID set intialValue
    */
   if (!initialValue) {
-    initialValue = tenantOptions.length > 1 ? undefined : tenantOptions[0]?.value
+    const hasGlobalAccess =
+      typeof userHasAccessToAllTenants === 'function' ? userHasAccessToAllTenants(user) : false
+
+    initialValue = hasGlobalAccess
+      ? undefined
+      : tenantOptions.length > 1
+        ? undefined
+        : tenantOptions[0]?.value
   }
 
   return (

--- a/packages/plugin-multi-tenant/src/providers/TenantSelectionProvider/tenantSelection.unit.spec.ts
+++ b/packages/plugin-multi-tenant/src/providers/TenantSelectionProvider/tenantSelection.unit.spec.ts
@@ -1,13 +1,15 @@
-import { describe, it, expect } from 'vitest'
+import { describe, expect, it } from 'vitest'
+
+type TenantUser = { id: string; role: string }
 
 describe('Multi-Tenant Single-Tenant Auto-Select Protection (#17833)', () => {
   it('preserves undefined initialValue for users with global access (userHasAccessToAllTenants)', () => {
     const tenantOptions = [{ label: 'Tenant 1', value: 'tenant-1' }]
-    const user = { id: 'admin-1', role: 'super-admin' }
-    const userHasAccessToAllTenants = (u: any) => u.role === 'super-admin'
+    const user: TenantUser = { id: 'admin-1', role: 'super-admin' }
+    const userHasAccessToAllTenants = (currentUser: TenantUser) =>
+      currentUser.role === 'super-admin'
 
-    const hasGlobalAccess =
-      typeof userHasAccessToAllTenants === 'function' ? userHasAccessToAllTenants(user) : false
+    const hasGlobalAccess = userHasAccessToAllTenants(user)
 
     const initialValue = hasGlobalAccess
       ? undefined
@@ -20,11 +22,11 @@ describe('Multi-Tenant Single-Tenant Auto-Select Protection (#17833)', () => {
 
   it('auto-selects the single tenant when the user does not have global access', () => {
     const tenantOptions = [{ label: 'Tenant 1', value: 'tenant-1' }]
-    const user = { id: 'user-1', role: 'member' }
-    const userHasAccessToAllTenants = (u: any) => u.role === 'super-admin'
+    const user: TenantUser = { id: 'user-1', role: 'member' }
+    const userHasAccessToAllTenants = (currentUser: TenantUser) =>
+      currentUser.role === 'super-admin'
 
-    const hasGlobalAccess =
-      typeof userHasAccessToAllTenants === 'function' ? userHasAccessToAllTenants(user) : false
+    const hasGlobalAccess = userHasAccessToAllTenants(user)
 
     const initialValue = hasGlobalAccess
       ? undefined
@@ -40,7 +42,7 @@ describe('Multi-Tenant Single-Tenant Auto-Select Protection (#17833)', () => {
       { label: 'Tenant 1', value: 'tenant-1' },
       { label: 'Tenant 2', value: 'tenant-2' },
     ]
-    const user = { id: 'user-1', role: 'member' }
+    const user: TenantUser = { id: 'user-1', role: 'member' }
     const userHasAccessToAllTenants = () => false
 
     const hasGlobalAccess = userHasAccessToAllTenants()

--- a/packages/plugin-multi-tenant/src/providers/TenantSelectionProvider/tenantSelection.unit.test.ts
+++ b/packages/plugin-multi-tenant/src/providers/TenantSelectionProvider/tenantSelection.unit.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest'
+
+describe('Multi-Tenant Single-Tenant Auto-Select Protection (#17833)', () => {
+  it('preserves undefined initialValue for users with global access (userHasAccessToAllTenants)', () => {
+    const tenantOptions = [{ label: 'Tenant 1', value: 'tenant-1' }]
+    const user = { id: 'admin-1', role: 'super-admin' }
+    const userHasAccessToAllTenants = (u: any) => u.role === 'super-admin'
+
+    const hasGlobalAccess =
+      typeof userHasAccessToAllTenants === 'function' ? userHasAccessToAllTenants(user) : false
+
+    const initialValue = hasGlobalAccess
+      ? undefined
+      : tenantOptions.length > 1
+        ? undefined
+        : tenantOptions[0]?.value
+
+    expect(initialValue).toBeUndefined()
+  })
+
+  it('auto-selects the single tenant when the user does not have global access', () => {
+    const tenantOptions = [{ label: 'Tenant 1', value: 'tenant-1' }]
+    const user = { id: 'user-1', role: 'member' }
+    const userHasAccessToAllTenants = (u: any) => u.role === 'super-admin'
+
+    const hasGlobalAccess =
+      typeof userHasAccessToAllTenants === 'function' ? userHasAccessToAllTenants(user) : false
+
+    const initialValue = hasGlobalAccess
+      ? undefined
+      : tenantOptions.length > 1
+        ? undefined
+        : tenantOptions[0]?.value
+
+    expect(initialValue).toBe('tenant-1')
+  })
+
+  it('preserves undefined initialValue when multiple tenants exist', () => {
+    const tenantOptions = [
+      { label: 'Tenant 1', value: 'tenant-1' },
+      { label: 'Tenant 2', value: 'tenant-2' },
+    ]
+    const user = { id: 'user-1', role: 'member' }
+    const userHasAccessToAllTenants = () => false
+
+    const hasGlobalAccess = userHasAccessToAllTenants()
+
+    const initialValue = hasGlobalAccess
+      ? undefined
+      : tenantOptions.length > 1
+        ? undefined
+        : tenantOptions[0]?.value
+
+    expect(initialValue).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## 📌 Summary
Fixes #17833

Fixes an issue in `@payloadcms/plugin-multi-tenant` where single-tenant auto-selection overrode the server's intentional "no tenant selected" state on every page mount for users with `userHasAccessToAllTenants`.

---

## 🔍 Root Cause Analysis
When an installation had exactly one tenant, `TenantSelectionProvider` unconditionally auto-selected the first tenant and wrote the `payload-tenant` cookie, ignoring whether the user had global access (`userHasAccessToAllTenants`) and desired an unselected platform-wide view. On the client, the sync effect and `setTenant` also forced re-selection of the single tenant even when clearing the selection or when `initialValue` was undefined.

---

## 🛠️ Solution
- In `TenantSelectionProvider` (server component), checked `userHasAccessToAllTenants(user)` before falling back to auto-selecting the single tenant, ensuring users with global access retain `initialValue = undefined` when no tenant cookie is set.
- In `TenantSelectionProviderClient`, only auto-select the single tenant and set the cookie if `initialValue` is defined, and allow `setTenant({ id: undefined })` to clear tenant selection regardless of tenant count.
- Added unit tests in `packages/plugin-multi-tenant/src/providers/TenantSelectionProvider/tenantSelection.unit.test.ts`.
