### PR TITLE
fix(plugin-mcp): safe schema handling in withoutRequired (#17844)

### DIFF
--- a/packages/plugin-mcp/src/mcp/builtin/validateEntityData.ts
+++ b/packages/plugin-mcp/src/mcp/builtin/validateEntityData.ts
@@ -127,6 +127,9 @@ const validateData = ({
 
 /** Updates are partial — drop the schema's top-level `required` before validating. */
 const withoutRequired = (schema: JsonSchemaType): JsonSchemaType => {
+  if (!schema || typeof schema !== 'object') {
+    return schema
+  }
   const { required: _required, ...rest } = schema
   return rest
 }


### PR DESCRIPTION
# Title
fix(plugin-mcp): guard against non-object schemas in update validator withoutRequired (#17844)

## Description
- Adds guard checking for valid schema object before destructuring `required` in `withoutRequired`.
- Prevents runtime crashes (`TypeError`) during MCP update tool registration when entity schema generation returns a permissive or non-object fallback.

Closes #17844
