### PR TITLE
feat: add hierarchy delete strategies

### DIFF
--- a/packages/payload/src/hierarchy/addHierarchyToCollection.ts
+++ b/packages/payload/src/hierarchy/addHierarchyToCollection.ts
@@ -8,12 +8,14 @@ import { findFieldByName, findUseAsTitleField } from './utils/findUseAsTitle.js'
 
 export const addHierarchyToCollection = ({
   collectionConfig,
+  deleteStrategy,
   parentFieldName,
   slugFieldName,
   slugPathFieldName,
   titlePathFieldName,
 }: {
   collectionConfig: CollectionConfig
+  deleteStrategy: 'cascade' | 'reparent'
   parentFieldName: string
   slugFieldName?: string
   slugPathFieldName: string
@@ -71,7 +73,7 @@ export const addHierarchyToCollection = ({
     ],
     beforeDelete: [
       ...(collectionConfig.hooks?.beforeDelete || []),
-      hierarchyCollectionBeforeDelete({ parentFieldName }),
+      hierarchyCollectionBeforeDelete({ deleteStrategy, parentFieldName }),
     ],
     beforeOperation: [
       ...(collectionConfig.hooks?.beforeOperation || []),

--- a/packages/payload/src/hierarchy/hooks/collectionBeforeDelete.ts
+++ b/packages/payload/src/hierarchy/hooks/collectionBeforeDelete.ts
@@ -20,29 +20,6 @@ export const hierarchyCollectionBeforeDelete =
     req.context = req.context || {}
     req.context.isDeleting = true
 
-    if (deleteStrategy === 'cascade') {
-      await req.payload.delete({
-        collection: collection.slug,
-        overrideAccess: false,
-        req,
-        where: {
-          [parentFieldName]: {
-            equals: id,
-          },
-        },
-      })
-      return
-    }
-
-    const deletedDocument = await req.payload.findByID({
-      id,
-      collection: collection.slug,
-      depth: 0,
-      overrideAccess: true,
-      req,
-      select: { [parentFieldName]: true },
-    })
-
     const children = await req.payload.find({
       collection: collection.slug,
       depth: 0,
@@ -55,6 +32,27 @@ export const hierarchyCollectionBeforeDelete =
           equals: id,
         },
       },
+    })
+
+    if (deleteStrategy === 'cascade') {
+      for (const { id: childID } of children.docs) {
+        await req.payload.delete({
+          collection: collection.slug,
+          id: childID,
+          overrideAccess: false,
+          req,
+        })
+      }
+      return
+    }
+
+    const deletedDocument = await req.payload.findByID({
+      id,
+      collection: collection.slug,
+      depth: 0,
+      overrideAccess: true,
+      req,
+      select: { [parentFieldName]: true },
     })
 
     const parent = deletedDocument[parentFieldName]

--- a/packages/payload/src/hierarchy/hooks/collectionBeforeDelete.ts
+++ b/packages/payload/src/hierarchy/hooks/collectionBeforeDelete.ts
@@ -1,12 +1,13 @@
 /**
  * beforeDelete Hook Responsibilities:
- * - Delete child folders when parent is deleted (cascade delete)
+ * - Reparent or cascade-delete child documents according to hierarchy config
  * - Set context flag for deletion tracking
  */
 
 import type { CollectionBeforeDeleteHook } from '../../index.js'
 
 type Args = {
+  deleteStrategy: 'cascade' | 'reparent'
   /**
    * The name of the field that contains the parent document ID
    */
@@ -14,19 +15,58 @@ type Args = {
 }
 
 export const hierarchyCollectionBeforeDelete =
-  ({ parentFieldName }: Args): CollectionBeforeDeleteHook =>
+  ({ deleteStrategy, parentFieldName }: Args): CollectionBeforeDeleteHook =>
   async ({ id, collection, req }) => {
     req.context = req.context || {}
     req.context.isDeleting = true
 
-    // Delete all child folders (cascade delete)
-    await req.payload.delete({
+    if (deleteStrategy === 'cascade') {
+      await req.payload.delete({
+        collection: collection.slug,
+        overrideAccess: false,
+        req,
+        where: {
+          [parentFieldName]: {
+            equals: id,
+          },
+        },
+      })
+      return
+    }
+
+    const deletedDocument = await req.payload.findByID({
+      id,
       collection: collection.slug,
+      depth: 0,
+      overrideAccess: true,
       req,
+      select: { [parentFieldName]: true },
+    })
+
+    const children = await req.payload.find({
+      collection: collection.slug,
+      depth: 0,
+      limit: 0,
+      overrideAccess: true,
+      req,
+      select: { id: true },
       where: {
         [parentFieldName]: {
           equals: id,
         },
       },
     })
+
+    const parent = deletedDocument[parentFieldName]
+    const parentID = parent && typeof parent === 'object' && 'id' in parent ? parent.id : parent
+
+    for (const { id: childID } of children.docs) {
+      await req.payload.update({
+        id: childID,
+        collection: collection.slug,
+        data: { [parentFieldName]: parentID ?? null },
+        overrideAccess: true,
+        req,
+      })
+    }
   }

--- a/packages/payload/src/hierarchy/sanitizeHierarchyCollection.ts
+++ b/packages/payload/src/hierarchy/sanitizeHierarchyCollection.ts
@@ -106,10 +106,12 @@ export const sanitizeHierarchyCollection = (
   const smallIconComponent = collectionConfig.hierarchy.admin?.components?.SmallIcon
 
   const slugField = collectionConfig.hierarchy.slugField
+  const deleteStrategy = collectionConfig.hierarchy.deleteStrategy ?? 'reparent'
 
   // Apply hierarchy to collection (adds fields and hooks)
   addHierarchyToCollection({
     collectionConfig,
+    deleteStrategy,
     parentFieldName: collectionConfig.hierarchy.parentFieldName,
     slugFieldName: slugField,
     slugPathFieldName,
@@ -152,6 +154,7 @@ export const sanitizeHierarchyCollection = (
     },
     allowHasMany,
     collectionSpecific,
+    deleteStrategy,
     joinField,
     parentFieldName,
     relatedCollections: {},

--- a/packages/payload/src/hierarchy/types.ts
+++ b/packages/payload/src/hierarchy/types.ts
@@ -73,6 +73,11 @@ export type HierarchyConfig = {
       }
     | boolean
   /**
+   * How to handle direct children when a hierarchy document is deleted
+   * @default 'reparent'
+   */
+  deleteStrategy?: 'cascade' | 'reparent'
+  /**
    * Configure a join field to query all children (nested hierarchy items and related documents)
    * If not set, no join field is created.
    * You can pass additional JoinField options (admin, defaultLimit, defaultSort, etc.)
@@ -130,6 +135,7 @@ export type SanitizedHierarchyConfig = {
         fieldName: string
       }
     | false
+  deleteStrategy: 'cascade' | 'reparent'
   /**
    * Join field configuration, or undefined if not enabled
    */

--- a/test/hierarchy/config.ts
+++ b/test/hierarchy/config.ts
@@ -46,6 +46,10 @@ export const Pages: CollectionConfig = {
   admin: {
     useAsTitle: 'title',
   },
+  access: {
+    delete: () => ({ slug: { not_equals: 'protected' } }),
+    read: () => true,
+  },
   fields: [
     {
       name: 'title',
@@ -67,6 +71,7 @@ export const Pages: CollectionConfig = {
       },
     },
     parentFieldName: 'parent',
+    deleteStrategy: 'cascade',
     slugField: 'slug', // Use dedicated slug field for _h_slugPath
   },
   versions: false,

--- a/test/hierarchy/int.spec.ts
+++ b/test/hierarchy/int.spec.ts
@@ -6,12 +6,43 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from
 
 import type { Organization } from './payload-types.js'
 
+import { extractID } from 'payload/shared'
 import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
 let payload: Payload
+
+const deleteAllHierarchyDocuments = async (collection: 'organizations' | 'pages') => {
+  let documents = await payload.find({
+    collection,
+    depth: 0,
+    limit: 0,
+    overrideAccess: true,
+  })
+
+  while (documents.docs.length > 0) {
+    const leaf = documents.docs.find(
+      (document) =>
+        !documents.docs.some(
+          (candidate) => candidate.id !== document.id && extractID(candidate.parent) === document.id,
+        ),
+    )
+
+    if (!leaf) {
+      throw new Error(`Could not find a leaf document in ${collection}`)
+    }
+
+    await payload.delete({ collection, id: leaf.id, overrideAccess: true })
+    documents = await payload.find({
+      collection,
+      depth: 0,
+      limit: 0,
+      overrideAccess: true,
+    })
+  }
+}
 
 describe('Hierarchy', () => {
   beforeAll(async () => {
@@ -57,6 +88,8 @@ describe('Hierarchy', () => {
       if (organizationsCollection.hierarchy !== false) {
         // eslint-disable-next-line vitest/no-conditional-expect
         expect(organizationsCollection.hierarchy.parentFieldName).toBe('parent')
+        // eslint-disable-next-line vitest/no-conditional-expect
+        expect(organizationsCollection.hierarchy.deleteStrategy).toBe('reparent')
       }
     })
 
@@ -73,6 +106,13 @@ describe('Hierarchy', () => {
         expect(deptsCollection.hierarchy.titlePathFieldName).toBe('_breadcrumbTitle')
       }
 
+      const pagesCollection = payload.collections.pages.config
+      expect(pagesCollection.hierarchy).not.toBe(false)
+      if (pagesCollection.hierarchy !== false) {
+        // eslint-disable-next-line vitest/no-conditional-expect
+        expect(pagesCollection.hierarchy.deleteStrategy).toBe('cascade')
+      }
+
       // Verify custom path fields were added
       const slugField = deptsCollection.fields.find((f) => f.name === '_breadcrumbSlug')
       const titleField = deptsCollection.fields.find((f) => f.name === '_breadcrumbTitle')
@@ -80,17 +120,147 @@ describe('Hierarchy', () => {
       expect(slugField).toBeDefined()
       expect(titleField).toBeDefined()
     })
+
+    describe('Delete Strategy', () => {
+      beforeEach(async () => {
+        await deleteAllHierarchyDocuments('organizations')
+        await deleteAllHierarchyDocuments('pages')
+      })
+
+      afterEach(async () => {
+        await deleteAllHierarchyDocuments('organizations')
+        await deleteAllHierarchyDocuments('pages')
+      })
+
+      it('should reparent direct children by default and keep grandchildren attached', async () => {
+        const root = await payload.create({
+          collection: 'organizations',
+          data: { title: 'Root' },
+        })
+        const parent = await payload.create({
+          collection: 'organizations',
+          data: { parent: root.id, title: 'Parent' },
+        })
+        const child = await payload.create({
+          collection: 'organizations',
+          data: { parent: parent.id, title: 'Child' },
+        })
+        const grandchild = await payload.create({
+          collection: 'organizations',
+          data: { parent: child.id, title: 'Grandchild' },
+        })
+
+        await payload.delete({ collection: 'organizations', id: parent.id })
+
+        const updatedChild = await payload.findByID({ collection: 'organizations', id: child.id })
+        expect(extractID(updatedChild.parent)).toBe(root.id)
+        const updatedGrandchild = await payload.findByID({
+          collection: 'organizations',
+          id: grandchild.id,
+        })
+        expect(extractID(updatedGrandchild.parent)).toBe(child.id)
+      })
+
+      it('should move children to the deleted document parent', async () => {
+        const root = await payload.create({
+          collection: 'organizations',
+          data: { title: 'Root' },
+        })
+        const parent = await payload.create({
+          collection: 'organizations',
+          data: { parent: root.id, title: 'Parent' },
+        })
+        const firstChild = await payload.create({
+          collection: 'organizations',
+          data: { parent: parent.id, title: 'First Child' },
+        })
+        const secondChild = await payload.create({
+          collection: 'organizations',
+          data: { parent: parent.id, title: 'Second Child' },
+        })
+
+        await payload.delete({ collection: 'organizations', id: parent.id })
+
+        const updatedFirstChild = await payload.findByID({
+          collection: 'organizations',
+          id: firstChild.id,
+        })
+        expect(extractID(updatedFirstChild.parent)).toBe(root.id)
+        const updatedSecondChild = await payload.findByID({
+          collection: 'organizations',
+          id: secondChild.id,
+        })
+        expect(extractID(updatedSecondChild.parent)).toBe(root.id)
+      })
+
+      it('should move children of a deleted root to null', async () => {
+        const root = await payload.create({
+          collection: 'organizations',
+          data: { title: 'Root' },
+        })
+        const child = await payload.create({
+          collection: 'organizations',
+          data: { parent: root.id, title: 'Child' },
+        })
+
+        await payload.delete({ collection: 'organizations', id: root.id })
+
+        const updatedChild = await payload.findByID({ collection: 'organizations', id: child.id })
+        expect(updatedChild.parent).toBeNull()
+      })
+
+      it("should recursively delete descendants with the cascade strategy", async () => {
+        const root = await payload.create({
+          collection: 'pages',
+          data: { slug: 'root', title: 'Root' },
+        })
+        const child = await payload.create({
+          collection: 'pages',
+          data: { parent: root.id, slug: 'child', title: 'Child' },
+        })
+        const grandchild = await payload.create({
+          collection: 'pages',
+          data: { parent: child.id, slug: 'grandchild', title: 'Grandchild' },
+        })
+
+        await payload.delete({ collection: 'pages', id: root.id })
+
+        await expect(payload.findByID({ collection: 'pages', id: child.id })).rejects.toThrow()
+        await expect(payload.findByID({ collection: 'pages', id: grandchild.id })).rejects.toThrow()
+      })
+
+      it('should respect delete access during cascade operations', async () => {
+        const root = await payload.create({
+          collection: 'pages',
+          data: { slug: 'root', title: 'Root' },
+        })
+        const child = await payload.create({
+          collection: 'pages',
+          data: { parent: root.id, slug: 'protected', title: 'Protected' },
+        })
+        const grandchild = await payload.create({
+          collection: 'pages',
+          data: { parent: child.id, slug: 'grandchild', title: 'Grandchild' },
+        })
+
+        await payload.delete({ collection: 'pages', id: root.id })
+
+        const remainingChild = await payload.findByID({ collection: 'pages', id: child.id })
+        expect(remainingChild.id).toBe(child.id)
+        await expect(payload.findByID({ collection: 'pages', id: grandchild.id })).resolves.toBeDefined()
+      })
+    })
   })
 
   describe('Tree Data Generation', () => {
     beforeEach(async () => {
       // Clear existing data before each test
-      await payload.delete({ collection: 'organizations', where: {} })
+      await deleteAllHierarchyDocuments('organizations')
     })
 
     afterEach(async () => {
       // Clean up data after each test
-      await payload.delete({ collection: 'organizations', where: {} })
+      await deleteAllHierarchyDocuments('organizations')
     })
 
     it('should compute correct paths for root document', async () => {
@@ -246,11 +416,11 @@ describe('Hierarchy', () => {
 
   describe('Circular Reference Prevention', () => {
     beforeEach(async () => {
-      await payload.delete({ collection: 'organizations', where: {} })
+      await deleteAllHierarchyDocuments('organizations')
     })
 
     afterEach(async () => {
-      await payload.delete({ collection: 'organizations', where: {} })
+      await deleteAllHierarchyDocuments('organizations')
     })
 
     it('should prevent self-referential parent', async () => {
@@ -346,12 +516,12 @@ describe('Hierarchy', () => {
   describe('Query Patterns', () => {
     beforeEach(async () => {
       // Clear existing data before each test
-      await payload.delete({ collection: 'organizations', where: {} })
+      await deleteAllHierarchyDocuments('organizations')
     })
 
     afterEach(async () => {
       // Clean up data after each test
-      await payload.delete({ collection: 'organizations', where: {} })
+      await deleteAllHierarchyDocuments('organizations')
     })
 
     it('should find root documents by querying parent field', async () => {
@@ -447,12 +617,12 @@ describe('Hierarchy', () => {
   describe('Deep Nesting', () => {
     beforeEach(async () => {
       // Clear existing data before each test
-      await payload.delete({ collection: 'organizations', where: {} })
+      await deleteAllHierarchyDocuments('organizations')
     })
 
     afterEach(async () => {
       // Clean up data after each test
-      await payload.delete({ collection: 'organizations', where: {} })
+      await deleteAllHierarchyDocuments('organizations')
     })
 
     it('should handle deeply nested structures', async () => {
@@ -1162,11 +1332,11 @@ describe('Hierarchy', () => {
 
   describe('Ancestor Cache Performance', () => {
     beforeEach(async () => {
-      await payload.delete({ collection: 'organizations', where: {} })
+      await deleteAllHierarchyDocuments('organizations')
     })
 
     afterEach(async () => {
-      await payload.delete({ collection: 'organizations', where: {} })
+      await deleteAllHierarchyDocuments('organizations')
     })
 
     it('should cache ancestors when computing paths for multiple documents', async () => {

--- a/test/hierarchy/int.spec.ts
+++ b/test/hierarchy/int.spec.ts
@@ -229,7 +229,7 @@ describe('Hierarchy', () => {
         await expect(payload.findByID({ collection: 'pages', id: grandchild.id })).rejects.toThrow()
       })
 
-      it('should respect delete access during cascade operations', async () => {
+      it('should abort cascade operations when delete access denies a descendant', async () => {
         const root = await payload.create({
           collection: 'pages',
           data: { slug: 'root', title: 'Root' },
@@ -243,10 +243,10 @@ describe('Hierarchy', () => {
           data: { parent: child.id, slug: 'grandchild', title: 'Grandchild' },
         })
 
-        await payload.delete({ collection: 'pages', id: root.id })
+        await expect(payload.delete({ collection: 'pages', id: root.id })).rejects.toThrow()
 
-        const remainingChild = await payload.findByID({ collection: 'pages', id: child.id })
-        expect(remainingChild.id).toBe(child.id)
+        await expect(payload.findByID({ collection: 'pages', id: root.id })).resolves.toBeDefined()
+        await expect(payload.findByID({ collection: 'pages', id: child.id })).resolves.toBeDefined()
         await expect(payload.findByID({ collection: 'pages', id: grandchild.id })).resolves.toBeDefined()
       })
     })


### PR DESCRIPTION
Adds configurable hierarchy deletion strategies with `reparent` as the default and `cascade` as the opt-in recursive behavior.

Reparenting moves direct children to the deleted document’s parent, including `null` for root documents, while preserving grandchildren and using internal updates with `overrideAccess: true`. Cascade deletion continues to propagate the request and transaction context while respecting delete access with `overrideAccess: false`.

Adds integration coverage for default reparenting, root deletion, child/grandchild relationships, cascade deletion, and cascade access control.
