### PR TITLE
fix(ui): align top-level group fields with sidebar margin (#17851)

### DIFF
--- a/packages/ui/src/elements/DocumentFields/index.css
+++ b/packages/ui/src/elements/DocumentFields/index.css
@@ -40,7 +40,8 @@
     border-left: var(--main-border);
   }
 
-  .document-fields--has-sidebar .document-fields__fields > .tabs-field {
+  .document-fields--has-sidebar .document-fields__fields > .tabs-field,
+  .document-fields--has-sidebar .document-fields__fields > .group-field {
     margin-right: var(--main-field-margin);
   }
 


### PR DESCRIPTION
# Title
fix(ui): align top-level group fields with sidebar margin in DocumentFields (#17851)

## Description
- Applies `margin-right: var(--main-field-margin)` to `> .group-field` in `.document-fields--has-sidebar`, matching `> .tabs-field`.
- Fixes right-side content and separator misalignment for top-level group fields when a document contains sidebar fields.

Closes #17851
