### PR TITLE
fix(ui): preserve columnState fallback in setActiveColumns (#17792)

### DIFF
--- a/packages/ui/src/providers/TableColumns/index.tsx
+++ b/packages/ui/src/providers/TableColumns/index.tsx
@@ -91,20 +91,22 @@ export const TableColumnsProvider: React.FC<TableColumnsProviderProps> = ({
 
   const setActiveColumns = useCallback(
     async (columns: string[]) => {
-      const newColumnState = currentQuery.columns
+      const newColumnState = Array.isArray(currentQuery?.columns)
+        ? [...currentQuery.columns]
+        : columnState?.map((c) => (c.active ? c.accessor : `-${c.accessor}`)) || []
 
       columns.forEach((colName) => {
-        const colIndex = newColumnState.findIndex((c) => colName === c)
+        const colIndex = newColumnState.findIndex((c) => colName === c || c === `-${colName}`)
 
         // ensure the name does not begin with a `-` which denotes an inactive column
-        if (colIndex !== undefined && newColumnState[colIndex][0] === '-') {
-          newColumnState[colIndex] = colName.slice(1)
+        if (colIndex !== -1 && newColumnState[colIndex].startsWith('-')) {
+          newColumnState[colIndex] = colName.replace(/^-/, '')
         }
       })
 
       await refineListData({ columns: newColumnState })
     },
-    [currentQuery, refineListData],
+    [currentQuery, columnState, refineListData],
   )
 
   const resetColumnsState = React.useCallback(async () => {


### PR DESCRIPTION
# Title
fix(ui): preserve active columnState fallback in setActiveColumns when query.columns is undefined (#17792)

## Description
- Updates `setActiveColumns` in `TableColumnsProvider` to fallback to current `columnState` when `currentQuery?.columns` is not present in URL search parameters.
- Fixes issue where navigating pagination after a browser refresh discarded user-customized column visibility.

Closes #17792
