### PR TITLE
fix: save collection order changes as drafts

### DIFF
--- a/packages/payload/src/config/orderable/index.ts
+++ b/packages/payload/src/config/orderable/index.ts
@@ -162,9 +162,13 @@ export const addOrderableEndpoint = (
         status: 400,
       })
     }
+    const draftsEnabled = hasDraftsEnabled(collection)
+    const shouldUseDraftOrder =
+      draftsEnabled && collection.orderable === true && orderableFieldName === '_order'
 
     const { joinScopeWhere, targetDoc } = await getJoinScopeContext({
       collectionSlug: collection.slug,
+      draft: shouldUseDraftOrder,
       joinFieldPathsByCollection,
       orderableFieldName,
       req,
@@ -253,6 +257,7 @@ export const addOrderableEndpoint = (
     const targetId = target.id
     const targetKey = await resolvePendingTargetKey({
       collectionSlug: collection.slug,
+      draft: shouldUseDraftOrder,
       orderableFieldName,
       req,
       targetDoc,
@@ -266,6 +271,7 @@ export const addOrderableEndpoint = (
     const adjacentDoc = await req.payload.find({
       collection: collection.slug,
       depth: 0,
+      draft: shouldUseDraftOrder,
       limit: 1,
       pagination: false,
       select: { [orderableFieldName]: true },
@@ -288,13 +294,11 @@ export const addOrderableEndpoint = (
         ? generateNKeysBetween(targetKey, adjacentDocKey, docsToMove.length)
         : generateNKeysBetween(adjacentDocKey, targetKey, docsToMove.length)
 
-    const draftsEnabled = hasDraftsEnabled(collection)
-
     // Update each document with its new order value
     for (const [index, id] of docsToMove.entries()) {
-      let draft: boolean | undefined
+      let draft: boolean | undefined = shouldUseDraftOrder ? true : undefined
 
-      if (draftsEnabled) {
+      if (draftsEnabled && !shouldUseDraftOrder) {
         const latestVersion = await getLatestCollectionVersion({
           id,
           config: collection,

--- a/packages/payload/src/config/orderable/utils/getJoinScopeContext.ts
+++ b/packages/payload/src/config/orderable/utils/getJoinScopeContext.ts
@@ -8,6 +8,7 @@ import { getValueAtPath } from './getValueAtPath.js'
  */
 export async function getJoinScopeContext(args: {
   collectionSlug: string
+  draft?: boolean
   joinFieldPathsByCollection: Map<string, Map<string, string>>
   orderableFieldName: string
   req: Parameters<PayloadHandler>[0]
@@ -16,7 +17,8 @@ export async function getJoinScopeContext(args: {
   joinScopeWhere: ReturnType<typeof buildJoinScopeWhere>
   targetDoc: null | Record<string, unknown>
 }> {
-  const { collectionSlug, joinFieldPathsByCollection, orderableFieldName, req, target } = args
+  const { collectionSlug, draft, joinFieldPathsByCollection, orderableFieldName, req, target } =
+    args
 
   const joinOnFieldPath = joinFieldPathsByCollection.get(collectionSlug)?.get(orderableFieldName)
   let targetDoc: null | Record<string, unknown> = null
@@ -34,6 +36,7 @@ export async function getJoinScopeContext(args: {
         id: targetID,
         collection: collectionSlug,
         depth: 0,
+        draft,
         req,
         select: {
           ...(joinOnFieldPath ? { [joinOnFieldPath]: true } : {}),

--- a/packages/payload/src/config/orderable/utils/resolvePendingTargetKey.ts
+++ b/packages/payload/src/config/orderable/utils/resolvePendingTargetKey.ts
@@ -5,13 +5,14 @@ import type { PayloadHandler } from '../../types.js'
  */
 export async function resolvePendingTargetKey(args: {
   collectionSlug: string
+  draft?: boolean
   orderableFieldName: string
   req: Parameters<PayloadHandler>[0]
   targetDoc: null | Record<string, unknown>
   targetID: string
   targetKey: string
 }): Promise<null | string> {
-  const { collectionSlug, orderableFieldName, req, targetDoc, targetID, targetKey } = args
+  const { collectionSlug, draft, orderableFieldName, req, targetDoc, targetID, targetKey } = args
 
   if (targetKey !== 'pending') {
     return targetKey
@@ -26,6 +27,7 @@ export async function resolvePendingTargetKey(args: {
     id: targetID,
     collection: collectionSlug,
     depth: 0,
+    draft,
     req,
     select: { [orderableFieldName]: true },
   })

--- a/test/sort/int.spec.ts
+++ b/test/sort/int.spec.ts
@@ -485,6 +485,41 @@ describe('Sort', () => {
       let orderable2: Orderable
       let orderableDraft1: Draft
       let orderableDraft2: Draft
+
+      const createPublishedOrderableDraft = (text: string) =>
+        payload.create({
+          collection: draftsSlug,
+          data: { _status: 'published', text },
+        })
+
+      const deleteOrderableDrafts = async (...docs: Draft[]) => {
+        for (const doc of docs) {
+          await payload.delete({ id: doc.id, collection: draftsSlug })
+        }
+      }
+
+      const reorderDraft = ({
+        doc,
+        target,
+        targetKey = target._order,
+      }: {
+        doc: Draft
+        target: Draft
+        targetKey?: Draft['_order']
+      }) =>
+        restClient.POST('/reorder', {
+          body: JSON.stringify({
+            collectionSlug: draftsSlug,
+            docsToMove: [doc.id],
+            newKeyWillBe: 'greater',
+            orderableFieldName: '_order',
+            target: {
+              id: target.id,
+              key: targetKey,
+            },
+          }),
+        })
+
       beforeAll(async () => {
         orderable1 = await payload.create({
           collection: orderableSlug,
@@ -592,6 +627,117 @@ describe('Sort', () => {
         expect(parseInt(ordered.docs[0]._order, 36)).toBeLessThan(
           parseInt(ordered.docs[1]._order, 36),
         )
+      })
+
+      it('should stage collection reordering until the moved document is published', async () => {
+        const first = await createPublishedOrderableDraft('Staged order first')
+        const second = await createPublishedOrderableDraft('Staged order second')
+
+        const res = await reorderDraft({ doc: first, target: second })
+
+        expect(res.status).toStrictEqual(200)
+
+        const where = {
+          id: {
+            in: [first.id, second.id],
+          },
+        }
+        const draftOrder = await payload.find({
+          collection: draftsSlug,
+          draft: true,
+          sort: '_order',
+          where,
+        })
+        const publishedOrder = await payload.find({
+          collection: draftsSlug,
+          draft: false,
+          sort: '_order',
+          where,
+        })
+
+        expect(draftOrder.docs.map(({ id }) => id)).toEqual([second.id, first.id])
+        expect(draftOrder.docs.find(({ id }) => id === first.id)?._status).toBe('draft')
+        expect(publishedOrder.docs.map(({ id }) => id)).toEqual([first.id, second.id])
+
+        await payload.update({
+          id: first.id,
+          collection: draftsSlug,
+          data: {
+            _status: 'published',
+          },
+          draft: true,
+        })
+
+        const orderAfterPublish = await payload.find({
+          collection: draftsSlug,
+          draft: false,
+          sort: '_order',
+          where,
+        })
+
+        expect(orderAfterPublish.docs.map(({ id }) => id)).toEqual([second.id, first.id])
+
+        await deleteOrderableDrafts(first, second)
+      })
+
+      it('should calculate consecutive collection reorders from the draft order', async () => {
+        const first = await createPublishedOrderableDraft('Consecutive order first')
+        const second = await createPublishedOrderableDraft('Consecutive order second')
+        const third = await createPublishedOrderableDraft('Consecutive order third')
+        const fourth = await createPublishedOrderableDraft('Consecutive order fourth')
+
+        await reorderDraft({ doc: first, target: third })
+        await reorderDraft({ doc: second, target: third })
+
+        const draftOrder = await payload.find({
+          collection: draftsSlug,
+          draft: true,
+          sort: '_order',
+          where: {
+            id: {
+              in: [first.id, second.id, third.id, fourth.id],
+            },
+          },
+        })
+
+        expect(draftOrder.docs.map(({ id }) => id)).toEqual([
+          third.id,
+          second.id,
+          first.id,
+          fourth.id,
+        ])
+
+        const firstDraftOrder = draftOrder.docs.find(({ id }) => id === first.id)?._order
+        const secondDraftOrder = draftOrder.docs.find(({ id }) => id === second.id)?._order
+
+        expect(secondDraftOrder).not.toBe(firstDraftOrder)
+        expect(secondDraftOrder! < firstDraftOrder!).toBe(true)
+
+        await deleteOrderableDrafts(first, second, third, fourth)
+      })
+
+      it('should resolve a pending collection reorder target from its draft order', async () => {
+        const first = await createPublishedOrderableDraft('Pending order first')
+        const second = await createPublishedOrderableDraft('Pending order second')
+        const third = await createPublishedOrderableDraft('Pending order third')
+
+        await reorderDraft({ doc: first, target: third })
+        await reorderDraft({ doc: second, target: first, targetKey: 'pending' })
+
+        const draftOrder = await payload.find({
+          collection: draftsSlug,
+          draft: true,
+          sort: '_order',
+          where: {
+            id: {
+              in: [first.id, second.id, third.id],
+            },
+          },
+        })
+
+        expect(draftOrder.docs.map(({ id }) => id)).toEqual([third.id, first.id, second.id])
+
+        await deleteOrderableDrafts(first, second, third)
       })
 
       it('should not unpublish a published document with a newer draft when reordering', async () => {


### PR DESCRIPTION
Saves collection ordering changes as drafts, when enabled. Queries for published docs now retain the previous order until the moved document is published, more closely aligning with expected behavior.

Use case: image you have a front-end website that renders a list of documents, queried by order. You might not want reorders to be made live until you explicitly publish them.

Collections without drafts and orderable joins retain their existing behavior.

<!-- e2e-pr-media:start -->
### Before
https://github.com/user-attachments/assets/eddf3d1b-d495-4895-a906-d2a46903461a

### After
https://github.com/user-attachments/assets/08c918e5-9ec5-45b9-a3fb-b46b5665d603
<!-- e2e-pr-media:end -->
