### PR TITLE
fix(storage-vercel-blob): prevent client upload file overwrite (#17823)

### DIFF
--- a/packages/storage-vercel-blob/src/adapter.ts
+++ b/packages/storage-vercel-blob/src/adapter.ts
@@ -75,7 +75,7 @@ export function createVercelBlobAdapter({
             token: await generateClientTokenFromReadWriteToken({
               addRandomSuffix,
               allowedContentTypes: mimeType ? [mimeType] : undefined,
-              allowOverwrite: true,
+              allowOverwrite: false,
               cacheControlMaxAge,
               maximumSizeInBytes: filesize,
               pathname: resolved.fileKey,


### PR DESCRIPTION
# Title
fix(storage-vercel-blob): prevent client uploads from overwriting existing files on filename collision (#17823)

## Description
- Sets `allowOverwrite: false` when generating client upload tokens via `generateClientTokenFromReadWriteToken`.
- Prevents subsequent uploads with colliding filenames from replacing existing files in the Vercel Blob store and resulting in 404s for the uniquified record row.

Closes #17823
