### PR TITLE
fix(ui): fallback to permissions when permissions.fields is undefined for group fields (#17812)

### DIFF
--- a/packages/ui/src/fields/Group/index.tsx
+++ b/packages/ui/src/fields/Group/index.tsx
@@ -114,7 +114,7 @@ export const GroupFieldComponent: GroupFieldClientComponent = (props) => {
               parentIndexPath=""
               parentPath={path}
               parentSchemaPath={schemaPath}
-              permissions={permissions === true ? permissions : permissions?.fields}
+              permissions={permissions === true ? permissions : (permissions?.fields ?? permissions)}
               readOnly={readOnly}
             />
           ) : (


### PR DESCRIPTION
# Title
fix(ui): fallback to parent permissions when field permissions are undefined for group fields (#17812)

## Description
- Updates `GroupFieldComponent` to pass `(permissions?.fields ?? permissions)` to `RenderFields` for named group fields.
- Fixes bug where group children were dropped during render because top-level collections or globals with default permissions did not define an explicit `permissions.fields` sub-object.
- Ensures all child inputs inside `group` fields render properly in the admin panel.

Closes #17812
