### PR TITLE
fix: report non-zero exit when payload CLI config never settles

### DIFF
--- a/packages/payload/bin.js
+++ b/packages/payload/bin.js
@@ -15,7 +15,10 @@ if (disableTranspile) {
     await bin()
   }
 
-  void start()
+  void start().catch((err) => {
+    console.error(err)
+    process.exit(1)
+  })
 } else {
   const filename = fileURLToPath(import.meta.url)
   const dirname = path.dirname(filename)
@@ -41,7 +44,10 @@ if (disableTranspile) {
       await bin()
     }
 
-    void start()
+    void start().catch((err) => {
+      console.error(err)
+      process.exit(1)
+    })
   } else if (useSwc) {
     const { register } = await import('node:module')
     // Remove --use-swc from arguments
@@ -60,6 +66,9 @@ if (disableTranspile) {
       await bin()
     }
 
-    void start()
+    void start().catch((err) => {
+      console.error(err)
+      process.exit(1)
+    })
   }
 }

--- a/packages/payload/src/bin/index.spec.ts
+++ b/packages/payload/src/bin/index.spec.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const loadEnvMock = vi.fn()
+const findConfigMock = vi.fn()
+const migrateMock = vi.fn()
+
+// Mock every collaborator so importing the bin entry stays isolated from the
+// payload core and never touches the filesystem or a real config.
+vi.mock('./loadEnv.js', () => ({ loadEnv: loadEnvMock }))
+vi.mock('../config/find.js', () => ({ findConfig: findConfigMock }))
+vi.mock('../index.js', () => ({ default: {}, getPayload: vi.fn() }))
+vi.mock('croner', () => ({ Cron: vi.fn() }))
+vi.mock('./build.js', () => ({ build: vi.fn() }))
+vi.mock('./generateImportMap/index.js', () => ({ generateImportMap: vi.fn() }))
+vi.mock('./generateTypes.js', () => ({ generateTypes: vi.fn() }))
+vi.mock('./info.js', () => ({ info: vi.fn() }))
+vi.mock('./migrate.js', () => ({
+  availableCommands: [
+    'migrate',
+    'migrate:create',
+    'migrate:down',
+    'migrate:refresh',
+    'migrate:reset',
+    'migrate:status',
+    'migrate:fresh',
+  ],
+  migrate: migrateMock,
+}))
+
+// Imported after mocks are registered
+const { bin } = await import('./index.js')
+
+describe('bin', () => {
+  let exitMock: ReturnType<typeof vi.spyOn>
+  let errorSpy: ReturnType<typeof vi.spyOn>
+  let originalArgv: string[]
+  let originalExitCode: typeof process.exitCode
+
+  beforeEach(() => {
+    originalArgv = process.argv
+    originalExitCode = process.exitCode
+    process.exitCode = 0
+    loadEnvMock.mockReset()
+    findConfigMock.mockReset()
+    // Throw from the mock so control stops exactly where the real process.exit would.
+    exitMock = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit:${code}`)
+    }) as never)
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    vi.spyOn(console, 'log').mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    process.argv = originalArgv
+    process.exitCode = originalExitCode
+    vi.restoreAllMocks()
+  })
+
+  it('defaults process.exitCode to 1 at entry so a never-settling run reports failure', async () => {
+    // loadEnv is the first call after the guard; making it throw proves the guard
+    // is already in place before any work that could hang or be dropped runs.
+    loadEnvMock.mockImplementation(() => {
+      throw new Error('boom')
+    })
+    process.argv = ['node', 'payload', 'migrate']
+
+    await expect(bin()).rejects.toThrow('boom')
+    expect(process.exitCode).toBe(1)
+  })
+
+  it('exits 1 with a clear message when the config fails to load', async () => {
+    findConfigMock.mockImplementation(() => {
+      throw new Error('no config found')
+    })
+    process.argv = ['node', 'payload', 'migrate']
+
+    await expect(bin()).rejects.toThrow('process.exit:1')
+    expect(errorSpy).toHaveBeenCalledWith('Failed to load the Payload config.')
+    expect(exitMock).toHaveBeenCalledWith(1)
+    expect(process.exitCode).toBe(1)
+  })
+})

--- a/packages/payload/src/bin/index.ts
+++ b/packages/payload/src/bin/index.ts
@@ -27,6 +27,11 @@ const availableScripts = [
 ] as const
 
 export const bin = async () => {
+  // Default to failure. A dropped or never-settling config import drains the event
+  // loop and lets Node exit before the explicit exit(0) below runs; without this the
+  // process would report success. The success paths set 0 explicitly.
+  process.exitCode = 1
+
   loadEnv()
   process.env.DISABLE_PAYLOAD_HMR = 'true'
 
@@ -104,11 +109,18 @@ async function runBinScript({
     return {}
   }
 
-  const configPath = findConfig()
-  const configPromise = await import(pathToFileURL(configPath).toString())
-  let config = await configPromise
-  if (config.default) {
-    config = await config.default
+  let config
+  try {
+    const configPath = findConfig()
+    const configModule = await import(pathToFileURL(configPath).toString())
+    config = await configModule
+    if (config.default) {
+      config = await config.default
+    }
+  } catch (err) {
+    console.error('Failed to load the Payload config.')
+    console.error(err)
+    process.exit(1)
   }
 
   const userBinScript = Array.isArray(config.bin)


### PR DESCRIPTION
The Payload CLI could exit 0 after silently failing to load the config. `payload build` and the deploy steps after it then treated a non-build as success. This change makes the CLI report a non-zero exit whenever the config never loads.

```console
# Config import dropped on an unsupported Node version
$ payload build
# before: no output, exit 0  (deploy continues against a missing build)
# after:  exit 1
```

Resolves [PYLD-3524](https://linear.app/figma/issue/PYLD-3524)

## Root Cause

On an unsupported Node version, the ESM loader can drop the pending config import. The returned promise never settles: it neither resolves nor rejects. `bin.js` runs the CLI as a floating `void start()` with no rejection handler. `runBinScript` imported the config with no guard. A never-settling promise does not keep the event loop alive, so the loop drains and Node exits 0 with no output. A `try/catch` or `.catch()` cannot trap a promise that never rejects, so the exit code itself had to fail closed.

## Key Changes

- **Fail-closed exit code**
  - `bin()` sets `process.exitCode = 1` at entry. The success paths still call `process.exit(0)` explicitly. A drained event loop now carries 1 instead of 0.
- **Guarded config load**
  - The config load in `runBinScript` is wrapped in try/catch. A config that throws logs a clear message and exits 1.
- **Handled CLI entry rejections**
  - The three `void start()` paths in `bin.js` gain `.catch()`. A rejected startup logs the error and exits 1.

## Design Decisions

- The entry-level `exitCode` guard is the only change that covers a never-settling promise. The try/catch and `.catch()` cover a config that throws, not one that hangs. Both ship as defense in depth, not as the fix.
- The cron path keeps exit 1 on a drained loop. A cron daemon reaching loop-drain is abnormal, so a non-zero code is the honest signal.

## Overall Flow

```mermaid
flowchart TD
    A[Config import dropped on unsupported Node] --> B[start promise never settles]
    B --> C[Event loop drains]
    C --> D{exitCode guard}
    D -->|before| E[exit 0, silent success]
    D -->|after| F[exit 1, failure surfaced]
```

## References / Links

- [payloadcms/payload#17781](https://github.com/payloadcms/payload/pull/17781): sibling fix exposing `payload build` child-process signal failures.
