### PR TITLE
chore: make overrideAccess explicit in tests

### DIFF
--- a/test/__helpers/e2e/preferences.ts
+++ b/test/__helpers/e2e/preferences.ts
@@ -30,6 +30,7 @@ export const upsertPreferences = async <
             { 'user.relationTo': { equals: user.collection } },
           ],
         },
+        overrideAccess: true,
       })
       ?.then((res) => res.docs?.[0])
 
@@ -45,6 +46,7 @@ export const upsertPreferences = async <
           },
           value,
         },
+        overrideAccess: true,
       })
     } else {
       const newValue = typeof value === 'object' ? { ...(prefs?.value || {}), ...value } : value
@@ -60,6 +62,7 @@ export const upsertPreferences = async <
           },
           value: newValue,
         },
+        overrideAccess: true,
       })
 
       if (prefs?.status >= 400) {
@@ -92,6 +95,7 @@ export const deletePreferences = async <TConfig extends GeneratedTypes<any>>({
           { 'user.relationTo': { equals: user.collection } },
         ],
       },
+      overrideAccess: true,
     })
   } catch (e) {
     console.error('Error deleting prefs', e)

--- a/test/__helpers/shared/sdk/types.ts
+++ b/test/__helpers/shared/sdk/types.ts
@@ -57,7 +57,7 @@ export type CreateArgs<
   file?: File
   filePath?: string
   locale?: string
-  overrideAccess?: boolean
+  overrideAccess: boolean
   overwriteExistingFiles?: boolean
   showHiddenFields?: boolean
   user?: TypeWithID
@@ -92,7 +92,7 @@ export type UpdateBaseArgs<
   file?: File
   filePath?: string
   locale?: string
-  overrideAccess?: boolean
+  overrideAccess: boolean
   overwriteExistingFiles?: boolean
   showHiddenFields?: boolean
   user?: TypeWithID
@@ -108,6 +108,7 @@ export type UpdateGlobalArgs<
   TSlug extends keyof TGeneratedTypes['globals'],
 > = {
   data: DeepPartial<TGeneratedTypes['globals'][TSlug]>
+  overrideAccess: boolean
   slug: TSlug
 } & BaseArgs
 
@@ -122,7 +123,7 @@ export type FindArgs<
   fallbackLocale?: string
   limit?: number
   locale?: string
-  overrideAccess?: boolean
+  overrideAccess: boolean
   page?: number
   pagination?: boolean
   showHiddenFields?: boolean
@@ -141,6 +142,7 @@ export type LoginArgs<
     email: string
     password: string
   }
+  overrideAccess: boolean
 } & BaseArgs
 
 export type DeleteArgs<
@@ -149,7 +151,7 @@ export type DeleteArgs<
 > = {
   collection: TSlug
   id?: string
-  overrideAccess?: boolean
+  overrideAccess: boolean
   trash?: boolean
   where?: Where
 } & BaseArgs

--- a/test/_community/config.ts
+++ b/test/_community/config.ts
@@ -37,6 +37,7 @@ export default buildConfigWithDefaults({
         email: devUser.email,
         password: devUser.password,
       },
+      overrideAccess: true,
     })
 
     await payload.create({
@@ -44,6 +45,7 @@ export default buildConfigWithDefaults({
       data: {
         title: 'example post',
       },
+      overrideAccess: true,
     })
   },
 })

--- a/test/_community/int.spec.ts
+++ b/test/_community/int.spec.ts
@@ -37,6 +37,7 @@ test.suite({ config: './config.ts' })('_Community Tests', () => {
         title: 'LOCAL API EXAMPLE',
       },
       context: {},
+      overrideAccess: true,
     })
 
     expect(newPost.title).toEqual('LOCAL API EXAMPLE')

--- a/test/a11y/config.ts
+++ b/test/a11y/config.ts
@@ -45,6 +45,7 @@ export default buildConfigWithDefaults({
         email: devUser.email,
         password: devUser.password,
       },
+      overrideAccess: true,
     })
 
     await payload.create({
@@ -52,6 +53,7 @@ export default buildConfigWithDefaults({
       data: {
         title: 'example post',
       },
+      overrideAccess: true,
     })
   },
 })

--- a/test/a11y/e2e.spec.ts
+++ b/test/a11y/e2e.spec.ts
@@ -260,6 +260,7 @@ test.describe.skip('A11y', () => {
         data: {
           title: 'Test Post for Horizontal Overflow',
         },
+        overrideAccess: true,
       })
 
       await page.setViewportSize({ height: 568, width: 320 })

--- a/test/access-control/collections/ReadRestricted/seed.ts
+++ b/test/access-control/collections/ReadRestricted/seed.ts
@@ -73,6 +73,7 @@ export const seedReadRestricted = async (payload: Payload): Promise<void> => {
         restrictedAdvanced: 'Hidden advanced setting',
       },
     },
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -118,6 +119,7 @@ export const seedReadRestricted = async (payload: Payload): Promise<void> => {
         restrictedAdvanced: 'Private advanced config',
       },
     },
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -157,5 +159,6 @@ export const seedReadRestricted = async (payload: Payload): Promise<void> => {
         restrictedAdvanced: 'Third advanced hidden',
       },
     },
+    overrideAccess: true,
   })
 }

--- a/test/access-control/e2e.spec.ts
+++ b/test/access-control/e2e.spec.ts
@@ -186,6 +186,7 @@ describe('Access Control', () => {
 
       await payload.delete({
         collection: 'field-restricted-update-based-on-data',
+        overrideAccess: true,
         where: {
           id: {
             exists: true,
@@ -236,6 +237,7 @@ describe('Access Control', () => {
 
       await payload.delete({
         collection: 'field-restricted-update-based-on-data',
+        overrideAccess: true,
         where: {
           id: {
             exists: true,
@@ -400,6 +402,7 @@ describe('Access Control', () => {
         data: {
           name: 'name',
         },
+        overrideAccess: true,
       })
     })
 
@@ -451,6 +454,7 @@ describe('Access Control', () => {
         data: {
           name: 'name',
         },
+        overrideAccess: true,
       })
     })
 
@@ -517,6 +521,7 @@ describe('Access Control', () => {
         data: {
           name: 'unrestricted-123',
         },
+        overrideAccess: true,
       })
 
       await page.goto(unrestrictedURL.edit(unrestrictedDoc.id.toString()))
@@ -578,6 +583,7 @@ describe('Access Control', () => {
           data: {
             name: 'unrestricted-123',
           },
+          overrideAccess: true,
         })
         await page.goto(unrestrictedURL.edit(unrestrictedDoc.id.toString()))
         const field = page.locator('#field-userRestrictedDocs')
@@ -612,6 +618,7 @@ describe('Access Control', () => {
           data: {
             name: 'dev@payloadcms.com',
           },
+          overrideAccess: true,
         })
 
         await page.goto(userRestrictedGlobalURL.global(userRestrictedGlobalSlug))
@@ -629,6 +636,7 @@ describe('Access Control', () => {
           data: {
             name: 'anonymous@payloadcms.com',
           },
+          overrideAccess: true,
         })
 
         await page.goto(userRestrictedGlobalURL.global(userRestrictedGlobalSlug))
@@ -663,6 +671,7 @@ describe('Access Control', () => {
         data: {
           name: 'name',
         },
+        overrideAccess: true,
       })
 
       await payload.update({
@@ -671,6 +680,7 @@ describe('Access Control', () => {
         data: {
           hidden: true,
         },
+        overrideAccess: true,
       })
     })
 
@@ -696,6 +706,7 @@ describe('Access Control', () => {
           approvedTitle: 'Title',
           lockTitle: true,
         },
+        overrideAccess: true,
       })
     })
 
@@ -820,6 +831,7 @@ describe('Access Control', () => {
           email: publicUserEmail,
           password: devUser.password,
         },
+        overrideAccess: true,
       })
 
       await context.addCookies([
@@ -895,10 +907,11 @@ describe('Access Control', () => {
       const existing = await payload.find({
         collection: authSlug,
         limit: 1,
+        overrideAccess: true,
         where: { email: { equals: 'test@payloadcms.com' } },
       })
       for (const doc of existing.docs) {
-        await payload.delete({ id: doc.id, collection: authSlug })
+        await payload.delete({ id: doc.id, collection: authSlug, overrideAccess: true })
       }
 
       existingDoc = await payload.create({
@@ -907,12 +920,13 @@ describe('Access Control', () => {
           email: 'test@payloadcms.com',
           password: 'test',
         },
+        overrideAccess: true,
       })
     })
 
     afterAll(async () => {
       if (existingDoc?.id) {
-        await payload.delete({ id: existingDoc.id, collection: authSlug })
+        await payload.delete({ id: existingDoc.id, collection: authSlug, overrideAccess: true })
       }
     })
     test('should show email as readonly when user does not have update permission', async () => {
@@ -1797,6 +1811,7 @@ describe('Access Control', () => {
           },
           title: 'Test Document',
         },
+        overrideAccess: true,
       })
 
       await page.goto(blocksFieldAccessUrl.edit(doc.id))
@@ -1840,6 +1855,7 @@ describe('Access Control', () => {
           await payload.delete({
             id,
             collection: differentiatedTrashSlug,
+            overrideAccess: true,
             trash: true,
           })
         }
@@ -1862,6 +1878,7 @@ describe('Access Control', () => {
           const doc = await payload.create({
             collection: differentiatedTrashSlug,
             data: { _status: 'published', title: 'Test Doc' },
+            overrideAccess: true,
           })
           createdDocIds.push(doc.id)
 
@@ -1878,6 +1895,7 @@ describe('Access Control', () => {
           const doc = await payload.create({
             collection: differentiatedTrashSlug,
             data: { _status: 'published', title: 'Test Doc' },
+            overrideAccess: true,
           })
           createdDocIds.push(doc.id)
 
@@ -1895,6 +1913,7 @@ describe('Access Control', () => {
           const doc = await payload.create({
             collection: differentiatedTrashSlug,
             data: { _status: 'published', title: 'Test Doc For Perma Delete' },
+            overrideAccess: true,
           })
           // Don't add to createdDocIds since we're permanently deleting it
 
@@ -1922,6 +1941,7 @@ describe('Access Control', () => {
               deletedAt: new Date().toISOString(),
               title: 'Admin Trashed Doc View Test',
             },
+            overrideAccess: true,
           })
           // Don't add to createdDocIds since we're permanently deleting it
 
@@ -1972,6 +1992,7 @@ describe('Access Control', () => {
           const doc = await payload.create({
             collection: differentiatedTrashSlug,
             data: { _status: 'published', title: 'Test Doc' },
+            overrideAccess: true,
           })
           createdDocIds.push(doc.id)
 
@@ -1988,6 +2009,7 @@ describe('Access Control', () => {
           const doc = await payload.create({
             collection: differentiatedTrashSlug,
             data: { _status: 'published', title: 'Test Doc' },
+            overrideAccess: true,
           })
           createdDocIds.push(doc.id)
 
@@ -2007,6 +2029,7 @@ describe('Access Control', () => {
           const doc = await payload.create({
             collection: differentiatedTrashSlug,
             data: { _status: 'published', title: 'Test Doc For Trash' },
+            overrideAccess: true,
           })
           createdDocIds.push(doc.id)
 
@@ -2033,6 +2056,7 @@ describe('Access Control', () => {
               deletedAt: new Date().toISOString(),
               title: 'Trashed Doc View Test',
             },
+            overrideAccess: true,
           })
           createdDocIds.push(doc.id)
 
@@ -2071,6 +2095,7 @@ describe('Access Control', () => {
           await payload.delete({
             id,
             collection: restrictedTrashSlug,
+            overrideAccess: true,
             trash: true,
           })
         }
@@ -2086,6 +2111,7 @@ describe('Access Control', () => {
           const doc = await payload.create({
             collection: restrictedTrashSlug,
             data: { _status: 'published', title: 'Test Doc' },
+            overrideAccess: true,
           })
           createdDocIds.push(doc.id)
 
@@ -2102,6 +2128,7 @@ describe('Access Control', () => {
           const doc = await payload.create({
             collection: restrictedTrashSlug,
             data: { _status: 'published', title: 'Test Doc' },
+            overrideAccess: true,
           })
           createdDocIds.push(doc.id)
 
@@ -2119,6 +2146,7 @@ describe('Access Control', () => {
           const doc = await payload.create({
             collection: restrictedTrashSlug,
             data: { _status: 'published', title: 'Test Doc For Trash' },
+            overrideAccess: true,
           })
           createdDocIds.push(doc.id)
 
@@ -2140,6 +2168,7 @@ describe('Access Control', () => {
           const doc = await payload.create({
             collection: restrictedTrashSlug,
             data: { _status: 'published', title: 'Test Doc For Perma Delete' },
+            overrideAccess: true,
           })
           // Don't add to createdDocIds since we're permanently deleting it
 
@@ -2180,6 +2209,7 @@ describe('Access Control', () => {
           const doc = await payload.create({
             collection: restrictedTrashSlug,
             data: { _status: 'published', title: 'Test Doc' },
+            overrideAccess: true,
           })
           createdDocIds.push(doc.id)
 
@@ -2204,6 +2234,7 @@ describe('Access Control', () => {
             await payload.delete({
               id,
               collection: differentiatedTrashSlug,
+              overrideAccess: true,
               trash: true,
             })
           }
@@ -2219,6 +2250,7 @@ describe('Access Control', () => {
             const doc = await payload.create({
               collection: differentiatedTrashSlug,
               data: { _status: 'published', title: 'Bulk Test Doc 1' },
+              overrideAccess: true,
             })
             createdDocIds.push(doc.id)
 
@@ -2262,6 +2294,7 @@ describe('Access Control', () => {
             const doc = await payload.create({
               collection: differentiatedTrashSlug,
               data: { _status: 'published', title: 'Bulk Test Doc Regular User' },
+              overrideAccess: true,
             })
             createdDocIds.push(doc.id)
 
@@ -2288,6 +2321,7 @@ describe('Access Control', () => {
             const doc = await payload.create({
               collection: differentiatedTrashSlug,
               data: { _status: 'published', title: 'Bulk Test Doc Regular User 2' },
+              overrideAccess: true,
             })
             createdDocIds.push(doc.id)
 
@@ -2323,6 +2357,7 @@ describe('Access Control', () => {
             await payload.delete({
               id,
               collection: restrictedTrashSlug,
+              overrideAccess: true,
               trash: true,
             })
           }
@@ -2338,6 +2373,7 @@ describe('Access Control', () => {
             const doc = await payload.create({
               collection: restrictedTrashSlug,
               data: { _status: 'published', title: 'Restricted Bulk Test Doc' },
+              overrideAccess: true,
             })
             createdDocIds.push(doc.id)
 
@@ -2381,6 +2417,7 @@ describe('Access Control', () => {
             const doc = await payload.create({
               collection: restrictedTrashSlug,
               data: { _status: 'published', title: 'Restricted Bulk Test Doc Regular User' },
+              overrideAccess: true,
             })
             createdDocIds.push(doc.id)
 
@@ -2416,6 +2453,7 @@ describe('Access Control', () => {
               await payload.delete({
                 id,
                 collection: differentiatedTrashSlug,
+                overrideAccess: true,
                 trash: true,
               })
             } catch (_e) {
@@ -2439,6 +2477,7 @@ describe('Access Control', () => {
                 deletedAt: new Date().toISOString(),
                 title: 'Trash View Bulk Test Admin',
               },
+              overrideAccess: true,
             })
             createdDocIds.push(doc.id)
 
@@ -2487,6 +2526,7 @@ describe('Access Control', () => {
                 deletedAt: new Date().toISOString(),
                 title: 'Trash View Bulk Test Regular',
               },
+              overrideAccess: true,
             })
             createdDocIds.push(doc.id)
 
@@ -2519,5 +2559,6 @@ async function createDoc(data: any): Promise<Record<string, unknown> & TypeWithI
   return payload.create({
     collection: slug,
     data,
+    overrideAccess: true,
   }) as any as Promise<Record<string, unknown> & TypeWithID>
 }

--- a/test/access-control/getConfig.ts
+++ b/test/access-control/getConfig.ts
@@ -890,7 +890,7 @@ export const getConfig: () => Partial<Config> = () => ({
       slug: 'test',
       access: {
         read: async ({ req: { payload } }) => {
-          const access = await payload.findGlobal({ slug: 'settings' })
+          const access = await payload.findGlobal({ slug: 'settings', overrideAccess: true })
           return Boolean(access.test)
         },
       },
@@ -952,6 +952,7 @@ export const seed: NonNullable<Config['onInit']> = async (payload) => {
       email: devUser.email,
       password: devUser.password,
     },
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -960,6 +961,7 @@ export const seed: NonNullable<Config['onInit']> = async (payload) => {
       email: nonAdminEmail,
       password: 'test',
     },
+    overrideAccess: true,
   })
 
   // Regular user - can access admin panel but has limited delete permissions
@@ -970,6 +972,7 @@ export const seed: NonNullable<Config['onInit']> = async (payload) => {
       password: 'test',
       roles: ['user'],
     },
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -978,6 +981,7 @@ export const seed: NonNullable<Config['onInit']> = async (payload) => {
       email: publicUserEmail,
       password: 'test',
     },
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -985,6 +989,7 @@ export const seed: NonNullable<Config['onInit']> = async (payload) => {
     data: {
       restrictedField: 'restricted',
     },
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -992,6 +997,7 @@ export const seed: NonNullable<Config['onInit']> = async (payload) => {
     data: {
       name: 'read-only',
     },
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -1040,6 +1046,7 @@ export const seed: NonNullable<Config['onInit']> = async (payload) => {
       },
       title: 'Blocks Field Access Test Document',
     },
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -1047,6 +1054,7 @@ export const seed: NonNullable<Config['onInit']> = async (payload) => {
     data: {
       name: 'versioned',
     },
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -1063,6 +1071,7 @@ export const seed: NonNullable<Config['onInit']> = async (payload) => {
         },
       ],
     },
+    overrideAccess: true,
   })
 
   await payload.updateGlobal({
@@ -1070,6 +1079,7 @@ export const seed: NonNullable<Config['onInit']> = async (payload) => {
     data: {
       name: 'dev@payloadcms.com',
     },
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -1107,6 +1117,7 @@ export const seed: NonNullable<Config['onInit']> = async (payload) => {
         richText2: buildEditorState<DefaultNodeTypes>({ text: 'Text8' }),
       },
     },
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -1122,6 +1133,7 @@ export const seed: NonNullable<Config['onInit']> = async (payload) => {
         text: 'Text2',
       },
     },
+    overrideAccess: true,
   })
 
   // Seed read-restricted collection
@@ -1134,6 +1146,7 @@ export const seed: NonNullable<Config['onInit']> = async (payload) => {
       _status: 'published',
       title: 'Differentiated Doc 1',
     },
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -1142,5 +1155,6 @@ export const seed: NonNullable<Config['onInit']> = async (payload) => {
       _status: 'published',
       title: 'Restricted Doc 1',
     },
+    overrideAccess: true,
   })
 }

--- a/test/access-control/int.spec.ts
+++ b/test/access-control/int.spec.ts
@@ -40,11 +40,13 @@ test.suite({ config: './config.ts' })('Access Control', () => {
     post1 = await payload.create({
       collection: slug,
       data: {},
+      overrideAccess: true,
     })
 
     restricted = await payload.create({
       collection: fullyRestrictedSlug,
       data: { name: 'restricted' },
+      overrideAccess: true,
     })
   })
 
@@ -64,6 +66,7 @@ test.suite({ config: './config.ts' })('Access Control', () => {
             value: 'private_value',
           },
         },
+        overrideAccess: true,
       })
 
       await payload.update({
@@ -72,12 +75,14 @@ test.suite({ config: './config.ts' })('Access Control', () => {
         data: {
           title: 'Doc Title',
         },
+        overrideAccess: true,
       })
 
       const updatedDoc = await payload.findByID({
         id: doc.id,
         collection: hiddenFieldsSlug,
         showHiddenFields: true,
+        overrideAccess: true,
       })
 
       expect(updatedDoc.partiallyHiddenGroup.value).toStrictEqual('private_value')
@@ -101,6 +106,7 @@ test.suite({ config: './config.ts' })('Access Control', () => {
             value: 'private_value',
           },
         },
+        overrideAccess: true,
       })
 
       await payload.update({
@@ -111,12 +117,14 @@ test.suite({ config: './config.ts' })('Access Control', () => {
         where: {
           id: { equals: docsMany.id },
         },
+        overrideAccess: true,
       })
 
       const updatedMany = await payload.findByID({
         id: docsMany.id,
         collection: hiddenFieldsSlug,
         showHiddenFields: true,
+        overrideAccess: true,
       })
 
       expect(updatedMany.partiallyHiddenGroup.value).toStrictEqual('private_value')
@@ -138,6 +146,7 @@ test.suite({ config: './config.ts' })('Access Control', () => {
             },
           ],
         },
+        overrideAccess: true,
       })
 
       const doc = await payload.findByID({
@@ -154,6 +163,7 @@ test.suite({ config: './config.ts' })('Access Control', () => {
       const docOverride = await payload.findByID({
         id,
         collection: siblingDataSlug,
+        overrideAccess: true,
       })
 
       expect(docOverride.array?.[0].text).toBe(firstArrayText)
@@ -168,6 +178,7 @@ test.suite({ config: './config.ts' })('Access Control', () => {
         data: {
           cannotMutateRequired: 'original',
         },
+        overrideAccess: true,
       })
 
       const updatedDoc = await payload.update({
@@ -189,6 +200,7 @@ test.suite({ config: './config.ts' })('Access Control', () => {
         data: {
           cannotMutateRequired: 'original',
         },
+        overrideAccess: true,
       })
 
       const updatedDoc = await payload.update({
@@ -213,6 +225,7 @@ test.suite({ config: './config.ts' })('Access Control', () => {
           cannotMutateRequired: 'cannotMutateRequired',
           cannotMutateNotRequired: 'cannotMutateNotRequired',
         },
+        overrideAccess: true,
       })
 
       const updatedDoc = await payload.update({
@@ -236,6 +249,7 @@ test.suite({ config: './config.ts' })('Access Control', () => {
           title: 'Test Title',
         },
         showHiddenFields: true,
+        overrideAccess: true,
       })
 
       expect(doc.hiddenWithDefault).toBe('default value')
@@ -407,7 +421,7 @@ test.suite({ config: './config.ts' })('Access Control', () => {
           { restrictedField: 'restricted' },
         )
 
-        const retrievedDoc = await payload.findByID({ id, collection: slug })
+        const retrievedDoc = await payload.findByID({ id, collection: slug, overrideAccess: true })
 
         expect(retrievedDoc.restrictedField).toStrictEqual(restrictedField)
       })
@@ -505,6 +519,7 @@ test.suite({ config: './config.ts' })('Access Control', () => {
           id: post1.id,
           collection: slug,
           data: { restrictedField: restricted.id },
+          overrideAccess: true,
         })
 
         expect(doc).toMatchObject({ id: post1.id })
@@ -544,6 +559,7 @@ test.suite({ config: './config.ts' })('Access Control', () => {
           where: {
             id: { equals: post1.id },
           },
+          overrideAccess: true,
         })
 
         expect(doc.docs[0]).toMatchObject({ id: post1.id })
@@ -581,6 +597,7 @@ test.suite({ config: './config.ts' })('Access Control', () => {
           id: restricted.id,
           collection: fullyRestrictedSlug,
           data: { name: updatedName },
+          overrideAccess: true,
         })
 
         expect(doc).toMatchObject({ id: restricted.id, name: updatedName })
@@ -620,6 +637,7 @@ test.suite({ config: './config.ts' })('Access Control', () => {
           where: {
             id: { equals: restricted.id },
           },
+          overrideAccess: true,
         })
 
         expect(doc.docs[0]).toMatchObject({ id: restricted.id, name: updatedName })
@@ -634,6 +652,7 @@ test.suite({ config: './config.ts' })('Access Control', () => {
         data: {
           title: 'hello',
         },
+        overrideAccess: true,
       })
 
       await payload.create({
@@ -642,6 +661,7 @@ test.suite({ config: './config.ts' })('Access Control', () => {
           hidden: true,
           title: 'hello',
         },
+        overrideAccess: true,
       })
 
       const { docs } = await payload.find({
@@ -658,6 +678,7 @@ test.suite({ config: './config.ts' })('Access Control', () => {
         data: {
           title: 'hello',
         },
+        overrideAccess: true,
       })
 
       await payload.create({
@@ -666,6 +687,7 @@ test.suite({ config: './config.ts' })('Access Control', () => {
           hidden: true,
           title: 'hello',
         },
+        overrideAccess: true,
       })
 
       const { totalDocs } = await payload.count({
@@ -683,6 +705,7 @@ test.suite({ config: './config.ts' })('Access Control', () => {
           name: 'match',
           hidden: true,
         },
+        overrideAccess: true,
       })
 
       await payload.create({
@@ -691,6 +714,7 @@ test.suite({ config: './config.ts' })('Access Control', () => {
           name: 'match',
           hidden: false,
         },
+        overrideAccess: true,
       })
 
       const { docs } = await payload.findVersions({
@@ -710,14 +734,17 @@ test.suite({ config: './config.ts' })('Access Control', () => {
       await payload.create({
         collection: 'fields-and-top-access',
         data: { secret: 'will-fail-access-read' },
+        overrideAccess: true,
       })
       const { id: hitID } = await payload.create({
         collection: 'fields-and-top-access',
         data: { secret: 'will-success-access-read' },
+        overrideAccess: true,
       })
       await payload.create({
         collection: 'fields-and-top-access',
         data: { secret: 'will-fail-access-read' },
+        overrideAccess: true,
       })
 
       // assert find, only will-success should be in the result
@@ -752,19 +779,22 @@ test.suite({ config: './config.ts' })('Access Control', () => {
       payload,
     }) => {
       // clean up
-      await payload.delete({ collection: 'fields-and-top-access', where: {} })
+      await payload.delete({ collection: 'fields-and-top-access', where: {}, overrideAccess: true })
 
       await payload.create({
         collection: 'fields-and-top-access',
         data: { secret: 'will-fail-access-read' },
+        overrideAccess: true,
       })
       const { id: hitID } = await payload.create({
         collection: 'fields-and-top-access',
         data: { secret: 'will-success-access-read' },
+        overrideAccess: true,
       })
       await payload.create({
         collection: 'fields-and-top-access',
         data: { secret: 'will-fail-access-read' },
+        overrideAccess: true,
       })
 
       // Assert findVersions only will-success should be in the result
@@ -807,6 +837,7 @@ test.suite({ config: './config.ts' })('Access Control', () => {
           data: {
             email: 'dev@payloadcms.com',
           },
+          overrideAccess: true,
         })
       } finally {
         // Restore the original Date.now() after the forgotPassword call
@@ -836,6 +867,7 @@ test.suite({ config: './config.ts' })('Access Control', () => {
         data: {
           title: 'Test Document',
         },
+        overrideAccess: true,
       })
 
       const req = await createLocalReq(
@@ -904,6 +936,7 @@ test.suite({ config: './config.ts' })('Access Control', () => {
         data: {
           title: 'Test Document 2',
         },
+        overrideAccess: true,
       })
 
       // Create non-admin user request
@@ -974,6 +1007,7 @@ test.suite({ config: './config.ts' })('Access Control', () => {
         collection: 'users',
         limit: 1,
         where: { email: { equals: 'dev@payloadcms.com' } },
+        overrideAccess: true,
       })
       adminUser = { ...adminDocs[0], collection: 'users' }
 
@@ -981,6 +1015,7 @@ test.suite({ config: './config.ts' })('Access Control', () => {
         collection: publicUsersSlug,
         limit: 1,
         where: { email: { equals: publicUserEmail } },
+        overrideAccess: true,
       })
       publicUser = { ...publicDocs[0], collection: publicUsersSlug }
     })

--- a/test/access-control/postgres-logs.int.spec.ts
+++ b/test/access-control/postgres-logs.int.spec.ts
@@ -39,6 +39,7 @@ test.suite({ config: './config.postgreslogs.ts', db: (adapter) => adapter.starts
               title: 'Test Document',
               userRole: 'admin',
             },
+            overrideAccess: true,
           })
 
           const consoleCount = vitest.spyOn(console, 'log').mockImplementation(() => {})
@@ -81,6 +82,7 @@ test.suite({ config: './config.postgreslogs.ts', db: (adapter) => adapter.starts
               title: 'Test Document',
               userRole: 'noAccess',
             },
+            overrideAccess: true,
           })
 
           const consoleCount = vitest.spyOn(console, 'log').mockImplementation(() => {})
@@ -128,6 +130,7 @@ test.suite({ config: './config.postgreslogs.ts', db: (adapter) => adapter.starts
               updateRole: 'noAccess',
               deleteRole: 'admin',
             },
+            overrideAccess: true,
           })
 
           const consoleCount = vitest.spyOn(console, 'log').mockImplementation(() => {})
@@ -173,6 +176,7 @@ test.suite({ config: './config.postgreslogs.ts', db: (adapter) => adapter.starts
               updateRole: 'noAccess',
               deleteRole: 'admin',
             },
+            overrideAccess: true,
           })
 
           const consoleCount = vitest.spyOn(console, 'log').mockImplementation(() => {})
@@ -217,6 +221,7 @@ test.suite({ config: './config.postgreslogs.ts', db: (adapter) => adapter.starts
               updateRole: 'admin',
               deleteRole: 'noAccess',
             },
+            overrideAccess: true,
           })
 
           const permissions = await getEntityPermissions({
@@ -253,6 +258,7 @@ test.suite({ config: './config.postgreslogs.ts', db: (adapter) => adapter.starts
               updateRole: 'noAccess',
               deleteRole: 'admin',
             },
+            overrideAccess: true,
           })
 
           const consoleCount = vitest.spyOn(console, 'log').mockImplementation(() => {})

--- a/test/admin-bar/config.ts
+++ b/test/admin-bar/config.ts
@@ -30,6 +30,7 @@ export default buildConfigWithDefaults({
         email: devUser.email,
         password: devUser.password,
       },
+      overrideAccess: true,
     })
 
     await payload.create({
@@ -37,6 +38,7 @@ export default buildConfigWithDefaults({
       data: {
         title: 'example post',
       },
+      overrideAccess: true,
     })
   },
 })

--- a/test/admin-root/config.ts
+++ b/test/admin-root/config.ts
@@ -49,6 +49,7 @@ export default buildConfigWithDefaults({
         email: devUser.email,
         password: devUser.password,
       },
+      overrideAccess: true,
     })
 
     await payload.create({
@@ -56,6 +57,7 @@ export default buildConfigWithDefaults({
       data: {
         text: 'example post',
       },
+      overrideAccess: true,
     })
   },
 })

--- a/test/admin-root/int.spec.ts
+++ b/test/admin-root/int.spec.ts
@@ -36,6 +36,7 @@ test.suite({ config: './config.ts' })('Admin (Root) Tests', () => {
       data: {
         text: 'LOCAL API EXAMPLE',
       },
+      overrideAccess: true,
     })
 
     expect(newPost.text).toEqual('LOCAL API EXAMPLE')

--- a/test/admin-routing/config.ts
+++ b/test/admin-routing/config.ts
@@ -21,6 +21,7 @@ export default buildConfigWithDefaults({
   seed: async (payload) => {
     const { totalDocs } = await payload.count({
       collection: 'users',
+      overrideAccess: true,
     })
 
     if (totalDocs > 0) {
@@ -33,6 +34,7 @@ export default buildConfigWithDefaults({
         email: devUser.email,
         password: devUser.password,
       },
+      overrideAccess: true,
     })
   },
 })

--- a/test/admin/components/views/CustomProtectedView/index.tsx
+++ b/test/admin/components/views/CustomProtectedView/index.tsx
@@ -21,6 +21,7 @@ export async function CustomProtectedView({ initPageResult }: AdminViewServerPro
 
   const settings = await req.payload.findGlobal({
     slug: settingsGlobalSlug,
+    overrideAccess: true,
   })
 
   if (!settings?.canAccessProtected) {

--- a/test/admin/e2e/document-view/e2e.spec.ts
+++ b/test/admin/e2e/document-view/e2e.spec.ts
@@ -118,6 +118,7 @@ describe('Document View', () => {
         const noAPIViewDoc = await payload.create({
           collection: noApiViewCollectionSlug,
           data: {},
+          overrideAccess: true,
         })
 
         const urlUtil = new AdminUrlUtil(serverURL, noApiViewCollectionSlug)
@@ -955,5 +956,6 @@ async function createPost(overrides?: Partial<Post>): Promise<Post> {
       title,
       ...overrides,
     },
+    overrideAccess: true,
   }) as unknown as Promise<Post>
 }

--- a/test/admin/e2e/general/e2e.spec.ts
+++ b/test/admin/e2e/general/e2e.spec.ts
@@ -1258,6 +1258,7 @@ async function createPost(overrides?: Partial<Post>): Promise<Post> {
       title,
       ...overrides,
     },
+    overrideAccess: true,
   }) as unknown as Promise<Post>
 }
 
@@ -1268,5 +1269,6 @@ async function createGeo(overrides?: Partial<Geo>): Promise<Geo> {
       point: [4, -4],
       ...overrides,
     },
+    overrideAccess: true,
   }) as unknown as Promise<Geo>
 }

--- a/test/admin/e2e/list-view/e2e.spec.ts
+++ b/test/admin/e2e/list-view/e2e.spec.ts
@@ -120,6 +120,7 @@ describe('List View', () => {
         email: devUser.email,
         password: devUser.password,
       },
+      overrideAccess: true,
     })
   })
 
@@ -171,6 +172,7 @@ describe('List View', () => {
         await payload.delete({
           id,
           collection: listViewSelectAPISlug,
+          overrideAccess: true,
         })
       }
       fallbackDocumentIDs.length = 0
@@ -190,6 +192,7 @@ describe('List View', () => {
         data: {
           title: 'Fallback test title',
         },
+        overrideAccess: true,
       })
       fallbackDocumentIDs.push(doc.id)
       const selectAPIUrl = new AdminUrlUtil(serverURL, listViewSelectAPISlug)
@@ -477,9 +480,9 @@ describe('List View', () => {
       await createPost({ title: 'Cafe' })
 
       await addListFilter({
-        page,
         fieldLabel: 'Title',
         operatorLabel: 'contains',
+        page,
         value: 'Café',
       })
 
@@ -1101,6 +1104,7 @@ describe('List View', () => {
             description: 'This is a test description',
             title: 'This is a test title',
           },
+          overrideAccess: true,
         })
 
         const selectAPIUrl = new AdminUrlUtil(serverURL, listViewSelectAPISlug)
@@ -1158,6 +1162,7 @@ describe('List View', () => {
             },
             title: 'This is a test title',
           },
+          overrideAccess: true,
         })
 
         const selectAPIUrl = new AdminUrlUtil(serverURL, listViewSelectAPISlug)
@@ -1186,6 +1191,7 @@ describe('List View', () => {
         await payload.delete({
           id: doc.id,
           collection: listViewSelectAPISlug,
+          overrideAccess: true,
         })
       })
     })
@@ -1491,7 +1497,7 @@ describe('List View', () => {
     })
 
     test('should hide edit many from collection with disableBulkEdit: true', async () => {
-      await payload.create({ collection: 'disable-bulk-edit', data: {} })
+      await payload.create({ collection: 'disable-bulk-edit', data: {}, overrideAccess: true })
       await page.goto(disableBulkEditUrl.list)
 
       // select one row
@@ -1621,6 +1627,7 @@ describe('List View', () => {
     test('should persist per-page limit in list drawer', async () => {
       await payload.delete({
         collection: listDrawerSlug,
+        overrideAccess: true,
         where: {},
       })
 
@@ -1633,6 +1640,7 @@ describe('List View', () => {
             title: `List Drawer Item ${i + 1}`,
           },
           disableTransaction: true,
+          overrideAccess: true,
         })
       })
 
@@ -1997,12 +2005,14 @@ describe('List View', () => {
 
     await payload.delete({
       collection: 'custom-list-drawer',
+      overrideAccess: true,
       where: { id: { exists: true } },
     })
 
     const { id } = await payload.create({
       collection: 'custom-list-drawer',
       data: {},
+      overrideAccess: true,
     })
 
     await page.goto(url.list)
@@ -2033,6 +2043,7 @@ describe('List View', () => {
       // Clean up any existing formatDocURL documents
       await payload.delete({
         collection: formatDocURLCollectionSlug,
+        overrideAccess: true,
         where: { id: { exists: true } },
       })
     })
@@ -2042,11 +2053,13 @@ describe('List View', () => {
       await payload.create({
         collection: formatDocURLCollectionSlug,
         data: { description: 'This should not be linkable', title: 'no-link' },
+        overrideAccess: true,
       })
 
       const normalDoc = await payload.create({
         collection: formatDocURLCollectionSlug,
         data: { description: 'This should be linkable normally', title: 'normal' },
+        overrideAccess: true,
       })
 
       await page.goto(formatDocURLUrl.list)
@@ -2073,6 +2086,7 @@ describe('List View', () => {
       await payload.create({
         collection: formatDocURLCollectionSlug,
         data: { description: 'This should link to custom destination', title: 'custom-link' },
+        overrideAccess: true,
       })
 
       await page.goto(formatDocURLUrl.list)
@@ -2091,6 +2105,7 @@ describe('List View', () => {
       const adminDoc = await payload.create({
         collection: formatDocURLCollectionSlug,
         data: { description: 'This should have admin query param', title: 'admin-test' },
+        overrideAccess: true,
       })
 
       await page.goto(formatDocURLUrl.list)
@@ -2114,6 +2129,7 @@ describe('List View', () => {
       const trashDoc = await payload.create({
         collection: formatDocURLCollectionSlug,
         data: { description: 'This should show trash URL', title: 'trash-test' },
+        overrideAccess: true,
       })
 
       // Move the document to trash by setting deletedAt (not delete)
@@ -2123,6 +2139,7 @@ describe('List View', () => {
         data: {
           deletedAt: new Date().toISOString(),
         },
+        overrideAccess: true,
       })
 
       // Go to trash view
@@ -2151,6 +2168,7 @@ describe('List View', () => {
           description: 'This is a published document',
           title: 'published-test',
         },
+        overrideAccess: true,
       })
 
       await page.goto(formatDocURLUrl.list)
@@ -2173,11 +2191,13 @@ describe('List View', () => {
       await payload.create({
         collection: formatDocURLCollectionSlug,
         data: { description: 'This should not be linkable in drawer', title: 'no-link' },
+        overrideAccess: true,
       })
 
       await payload.create({
         collection: formatDocURLCollectionSlug,
         data: { description: 'This should be linkable in drawer', title: 'linkable' },
+        overrideAccess: true,
       })
 
       await page.goto(formatDocURLUrl.list)
@@ -2218,11 +2238,16 @@ async function createPost(overrides?: Partial<Post>): Promise<Post> {
       ...overrides,
     },
     disableTransaction: true,
+    overrideAccess: true,
   }) as unknown as Promise<Post>
 }
 
 async function deleteAllPosts() {
-  await payload.delete({ collection: postsCollectionSlug, where: { id: { exists: true } } })
+  await payload.delete({
+    collection: postsCollectionSlug,
+    overrideAccess: true,
+    where: { id: { exists: true } },
+  })
 }
 
 async function createGeo(overrides?: Partial<Geo>): Promise<Geo> {
@@ -2233,6 +2258,7 @@ async function createGeo(overrides?: Partial<Geo>): Promise<Geo> {
       ...overrides,
     },
     disableTransaction: true,
+    overrideAccess: true,
   }) as unknown as Promise<Geo>
 }
 
@@ -2244,6 +2270,7 @@ async function createNoTimestampPost(overrides?: Partial<Post>): Promise<Post> {
       ...overrides,
     },
     disableTransaction: true,
+    overrideAccess: true,
   }) as unknown as Promise<Post>
 }
 
@@ -2254,6 +2281,7 @@ async function createArray() {
       array: [{ text: 'test' }],
     },
     disableTransaction: true,
+    overrideAccess: true,
   })
 }
 
@@ -2265,5 +2293,6 @@ async function createVirtualDoc(overrides?: Partial<Virtual>): Promise<Virtual> 
       ...overrides,
     },
     disableTransaction: true,
+    overrideAccess: true,
   }) as unknown as Promise<Virtual>
 }

--- a/test/admin/seed.ts
+++ b/test/admin/seed.ts
@@ -265,6 +265,7 @@ export const seed = async (_payload: Payload) => {
   await _payload.delete({
     collection: with300DocumentsSlug,
     where: {},
+    overrideAccess: true,
   })
 
   // Create 300 documents of with300Documents
@@ -276,6 +277,7 @@ export const seed = async (_payload: Payload) => {
         id: index,
         text: `document ${index}`,
       },
+      overrideAccess: true,
     })
   })
 

--- a/test/array-update/config.ts
+++ b/test/array-update/config.ts
@@ -145,6 +145,7 @@ export default buildConfigWithDefaults({
         email: devUser.email,
         password: devUser.password,
       },
+      overrideAccess: true,
     })
   },
 })

--- a/test/array-update/int.spec.ts
+++ b/test/array-update/int.spec.ts
@@ -24,6 +24,7 @@ test.suite({ config: './config.ts' })('array-update', () => {
           },
         ],
       },
+      overrideAccess: true,
     })
 
     const arrayWithExistingValues = [...doc.arrayOfFields]
@@ -41,6 +42,7 @@ test.suite({ config: './config.ts' })('array-update', () => {
       data: {
         arrayOfFields: arrayWithExistingValues,
       },
+      overrideAccess: true,
     })
 
     expect(updatedDoc.arrayOfFields?.[0]).toMatchObject({
@@ -70,6 +72,7 @@ test.suite({ config: './config.ts' })('array-update', () => {
           secondArrayItem,
         ],
       },
+      overrideAccess: true,
     })
 
     const updatedDoc = await payload.update({
@@ -88,6 +91,7 @@ test.suite({ config: './config.ts' })('array-update', () => {
           },
         ],
       },
+      overrideAccess: true,
     })
 
     expect(updatedDoc.arrayOfFields?.[0].required).toStrictEqual(updatedText)
@@ -102,10 +106,12 @@ test.suite({ config: './config.ts' })('array-update', () => {
     const docA = await payload.create({
       collection: arraySlug,
       data: { arrayOfFields: [] },
+      overrideAccess: true,
     })
     const docB = await payload.create({
       collection: arraySlug,
       data: { arrayOfFields: [] },
+      overrideAccess: true,
     })
 
     const reusedRowID = '6116a7f0f0f0f0f0f0f0f0f0'
@@ -123,13 +129,14 @@ test.suite({ config: './config.ts' })('array-update', () => {
         ],
       },
       where: { id: { in: [docA.id, docB.id] } },
+      overrideAccess: true,
     })
 
     expect(errors).toHaveLength(0)
     expect(docs).toHaveLength(2)
 
-    const updatedA = await payload.findByID({ id: docA.id, collection: arraySlug })
-    const updatedB = await payload.findByID({ id: docB.id, collection: arraySlug })
+    const updatedA = await payload.findByID({ id: docA.id, collection: arraySlug, overrideAccess: true })
+    const updatedB = await payload.findByID({ id: docB.id, collection: arraySlug, overrideAccess: true })
 
     expect(updatedA.arrayOfFields?.[0].required).toBe('bulk value')
     expect(updatedB.arrayOfFields?.[0].required).toBe('bulk value')
@@ -148,10 +155,12 @@ test.suite({ config: './config.ts' })('array-update', () => {
     const docWithExistingRow = await payload.create({
       collection: arraySlug,
       data: { arrayOfFields: [{ required: 'existing row' }] },
+      overrideAccess: true,
     })
     const otherDoc = await payload.create({
       collection: arraySlug,
       data: { arrayOfFields: [] },
+      overrideAccess: true,
     })
 
     const existingRowID = docWithExistingRow.arrayOfFields![0].id
@@ -165,6 +174,7 @@ test.suite({ config: './config.ts' })('array-update', () => {
         ],
       },
       where: { id: { in: [docWithExistingRow.id, otherDoc.id] } },
+      overrideAccess: true,
     })
 
     expect(errors).toHaveLength(0)
@@ -172,8 +182,9 @@ test.suite({ config: './config.ts' })('array-update', () => {
     const updatedWithExistingRow = await payload.findByID({
       id: docWithExistingRow.id,
       collection: arraySlug,
+      overrideAccess: true,
     })
-    const updatedOther = await payload.findByID({ id: otherDoc.id, collection: arraySlug })
+    const updatedOther = await payload.findByID({ id: otherDoc.id, collection: arraySlug, overrideAccess: true })
 
     expect(updatedWithExistingRow.arrayOfFields?.[0].id).toBe(existingRowID)
     expect(updatedWithExistingRow.arrayOfFields?.[0].required).toBe('updated existing row')
@@ -185,8 +196,8 @@ test.suite({ config: './config.ts' })('array-update', () => {
   test('should assign fresh row IDs for localized arrays, groups and blocks on bulk update', async ({
     payload,
   }) => {
-    const docA = await payload.create({ collection: complexSlug, data: {} })
-    const docB = await payload.create({ collection: complexSlug, data: {} })
+    const docA = await payload.create({ collection: complexSlug, data: {}, overrideAccess: true })
+    const docB = await payload.create({ collection: complexSlug, data: {}, overrideAccess: true })
 
     const { docs, errors } = await payload.update({
       collection: complexSlug,
@@ -208,13 +219,14 @@ test.suite({ config: './config.ts' })('array-update', () => {
         },
       },
       where: { id: { in: [docA.id, docB.id] } },
+      overrideAccess: true,
     })
 
     expect(errors).toHaveLength(0)
     expect(docs).toHaveLength(2)
 
-    const updatedA = await payload.findByID({ id: docA.id, collection: complexSlug })
-    const updatedB = await payload.findByID({ id: docB.id, collection: complexSlug })
+    const updatedA = await payload.findByID({ id: docA.id, collection: complexSlug, overrideAccess: true })
+    const updatedB = await payload.findByID({ id: docB.id, collection: complexSlug, overrideAccess: true })
 
     expect(updatedA.localizedArray?.[0].text).toBe('localized value')
     expect(updatedB.localizedArray?.[0].text).toBe('localized value')

--- a/test/auth-basic/e2e.spec.ts
+++ b/test/auth-basic/e2e.spec.ts
@@ -107,6 +107,7 @@ describe('Auth (Basic)', () => {
           exists: true,
         },
       },
+      overrideAccess: true,
     })
 
     await ensureCompilationIsDone({
@@ -124,6 +125,7 @@ describe('Auth (Basic)', () => {
           exists: true,
         },
       },
+      overrideAccess: true,
     })
   })
 
@@ -142,6 +144,7 @@ describe('Auth (Basic)', () => {
       await expect(async () => {
         const users = await payload.find({
           collection: 'users',
+          overrideAccess: true,
         })
 
         expect(users.totalDocs).toBe(1)

--- a/test/auth-session/config.ts
+++ b/test/auth-session/config.ts
@@ -76,6 +76,7 @@ export default buildConfigWithDefaults({
     const existingUsers = await payload.find({
       collection: authSessionUsersSlug,
       limit: 1,
+      overrideAccess: true,
     })
 
     if (existingUsers.docs.length === 0) {
@@ -84,6 +85,7 @@ export default buildConfigWithDefaults({
         data: {
           name: 'Session Test User',
         },
+        overrideAccess: true,
       })
     }
 

--- a/test/auth-session/testOAuthProvider.ts
+++ b/test/auth-session/testOAuthProvider.ts
@@ -169,6 +169,7 @@ export const authenticateTestOAuthSession: AuthStrategyFunction = async ({
   const user = await payload.findByID({
     id: lookup.session.userID,
     collection: authSessionUsersSlug,
+    overrideAccess: true,
   })
 
   return {
@@ -273,6 +274,7 @@ const loginTestOAuthSession: Endpoint = {
     const result = await req.payload.find({
       collection: authSessionUsersSlug,
       limit: 1,
+      overrideAccess: true,
     })
     const user = result.docs[0]
 

--- a/test/auth/custom-strategy/config.ts
+++ b/test/auth/custom-strategy/config.ts
@@ -22,10 +22,13 @@ const customAuthenticationStrategy: AuthStrategyFunction = async ({ headers, pay
         equals: headers.get('secret'),
       },
     },
+    overrideAccess: true,
   })
 
   const user = usersQuery.docs[0] || null
-  if (!user) return { user: null }
+  if (!user) {
+    return { user: null }
+  }
 
   return {
     responseHeaders: new Headers({

--- a/test/auth/e2e.spec.ts
+++ b/test/auth/e2e.spec.ts
@@ -70,6 +70,7 @@ describe('Auth', () => {
             exists: true,
           },
         },
+        overrideAccess: true,
       })
     })
 
@@ -182,12 +183,14 @@ describe('Auth', () => {
           collection: slug,
           limit: 1,
           where: { email: { equals: devUser.email } },
+          overrideAccess: true,
         })
 
         await payload.update({
           id: docs[0]!.id,
           collection: slug,
           data: { password: devUser.password },
+          overrideAccess: true,
         })
       })
 
@@ -336,6 +339,7 @@ describe('Auth', () => {
             collection: 'payload-locked-documents',
             limit: 1,
             pagination: false,
+            overrideAccess: true,
           })
 
           return lockedDocs.docs.length
@@ -376,6 +380,7 @@ describe('Auth', () => {
             apiKey: uuid(),
             enableAPIKey: true,
           },
+          overrideAccess: true,
         })
       })
 
@@ -441,6 +446,7 @@ describe('Auth', () => {
             apiKey: uuid(),
             enableAPIKey: true,
           },
+          overrideAccess: true,
         })
       })
 
@@ -457,6 +463,7 @@ describe('Auth', () => {
         const users = await payload.find({
           collection: slug,
           limit: 1,
+          overrideAccess: true,
         })
 
         const userDocumentRoute = formatAdminURL({
@@ -492,6 +499,7 @@ describe('Auth', () => {
         const notInUserCollection = await payload.create({
           collection: 'relationsCollection',
           data: {},
+          overrideAccess: true,
         })
 
         await logout(page, serverURL)

--- a/test/auth/forgot-password-localized/int.spec.ts
+++ b/test/auth/forgot-password-localized/int.spec.ts
@@ -29,6 +29,7 @@ test.suite({ config: './config.ts' })('Forgot password operation with localized 
       data: {
         localizedField: 'Polish content',
       },
+      overrideAccess: true,
     })
   })
 
@@ -40,6 +41,7 @@ test.suite({ config: './config.ts' })('Forgot password operation with localized 
       collection: collectionSlug,
       data: { email: devUser.email },
       disableEmail: true,
+      overrideAccess: true,
     })
 
     // Verify token was generated successfully
@@ -55,6 +57,7 @@ test.suite({ config: './config.ts' })('Forgot password operation with localized 
         collection: collectionSlug,
         data: { email: devUser.email },
         disableEmail: true,
+        overrideAccess: true,
       }),
     ).resolves.not.toThrow()
   })

--- a/test/auth/int.spec.ts
+++ b/test/auth/int.spec.ts
@@ -204,11 +204,13 @@ test.suite({ config: './config.ts' })('Auth', () => {
           password: testPassword,
           roles: ['user'],
         },
+        overrideAccess: true,
       })
 
       const userBefore: any = await payload.findByID({
         id: testUser.id,
         collection: slug,
+        overrideAccess: true,
       })
       const sessionCountBefore = userBefore.sessions?.length || 0
 
@@ -245,6 +247,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
       const userAfter: any = await payload.findByID({
         id: testUser.id,
         collection: slug,
+        overrideAccess: true,
       })
 
       expect(userAfter.loginMetadata).toHaveLength(2)
@@ -257,6 +260,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
       await payload.delete({
         id: testUser.id,
         collection: slug,
+        overrideAccess: true,
       })
     })
 
@@ -286,6 +290,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
           data: {
             password: 'test',
           },
+          overrideAccess: true,
         })
 
         expect(result.id).toStrictEqual(loggedInUser.id)
@@ -394,6 +399,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
             email: 'dev@example.com',
             password: 'test',
           },
+          overrideAccess: true,
         })
 
         const response = await restClient.GET(`/${slug}/me`, {
@@ -448,6 +454,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
           data: {
             custom: 'Goodbye, world!',
           },
+          overrideAccess: true,
         })
 
         const response = await restClient.POST(`/${slug}/refresh-token`, {
@@ -470,10 +477,12 @@ test.suite({ config: './config.ts' })('Auth', () => {
         const user = await payload.create({
           collection: slug,
           data: { apiKey, email: 'user@example.com', enableAPIKey: true, password: 'Password123' },
+          overrideAccess: true,
         })
         const { token } = await payload.login({
           collection: 'users',
           data: { email: 'user@example.com', password: 'Password123' },
+          overrideAccess: true,
         })
         await restClient.POST('/users/refresh-token', {
           headers: { Authorization: `JWT ${token}` },
@@ -498,11 +507,13 @@ test.suite({ config: './config.ts' })('Auth', () => {
             enableAPIKey: true,
             password: 'Password123',
           },
+          overrideAccess: true,
         })
 
         const { token } = await payload.login({
           collection: 'users',
           data: { email: 'user@example.com', password: 'Password123' },
+          overrideAccess: true,
         })
 
         const res = await restClient
@@ -563,6 +574,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
               equals: emailToVerify,
             },
           },
+          overrideAccess: true,
         })
 
         const { _verificationToken, _verified } = userResult.docs[0]
@@ -585,6 +597,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
               equals: emailToVerify,
             },
           },
+          overrideAccess: true,
         })
 
         const { _verificationToken: afterToken, _verified: afterVerified } =
@@ -658,6 +671,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
                 },
               ],
             },
+            overrideAccess: true,
           })
 
           expect(data.doc.key).toStrictEqual(key)
@@ -708,6 +722,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
                 },
               ],
             },
+            overrideAccess: true,
           })
 
           expect((result.docs[0]?.value as any)?.property).toStrictEqual('updated')
@@ -744,6 +759,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
                 },
               ],
             },
+            overrideAccess: true,
           })
 
           expect(result.docs).toHaveLength(0)
@@ -776,6 +792,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
             collection: publicUsersSlug,
             id: publicUserId,
             showHiddenFields: true,
+            overrideAccess: true,
           })
           await restClient.POST(`/${publicUsersSlug}/verify/${(user as any)._verificationToken}`)
 
@@ -824,6 +841,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
           const before = await payload.find({
             collection: 'payload-preferences',
             where: { 'user.relationTo': { equals: 'users' } },
+            overrideAccess: true,
           })
           expect(before.docs).toHaveLength(1)
 
@@ -834,6 +852,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
           const after = await payload.find({
             collection: 'payload-preferences',
             where: { 'user.relationTo': { equals: 'users' } },
+            overrideAccess: true,
           })
           expect(after.docs).toHaveLength(1)
           expect((after.docs[0]?.value as any)?.data).toBe('admin-sensitive')
@@ -843,12 +862,14 @@ test.suite({ config: './config.ts' })('Auth', () => {
           const publicPrefs = await payload.find({
             collection: 'payload-preferences',
             where: { 'user.relationTo': { equals: publicUsersSlug } },
+            overrideAccess: true,
           })
           expect(publicPrefs.docs).toHaveLength(1)
 
           const adminPrefs = await payload.find({
             collection: 'payload-preferences',
             where: { 'user.relationTo': { equals: 'users' } },
+            overrideAccess: true,
           })
           expect(adminPrefs.docs).toHaveLength(1)
         })
@@ -936,6 +957,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
                 equals: userEmail,
               },
             },
+            overrideAccess: true,
           })
 
           const { lockUntil, loginAttempts } = userResult.docs[0]!
@@ -980,6 +1002,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
                 equals: userEmail,
               },
             },
+            overrideAccess: true,
           })
 
           const { lockUntil, loginAttempts } = userResult.docs[0]!
@@ -1071,6 +1094,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
                 equals: userEmail,
               },
             },
+            overrideAccess: true,
           })
 
           expect(lockedUser.docs[0]!.loginAttempts).toBe(2)
@@ -1089,6 +1113,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
             collection: slug,
             id: lockedUser.docs[0]!.id,
             showHiddenFields: true,
+            overrideAccess: true,
           })
 
           expect(userAfterUpdate.lockUntil).toEqual(manuallyReleaseLock)
@@ -1113,6 +1138,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
                 equals: userEmail,
               },
             },
+            overrideAccess: true,
           })
 
           const { lockUntil, loginAttempts } = userResult.docs[0]
@@ -1142,6 +1168,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
           email: devUser.email,
         },
         disableEmail: true,
+        overrideAccess: true,
       })
 
       const result = await payload
@@ -1167,6 +1194,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
           password: 'test',
           roles: ['admin'],
         },
+        overrideAccess: true,
       })
 
       const response = await restClient.POST(`/${slug}/login`, {
@@ -1193,6 +1221,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
         data: {
           roles: ['editor'],
         },
+        overrideAccess: true,
       })
 
       const editorMe = await restClient
@@ -1234,6 +1263,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
           email,
           // password is not required
         },
+        overrideAccess: true,
       })
       expect(user.email).toStrictEqual(email)
     })
@@ -1267,6 +1297,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
           email: devUser.email,
           password: devUser.password,
         },
+        overrideAccess: true,
       })
 
       await expect(
@@ -1276,6 +1307,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
             email: devUser.email,
             password: devUser.password,
           },
+          overrideAccess: true,
         }),
       ).rejects.toThrow('You are not allowed to perform this action.')
     })
@@ -1295,12 +1327,14 @@ test.suite({ config: './config.ts' })('Auth', () => {
       const doc = await payload.create({
         collection: 'disable-local-strategy-password',
         data: { password: '123' },
+        overrideAccess: true,
       })
       expect(doc.password).toBe('123')
       const updated = await payload.update({
         id: doc.id,
         collection: 'disable-local-strategy-password',
         data: { password: '1234' },
+        overrideAccess: true,
       })
       expect(updated.password).toBe('1234')
     })
@@ -1310,6 +1344,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
     test('should authenticate via the correct API key user', async ({ payload, restClient }) => {
       const usersQuery = await payload.find({
         collection: apiKeysSlug,
+        overrideAccess: true,
       })
 
       const [user1, user2] = usersQuery.docs
@@ -1339,6 +1374,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
     }) => {
       const usersQuery = await payload.find({
         collection: apiKeysSlug,
+        overrideAccess: true,
       })
 
       const [user] = usersQuery.docs as [ApiKey]
@@ -1377,6 +1413,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
           apiKey,
           enableAPIKey: true,
         },
+        overrideAccess: true,
       })
 
       const updatedUser = await payload.update({
@@ -1385,6 +1422,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
         data: {
           enableAPIKey: true,
         },
+        overrideAccess: true,
       })
 
       const userResult = await payload.find({
@@ -1394,6 +1432,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
             equals: user.id,
           },
         },
+        overrideAccess: true,
       })
 
       expect(updatedUser.apiKey).toStrictEqual(user.apiKey)
@@ -1408,6 +1447,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
           apiKey,
           enableAPIKey: true,
         },
+        overrideAccess: true,
       })
 
       const updatedUser = await payload.update({
@@ -1416,6 +1456,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
         data: {
           apiKey: null,
         },
+        overrideAccess: true,
       })
 
       // use the api key in a fetch to assert that it is disabled
@@ -1442,6 +1483,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
           apiKey,
           enableAPIKey: true,
         },
+        overrideAccess: true,
       })
 
       const updatedUser = await payload.update({
@@ -1450,6 +1492,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
         data: {
           enableAPIKey: false,
         },
+        overrideAccess: true,
       })
 
       // use the api key in a fetch to assert that it is disabled
@@ -1474,6 +1517,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
           email: devUser.email,
           password: devUser.password,
         },
+        overrideAccess: true,
       })
 
       expect(authenticated.token).toBeTruthy()
@@ -1489,6 +1533,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
           password: 'test',
           roles: ['user'],
         },
+        overrideAccess: true,
       })
 
       expect(createdUser.collection).toBe(slug)
@@ -1496,6 +1541,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
       const foundUser = await payload.findByID({
         id: createdUser.id,
         collection: slug,
+        overrideAccess: true,
       })
 
       expect(foundUser.collection).toBe(slug)
@@ -1503,6 +1549,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
       const foundUsers = await payload.find({
         collection: slug,
         where: { id: { equals: createdUser.id } },
+        overrideAccess: true,
       })
 
       expect(foundUsers.docs[0]?.collection).toBe(slug)
@@ -1511,6 +1558,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
         id: createdUser.id,
         collection: slug,
         data: { roles: ['admin'] },
+        overrideAccess: true,
       })
 
       expect(updatedUser.collection).toBe(slug)
@@ -1518,6 +1566,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
       const deletedUser = await payload.delete({
         id: createdUser.id,
         collection: slug,
+        overrideAccess: true,
       })
 
       expect(deletedUser.collection).toBe(slug)
@@ -1529,6 +1578,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
         data: {
           enableAPIKey: true,
         },
+        overrideAccess: true,
       })
 
       expect(createdApiKey.collection).toBe(apiKeysSlug)
@@ -1536,6 +1586,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
       const foundApiKey = await payload.findByID({
         id: createdApiKey.id,
         collection: apiKeysSlug,
+        overrideAccess: true,
       })
 
       expect(foundApiKey.collection).toBe(apiKeysSlug)
@@ -1543,6 +1594,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
       const foundApiKeys = await payload.find({
         collection: apiKeysSlug,
         where: { id: { equals: createdApiKey.id } },
+        overrideAccess: true,
       })
 
       expect(foundApiKeys.docs[0]?.collection).toBe(apiKeysSlug)
@@ -1551,6 +1603,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
         id: createdApiKey.id,
         collection: apiKeysSlug,
         data: { enableAPIKey: false },
+        overrideAccess: true,
       })
 
       expect(updatedApiKey.collection).toBe(apiKeysSlug)
@@ -1558,6 +1611,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
       const deletedApiKey = await payload.delete({
         id: createdApiKey.id,
         collection: apiKeysSlug,
+        overrideAccess: true,
       })
 
       expect(deletedApiKey.collection).toBe(apiKeysSlug)
@@ -1569,6 +1623,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
         data: {
           email: 'dev@payloadcms.com',
         },
+        overrideAccess: true,
       })
 
       const reset = await payload.resetPassword({
@@ -1601,6 +1656,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
           data: {
             email: 'dev@payloadcms.com',
           },
+          overrideAccess: true,
         })
       } finally {
         // Restore the original Date.now() after the forgotPassword call
@@ -1832,6 +1888,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
           email: devUser.email,
           password: devUser.password,
         },
+        overrideAccess: true,
       })
 
       expect(authenticated.token).toBeTruthy()
@@ -1868,6 +1925,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
           email: devUser.email,
           password: devUser.password,
         },
+        overrideAccess: true,
       })
 
       const authenticated2 = await payload.login({
@@ -1876,6 +1934,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
           email: devUser.email,
           password: devUser.password,
         },
+        overrideAccess: true,
       })
 
       await restClient.POST(`/${slug}/logout`, {
@@ -1915,6 +1974,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
           email: devUser.email,
           password: devUser.password,
         },
+        overrideAccess: true,
       })
 
       const decoded = jwtDecode<{ sid: string }>(String(authenticated.token))
@@ -1970,6 +2030,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
           email: devUser.email,
           password: devUser.password,
         },
+        overrideAccess: true,
       })
       const { sid } = jwtDecode<{ sid: string }>(String(authenticated.token))
 
@@ -2007,6 +2068,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
           email: devUser.email,
           password: devUser.password,
         },
+        overrideAccess: true,
       })
 
       await restClient.POST(`/${slug}/logout?allSessions=true`, {
@@ -2053,6 +2115,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
             },
           ],
         },
+        overrideAccess: true,
       })
 
       expect(userWithExpiredSession.sessions).toHaveLength(1)
@@ -2063,6 +2126,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
           email: devUser.email,
           password: devUser.password,
         },
+        overrideAccess: true,
       })
 
       const user2 = await payload.db.find<User>({
@@ -2086,6 +2150,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
           password: 'test123',
           roles: ['admin'],
         },
+        overrideAccess: true,
       })
 
       const originalUpdatedAt = testUser.updatedAt
@@ -2100,6 +2165,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
           email: testUser.email,
           password: 'test123',
         },
+        overrideAccess: true,
       })
 
       // Fetch the user to check updatedAt
@@ -2127,6 +2193,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
           password: 'test123',
           roles: ['admin'],
         },
+        overrideAccess: true,
       })
 
       const authenticated = await payload.login({
@@ -2135,6 +2202,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
           email: testUser.email,
           password: 'test123',
         },
+        overrideAccess: true,
       })
 
       const userAfterLogin = await payload.db.findOne<User>({
@@ -2184,6 +2252,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
           password: 'test123',
           roles: ['admin'],
         },
+        overrideAccess: true,
       })
 
       const authenticated = await payload.login({
@@ -2192,6 +2261,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
           email: testUser.email,
           password: 'test123',
         },
+        overrideAccess: true,
       })
 
       const userAfterLogin = await payload.db.findOne<User>({
@@ -2266,6 +2336,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
       const user = await payload.create({
         collection,
         data: { apiKey: rawApiKey, enableAPIKey: true, ...data },
+        overrideAccess: true,
       })
       createdIDs.push({ id: user.id, collection })
 
@@ -2292,6 +2363,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
       const user = await payload.create({
         collection,
         data: { apiKey: rawApiKey, enableAPIKey: true },
+        overrideAccess: true,
       })
       createdIDs.push({ id: user.id, collection })
 
@@ -2314,7 +2386,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
         idsByCollection.set(collection, [...(idsByCollection.get(collection) ?? []), id])
       }
       for (const [collection, ids] of idsByCollection) {
-        await payload.delete({ collection, where: { id: { in: ids } } })
+        await payload.delete({ collection, where: { id: { in: ids } }, overrideAccess: true })
       }
       createdIDs.length = 0
     })
@@ -2430,7 +2502,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
       expect(payload.decrypt(raw.apiKey)).toBe(rawApiKey)
 
       // Remove the corrupt row; the re-run completes and skips the migrated row.
-      await payload.delete({ id: corrupt.id, collection: rotateSecretSecondarySlug })
+      await payload.delete({ id: corrupt.id, collection: rotateSecretSecondarySlug, overrideAccess: true })
       const rerun = await rotateSecret(rotateArgs)
       expect(rerun).toEqual({ migrated: 0, skipped: 1 })
     })
@@ -2491,6 +2563,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
       const user = await payload.create({
         collection: rotateSecretSlug,
         data: { apiKey: rawApiKey, enableAPIKey: true },
+        overrideAccess: true,
       })
       createdIDs.push({ id: user.id, collection: rotateSecretSlug })
 
@@ -2529,6 +2602,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
       const user = await payload.create({
         collection: rotateSecretSlug,
         data: { apiKey: rawApiKey, enableAPIKey: true },
+        overrideAccess: true,
       })
       createdIDs.push({ id: user.id, collection: rotateSecretSlug })
 
@@ -2541,7 +2615,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
 
       // Reading through the Local API runs the afterRead decrypt hook, which must
       // mask the undecryptable field rather than failing the whole document read.
-      const doc = await payload.findByID({ collection: rotateSecretSlug, id: user.id })
+      const doc = await payload.findByID({ collection: rotateSecretSlug, id: user.id, overrideAccess: true })
       expect(doc.apiKey).toBeNull()
     })
 
@@ -2571,6 +2645,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
       const { token } = await payload.login({
         collection: rotateSecretLoginSlug,
         data: { email: loginEmail, password: loginPassword },
+        overrideAccess: true,
       })
       expect(token).toBeDefined()
     })
@@ -2651,7 +2726,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
       payload,
       restClient,
     }) => {
-      const { token, user } = await payload.login({ collection: slug, data: { email, password } })
+      const { token, user } = await payload.login({ collection: slug, data: { email, password }, overrideAccess: true })
 
       const { exp: _exp, iat: _iat, ...claims } = jwtDecode<Record<string, unknown>>(token)
       const nowInSeconds = Math.floor(Date.now() / 1000)

--- a/test/auth/removed-token/int.spec.ts
+++ b/test/auth/removed-token/int.spec.ts
@@ -98,6 +98,7 @@ test.suite({ config: './config.ts' })('Remove token from auth responses', () => 
       collection: collectionSlug,
       data: { email: devUser.email },
       disableEmail: true,
+      overrideAccess: true,
     })
 
     const response = await restClient.POST(`/${collectionSlug}/reset-password`, {

--- a/test/auth/seed.ts
+++ b/test/auth/seed.ts
@@ -14,6 +14,7 @@ export const seed: Config['onInit'] = async (payload) => {
       password: devUser.password,
       roles: ['admin'],
     },
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -22,6 +23,7 @@ export const seed: Config['onInit'] = async (payload) => {
       apiKey: uuid(),
       enableAPIKey: true,
     },
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -30,5 +32,6 @@ export const seed: Config['onInit'] = async (payload) => {
       apiKey: uuid(),
       enableAPIKey: true,
     },
+    overrideAccess: true,
   })
 }

--- a/test/base-access/int.spec.ts
+++ b/test/base-access/int.spec.ts
@@ -42,6 +42,7 @@ test.suite({ config: './config.ts' })('baseAccess', () => {
       await payload.create({
         collection: postsSlug,
         data,
+        overrideAccess: true,
       })
     }
     const req = await createRequest({
@@ -86,6 +87,7 @@ test.suite({ config: './config.ts' })('baseAccess', () => {
       collection: postsSlug,
       data,
       req,
+      overrideAccess: true,
     })
 
     expect(doc.title).toBe(data.title)

--- a/test/base-path/seed/index.ts
+++ b/test/base-path/seed/index.ts
@@ -9,6 +9,7 @@ export const seed: Config['onInit'] = async (payload) => {
       email: devUser.email,
       password: devUser.password,
     },
+    overrideAccess: true,
   })
 
   // Seed some sample posts
@@ -18,6 +19,7 @@ export const seed: Config['onInit'] = async (payload) => {
       content: 'This is the content of the first post.',
       title: 'First Post',
     },
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -26,6 +28,7 @@ export const seed: Config['onInit'] = async (payload) => {
       content: 'This is the content of the second post.',
       title: 'Second Post',
     },
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -34,5 +37,6 @@ export const seed: Config['onInit'] = async (payload) => {
       content: 'This is the content of the third post.',
       title: 'Third Post',
     },
+    overrideAccess: true,
   })
 }

--- a/test/benchmark-blocks/config.ts
+++ b/test/benchmark-blocks/config.ts
@@ -48,6 +48,7 @@ export default buildConfigWithDefaults({
         email: devUser.email,
         password: devUser.password,
       },
+      overrideAccess: true,
     })
 
     await payload.create({
@@ -55,6 +56,7 @@ export default buildConfigWithDefaults({
       data: {
         title: 'example post',
       },
+      overrideAccess: true,
     })
   },
 })

--- a/test/bulk-edit/e2e.spec.ts
+++ b/test/bulk-edit/e2e.spec.ts
@@ -467,6 +467,7 @@ test.describe('Bulk Edit', () => {
       collection: postsSlug,
       depth: 0,
       limit: 1,
+      overrideAccess: true,
       where: {
         id: {
           equals: postID,
@@ -507,6 +508,7 @@ test.describe('Bulk Edit', () => {
       .find({
         collection: 'posts',
         limit: 1,
+        overrideAccess: true,
       })
       ?.then((res) => res.docs[0])
 
@@ -692,6 +694,7 @@ test.describe('Bulk Edit', () => {
         },
         title: 'Tab Title',
       },
+      overrideAccess: true,
     })
 
     await page.goto(tabsUrl.list)
@@ -730,6 +733,7 @@ test.describe('Bulk Edit', () => {
 
     const updatedDocQuery = await payload.find({
       collection: tabsSlug,
+      overrideAccess: true,
       where: {
         id: {
           equals: originalDoc.id,
@@ -754,6 +758,7 @@ test.describe('Bulk Edit', () => {
         },
         title: 'Tab Doc',
       },
+      overrideAccess: true,
     })
 
     await page.goto(tabsUrl.list)
@@ -790,6 +795,7 @@ test.describe('Bulk Edit', () => {
 
     const updatedDocQuery = await payload.find({
       collection: tabsSlug,
+      overrideAccess: true,
       where: {
         id: {
           equals: originalDoc.id,
@@ -802,22 +808,23 @@ test.describe('Bulk Edit', () => {
       .poll(() => updatedDoc?.tabTab?.tabText, { timeout: POLL_TOPASS_TIMEOUT })
       .toEqual('updated value')
 
-    await payload.delete({ id: originalDoc.id, collection: tabsSlug })
+    await payload.delete({ id: originalDoc.id, collection: tabsSlug, overrideAccess: true })
   })
 
   test('should include named-tab fields in bulk edit when a collection has a restricted field', async () => {
     const doc = await payload.create({
       collection: restrictedTabsSlug,
       data: { title: 'Restricted Tabs Doc' },
+      overrideAccess: true,
     })
 
     await page.goto(restrictedTabsUrl.list)
     await expect.poll(() => page.url(), { timeout: POLL_TOPASS_TIMEOUT }).toContain('limit=')
 
     await addListFilter({
-      page,
       fieldLabel: 'ID',
       operatorLabel: 'equals',
+      page,
       value: doc.id,
     })
 
@@ -843,13 +850,14 @@ test.describe('Bulk Edit', () => {
       selectMenu.locator('.rs__option', { hasText: exactText('Named Tab No Update') }),
     ).toBeHidden()
 
-    await payload.delete({ collection: restrictedTabsSlug, id: doc.id })
+    await payload.delete({ id: doc.id, collection: restrictedTabsSlug, overrideAccess: true })
   })
 
   test('should show clean labels for fields inside label-false groups and rows', async () => {
     const doc = await payload.create({
       collection: tabsSlug,
       data: { title: 'Label Test Doc' },
+      overrideAccess: true,
     })
 
     await page.goto(tabsUrl.list)
@@ -880,13 +888,14 @@ test.describe('Bulk Edit', () => {
     })
     await expect(option).toBeVisible()
 
-    await payload.delete({ id: doc.id, collection: tabsSlug })
+    await payload.delete({ id: doc.id, collection: tabsSlug, overrideAccess: true })
   })
 
   test('should fall back to the field name for fields with label: false', async () => {
     const doc = await payload.create({
       collection: tabsSlug,
       data: { title: 'No Label Doc' },
+      overrideAccess: true,
     })
 
     await page.goto(tabsUrl.list)
@@ -920,7 +929,7 @@ test.describe('Bulk Edit', () => {
     const optionTexts = await menu.locator('.rs__option').allInnerTexts()
     expect(optionTexts.every((text) => text.trim().length > 0)).toBe(true)
 
-    await payload.delete({ id: doc.id, collection: tabsSlug })
+    await payload.delete({ id: doc.id, collection: tabsSlug, overrideAccess: true })
   })
 
   test('should preserve beforeInput components when selecting multiple fields', async () => {
@@ -1064,7 +1073,11 @@ async function selectAllAndEditMany(page: Page): Promise<{ modal: Locator }> {
 }
 
 async function deleteAllPosts() {
-  await payload.delete({ collection: postsSlug, where: { id: { exists: true } } })
+  await payload.delete({
+    collection: postsSlug,
+    overrideAccess: true,
+    where: { id: { exists: true } },
+  })
 }
 
 async function createPost(
@@ -1073,6 +1086,7 @@ async function createPost(
 ): Promise<Post> {
   return payload.create({
     collection: postsSlug,
+    overrideAccess: true,
     ...(overrides || {}),
     data: {
       title: 'Post Title',

--- a/test/bulk-edit/seed.ts
+++ b/test/bulk-edit/seed.ts
@@ -10,6 +10,7 @@ export const seed = async (payload: Payload) => {
       email: devUser.email,
       password: devUser.password,
     },
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -17,5 +18,6 @@ export const seed = async (payload: Payload) => {
     data: {
       title: 'example post',
     },
+    overrideAccess: true,
   })
 }

--- a/test/cli/int.spec.ts
+++ b/test/cli/int.spec.ts
@@ -339,6 +339,7 @@ test.suite({ config: './config.ts' })('CLI', () => {
     const pages = await payload.count({
       collection: 'pages',
       where: { title: { equals: 'not created' } },
+      overrideAccess: true,
     })
 
     expect(output.exitCode).toBe(1)
@@ -400,6 +401,7 @@ test.suite({ config: './config.ts' })('CLI', () => {
     const seededPages = await payload.count({
       collection: 'pages',
       where: { title: { equals: 'Seeded page' } },
+      overrideAccess: true,
     })
 
     expect(output.exitCode).toBe(1)
@@ -491,6 +493,7 @@ test.suite({ config: './config.ts' })('CLI', () => {
         pagination: false,
         sort: 'title',
         where: { title: { in: ['one', 'two'] } },
+        overrideAccess: true,
       })
 
       expect(pages.docs).toHaveLength(2)
@@ -530,6 +533,7 @@ test.suite({ config: './config.ts' })('CLI', () => {
       collection: 'pages',
       pagination: false,
       where: { title: { in: ['file one', 'file two'] } },
+      overrideAccess: true,
     })
 
     expect(pages.docs).toHaveLength(2)
@@ -561,6 +565,7 @@ test.suite({ config: './config.ts' })('CLI', () => {
     const pages = await payload.find({
       collection: 'pages',
       where: { title: { equals: 'Merged input' } },
+      overrideAccess: true,
     })
 
     expect(pages.docs).toHaveLength(1)
@@ -606,6 +611,7 @@ test.suite({ config: './config.ts' })('CLI', () => {
     const created = await payload.find({
       collection: 'pages',
       where: { title: { equals: 'created' } },
+      overrideAccess: true,
     })
 
     expect(output.exitCode).toBe(1)
@@ -644,6 +650,7 @@ test.suite({ config: './config.ts' })('CLI', () => {
     const pages = await payload.find({
       collection: 'pages',
       where: { title: { equals: 'Seeded page' } },
+      overrideAccess: true,
     })
 
     expect(output.exitCode).toBe(1)
@@ -677,12 +684,13 @@ test.suite({ config: './config.ts' })('CLI', () => {
         requireMetadata: true,
         title: 'Nested update',
       },
+      overrideAccess: true,
     })
     const output = await cli({
       command: `updateDocument --slug pages --id ${page.id} --data '{"metadata":{"title":"Updated"}}' --returning --json`,
       reject: false,
     })
-    const updatedPage = await payload.findByID({ collection: 'pages', id: page.id })
+    const updatedPage = await payload.findByID({ collection: 'pages', id: page.id, overrideAccess: true })
 
     expect(output.exitCode).toBe(0)
     expect(updatedPage.metadata).toEqual({
@@ -697,11 +705,12 @@ test.suite({ config: './config.ts' })('CLI', () => {
       const page = await payload.create({
         collection: 'pages',
         data: { title: 'Numeric ID' },
+        overrideAccess: true,
       })
       const output = await cli(
         `updateDocument --slug pages --id ${page.id} --data '{"title":"Updated"}' --override-access false --json`,
       )
-      const updatedPage = await payload.findByID({ id: page.id, collection: 'pages' })
+      const updatedPage = await payload.findByID({ id: page.id, collection: 'pages', overrideAccess: true })
 
       expect(output.exitCode).toBe(0)
       expect(updatedPage.title).toBe('Updated')
@@ -715,17 +724,19 @@ test.suite({ config: './config.ts' })('CLI', () => {
     await payload.create({
       collection: 'custom-ids',
       data: { id: '1e5', title: 'Target' },
+      overrideAccess: true,
     })
     await payload.create({
       collection: 'custom-ids',
       data: { id: '100000', title: 'Other' },
+      overrideAccess: true,
     })
 
     const output = await cli(
       `updateDocument --slug custom-ids --id 1e5 --data '{"title":"Updated"}' --json`,
     )
-    const target = await payload.findByID({ id: '1e5', collection: 'custom-ids' })
-    const other = await payload.findByID({ id: '100000', collection: 'custom-ids' })
+    const target = await payload.findByID({ id: '1e5', collection: 'custom-ids', overrideAccess: true })
+    const other = await payload.findByID({ id: '100000', collection: 'custom-ids', overrideAccess: true })
 
     expect(output.exitCode).toBe(0)
     expect(target.title).toBe('Updated')
@@ -739,12 +750,13 @@ test.suite({ config: './config.ts' })('CLI', () => {
     await payload.create({
       collection: 'custom-ids',
       data: { id: '123', title: 'Target' },
+      overrideAccess: true,
     })
 
     const output = await cli(
       `updateDocument --input '{"slug":"custom-ids","id":123,"data":{"title":"Updated"},"overrideAccess":false}' --json`,
     )
-    const target = await payload.findByID({ id: '123', collection: 'custom-ids' })
+    const target = await payload.findByID({ id: '123', collection: 'custom-ids', overrideAccess: true })
 
     expect(output.exitCode).toBe(0)
     expect(target.title).toBe('Updated')
@@ -757,10 +769,12 @@ test.suite({ config: './config.ts' })('CLI', () => {
     await payload.create({
       collection: 'custom-ids',
       data: { id: '12345678901234567890', title: 'Target' },
+      overrideAccess: true,
     })
     await payload.create({
       collection: 'custom-ids',
       data: { id: '12345678901234567000', title: 'Rounded ID' },
+      overrideAccess: true,
     })
 
     const output = await cli('deleteDocuments --slug custom-ids --id 12345678901234567890 --json')
@@ -768,10 +782,12 @@ test.suite({ config: './config.ts' })('CLI', () => {
       id: '12345678901234567890',
       collection: 'custom-ids',
       disableErrors: true,
+      overrideAccess: true,
     })
     const roundedIDDocument = await payload.findByID({
       id: '12345678901234567000',
       collection: 'custom-ids',
+      overrideAccess: true,
     })
 
     expect(output.exitCode).toBe(0)
@@ -787,13 +803,14 @@ test.suite({ config: './config.ts' })('CLI', () => {
       collection: 'pages',
       limit: 1,
       where: { title: { equals: 'Seeded page' } },
+      overrideAccess: true,
     })
     const output = await cli({
       command: `duplicateDocument --slug pages --id ${seededPage.docs[0]!.id} --data '{"title":null}' --json`,
       reject: false,
     })
     const response = JSON.parse(output.stdout)
-    const pages = await payload.count({ collection: 'pages' })
+    const pages = await payload.count({ collection: 'pages', overrideAccess: true })
 
     expect(output.exitCode).toBe(1)
     expect(pages.totalDocs).toBe(1)
@@ -818,7 +835,7 @@ test.suite({ config: './config.ts' })('CLI', () => {
       reject: false,
     })
     const response = JSON.parse(output.stdout)
-    const settings = await payload.findGlobal({ slug: 'settings' })
+    const settings = await payload.findGlobal({ slug: 'settings', overrideAccess: true })
 
     expect(output.exitCode).toBe(1)
     expect(settings.title).toBe('Seeded settings')
@@ -846,6 +863,7 @@ test.suite({ config: './config.ts' })('CLI', () => {
       const updated = await payload.find({
         collection: 'pages',
         where: { title: { equals: 'Updated page' } },
+        overrideAccess: true,
       })
 
       expect(updated.docs).toHaveLength(1)
@@ -867,6 +885,7 @@ test.suite({ config: './config.ts' })('CLI', () => {
       collection: 'media',
       limit: 1,
       where: { title: { equals: 'Seeded media' } },
+      overrideAccess: true,
     })
     const output = await cli(
       `updateDocument --slug media --id ${seededMedia.docs[0]!.id} --data '{"title":"Updated media"}' --file ${uploadFile} --returning`,
@@ -874,6 +893,7 @@ test.suite({ config: './config.ts' })('CLI', () => {
     const updatedMedia = await payload.findByID({
       id: seededMedia.docs[0]!.id,
       collection: 'media',
+      overrideAccess: true,
     })
 
     expect(output.stdout).toContain('"title": "Updated media"')
@@ -1010,12 +1030,12 @@ test.suite({ config: './config.ts' })('CLI', () => {
     const migrationName = (await readdir(migrationsDirectory))
       .find((file) => file.endsWith('_pending.ts'))!
       .replace('.ts', '')
-    const migrationsBefore = await payload.find({ collection: 'payload-migrations', limit: 100 })
+    const migrationsBefore = await payload.find({ collection: 'payload-migrations', limit: 100, overrideAccess: true })
 
     expect(migrationsBefore.docs.find(({ name }) => name === migrationName)).toBeUndefined()
 
     const output = await cli('migrate --json')
-    const migrationsAfter = await payload.find({ collection: 'payload-migrations', limit: 100 })
+    const migrationsAfter = await payload.find({ collection: 'payload-migrations', limit: 100, overrideAccess: true })
 
     expect(migrationsAfter.docs.find(({ name }) => name === migrationName)).toMatchObject({
       batch: 1,
@@ -1036,12 +1056,12 @@ test.suite({ config: './config.ts' })('CLI', () => {
     const migrationName = (await readdir(migrationsDirectory))
       .find((file) => file.endsWith('_pending.ts'))!
       .replace('.ts', '')
-    const migrationsBefore = await payload.find({ collection: 'payload-migrations', limit: 100 })
+    const migrationsBefore = await payload.find({ collection: 'payload-migrations', limit: 100, overrideAccess: true })
 
     expect(migrationsBefore.docs.find(({ name }) => name === migrationName)).toBeUndefined()
 
     const output = await cli('migrate --help')
-    const migrationsAfter = await payload.find({ collection: 'payload-migrations', limit: 100 })
+    const migrationsAfter = await payload.find({ collection: 'payload-migrations', limit: 100, overrideAccess: true })
 
     expect(`${output.stdout}\n${output.stderr}`).toContain('Usage: payload migrate')
     expect(migrationsAfter.docs.find(({ name }) => name === migrationName)).toBeUndefined()
@@ -1089,12 +1109,12 @@ test.suite({ config: './config.ts' })('CLI', () => {
       .find((file) => file.endsWith('_down.ts'))!
       .replace('.ts', '')
     await cli('migrate --json')
-    const migrationsBefore = await payload.find({ collection: 'payload-migrations', limit: 100 })
+    const migrationsBefore = await payload.find({ collection: 'payload-migrations', limit: 100, overrideAccess: true })
 
     expect(migrationsBefore.docs.find(({ name }) => name === migrationName)).toBeDefined()
 
     const output = await cli('migrate:down --json')
-    const migrationsAfter = await payload.find({ collection: 'payload-migrations', limit: 100 })
+    const migrationsAfter = await payload.find({ collection: 'payload-migrations', limit: 100, overrideAccess: true })
 
     expect(migrationsAfter.docs.find(({ name }) => name === migrationName)).toBeUndefined()
 
@@ -1116,7 +1136,7 @@ test.suite({ config: './config.ts' })('CLI', () => {
     await cli('migrate --json')
 
     const output = await cli('migrate:down --help')
-    const migrationsAfter = await payload.find({ collection: 'payload-migrations', limit: 100 })
+    const migrationsAfter = await payload.find({ collection: 'payload-migrations', limit: 100, overrideAccess: true })
 
     expect(`${output.stdout}\n${output.stderr}`).toContain('Usage: payload migrate:down')
     expect(migrationsAfter.docs.find(({ name }) => name === migrationName)).toBeDefined()
@@ -1129,12 +1149,12 @@ test.suite({ config: './config.ts' })('CLI', () => {
       const migrationName = (await readdir(migrationsDirectory))
         .find((file) => file.endsWith('_fresh.ts'))!
         .replace('.ts', '')
-      const migrationsBefore = await payload.find({ collection: 'payload-migrations', limit: 100 })
+      const migrationsBefore = await payload.find({ collection: 'payload-migrations', limit: 100, overrideAccess: true })
 
       expect(migrationsBefore.docs.find(({ name }) => name === migrationName)).toBeUndefined()
 
       const output = await cli('migrate:fresh --force-accept-warning --json')
-      const migrationsAfter = await payload.find({ collection: 'payload-migrations', limit: 100 })
+      const migrationsAfter = await payload.find({ collection: 'payload-migrations', limit: 100, overrideAccess: true })
 
       expect(migrationsAfter.docs.find(({ name }) => name === migrationName)).toMatchObject({
         batch: 1,
@@ -1157,12 +1177,12 @@ test.suite({ config: './config.ts' })('CLI', () => {
     const migrationName = (await readdir(migrationsDirectory))
       .find((file) => file.endsWith('_fresh.ts'))!
       .replace('.ts', '')
-    const migrationsBefore = await payload.find({ collection: 'payload-migrations', limit: 100 })
+    const migrationsBefore = await payload.find({ collection: 'payload-migrations', limit: 100, overrideAccess: true })
 
     expect(migrationsBefore.docs.find(({ name }) => name === migrationName)).toBeUndefined()
 
     const output = await cli('migrate:fresh --help')
-    const migrationsAfter = await payload.find({ collection: 'payload-migrations', limit: 100 })
+    const migrationsAfter = await payload.find({ collection: 'payload-migrations', limit: 100, overrideAccess: true })
 
     expect(`${output.stdout}\n${output.stderr}`).toContain('Usage: payload migrate:fresh')
     expect(migrationsAfter.docs.find(({ name }) => name === migrationName)).toBeUndefined()
@@ -1174,13 +1194,13 @@ test.suite({ config: './config.ts' })('CLI', () => {
       .find((file) => file.endsWith('_refresh.ts'))!
       .replace('.ts', '')
     await cli('migrate --json')
-    const migrationsBefore = await payload.find({ collection: 'payload-migrations', limit: 100 })
+    const migrationsBefore = await payload.find({ collection: 'payload-migrations', limit: 100, overrideAccess: true })
     const migrationBefore = migrationsBefore.docs.find(({ name }) => name === migrationName)
 
     expect(migrationBefore).toBeDefined()
 
     const output = await cli('migrate:refresh --json')
-    const migrationsAfter = await payload.find({ collection: 'payload-migrations', limit: 100 })
+    const migrationsAfter = await payload.find({ collection: 'payload-migrations', limit: 100, overrideAccess: true })
     const migrationAfter = migrationsAfter.docs.find(({ name }) => name === migrationName)
 
     expect(migrationAfter).toBeDefined()
@@ -1205,6 +1225,7 @@ test.suite({ config: './config.ts' })('CLI', () => {
     const migrationsBefore = await payload.find({
       collection: 'payload-migrations',
       limit: 100,
+      overrideAccess: true,
     })
     const migrationBefore = migrationsBefore.docs.find(({ name }) => name === migrationName)
 
@@ -1212,6 +1233,7 @@ test.suite({ config: './config.ts' })('CLI', () => {
     const migrationsAfter = await payload.find({
       collection: 'payload-migrations',
       limit: 100,
+      overrideAccess: true,
     })
 
     expect(`${output.stdout}\n${output.stderr}`).toContain('Usage: payload migrate:refresh')
@@ -1226,12 +1248,12 @@ test.suite({ config: './config.ts' })('CLI', () => {
       .find((file) => file.endsWith('_reset.ts'))!
       .replace('.ts', '')
     await cli('migrate --json')
-    const migrationsBefore = await payload.find({ collection: 'payload-migrations', limit: 100 })
+    const migrationsBefore = await payload.find({ collection: 'payload-migrations', limit: 100, overrideAccess: true })
 
     expect(migrationsBefore.docs.find(({ name }) => name === migrationName)).toBeDefined()
 
     const output = await cli('migrate:reset --json')
-    const migrationsAfter = await payload.find({ collection: 'payload-migrations', limit: 100 })
+    const migrationsAfter = await payload.find({ collection: 'payload-migrations', limit: 100, overrideAccess: true })
 
     expect(migrationsAfter.docs).toHaveLength(0)
 
@@ -1256,6 +1278,7 @@ test.suite({ config: './config.ts' })('CLI', () => {
     const migrationsAfter = await payload.find({
       collection: 'payload-migrations',
       limit: 100,
+      overrideAccess: true,
     })
 
     expect(`${output.stdout}\n${output.stderr}`).toContain('Usage: payload migrate:reset')
@@ -1267,7 +1290,7 @@ test.suite({ config: './config.ts' })('CLI', () => {
     const migrationName = (await readdir(migrationsDirectory))
       .find((file) => file.endsWith('_status.ts'))!
       .replace('.ts', '')
-    const migrationsBefore = await payload.find({ collection: 'payload-migrations', limit: 100 })
+    const migrationsBefore = await payload.find({ collection: 'payload-migrations', limit: 100, overrideAccess: true })
 
     expect(migrationsBefore.docs.find(({ name }) => name === migrationName)).toBeUndefined()
 
@@ -1295,7 +1318,7 @@ test.suite({ config: './config.ts' })('CLI', () => {
       .replace('.ts', '')
 
     const output = await cli('migrate:status --help')
-    const migrationsAfter = await payload.find({ collection: 'payload-migrations', limit: 100 })
+    const migrationsAfter = await payload.find({ collection: 'payload-migrations', limit: 100, overrideAccess: true })
 
     expect(`${output.stdout}\n${output.stderr}`).toContain('Usage: payload migrate:status')
     expect(`${output.stdout}\n${output.stderr}`).not.toContain(migrationName)

--- a/test/collections-graphql/int.spec.ts
+++ b/test/collections-graphql/int.spec.ts
@@ -101,10 +101,10 @@ test.suite({ config: './config.ts' })('collections-graphql', () => {
     })
 
     test('should sort by multiple fields', async ({ payload, restClient }) => {
-      const doc1 = await payload.create({ collection: 'sort', data: { title: 'a', number: 1 } })
-      const doc2 = await payload.create({ collection: 'sort', data: { title: 'b', number: 1 } })
-      const doc3 = await payload.create({ collection: 'sort', data: { title: 'a', number: 2 } })
-      const doc4 = await payload.create({ collection: 'sort', data: { title: 'b', number: 3 } })
+      const doc1 = await payload.create({ collection: 'sort', data: { title: 'a', number: 1 }, overrideAccess: true })
+      const doc2 = await payload.create({ collection: 'sort', data: { title: 'b', number: 1 }, overrideAccess: true })
+      const doc3 = await payload.create({ collection: 'sort', data: { title: 'a', number: 2 }, overrideAccess: true })
+      const doc4 = await payload.create({ collection: 'sort', data: { title: 'b', number: 3 }, overrideAccess: true })
 
       const query = `query {
         Sorts(sort: "title, number") {
@@ -196,6 +196,7 @@ test.suite({ config: './config.ts' })('collections-graphql', () => {
           errorBeforeChange: true,
           title: firstTitle,
         },
+        overrideAccess: true,
       })
       const second = await payload.create({
         collection: errorOnHookSlug,
@@ -203,6 +204,7 @@ test.suite({ config: './config.ts' })('collections-graphql', () => {
           errorBeforeChange: true,
           title: secondTitle,
         },
+        overrideAccess: true,
       })
 
       const updated = 'updated title'
@@ -234,14 +236,17 @@ test.suite({ config: './config.ts' })('collections-graphql', () => {
       const createdResult = await payload.findByID({
         id: data.createPost.id,
         collection: slug,
+        overrideAccess: true,
       })
       const updateFirstResult = await payload.findByID({
         id: first.id,
         collection: errorOnHookSlug,
+        overrideAccess: true,
       })
       const updateSecondResult = await payload.findByID({
         id: second.id,
         collection: errorOnHookSlug,
+        overrideAccess: true,
       })
 
       expect(data?.createPost.id).toBeDefined()
@@ -335,11 +340,13 @@ test.suite({ config: './config.ts' })('collections-graphql', () => {
         const recalls = await payload.create({
           collection: relationSlug,
           data: { name: 'recalls' },
+          overrideAccess: true,
         })
 
         const electricCars = await payload.create({
           collection: relationSlug,
           data: { name: 'electric-cars' },
+          overrideAccess: true,
         })
 
         const mixedPost = await createPost(
@@ -737,6 +744,7 @@ test.suite({ config: './config.ts' })('collections-graphql', () => {
                 // only randomize longitude to make distance comparison easy
                 point: [Math.random(), 0],
               },
+              overrideAccess: true,
             })
           })
 
@@ -1014,6 +1022,7 @@ test.suite({ config: './config.ts' })('collections-graphql', () => {
           data: {
             name: 'test',
           },
+          overrideAccess: true,
         })
 
         await payload.create({
@@ -1022,11 +1031,13 @@ test.suite({ config: './config.ts' })('collections-graphql', () => {
             relationField: relation.id,
             title: 'has deleted relation',
           },
+          overrideAccess: true,
         })
 
         await payload.delete({
           id: relation.id,
           collection: relationSlug,
+          overrideAccess: true,
         })
 
         const query = `query {
@@ -1059,6 +1070,7 @@ test.suite({ config: './config.ts' })('collections-graphql', () => {
           data: {
             name: 'test',
           },
+          overrideAccess: true,
         })
 
         await payload.create({
@@ -1067,11 +1079,13 @@ test.suite({ config: './config.ts' })('collections-graphql', () => {
             relationHasManyField: [relation.id],
             title: 'has deleted relation hasMany',
           },
+          overrideAccess: true,
         })
 
         await payload.delete({
           id: relation.id,
           collection: relationSlug,
+          overrideAccess: true,
         })
 
         const query = `query {
@@ -1105,6 +1119,7 @@ test.suite({ config: './config.ts' })('collections-graphql', () => {
             },
           },
           locale: '*',
+          overrideAccess: true,
         })
 
         await payload.update({
@@ -1113,6 +1128,7 @@ test.suite({ config: './config.ts' })('collections-graphql', () => {
           data: {
             relationToSelf: newDoc.id,
           },
+          overrideAccess: true,
         })
 
         const query = `query {
@@ -1141,11 +1157,13 @@ test.suite({ config: './config.ts' })('collections-graphql', () => {
           collection: 'relation',
           data: { _status: 'draft', name: 'relation_1_draft' },
           draft: true,
+          overrideAccess: true,
         })
 
         const relation_2 = await payload.create({
           collection: 'relation',
           data: { name: 'relation_2', _status: 'published' },
+          overrideAccess: true,
         })
 
         await payload.create({
@@ -1156,9 +1174,10 @@ test.suite({ config: './config.ts' })('collections-graphql', () => {
             title: 'post with relations in draft',
             relationHasManyField: [relation_1_draft.id, relation_2.id],
           },
+          overrideAccess: true,
         })
 
-        await payload.delete({ collection: 'relation', id: relation_1_draft.id })
+        await payload.delete({ collection: 'relation', id: relation_1_draft.id, overrideAccess: true })
 
         const query = `query {
           Posts(draft:true,where: { title: { equals: "post with relations in draft" }}) {
@@ -1191,11 +1210,13 @@ test.suite({ config: './config.ts' })('collections-graphql', () => {
         const relation_1_draft = await payload.create({
           collection: 'relation',
           data: { name: 'restricted' },
+          overrideAccess: true,
         })
 
         const relation_2 = await payload.create({
           collection: 'relation',
           data: { name: 'relation_2' },
+          overrideAccess: true,
         })
 
         await payload.create({
@@ -1206,6 +1227,7 @@ test.suite({ config: './config.ts' })('collections-graphql', () => {
             title: 'post with relation restricted',
             relationHasManyField: [relation_1_draft.id, relation_2.id],
           },
+          overrideAccess: true,
         })
 
         const query = `query {
@@ -1245,6 +1267,7 @@ test.suite({ config: './config.ts' })('collections-graphql', () => {
         title: publishValue,
       },
       draft: false,
+      overrideAccess: true,
     })
 
     // create cyclical relationship
@@ -1254,6 +1277,7 @@ test.suite({ config: './config.ts' })('collections-graphql', () => {
       data: {
         relationToSelf: newDoc.id,
       },
+      overrideAccess: true,
     })
 
     // save new version
@@ -1264,6 +1288,7 @@ test.suite({ config: './config.ts' })('collections-graphql', () => {
         title: draftValue,
       },
       draft: true,
+      overrideAccess: true,
     })
 
     const draftParentPublishedChild = `{
@@ -1316,6 +1341,7 @@ test.suite({ config: './config.ts' })('collections-graphql', () => {
         title: 'example',
       },
       file,
+      overrideAccess: true,
     })
 
     // doc with upload relation
@@ -1324,6 +1350,7 @@ test.suite({ config: './config.ts' })('collections-graphql', () => {
       data: {
         media: mediaDoc.id,
       },
+      overrideAccess: true,
     })
 
     const query = `{
@@ -1472,6 +1499,7 @@ async function createPost({ payload }: { payload: Payload }, overrides?: Partial
   const doc = await payload.create({
     collection: slug,
     data: { title: 'title', ...overrides },
+    overrideAccess: true,
   })
   return doc
 }

--- a/test/collections-graphql/seed.ts
+++ b/test/collections-graphql/seed.ts
@@ -7,6 +7,7 @@ import { pointSlug, relationSlug, slug } from './shared.js'
 export const seed = async (_payload: Payload) => {
   await _payload.create({
     collection: 'users',
+    overrideAccess: true,
     data: {
       email: devUser.email,
       password: devUser.password,
@@ -15,6 +16,7 @@ export const seed = async (_payload: Payload) => {
 
   await _payload.create({
     collection: 'custom-ids',
+    overrideAccess: true,
     data: {
       id: 1,
       title: 'hello',
@@ -23,6 +25,7 @@ export const seed = async (_payload: Payload) => {
 
   await _payload.create({
     collection: slug,
+    overrideAccess: true,
     data: {
       relationToCustomID: 1,
       title: 'has custom ID relation',
@@ -31,6 +34,7 @@ export const seed = async (_payload: Payload) => {
 
   await _payload.create({
     collection: slug,
+    overrideAccess: true,
     data: {
       title: 'post1',
     },
@@ -38,6 +42,7 @@ export const seed = async (_payload: Payload) => {
 
   await _payload.create({
     collection: slug,
+    overrideAccess: true,
     data: {
       title: 'post2',
     },
@@ -45,6 +50,7 @@ export const seed = async (_payload: Payload) => {
 
   await _payload.create({
     collection: slug,
+    overrideAccess: true,
     data: {
       description: 'description',
       title: 'with-description',
@@ -53,6 +59,7 @@ export const seed = async (_payload: Payload) => {
 
   await _payload.create({
     collection: slug,
+    overrideAccess: true,
     data: {
       number: 1,
       title: 'numPost1',
@@ -61,6 +68,7 @@ export const seed = async (_payload: Payload) => {
 
   await _payload.create({
     collection: slug,
+    overrideAccess: true,
     data: {
       number: 2,
       title: 'numPost2',
@@ -69,6 +77,7 @@ export const seed = async (_payload: Payload) => {
 
   const rel1 = await _payload.create({
     collection: relationSlug,
+    overrideAccess: true,
     data: {
       name: 'name',
     },
@@ -76,6 +85,7 @@ export const seed = async (_payload: Payload) => {
 
   const rel2 = await _payload.create({
     collection: relationSlug,
+    overrideAccess: true,
     data: {
       name: 'name2',
     },
@@ -83,6 +93,7 @@ export const seed = async (_payload: Payload) => {
 
   await _payload.create({
     collection: slug,
+    overrideAccess: true,
     data: {
       relationHasManyField: rel1.id,
       title: 'rel to hasMany',
@@ -91,6 +102,7 @@ export const seed = async (_payload: Payload) => {
 
   await _payload.create({
     collection: slug,
+    overrideAccess: true,
     data: {
       relationHasManyField: rel2.id,
       title: 'rel to hasMany 2',
@@ -99,6 +111,7 @@ export const seed = async (_payload: Payload) => {
 
   await _payload.create({
     collection: slug,
+    overrideAccess: true,
     data: {
       relationMultiRelationTo: {
         relationTo: relationSlug,
@@ -110,6 +123,7 @@ export const seed = async (_payload: Payload) => {
 
   await _payload.create({
     collection: slug,
+    overrideAccess: true,
     data: {
       relationMultiRelationToHasMany: [
         {
@@ -127,11 +141,13 @@ export const seed = async (_payload: Payload) => {
 
   const payloadAPITest1 = await _payload.create({
     collection: 'payload-api-test-ones',
+    overrideAccess: true,
     data: {},
   })
 
   await _payload.create({
     collection: 'payload-api-test-twos',
+    overrideAccess: true,
     data: {
       relation: payloadAPITest1.id,
     },
@@ -139,6 +155,7 @@ export const seed = async (_payload: Payload) => {
 
   await _payload.create({
     collection: pointSlug,
+    overrideAccess: true,
     data: {
       point: [10, 20],
     },
@@ -146,6 +163,7 @@ export const seed = async (_payload: Payload) => {
 
   await _payload.create({
     collection: 'content-type',
+    overrideAccess: true,
     data: {},
   })
 }

--- a/test/collections-rest/bulk-delete-rollback.int.spec.ts
+++ b/test/collections-rest/bulk-delete-rollback.int.spec.ts
@@ -12,10 +12,12 @@ test.suite({ config: './config.ts' })('Collections REST - bulk delete rollback',
     await payload.create({
       collection: postsSlug,
       data: { title },
+      overrideAccess: true,
     })
     await payload.create({
       collection: postsSlug,
       data: { title },
+      overrideAccess: true,
     })
 
     const originalDeleteMany = payload.db.deleteMany.bind(payload.db)
@@ -33,6 +35,7 @@ test.suite({ config: './config.ts' })('Collections REST - bulk delete rollback',
     const result = await payload.delete({
       collection: postsSlug,
       where: { title: { equals: title } },
+      overrideAccess: true,
     })
 
     const deletedCollections = deleteManySpy.mock.calls.map(([args]) => args.collection)
@@ -57,6 +60,7 @@ test.suite({ config: './config.ts' })('Collections REST - bulk delete rollback',
     const remainingDocs = await payload.find({
       collection: postsSlug,
       where: { title: { equals: title } },
+      overrideAccess: true,
     })
 
     expect(remainingDocs.docs).toHaveLength(2)

--- a/test/collections-rest/config.ts
+++ b/test/collections-rest/config.ts
@@ -365,6 +365,7 @@ export default buildConfigWithDefaults({
         email: devUser.email,
         password: devUser.password,
       },
+      overrideAccess: true,
     })
 
     const rel1 = await payload.create({
@@ -372,12 +373,14 @@ export default buildConfigWithDefaults({
       data: {
         name: 'name',
       },
+      overrideAccess: true,
     })
     const rel2 = await payload.create({
       collection: relationSlug,
       data: {
         name: 'name2',
       },
+      overrideAccess: true,
     })
 
     await payload.create({
@@ -385,6 +388,7 @@ export default buildConfigWithDefaults({
       data: {
         point: [10, 20],
       },
+      overrideAccess: true,
     })
 
     // Relation - hasMany
@@ -394,6 +398,7 @@ export default buildConfigWithDefaults({
         relationHasManyField: rel1.id,
         title: 'rel to hasMany',
       },
+      overrideAccess: true,
     })
     await payload.create({
       collection: postsSlug,
@@ -401,6 +406,7 @@ export default buildConfigWithDefaults({
         relationHasManyField: rel2.id,
         title: 'rel to hasMany 2',
       },
+      overrideAccess: true,
     })
 
     // Relation - relationTo multi
@@ -413,6 +419,7 @@ export default buildConfigWithDefaults({
         },
         title: 'rel to multi',
       },
+      overrideAccess: true,
     })
 
     // Relation - relationTo multi hasMany
@@ -431,6 +438,7 @@ export default buildConfigWithDefaults({
         ],
         title: 'rel to multi hasMany',
       },
+      overrideAccess: true,
     })
 
     await payload.create({
@@ -439,6 +447,7 @@ export default buildConfigWithDefaults({
         id: 'test',
         name: 'inside row',
       },
+      overrideAccess: true,
     })
 
     await payload.create({
@@ -447,6 +456,7 @@ export default buildConfigWithDefaults({
         id: 123,
         name: 'name',
       },
+      overrideAccess: true,
     })
   },
 })

--- a/test/collections-rest/int.spec.ts
+++ b/test/collections-rest/int.spec.ts
@@ -127,6 +127,7 @@ test.suite({ config: './config.ts' })('collections-rest', () => {
       const doc = await payload.create({
         collection: largeDocumentsCollectionSlug,
         data: {},
+        overrideAccess: true,
       })
 
       const arrayData = new Array(500).fill({ text: randomUUID().repeat(100) })
@@ -212,6 +213,7 @@ test.suite({ config: './config.ts' })('collections-rest', () => {
           limit: 10,
           collection: postsSlug,
           where: { id: { in: ids } },
+          overrideAccess: true,
         })
         expect(resDocs.at(-1).description).toEqual('to-update')
       })
@@ -237,6 +239,7 @@ test.suite({ config: './config.ts' })('collections-rest', () => {
 
         const { docs } = await payload.find({
           collection: postsSlug,
+          overrideAccess: true,
         })
 
         expect(docs[0].description).not.toEqual(description)
@@ -270,6 +273,7 @@ test.suite({ config: './config.ts' })('collections-rest', () => {
 
         const { docs } = await payload.find({
           collection: postsSlug,
+          overrideAccess: true,
         })
 
         expect(docs[0].description).not.toEqual(description)
@@ -285,6 +289,7 @@ test.suite({ config: './config.ts' })('collections-rest', () => {
           data: {
             restrictedField: 'restricted',
           },
+          overrideAccess: true,
         })
 
         const description = 'description'
@@ -299,6 +304,7 @@ test.suite({ config: './config.ts' })('collections-rest', () => {
         const doc = await payload.findByID({
           id,
           collection: postsSlug,
+          overrideAccess: true,
         })
 
         expect(response.status).toEqual(400)
@@ -317,6 +323,7 @@ test.suite({ config: './config.ts' })('collections-rest', () => {
             errorBeforeChange: true,
             text,
           },
+          overrideAccess: true,
         })
         const successDoc = await payload.create({
           collection: errorOnHookSlug,
@@ -324,6 +331,7 @@ test.suite({ config: './config.ts' })('collections-rest', () => {
             errorBeforeChange: false,
             text,
           },
+          overrideAccess: true,
         })
 
         const update = 'update'
@@ -373,6 +381,7 @@ test.suite({ config: './config.ts' })('collections-rest', () => {
           const { docs, errors } = await payload.delete({
             collection: postsSlug,
             where: { title: { equals: 'title' } },
+            overrideAccess: true,
           })
 
           expect(errors).toHaveLength(0)
@@ -406,6 +415,7 @@ test.suite({ config: './config.ts' })('collections-rest', () => {
             errorAfterDelete: true,
             text: 'test',
           },
+          overrideAccess: true,
         })
         await payload.create({
           collection: errorOnHookSlug,
@@ -413,6 +423,7 @@ test.suite({ config: './config.ts' })('collections-rest', () => {
             errorAfterDelete: false,
             text: 'test',
           },
+          overrideAccess: true,
         })
 
         const response = await restClient.DELETE(`/${errorOnHookSlug}`, {
@@ -668,6 +679,7 @@ test.suite({ config: './config.ts' })('collections-rest', () => {
             data: {
               title: 'find me buddy',
             },
+            overrideAccess: true,
           })
 
           const response = await restClient.GET(`/${postsSlug}`, {
@@ -907,6 +919,7 @@ test.suite({ config: './config.ts' })('collections-rest', () => {
         const relationship = await payload.create({
           collection: relationSlug,
           data: {},
+          overrideAccess: true,
         })
 
         await createPost({ restClient }, { relationField: relationship.id, title: 'not-me' })
@@ -937,6 +950,7 @@ test.suite({ config: './config.ts' })('collections-rest', () => {
         const relationship = await payload.create({
           collection: relationSlug,
           data: {},
+          overrideAccess: true,
         })
 
         const post1 = await createPost(
@@ -1314,6 +1328,7 @@ test.suite({ config: './config.ts' })('collections-rest', () => {
             const created = await payload.create({
               collection: pointSlug,
               data: { point: [queryLng, pointLat] },
+              overrideAccess: true,
             })
 
             createdId = created.id
@@ -1336,7 +1351,7 @@ test.suite({ config: './config.ts' })('collections-rest', () => {
             expect(result.docs.map((d: { id: number | string }) => d.id)).toContain(createdId)
           } finally {
             if (createdId !== undefined) {
-              await payload.delete({ collection: pointSlug, id: createdId })
+              await payload.delete({ collection: pointSlug, id: createdId, overrideAccess: true })
             }
           }
         })
@@ -1379,6 +1394,7 @@ test.suite({ config: './config.ts' })('collections-rest', () => {
                     // only randomize longitude to make distance comparison easy
                     point: [Math.random(), 0],
                   },
+                  overrideAccess: true,
                 }),
               )
             }, Math.random())
@@ -1632,6 +1648,7 @@ test.suite({ config: './config.ts' })('collections-rest', () => {
             data: {
               name: 'test',
             },
+            overrideAccess: true,
           })
           for (let i = 0; i < 10; i++) {
             await createPost(
@@ -1909,9 +1926,11 @@ test.suite({ config: './config.ts' })('collections-rest', () => {
     }) => {
       const post = await createPost({ restClient })
       const id = typeof post.id === 'string' ? randomUUID() : 999
-      await expect(payload.findByID({ collection: 'posts', id })).rejects.toBeInstanceOf(NotFound)
       await expect(
-        payload.findByID({ collection: 'posts', id, disableErrors: true }),
+        payload.findByID({ collection: 'posts', id, overrideAccess: true }),
+      ).rejects.toBeInstanceOf(NotFound)
+      await expect(
+        payload.findByID({ collection: 'posts', id, disableErrors: true, overrideAccess: true }),
       ).resolves.toBeNull()
     })
   })
@@ -2023,6 +2042,7 @@ test.suite({ config: './config.ts' })('collections-rest', () => {
         collection: 'disabled-bulk-edit-docs',
         where: {},
         data: {},
+        overrideAccess: true,
       }),
     ).resolves.toBeTruthy()
   })
@@ -2045,12 +2065,14 @@ test.suite({ config: './config.ts' })('collections-rest', () => {
     const doc = await payload.create({
       collection: 'disabled-bulk-delete-docs',
       data: { text: 'should be deletable by id' },
+      overrideAccess: true,
     })
 
     await expect(
       payload.delete({
         collection: 'disabled-bulk-delete-docs',
         id: doc.id,
+        overrideAccess: true,
       }),
     ).resolves.toBeTruthy()
 
@@ -2058,6 +2080,7 @@ test.suite({ config: './config.ts' })('collections-rest', () => {
       payload.delete({
         collection: 'disabled-bulk-delete-docs',
         where: {},
+        overrideAccess: true,
       }),
     ).resolves.toBeTruthy()
   })
@@ -2085,5 +2108,6 @@ async function clearDocs({ payload }: { payload: Payload }): Promise<void> {
   await payload.delete({
     collection: postsSlug,
     where: { id: { exists: true } },
+    overrideAccess: true,
   })
 }

--- a/test/config/config.ts
+++ b/test/config/config.ts
@@ -128,7 +128,7 @@ export default buildConfigWithDefaults({
     },
   },
   seed: async (payload) => {
-    const { totalDocs } = await payload.count({ collection: 'users' })
+    const { totalDocs } = await payload.count({ collection: 'users', overrideAccess: true })
 
     if (totalDocs === 0) {
       await payload.create({
@@ -137,6 +137,7 @@ export default buildConfigWithDefaults({
           email: devUser.email,
           password: devUser.password,
         },
+        overrideAccess: true,
       })
     }
   },

--- a/test/config/customScript.ts
+++ b/test/config/customScript.ts
@@ -8,7 +8,7 @@ export const createStartServerCommand = defineCLICommand({
   description: 'Write the current users to the CLI test file.',
   handler: async ({ getPayload }) => {
     const payload = await getPayload()
-    const data = await payload.find({ collection: 'users' })
+    const data = await payload.find({ collection: 'users', overrideAccess: true })
 
     writeFileSync(testFilePath, JSON.stringify(data), 'utf-8')
   },

--- a/test/config/int.spec.ts
+++ b/test/config/int.spec.ts
@@ -51,6 +51,7 @@ test.suite({ config: './config.ts' })('Config', () => {
       // creation will reset the db schema.
       const result2: any = await payload2.create({
         collection: 'payload2',
+        overrideAccess: true,
         data: {
           title2: 'Payload 2',
         },
@@ -77,6 +78,7 @@ test.suite({ config: './config.ts' })('Config', () => {
       // If payload was still incorrectly cached, this would fail, as the old payload config would still be used
       const result3: any = await payload3.create({
         collection: 'payload3',
+        overrideAccess: true,
         data: {
           title3: 'Payload 3',
         },

--- a/test/custom-graphql/config.ts
+++ b/test/custom-graphql/config.ts
@@ -74,6 +74,7 @@ export default buildConfigWithDefaults({
         email: devUser.email,
         password: devUser.password,
       },
+      overrideAccess: true,
     })
   },
 })

--- a/test/dashboard/components/Count.tsx
+++ b/test/dashboard/components/Count.tsx
@@ -22,6 +22,7 @@ export default async function Count({ req, widgetData }: WidgetServerProps<Count
   try {
     const result = await payload.count({
       collection: selectedCollection,
+      overrideAccess: true,
     })
     count = result.totalDocs
   } catch (err) {

--- a/test/dashboard/seed.ts
+++ b/test/dashboard/seed.ts
@@ -9,6 +9,7 @@ export const seed = async (payload: BasePayload) => {
       email: devUser.email,
       password: devUser.password,
     },
+    overrideAccess: true,
   })
 
   // Create some sample data
@@ -23,6 +24,7 @@ export const seed = async (payload: BasePayload) => {
           status: ['open', 'in-progress', 'closed'][Math.floor(Math.random() * 3)],
           title: `Support Ticket #${i}`,
         },
+        overrideAccess: true,
       })
     }
 
@@ -41,6 +43,7 @@ export const seed = async (payload: BasePayload) => {
             description: `Revenue entry ${i} for ${month}`,
             source: 'Sample data',
           },
+          overrideAccess: true,
         })
       }
     }
@@ -107,6 +110,7 @@ export const seed = async (payload: BasePayload) => {
           status: 'scheduled',
           title: `Dashboard Event ${index + 1}`,
         },
+        overrideAccess: true,
       })
     }
 
@@ -129,6 +133,7 @@ export const seed = async (payload: BasePayload) => {
           status: 'scheduled',
           title: `Nested Event ${index + 1}`,
         },
+        overrideAccess: true,
       })
     }
 
@@ -150,6 +155,7 @@ export const seed = async (payload: BasePayload) => {
           ],
           title: `Event ${i}`,
         },
+        overrideAccess: true,
       })
     }
   } catch (err) {

--- a/test/database/int.spec.ts
+++ b/test/database/int.spec.ts
@@ -70,6 +70,7 @@ test.suite({ config: './config.ts' })('database', () => {
         email: devUser.email,
         password: devUser.password,
       },
+      overrideAccess: true,
     })
 
     user = loginResult.user
@@ -86,7 +87,7 @@ test.suite({ config: './config.ts' })('database', () => {
 
         // Awaiting a query guarantees the pool has been used and that nothing is
         // in flight while the counts below are read.
-        await payload.count({ collection: 'simple' })
+        await payload.count({ collection: 'simple', overrideAccess: true })
 
         expect(pool.totalCount).toBeGreaterThan(0)
 
@@ -128,6 +129,7 @@ test.suite({ config: './config.ts' })('database', () => {
       const doc = await payload.create({
         collection: 'custom-ids',
         data: {},
+        overrideAccess: true,
       })
 
       expect(doc.id).toBeDefined()
@@ -139,18 +141,21 @@ test.suite({ config: './config.ts' })('database', () => {
         data: {
           title: 'hey',
         },
+        overrideAccess: true,
       })
 
       await payload.update({
         id: doc.id,
         collection: 'custom-ids',
         data: {},
+        overrideAccess: true,
       })
 
       await payload.update({
         id: doc.id,
         collection: 'custom-ids',
         data: {},
+        overrideAccess: true,
       })
 
       const versionsQuery = await payload.db.findVersions({
@@ -193,6 +198,7 @@ test.suite({ config: './config.ts' })('database', () => {
           ],
           title: 'test',
         },
+        overrideAccess: true,
       })
 
       expect(doc.arrayWithIDs[0].id).toStrictEqual(arrayRowID)
@@ -219,11 +225,13 @@ test.suite({ config: './config.ts' })('database', () => {
           ],
           title: 'test',
         },
+        overrideAccess: true,
       })
 
       const duplicate = await payload.duplicate({
         id: doc.id,
         collection: postsSlug,
+        overrideAccess: true,
       })
 
       expect(duplicate.arrayWithIDs[0].id).not.toStrictEqual(arrayRowID)
@@ -233,14 +241,15 @@ test.suite({ config: './config.ts' })('database', () => {
     test('should properly give the result with hasMany relationships with custom numeric IDs', async ({
       payload,
     }) => {
-      await payload.create({ collection: 'categories-custom-id', data: { id: 9999 } })
+      await payload.create({ collection: 'categories-custom-id', data: { id: 9999 }, overrideAccess: true })
       const res = await payload.create({
         collection: 'posts',
         data: { categoriesCustomID: [9999], title: 'post' },
         depth: 0,
+        overrideAccess: true,
       })
       expect(res.categoriesCustomID[0]).toBe(9999)
-      const resFind = await payload.findByID({ id: res.id, collection: 'posts', depth: 0 })
+      const resFind = await payload.findByID({ id: res.id, collection: 'posts', depth: 0, overrideAccess: true })
       expect(resFind.categoriesCustomID[0]).toBe(9999)
     })
 
@@ -263,6 +272,7 @@ test.suite({ config: './config.ts' })('database', () => {
                   | typeof relationASlug
                   | typeof relationBSlug,
                 id,
+                overrideAccess: true,
               })
             } catch {
               // ignore: concurrent cleanup or FK already removed
@@ -276,6 +286,7 @@ test.suite({ config: './config.ts' })('database', () => {
           const doc = await payload.create({
             collection: postsSlug,
             data: { title: 'uuidv7 test' },
+            overrideAccess: true,
           })
 
           track(postsSlug, doc.id)
@@ -291,10 +302,12 @@ test.suite({ config: './config.ts' })('database', () => {
           const doc1 = await payload.create({
             collection: postsSlug,
             data: { title: 'uuidv7 first' },
+            overrideAccess: true,
           })
           const doc2 = await payload.create({
             collection: postsSlug,
             data: { title: 'uuidv7 second' },
+            overrideAccess: true,
           })
 
           track(postsSlug, doc1.id)
@@ -307,6 +320,7 @@ test.suite({ config: './config.ts' })('database', () => {
           const created = await payload.create({
             collection: postsSlug,
             data: { title: 'uuidv7 findable' },
+            overrideAccess: true,
           })
 
           track(postsSlug, created.id)
@@ -314,6 +328,7 @@ test.suite({ config: './config.ts' })('database', () => {
           const found = await payload.findByID({
             collection: postsSlug,
             id: created.id,
+            overrideAccess: true,
           })
 
           expect(found.id).toBe(created.id)
@@ -324,6 +339,7 @@ test.suite({ config: './config.ts' })('database', () => {
           const created = await payload.create({
             collection: postsSlug,
             data: { title: 'uuidv7 queryable' },
+            overrideAccess: true,
           })
 
           track(postsSlug, created.id)
@@ -331,6 +347,7 @@ test.suite({ config: './config.ts' })('database', () => {
           const result = await payload.find({
             collection: postsSlug,
             where: { id: { equals: created.id } },
+            overrideAccess: true,
           })
 
           expect(result.docs).toHaveLength(1)
@@ -341,6 +358,7 @@ test.suite({ config: './config.ts' })('database', () => {
           const relA = await payload.create({
             collection: relationASlug,
             data: { title: 'uuidv7 rel A' },
+            overrideAccess: true,
           })
           const relB = await payload.create({
             collection: relationBSlug,
@@ -348,6 +366,7 @@ test.suite({ config: './config.ts' })('database', () => {
               title: 'uuidv7 rel B',
               relationship: relA.id,
             },
+            overrideAccess: true,
           })
 
           track(relationBSlug, relB.id)
@@ -357,6 +376,7 @@ test.suite({ config: './config.ts' })('database', () => {
             collection: relationBSlug,
             id: relB.id,
             depth: 1,
+            overrideAccess: true,
           })
 
           expect(found.relationship).toBeDefined()
@@ -366,6 +386,7 @@ test.suite({ config: './config.ts' })('database', () => {
           const doc = await payload.create({
             collection: customIDsSlug,
             data: { title: 'v7 versioned' },
+            overrideAccess: true,
           })
 
           track(customIDsSlug, doc.id)
@@ -374,11 +395,13 @@ test.suite({ config: './config.ts' })('database', () => {
             collection: customIDsSlug,
             id: doc.id,
             data: { title: 'v7 versioned updated' },
+            overrideAccess: true,
           })
 
           const versions = await payload.findVersions({
             collection: customIDsSlug,
             where: { parent: { equals: doc.id } },
+            overrideAccess: true,
           })
 
           expect(versions.totalDocs).toBeGreaterThanOrEqual(1)
@@ -399,6 +422,7 @@ test.suite({ config: './config.ts' })('database', () => {
         data: {
           title: 'hello',
         },
+        overrideAccess: true,
       })
 
       const createdAtDate = new Date(result.createdAt)
@@ -419,11 +443,13 @@ test.suite({ config: './config.ts' })('database', () => {
           createdAt,
           title: 'hello',
         },
+        overrideAccess: true,
       })
 
       const doc = await payload.findByID({
         id: result.id,
         collection: postsSlug,
+        overrideAccess: true,
       })
 
       expect(result.createdAt).toStrictEqual(createdAt)
@@ -443,6 +469,7 @@ test.suite({ config: './config.ts' })('database', () => {
           title: 'hello',
           updatedAt,
         },
+        overrideAccess: true,
       })
 
       expect(result.updatedAt).toStrictEqual(updatedAt)
@@ -458,6 +485,7 @@ test.suite({ config: './config.ts' })('database', () => {
         data: {
           title: 'hello',
         },
+        overrideAccess: true,
       })
       const createdAt = new Date('2021-01-01T00:00:00.000Z').toISOString()
 
@@ -472,6 +500,7 @@ test.suite({ config: './config.ts' })('database', () => {
       const doc = await payload.findByID({
         id: result.id,
         collection: postsSlug,
+        overrideAccess: true,
       })
 
       expect(doc.createdAt).toStrictEqual(createdAt)
@@ -488,6 +517,7 @@ test.suite({ config: './config.ts' })('database', () => {
         data: {
           title: 'hello',
         },
+        overrideAccess: true,
       })
       const updatedAt = new Date('2021-01-01T00:00:00.000Z').toISOString()
 
@@ -502,6 +532,7 @@ test.suite({ config: './config.ts' })('database', () => {
       const doc = await payload.findByID({
         id: result.id,
         collection: postsSlug,
+        overrideAccess: true,
       })
 
       expect(doc.updatedAt).toStrictEqual(updatedAt)
@@ -518,6 +549,7 @@ test.suite({ config: './config.ts' })('database', () => {
         data: {
           title: 'hello',
         },
+        overrideAccess: true,
       })
 
       const result: any = await payload.db.updateOne({
@@ -544,6 +576,7 @@ test.suite({ config: './config.ts' })('database', () => {
         data: {
           title: 'hello',
         },
+        overrideAccess: true,
       })
 
       const result: any = await payload.db.updateOne({
@@ -569,6 +602,7 @@ test.suite({ config: './config.ts' })('database', () => {
         data: {
           title: 'hello',
         },
+        overrideAccess: true,
       })
       await payload.update({
         id: category.id,
@@ -576,11 +610,13 @@ test.suite({ config: './config.ts' })('database', () => {
         data: {
           title: 'hello2',
         },
+        overrideAccess: true,
       })
       const versions = await payload.findVersions({
         collection: 'categories',
         depth: 0,
         sort: '-createdAt',
+        overrideAccess: true,
       })
       const createdAt = new Date('2021-01-01T00:00:00.000Z').toISOString()
 
@@ -599,6 +635,7 @@ test.suite({ config: './config.ts' })('database', () => {
         collection: 'categories',
         depth: 0,
         sort: '-createdAt',
+        overrideAccess: true,
       })
       expect(updatedVersions.docs).toHaveLength(2)
       for (const version of updatedVersions.docs) {
@@ -621,6 +658,7 @@ test.suite({ config: './config.ts' })('database', () => {
         data: {
           title: 'hello',
         },
+        overrideAccess: true,
       })
       await payload.update({
         id: category.id,
@@ -628,11 +666,13 @@ test.suite({ config: './config.ts' })('database', () => {
         data: {
           title: 'hello2',
         },
+        overrideAccess: true,
       })
       const versions = await payload.findVersions({
         collection: 'categories',
         depth: 0,
         sort: '-createdAt',
+        overrideAccess: true,
       })
       const updatedAt = new Date('2021-01-01T00:00:00.000Z').toISOString()
 
@@ -651,6 +691,7 @@ test.suite({ config: './config.ts' })('database', () => {
         collection: 'categories',
         depth: 0,
         sort: '-updatedAt',
+        overrideAccess: true,
       })
       expect(updatedVersions.docs).toHaveLength(2)
       for (const version of updatedVersions.docs) {
@@ -673,6 +714,7 @@ test.suite({ config: './config.ts' })('database', () => {
         data: {
           title: 'hello',
         },
+        overrideAccess: true,
       })
       expect(createdDoc.createdAt).toBeUndefined()
       expect(createdDoc.updatedAt).toBeUndefined()
@@ -683,6 +725,7 @@ test.suite({ config: './config.ts' })('database', () => {
         data: {
           title: 'updated',
         },
+        overrideAccess: true,
       })
       expect(updated.createdAt).toBeUndefined()
       expect(updated.updatedAt).toBeUndefined()
@@ -695,6 +738,7 @@ test.suite({ config: './config.ts' })('database', () => {
           title: 'hello',
           updatedAt: date,
         },
+        overrideAccess: true,
       })
       expect(createdDocWithTimestamps.createdAt).toBeUndefined()
       expect(createdDocWithTimestamps.updatedAt).toBeUndefined()
@@ -707,6 +751,7 @@ test.suite({ config: './config.ts' })('database', () => {
           title: 'updated',
           updatedAt: date,
         },
+        overrideAccess: true,
       })
       expect(updatedDocWithTimestamps.createdAt).toBeUndefined()
       expect(updatedDocWithTimestamps.updatedAt).toBeUndefined()
@@ -803,6 +848,7 @@ test.suite({ config: './config.ts' })('database', () => {
           'confirm-password': 'some-password',
           email: 'user1@payloadcms.com',
         },
+        overrideAccess: true,
       })
 
       let keys = Object.keys(createdUser)
@@ -810,7 +856,7 @@ test.suite({ config: './config.ts' })('database', () => {
       expect(keys).not.toContain('password')
       expect(keys).not.toContain('confirm-password')
 
-      const foundUser = await payload.findByID({ id: createdUser.id, collection: 'users' })
+      const foundUser = await payload.findByID({ id: createdUser.id, collection: 'users', overrideAccess: true })
 
       keys = Object.keys(foundUser)
 
@@ -852,6 +898,7 @@ test.suite({ config: './config.ts' })('database', () => {
       data: {
         roles: ['admin'],
       },
+      overrideAccess: true,
     })
 
     const result = await payload.find({
@@ -861,12 +908,13 @@ test.suite({ config: './config.ts' })('database', () => {
           contains: 'admin',
         },
       },
+      overrideAccess: true,
     })
     expect(result.docs).toHaveLength(1)
 
     expect(result.docs.some((doc) => doc.id === id)).toBe(true)
 
-    await payload.delete({ collection: 'select-has-many', id })
+    await payload.delete({ collection: 'select-has-many', id, overrideAccess: true })
   })
 
   test('ensure querying hasMany select field with contains operator does not do partial matching', async ({
@@ -877,6 +925,7 @@ test.suite({ config: './config.ts' })('database', () => {
       data: {
         food: ['bananabread'],
       },
+      overrideAccess: true,
     })
 
     const result = await payload.find({
@@ -886,10 +935,11 @@ test.suite({ config: './config.ts' })('database', () => {
           contains: 'banana',
         },
       },
+      overrideAccess: true,
     })
     expect(result.docs).toHaveLength(0)
 
-    await payload.delete({ collection: 'select-has-many', id })
+    await payload.delete({ collection: 'select-has-many', id, overrideAccess: true })
   })
 
   test.describe('allow ID on create', () => {
@@ -913,7 +963,7 @@ test.suite({ config: './config.ts' })('database', () => {
         id = 9999
       }
 
-      const post = await payload.create({ collection: 'posts', data: { id, title: 'created' } })
+      const post = await payload.create({ collection: 'posts', data: { id, title: 'created' }, overrideAccess: true })
 
       expect(post.id).toBe(id)
     })
@@ -968,7 +1018,7 @@ test.suite({ config: './config.ts' })('database', () => {
   })
 
   test('should find distinct field values of the collection', async ({ payload }) => {
-    await payload.delete({ collection: 'posts', where: {} })
+    await payload.delete({ collection: 'posts', where: {}, overrideAccess: true })
     const titles = [
       'title-1',
       'title-2',
@@ -984,13 +1034,14 @@ test.suite({ config: './config.ts' })('database', () => {
     for (const { title } of titles) {
       const docsCount = Math.random() > 0.5 ? 3 : Math.random() > 0.5 ? 2 : 1
       for (let i = 0; i < docsCount; i++) {
-        await payload.create({ collection: 'posts', data: { title } })
+        await payload.create({ collection: 'posts', data: { title }, overrideAccess: true })
       }
     }
 
     const res = await payload.findDistinct({
       collection: 'posts',
       field: 'title',
+      overrideAccess: true,
     })
 
     expect(res.values).toStrictEqual(titles)
@@ -999,6 +1050,7 @@ test.suite({ config: './config.ts' })('database', () => {
       collection: 'posts',
       field: 'title',
       limit: 3,
+      overrideAccess: true,
     })
 
     expect(resLimit.values).toStrictEqual(
@@ -1011,6 +1063,7 @@ test.suite({ config: './config.ts' })('database', () => {
       collection: 'posts',
       field: 'title',
       sort: '-title',
+      overrideAccess: true,
     })
 
     expect(resDesc.values).toStrictEqual(titles.toReversed())
@@ -1018,13 +1071,14 @@ test.suite({ config: './config.ts' })('database', () => {
     const resAscDefault = await payload.findDistinct({
       collection: 'posts',
       field: 'title',
+      overrideAccess: true,
     })
 
     expect(resAscDefault.values).toStrictEqual(titles)
   })
 
   test('should sort find on a different field with findDistinct', async ({ payload }) => {
-    await payload.delete({ collection: 'posts', where: {} })
+    await payload.delete({ collection: 'posts', where: {}, overrideAccess: true })
     const titles: {
       title: string
     }[] = [
@@ -1054,6 +1108,7 @@ test.suite({ config: './config.ts' })('database', () => {
             number: numbers[titles.indexOf(entry)]! + Math.random(),
             title: entry.title,
           },
+          overrideAccess: true,
         })
       }
     }
@@ -1062,12 +1117,14 @@ test.suite({ config: './config.ts' })('database', () => {
       collection: 'posts',
       field: 'title',
       sort: '-number',
+      overrideAccess: true,
     })
 
     const resAsc = await payload.findDistinct({
       collection: 'posts',
       field: 'title',
       sort: 'number',
+      overrideAccess: true,
     })
 
     const reversed = titlesSortedByNumber.toReversed()
@@ -1077,7 +1134,7 @@ test.suite({ config: './config.ts' })('database', () => {
   })
 
   test('should populate distinct relationships when depth>0', async ({ payload }) => {
-    await payload.delete({ collection: 'posts', where: {} })
+    await payload.delete({ collection: 'posts', where: {}, overrideAccess: true })
 
     const categories = ['category-1', 'category-2', 'category-3', 'category-4'].map((title) => ({
       title,
@@ -1086,14 +1143,14 @@ test.suite({ config: './config.ts' })('database', () => {
     const categoriesIDS: { category: string }[] = []
 
     for (const { title } of categories) {
-      const doc = await payload.create({ collection: 'categories', data: { title } })
+      const doc = await payload.create({ collection: 'categories', data: { title }, overrideAccess: true })
       categoriesIDS.push({ category: doc.id })
     }
 
     for (const { category } of categoriesIDS) {
       const docsCount = Math.random() > 0.5 ? 3 : Math.random() > 0.5 ? 2 : 1
       for (let i = 0; i < docsCount; i++) {
-        await payload.create({ collection: 'posts', data: { category, title: randomUUID() } })
+        await payload.create({ collection: 'posts', data: { category, title: randomUUID() }, overrideAccess: true })
       }
     }
 
@@ -1101,6 +1158,7 @@ test.suite({ config: './config.ts' })('database', () => {
       collection: 'posts',
       field: 'category',
       sort: 'category.title',
+      overrideAccess: true,
     })
     expect(resultDepth0.values).toStrictEqual(categoriesIDS)
     const resultDepth1 = await payload.findDistinct({
@@ -1108,6 +1166,7 @@ test.suite({ config: './config.ts' })('database', () => {
       depth: 1,
       field: 'category',
       sort: 'category.title',
+      overrideAccess: true,
     })
 
     for (let i = 0; i < resultDepth1.values.length; i++) {
@@ -1122,8 +1181,8 @@ test.suite({ config: './config.ts' })('database', () => {
   test('should populate distinct relationships of hasMany: true when depth>0', async ({
     payload,
   }) => {
-    await payload.delete({ collection: 'posts', where: {} })
-    await payload.delete({ collection: 'categories', where: {} })
+    await payload.delete({ collection: 'posts', where: {}, overrideAccess: true })
+    await payload.delete({ collection: 'categories', where: {}, overrideAccess: true })
 
     const categories = ['category-1', 'category-2', 'category-3', 'category-4'].map((title) => ({
       title,
@@ -1132,7 +1191,7 @@ test.suite({ config: './config.ts' })('database', () => {
     const categoriesIDS: { categories: string }[] = []
 
     for (const { title } of categories) {
-      const doc = await payload.create({ collection: 'categories', data: { title } })
+      const doc = await payload.create({ collection: 'categories', data: { title }, overrideAccess: true })
       categoriesIDS.push({ categories: doc.id })
     }
 
@@ -1142,6 +1201,7 @@ test.suite({ config: './config.ts' })('database', () => {
         categories: [categoriesIDS[0]?.categories, categoriesIDS[1]?.categories],
         title: '1',
       },
+      overrideAccess: true,
     })
 
     await payload.create({
@@ -1154,6 +1214,7 @@ test.suite({ config: './config.ts' })('database', () => {
         ],
         title: '2',
       },
+      overrideAccess: true,
     })
 
     await payload.create({
@@ -1166,12 +1227,14 @@ test.suite({ config: './config.ts' })('database', () => {
         ],
         title: '3',
       },
+      overrideAccess: true,
     })
 
     const resultDepth0 = await payload.findDistinct({
       collection: 'posts',
       field: 'categories',
       sort: 'categories.title',
+      overrideAccess: true,
     })
     expect(resultDepth0.values).toStrictEqual(categoriesIDS)
     const resultDepth1 = await payload.findDistinct({
@@ -1179,6 +1242,7 @@ test.suite({ config: './config.ts' })('database', () => {
       depth: 1,
       field: 'categories',
       sort: 'categories.title',
+      overrideAccess: true,
     })
 
     for (let i = 0; i < resultDepth1.values.length; i++) {
@@ -1198,6 +1262,7 @@ test.suite({ config: './config.ts' })('database', () => {
       collection: 'posts',
       depth: 1,
       field: 'categories',
+      overrideAccess: true,
     })
 
     for (let i = 0; i < resultDepth1NoSort.values.length; i++) {
@@ -1212,47 +1277,56 @@ test.suite({ config: './config.ts' })('database', () => {
   test('should populate distinct relationships of polymorphic when depth>0', async ({
     payload,
   }) => {
-    await payload.delete({ collection: 'posts', where: {} })
-    await payload.delete({ collection: 'categories', where: {} })
+    await payload.delete({ collection: 'posts', where: {}, overrideAccess: true })
+    await payload.delete({ collection: 'categories', where: {}, overrideAccess: true })
 
     const category_1 = await payload.create({
       collection: 'categories',
       data: { title: 'category_1' },
+      overrideAccess: true,
     })
     const category_2 = await payload.create({
       collection: 'categories',
       data: { title: 'category_2' },
+      overrideAccess: true,
     })
     const category_3 = await payload.create({
       collection: 'categories',
       data: { title: 'category_3' },
+      overrideAccess: true,
     })
 
     const post_1 = await payload.create({
       collection: 'posts',
       data: { categoryPoly: { relationTo: 'categories', value: category_1.id }, title: 'post_1' },
+      overrideAccess: true,
     })
     const post_2 = await payload.create({
       collection: 'posts',
       data: { categoryPoly: { relationTo: 'categories', value: category_1.id }, title: 'post_2' },
+      overrideAccess: true,
     })
     const post_3 = await payload.create({
       collection: 'posts',
       data: { categoryPoly: { relationTo: 'categories', value: category_2.id }, title: 'post_3' },
+      overrideAccess: true,
     })
     const post_4 = await payload.create({
       collection: 'posts',
       data: { categoryPoly: { relationTo: 'categories', value: category_3.id }, title: 'post_4' },
+      overrideAccess: true,
     })
     const post_5 = await payload.create({
       collection: 'posts',
       data: { categoryPoly: { relationTo: 'categories', value: category_3.id }, title: 'post_5' },
+      overrideAccess: true,
     })
 
     const result = await payload.findDistinct({
       collection: 'posts',
       depth: 0,
       field: 'categoryPoly',
+      overrideAccess: true,
     })
 
     expect(result.values).toHaveLength(3)
@@ -1279,20 +1353,23 @@ test.suite({ config: './config.ts' })('database', () => {
   test('should populate distinct relationships of hasMany polymorphic when depth>0', async ({
     payload,
   }) => {
-    await payload.delete({ collection: 'posts', where: {} })
-    await payload.delete({ collection: 'categories', where: {} })
+    await payload.delete({ collection: 'posts', where: {}, overrideAccess: true })
+    await payload.delete({ collection: 'categories', where: {}, overrideAccess: true })
 
     const category_1 = await payload.create({
       collection: 'categories',
       data: { title: 'category_1' },
+      overrideAccess: true,
     })
     const category_2 = await payload.create({
       collection: 'categories',
       data: { title: 'category_2' },
+      overrideAccess: true,
     })
     const category_3 = await payload.create({
       collection: 'categories',
       data: { title: 'category_3' },
+      overrideAccess: true,
     })
 
     const post_1 = await payload.create({
@@ -1301,6 +1378,7 @@ test.suite({ config: './config.ts' })('database', () => {
         categoryPolyMany: [{ relationTo: 'categories', value: category_1.id }],
         title: 'post_1',
       },
+      overrideAccess: true,
     })
     const post_2 = await payload.create({
       collection: 'posts',
@@ -1308,6 +1386,7 @@ test.suite({ config: './config.ts' })('database', () => {
         categoryPolyMany: [{ relationTo: 'categories', value: category_1.id }],
         title: 'post_2',
       },
+      overrideAccess: true,
     })
     const post_3 = await payload.create({
       collection: 'posts',
@@ -1315,6 +1394,7 @@ test.suite({ config: './config.ts' })('database', () => {
         categoryPolyMany: [{ relationTo: 'categories', value: category_2.id }],
         title: 'post_3',
       },
+      overrideAccess: true,
     })
     const post_4 = await payload.create({
       collection: 'posts',
@@ -1322,6 +1402,7 @@ test.suite({ config: './config.ts' })('database', () => {
         categoryPolyMany: [{ relationTo: 'categories', value: category_3.id }],
         title: 'post_4',
       },
+      overrideAccess: true,
     })
     const post_5 = await payload.create({
       collection: 'posts',
@@ -1329,6 +1410,7 @@ test.suite({ config: './config.ts' })('database', () => {
         categoryPolyMany: [{ relationTo: 'categories', value: category_3.id }],
         title: 'post_5',
       },
+      overrideAccess: true,
     })
 
     const post_6 = await payload.create({
@@ -1337,12 +1419,14 @@ test.suite({ config: './config.ts' })('database', () => {
         categoryPolyMany: null,
         title: 'post_6',
       },
+      overrideAccess: true,
     })
 
     const result = await payload.findDistinct({
       collection: 'posts',
       depth: 0,
       field: 'categoryPolyMany',
+      overrideAccess: true,
     })
 
     expect(result.values).toHaveLength(4)
@@ -1371,34 +1455,38 @@ test.suite({ config: './config.ts' })('database', () => {
   })
 
   test('should find distinct values with field nested to a relationship', async ({ payload }) => {
-    await payload.delete({ collection: 'posts', where: {} })
-    await payload.delete({ collection: 'categories', where: {} })
+    await payload.delete({ collection: 'posts', where: {}, overrideAccess: true })
+    await payload.delete({ collection: 'categories', where: {}, overrideAccess: true })
 
     const category_1 = await payload.create({
       collection: 'categories',
       data: { title: 'category_1' },
+      overrideAccess: true,
     })
     const category_2 = await payload.create({
       collection: 'categories',
       data: { title: 'category_2' },
+      overrideAccess: true,
     })
     const category_3 = await payload.create({
       collection: 'categories',
       data: { title: 'category_3' },
+      overrideAccess: true,
     })
 
-    await payload.create({ collection: 'posts', data: { category: category_1, title: 'post' } })
-    await payload.create({ collection: 'posts', data: { category: category_2, title: 'post' } })
-    await payload.create({ collection: 'posts', data: { category: category_2, title: 'post' } })
-    await payload.create({ collection: 'posts', data: { category: category_2, title: 'post' } })
-    await payload.create({ collection: 'posts', data: { category: category_3, title: 'post' } })
-    await payload.create({ collection: 'posts', data: { category: category_3, title: 'post' } })
-    await payload.create({ collection: 'posts', data: { category: category_3, title: 'post' } })
-    await payload.create({ collection: 'posts', data: { category: category_3, title: 'post' } })
+    await payload.create({ collection: 'posts', data: { category: category_1, title: 'post' }, overrideAccess: true })
+    await payload.create({ collection: 'posts', data: { category: category_2, title: 'post' }, overrideAccess: true })
+    await payload.create({ collection: 'posts', data: { category: category_2, title: 'post' }, overrideAccess: true })
+    await payload.create({ collection: 'posts', data: { category: category_2, title: 'post' }, overrideAccess: true })
+    await payload.create({ collection: 'posts', data: { category: category_3, title: 'post' }, overrideAccess: true })
+    await payload.create({ collection: 'posts', data: { category: category_3, title: 'post' }, overrideAccess: true })
+    await payload.create({ collection: 'posts', data: { category: category_3, title: 'post' }, overrideAccess: true })
+    await payload.create({ collection: 'posts', data: { category: category_3, title: 'post' }, overrideAccess: true })
 
     const res = await payload.findDistinct({
       collection: 'posts',
       field: 'category.title',
+      overrideAccess: true,
     })
 
     expect(res.values).toEqual([
@@ -1417,34 +1505,38 @@ test.suite({ config: './config.ts' })('database', () => {
   test('should find distinct values with virtual field linked to a relationship', async ({
     payload,
   }) => {
-    await payload.delete({ collection: 'posts', where: {} })
-    await payload.delete({ collection: 'categories', where: {} })
+    await payload.delete({ collection: 'posts', where: {}, overrideAccess: true })
+    await payload.delete({ collection: 'categories', where: {}, overrideAccess: true })
 
     const category_1 = await payload.create({
       collection: 'categories',
       data: { title: 'category_1' },
+      overrideAccess: true,
     })
     const category_2 = await payload.create({
       collection: 'categories',
       data: { title: 'category_2' },
+      overrideAccess: true,
     })
     const category_3 = await payload.create({
       collection: 'categories',
       data: { title: 'category_3' },
+      overrideAccess: true,
     })
 
-    await payload.create({ collection: 'posts', data: { category: category_1, title: 'post' } })
-    await payload.create({ collection: 'posts', data: { category: category_2, title: 'post' } })
-    await payload.create({ collection: 'posts', data: { category: category_2, title: 'post' } })
-    await payload.create({ collection: 'posts', data: { category: category_2, title: 'post' } })
-    await payload.create({ collection: 'posts', data: { category: category_3, title: 'post' } })
-    await payload.create({ collection: 'posts', data: { category: category_3, title: 'post' } })
-    await payload.create({ collection: 'posts', data: { category: category_3, title: 'post' } })
-    await payload.create({ collection: 'posts', data: { category: category_3, title: 'post' } })
+    await payload.create({ collection: 'posts', data: { category: category_1, title: 'post' }, overrideAccess: true })
+    await payload.create({ collection: 'posts', data: { category: category_2, title: 'post' }, overrideAccess: true })
+    await payload.create({ collection: 'posts', data: { category: category_2, title: 'post' }, overrideAccess: true })
+    await payload.create({ collection: 'posts', data: { category: category_2, title: 'post' }, overrideAccess: true })
+    await payload.create({ collection: 'posts', data: { category: category_3, title: 'post' }, overrideAccess: true })
+    await payload.create({ collection: 'posts', data: { category: category_3, title: 'post' }, overrideAccess: true })
+    await payload.create({ collection: 'posts', data: { category: category_3, title: 'post' }, overrideAccess: true })
+    await payload.create({ collection: 'posts', data: { category: category_3, title: 'post' }, overrideAccess: true })
 
     const res = await payload.findDistinct({
       collection: 'posts',
       field: 'categoryTitle',
+      overrideAccess: true,
     })
 
     expect(res.values).toEqual([
@@ -1463,44 +1555,49 @@ test.suite({ config: './config.ts' })('database', () => {
   test('should find distinct values with field nested to a 2x relationship', async ({
     payload,
   }) => {
-    await payload.delete({ collection: 'posts', where: {} })
-    await payload.delete({ collection: 'categories', where: {} })
-    await payload.delete({ collection: 'simple', where: {} })
+    await payload.delete({ collection: 'posts', where: {}, overrideAccess: true })
+    await payload.delete({ collection: 'categories', where: {}, overrideAccess: true })
+    await payload.delete({ collection: 'simple', where: {}, overrideAccess: true })
 
-    const simple_1 = await payload.create({ collection: 'simple', data: { text: 'simple_1' } })
-    const simple_2 = await payload.create({ collection: 'simple', data: { text: 'simple_2' } })
-    const simple_3 = await payload.create({ collection: 'simple', data: { text: 'simple_3' } })
+    const simple_1 = await payload.create({ collection: 'simple', data: { text: 'simple_1' }, overrideAccess: true })
+    const simple_2 = await payload.create({ collection: 'simple', data: { text: 'simple_2' }, overrideAccess: true })
+    const simple_3 = await payload.create({ collection: 'simple', data: { text: 'simple_3' }, overrideAccess: true })
 
     const category_1 = await payload.create({
       collection: 'categories',
       data: { simple: simple_1, title: 'category_1' },
+      overrideAccess: true,
     })
     const category_2 = await payload.create({
       collection: 'categories',
       data: { simple: simple_2, title: 'category_2' },
+      overrideAccess: true,
     })
     const category_3 = await payload.create({
       collection: 'categories',
       data: { simple: simple_3, title: 'category_3' },
+      overrideAccess: true,
     })
     const category_4 = await payload.create({
       collection: 'categories',
       data: { simple: simple_3, title: 'category_4' },
+      overrideAccess: true,
     })
 
-    await payload.create({ collection: 'posts', data: { category: category_1, title: 'post' } })
-    await payload.create({ collection: 'posts', data: { category: category_2, title: 'post' } })
-    await payload.create({ collection: 'posts', data: { category: category_2, title: 'post' } })
-    await payload.create({ collection: 'posts', data: { category: category_2, title: 'post' } })
-    await payload.create({ collection: 'posts', data: { category: category_3, title: 'post' } })
-    await payload.create({ collection: 'posts', data: { category: category_3, title: 'post' } })
-    await payload.create({ collection: 'posts', data: { category: category_3, title: 'post' } })
-    await payload.create({ collection: 'posts', data: { category: category_3, title: 'post' } })
-    await payload.create({ collection: 'posts', data: { category: category_4, title: 'post' } })
+    await payload.create({ collection: 'posts', data: { category: category_1, title: 'post' }, overrideAccess: true })
+    await payload.create({ collection: 'posts', data: { category: category_2, title: 'post' }, overrideAccess: true })
+    await payload.create({ collection: 'posts', data: { category: category_2, title: 'post' }, overrideAccess: true })
+    await payload.create({ collection: 'posts', data: { category: category_2, title: 'post' }, overrideAccess: true })
+    await payload.create({ collection: 'posts', data: { category: category_3, title: 'post' }, overrideAccess: true })
+    await payload.create({ collection: 'posts', data: { category: category_3, title: 'post' }, overrideAccess: true })
+    await payload.create({ collection: 'posts', data: { category: category_3, title: 'post' }, overrideAccess: true })
+    await payload.create({ collection: 'posts', data: { category: category_3, title: 'post' }, overrideAccess: true })
+    await payload.create({ collection: 'posts', data: { category: category_4, title: 'post' }, overrideAccess: true })
 
     const res = await payload.findDistinct({
       collection: 'posts',
       field: 'category.simple.text',
+      overrideAccess: true,
     })
 
     expect(res.values).toEqual([
@@ -1519,44 +1616,49 @@ test.suite({ config: './config.ts' })('database', () => {
   test('should find distinct values with virtual field linked to a 2x relationship', async ({
     payload,
   }) => {
-    await payload.delete({ collection: 'posts', where: {} })
-    await payload.delete({ collection: 'categories', where: {} })
-    await payload.delete({ collection: 'simple', where: {} })
+    await payload.delete({ collection: 'posts', where: {}, overrideAccess: true })
+    await payload.delete({ collection: 'categories', where: {}, overrideAccess: true })
+    await payload.delete({ collection: 'simple', where: {}, overrideAccess: true })
 
-    const simple_1 = await payload.create({ collection: 'simple', data: { text: 'simple_1' } })
-    const simple_2 = await payload.create({ collection: 'simple', data: { text: 'simple_2' } })
-    const simple_3 = await payload.create({ collection: 'simple', data: { text: 'simple_3' } })
+    const simple_1 = await payload.create({ collection: 'simple', data: { text: 'simple_1' }, overrideAccess: true })
+    const simple_2 = await payload.create({ collection: 'simple', data: { text: 'simple_2' }, overrideAccess: true })
+    const simple_3 = await payload.create({ collection: 'simple', data: { text: 'simple_3' }, overrideAccess: true })
 
     const category_1 = await payload.create({
       collection: 'categories',
       data: { simple: simple_1, title: 'category_1' },
+      overrideAccess: true,
     })
     const category_2 = await payload.create({
       collection: 'categories',
       data: { simple: simple_2, title: 'category_2' },
+      overrideAccess: true,
     })
     const category_3 = await payload.create({
       collection: 'categories',
       data: { simple: simple_3, title: 'category_3' },
+      overrideAccess: true,
     })
     const category_4 = await payload.create({
       collection: 'categories',
       data: { simple: simple_3, title: 'category_4' },
+      overrideAccess: true,
     })
 
-    await payload.create({ collection: 'posts', data: { category: category_1, title: 'post' } })
-    await payload.create({ collection: 'posts', data: { category: category_2, title: 'post' } })
-    await payload.create({ collection: 'posts', data: { category: category_2, title: 'post' } })
-    await payload.create({ collection: 'posts', data: { category: category_2, title: 'post' } })
-    await payload.create({ collection: 'posts', data: { category: category_3, title: 'post' } })
-    await payload.create({ collection: 'posts', data: { category: category_3, title: 'post' } })
-    await payload.create({ collection: 'posts', data: { category: category_3, title: 'post' } })
-    await payload.create({ collection: 'posts', data: { category: category_3, title: 'post' } })
-    await payload.create({ collection: 'posts', data: { category: category_4, title: 'post' } })
+    await payload.create({ collection: 'posts', data: { category: category_1, title: 'post' }, overrideAccess: true })
+    await payload.create({ collection: 'posts', data: { category: category_2, title: 'post' }, overrideAccess: true })
+    await payload.create({ collection: 'posts', data: { category: category_2, title: 'post' }, overrideAccess: true })
+    await payload.create({ collection: 'posts', data: { category: category_2, title: 'post' }, overrideAccess: true })
+    await payload.create({ collection: 'posts', data: { category: category_3, title: 'post' }, overrideAccess: true })
+    await payload.create({ collection: 'posts', data: { category: category_3, title: 'post' }, overrideAccess: true })
+    await payload.create({ collection: 'posts', data: { category: category_3, title: 'post' }, overrideAccess: true })
+    await payload.create({ collection: 'posts', data: { category: category_3, title: 'post' }, overrideAccess: true })
+    await payload.create({ collection: 'posts', data: { category: category_4, title: 'post' }, overrideAccess: true })
 
     const res = await payload.findDistinct({
       collection: 'posts',
       field: 'categorySimpleText',
+      overrideAccess: true,
     })
 
     expect(res.values).toEqual([
@@ -1575,26 +1677,28 @@ test.suite({ config: './config.ts' })('database', () => {
   test('should find distinct values when the virtual field is linked to ID', async ({
     payload,
   }) => {
-    await payload.delete({ collection: 'posts', where: {} })
-    await payload.delete({ collection: 'categories', where: {} })
+    await payload.delete({ collection: 'posts', where: {}, overrideAccess: true })
+    await payload.delete({ collection: 'categories', where: {}, overrideAccess: true })
     const category = await payload.create({
       collection: 'categories',
       data: { title: 'category' },
+      overrideAccess: true,
     })
-    await payload.create({ collection: 'posts', data: { category, title: 'post' } })
-    const distinct = await payload.findDistinct({ collection: 'posts', field: 'categoryID' })
+    await payload.create({ collection: 'posts', data: { category, title: 'post' }, overrideAccess: true })
+    const distinct = await payload.findDistinct({ collection: 'posts', field: 'categoryID', overrideAccess: true })
     expect(distinct.values).toStrictEqual([{ categoryID: category.id }])
   })
 
   test('should find distinct values by the explicit ID field path', async ({ payload }) => {
-    await payload.delete({ collection: 'posts', where: {} })
-    await payload.delete({ collection: 'categories', where: {} })
+    await payload.delete({ collection: 'posts', where: {}, overrideAccess: true })
+    await payload.delete({ collection: 'categories', where: {}, overrideAccess: true })
     const category = await payload.create({
       collection: 'categories',
       data: { title: 'category' },
+      overrideAccess: true,
     })
-    await payload.create({ collection: 'posts', data: { category, title: 'post' } })
-    const distinct = await payload.findDistinct({ collection: 'posts', field: 'category.id' })
+    await payload.create({ collection: 'posts', data: { category, title: 'post' }, overrideAccess: true })
+    const distinct = await payload.findDistinct({ collection: 'posts', field: 'category.id', overrideAccess: true })
     expect(distinct.values).toStrictEqual([{ 'category.id': category.id }])
   })
 
@@ -1608,6 +1712,7 @@ test.suite({ config: './config.ts' })('database', () => {
         const cat = await payload.create({
           collection: 'categories',
           data: { title: `DistinctTest-Cat-${i + 1}-${Date.now()}` },
+          overrideAccess: true,
         })
         return cat.id
       })
@@ -1621,6 +1726,7 @@ test.suite({ config: './config.ts' })('database', () => {
             category: categoryId,
             title: `DistinctTest-Post-${i + 1}-${Date.now()}`,
           },
+          overrideAccess: true,
         })
         return post.id
       })
@@ -1653,6 +1759,7 @@ test.suite({ config: './config.ts' })('database', () => {
             contains: 'DistinctTest-Post',
           },
         },
+        overrideAccess: true,
       })
 
       expect(page1.totalDocs).toBe(15)
@@ -1673,6 +1780,7 @@ test.suite({ config: './config.ts' })('database', () => {
             contains: 'DistinctTest-Post',
           },
         },
+        overrideAccess: true,
       })
 
       expect(page2.totalDocs).toBe(15)
@@ -1711,6 +1819,7 @@ test.suite({ config: './config.ts' })('database', () => {
           })),
           title: `${testPrefix}-${i}`,
         },
+        overrideAccess: true,
       })
 
       createdIds.push(String(doc.id))
@@ -1722,6 +1831,7 @@ test.suite({ config: './config.ts' })('database', () => {
       page: 1,
       sort: 'arrayWithIDs.text',
       where: { title: { contains: testPrefix } },
+      overrideAccess: true,
     })
 
     const page2 = await payload.find({
@@ -1730,6 +1840,7 @@ test.suite({ config: './config.ts' })('database', () => {
       page: 2,
       sort: 'arrayWithIDs.text',
       where: { title: { contains: testPrefix } },
+      overrideAccess: true,
     })
 
     expect(page1.totalDocs).toBe(TOTAL)
@@ -1763,29 +1874,33 @@ test.suite({ config: './config.ts' })('database', () => {
     await payload.delete({
       collection: postsSlug,
       where: { id: { in: createdIds } },
+      overrideAccess: true,
     })
   })
 
   test.describe('Compound Indexes', () => {
     test.beforeEach(async ({ payload }) => {
-      await payload.delete({ collection: 'compound-indexes', where: {} })
+      await payload.delete({ collection: 'compound-indexes', where: {}, overrideAccess: true })
     })
 
     test('top level: should throw a unique error', async ({ payload }) => {
       await payload.create({
         collection: 'compound-indexes',
         data: { one: '1', three: randomUUID(), two: '2' },
+        overrideAccess: true,
       })
 
       // does not fail
       await payload.create({
         collection: 'compound-indexes',
         data: { one: '1', three: randomUUID(), two: '3' },
+        overrideAccess: true,
       })
       // does not fail
       await payload.create({
         collection: 'compound-indexes',
         data: { one: '-1', three: randomUUID(), two: '2' },
+        overrideAccess: true,
       })
 
       // fails
@@ -1793,6 +1908,7 @@ test.suite({ config: './config.ts' })('database', () => {
         payload.create({
           collection: 'compound-indexes',
           data: { one: '1', three: randomUUID(), two: '2' },
+          overrideAccess: true,
         }),
       ).rejects.toBeTruthy()
     })
@@ -1805,17 +1921,20 @@ test.suite({ config: './config.ts' })('database', () => {
           one: randomUUID(),
           three: '3',
         },
+        overrideAccess: true,
       })
 
       // does not fail
       await payload.create({
         collection: 'compound-indexes',
         data: { group: { four: '5' }, one: randomUUID(), three: '3' },
+        overrideAccess: true,
       })
       // does not fail
       await payload.create({
         collection: 'compound-indexes',
         data: { group: { four: '4' }, one: randomUUID(), three: '4' },
+        overrideAccess: true,
       })
 
       // fails
@@ -1823,6 +1942,7 @@ test.suite({ config: './config.ts' })('database', () => {
         payload.create({
           collection: 'compound-indexes',
           data: { group: { four: '4' }, one: randomUUID(), three: '3' },
+          overrideAccess: true,
         }),
       ).rejects.toBeTruthy()
     })
@@ -1867,6 +1987,7 @@ test.suite({ config: './config.ts' })('database', () => {
       await payload.db.migrate()
       const { docs } = await payload.find({
         collection: 'payload-migrations',
+        overrideAccess: true,
       })
       const migration = docs[0]
       expect(migration?.name).toContain('_test')
@@ -1887,6 +2008,7 @@ test.suite({ config: './config.ts' })('database', () => {
       await payload.db.migrateFresh({ forceAcceptWarning: true })
       const { docs } = await payload.find({
         collection: 'payload-migrations',
+        overrideAccess: true,
       })
       const migration = docs[0]
       expect(migration.name).toContain('_test')
@@ -1908,7 +2030,7 @@ test.suite({ config: './config.ts' })('database', () => {
       // migrate current to test
       await payload.db.migrate()
 
-      const { docs } = await payload.find({ collection: 'payload-migrations' })
+      const { docs } = await payload.find({ collection: 'payload-migrations', overrideAccess: true })
       expect(docs.some((doc) => doc.name.includes('migration_to_down'))).toBeTruthy()
 
       let error
@@ -1920,12 +2042,13 @@ test.suite({ config: './config.ts' })('database', () => {
 
       const migrations = await payload.find({
         collection: 'payload-migrations',
+        overrideAccess: true,
       })
 
       expect(error).toBeUndefined()
       expect(migrations.docs.some((doc) => doc.name.includes('migration_to_down'))).toBeFalsy()
 
-      await payload.delete({ collection: 'payload-migrations', where: {} })
+      await payload.delete({ collection: 'payload-migrations', where: {}, overrideAccess: true })
     })
 
     // known drizzle issue: https://github.com/payloadcms/payload/issues/4597
@@ -1939,6 +2062,7 @@ test.suite({ config: './config.ts' })('database', () => {
 
       const migrations = await payload.find({
         collection: 'payload-migrations',
+        overrideAccess: true,
       })
 
       expect(error).toBeUndefined()
@@ -1957,6 +2081,7 @@ test.suite({ config: './config.ts' })('database', () => {
 
     const migrations = await payload.find({
       collection: 'payload-migrations',
+      overrideAccess: true,
     })
 
     expect(error).toBeUndefined()
@@ -2128,6 +2253,7 @@ test.suite({ config: './config.ts' })('database', () => {
         data: {
           title: 'hello',
         },
+        overrideAccess: true,
       })
 
       const { id } = await payload.create({
@@ -2152,11 +2278,13 @@ test.suite({ config: './config.ts' })('database', () => {
           select: ['a', 'b'],
           text: 'test',
         },
+        overrideAccess: true,
       })
 
       const doc = await payload.findByID({
         id,
         collection: 'custom-schema',
+        overrideAccess: true,
       })
 
       expect(doc.relationship[0].title).toStrictEqual(relationA.title)
@@ -2179,6 +2307,7 @@ test.suite({ config: './config.ts' })('database', () => {
           array: [{ text: 'array row' }],
           select: ['a', 'b'],
         },
+        overrideAccess: true,
       })
 
       await payload.db.updateOne({
@@ -2192,6 +2321,7 @@ test.suite({ config: './config.ts' })('database', () => {
       const updated = await payload.findByID({
         collection: customSchemaSlug,
         id: doc.id,
+        overrideAccess: true,
       })
 
       expect(updated.array).toHaveLength(0)
@@ -2200,6 +2330,7 @@ test.suite({ config: './config.ts' })('database', () => {
       await payload.delete({
         collection: customSchemaSlug,
         id: doc.id,
+        overrideAccess: true,
       })
     })
 
@@ -2211,6 +2342,7 @@ test.suite({ config: './config.ts' })('database', () => {
         data: {
           select: ['a', 'b'],
         },
+        overrideAccess: true,
       })
 
       await payload.db.updateOne({
@@ -2224,6 +2356,7 @@ test.suite({ config: './config.ts' })('database', () => {
       const updated = await payload.findByID({
         collection: customSchemaSlug,
         id: doc.id,
+        overrideAccess: true,
       })
 
       expect(updated.select).toHaveLength(0)
@@ -2231,6 +2364,7 @@ test.suite({ config: './config.ts' })('database', () => {
       await payload.delete({
         collection: customSchemaSlug,
         id: doc.id,
+        overrideAccess: true,
       })
     })
 
@@ -2244,8 +2378,9 @@ test.suite({ config: './config.ts' })('database', () => {
             },
           ],
         },
+        overrideAccess: true,
       })
-      const res = await payload.findByID({ id, collection: 'aliases' })
+      const res = await payload.findByID({ id, collection: 'aliases', overrideAccess: true })
       expect(
         res.thisIsALongFieldNameThatCanCauseAPostgresErrorEvenThoughWeSetAShorterDBName,
       ).toHaveLength(1)
@@ -2279,12 +2414,14 @@ test.suite({ config: './config.ts' })('database', () => {
               title,
             },
             req,
+            overrideAccess: true,
           })
 
           await expect(() =>
             payload.findByID({
               id: first.id,
               collection,
+              overrideAccess: true,
               // omitting req for isolation
             }),
           ).rejects.toThrow('Not Found')
@@ -2295,6 +2432,7 @@ test.suite({ config: './config.ts' })('database', () => {
               title,
             },
             req,
+            overrideAccess: true,
           })
 
           await commitTransaction(req)
@@ -2304,11 +2442,13 @@ test.suite({ config: './config.ts' })('database', () => {
             id: first.id,
             collection,
             req,
+            overrideAccess: true,
           })
           const secondResult = await payload.findByID({
             id: second.id,
             collection,
             req,
+            overrideAccess: true,
           })
 
           expect(firstResult.id).toStrictEqual(first.id)
@@ -2331,6 +2471,7 @@ test.suite({ config: './config.ts' })('database', () => {
                 title,
               },
               req: isolateObjectProperty(req, 'transactionID'),
+              overrideAccess: true,
             })
             .then((res) => {
               first = res
@@ -2343,6 +2484,7 @@ test.suite({ config: './config.ts' })('database', () => {
                 title,
               },
               req: isolateObjectProperty(req, 'transactionID'),
+              overrideAccess: true,
             })
             .then((res) => {
               second = res
@@ -2355,10 +2497,12 @@ test.suite({ config: './config.ts' })('database', () => {
           const firstResult = await payload.findByID({
             id: first.id,
             collection,
+            overrideAccess: true,
           })
           const secondResult = await payload.findByID({
             id: second.id,
             collection,
+            overrideAccess: true,
           })
 
           expect(firstResult.id).toStrictEqual(first.id)
@@ -2379,6 +2523,7 @@ test.suite({ config: './config.ts' })('database', () => {
               title,
             },
             req,
+            overrideAccess: true,
           })
 
           try {
@@ -2389,6 +2534,7 @@ test.suite({ config: './config.ts' })('database', () => {
                 title,
               },
               req,
+              overrideAccess: true,
             })
           } catch (error: unknown) {
             // catch error and carry on
@@ -2404,6 +2550,7 @@ test.suite({ config: './config.ts' })('database', () => {
               id: first.id,
               collection,
               req,
+              overrideAccess: true,
             }),
           ).rejects.toThrow('Not Found')
         })
@@ -2416,11 +2563,13 @@ test.suite({ config: './config.ts' })('database', () => {
             data: {
               title,
             },
+            overrideAccess: true,
           })
 
           await payload.delete({
             id: missing.id,
             collection,
+            overrideAccess: true,
           })
 
           const req = {
@@ -2436,6 +2585,7 @@ test.suite({ config: './config.ts' })('database', () => {
               title,
             },
             req,
+            overrideAccess: true,
           })
 
           // Hooks commonly look up a related doc and tolerate it being gone. A read
@@ -2446,6 +2596,7 @@ test.suite({ config: './config.ts' })('database', () => {
               id: missing.id,
               collection,
               req,
+              overrideAccess: true,
             }),
           ).rejects.toThrow('Not Found')
 
@@ -2456,6 +2607,7 @@ test.suite({ config: './config.ts' })('database', () => {
           const result = await payload.findByID({
             id: created.id,
             collection,
+            overrideAccess: true,
           })
 
           expect(result.id).toStrictEqual(created.id)
@@ -2463,6 +2615,7 @@ test.suite({ config: './config.ts' })('database', () => {
           await payload.delete({
             id: created.id,
             collection,
+            overrideAccess: true,
           })
         })
       }
@@ -2520,6 +2673,7 @@ test.suite({ config: './config.ts' })('database', () => {
             },
             depth: 0,
             disableTransaction: true,
+            overrideAccess: true,
           })
         })
         test('should not use transaction calling create() with disableTransaction', () => {
@@ -2535,6 +2689,7 @@ test.suite({ config: './config.ts' })('database', () => {
               title,
             },
             disableTransaction: true,
+            overrideAccess: true,
           })
 
           expect(result.hasTransaction).toBeFalsy()
@@ -2549,6 +2704,7 @@ test.suite({ config: './config.ts' })('database', () => {
               title,
             },
             disableTransaction: true,
+            overrideAccess: true,
           })
 
           expect(result.hasTransaction).toBeFalsy()
@@ -2565,6 +2721,7 @@ test.suite({ config: './config.ts' })('database', () => {
           data: {
             title: 'hello',
           },
+          overrideAccess: true,
         })
       }
 
@@ -2577,6 +2734,7 @@ test.suite({ config: './config.ts' })('database', () => {
         where: {
           title: { equals: 'hello' },
         },
+        overrideAccess: true,
       })
 
       const findResult = await payload.find({
@@ -2584,6 +2742,7 @@ test.suite({ config: './config.ts' })('database', () => {
         where: {
           title: { exists: true },
         },
+        overrideAccess: true,
       })
 
       const helloDocs = findResult.docs.filter((doc) => doc.title === 'hello')
@@ -2601,15 +2760,16 @@ test.suite({ config: './config.ts' })('database', () => {
 
       try {
         const posts = await Promise.all([
-          payload.create({ collection, data: { title: 'test1' } }),
-          payload.create({ collection, data: { title: 'test2' } }),
-          payload.create({ collection, data: { title: 'test3' } }),
+          payload.create({ collection, data: { title: 'test1' }, overrideAccess: true }),
+          payload.create({ collection, data: { title: 'test2' }, overrideAccess: true }),
+          payload.create({ collection, data: { title: 'test3' }, overrideAccess: true }),
         ])
 
         const result = await payload.update({
           collection,
           data: { title: 'updated' },
           where: { id: { in: posts.map((p) => p.id) } },
+          overrideAccess: true,
         })
 
         expect(result.docs).toHaveLength(3)
@@ -2625,13 +2785,14 @@ test.suite({ config: './config.ts' })('database', () => {
 
       try {
         const posts = await Promise.all([
-          payload.create({ collection, data: { title: 'toDelete1' } }),
-          payload.create({ collection, data: { title: 'toDelete2' } }),
+          payload.create({ collection, data: { title: 'toDelete1' }, overrideAccess: true }),
+          payload.create({ collection, data: { title: 'toDelete2' }, overrideAccess: true }),
         ])
 
         const result = await payload.delete({
           collection,
           where: { id: { in: posts.map((p) => p.id) } },
+          overrideAccess: true,
         })
 
         expect(result.docs).toHaveLength(2)
@@ -2647,6 +2808,7 @@ test.suite({ config: './config.ts' })('database', () => {
         data: {
           point: [5, 10],
         },
+        overrideAccess: true,
       })
 
       expect(result.point).toEqual([5, 10])
@@ -2667,6 +2829,7 @@ test.suite({ config: './config.ts' })('database', () => {
         data: {
           title: 'notupdated',
         },
+        overrideAccess: true,
       })
 
       // Create 5 posts
@@ -2676,6 +2839,7 @@ test.suite({ config: './config.ts' })('database', () => {
           data: {
             title: `v1 ${i}`,
           },
+          overrideAccess: true,
         })
       }
 
@@ -2705,6 +2869,7 @@ test.suite({ config: './config.ts' })('database', () => {
             equals: 'updated',
           },
         },
+        overrideAccess: true,
       })
 
       expect(docs).toHaveLength(5)
@@ -2720,6 +2885,7 @@ test.suite({ config: './config.ts' })('database', () => {
             not_equals: 'updated',
           },
         },
+        overrideAccess: true,
       })
 
       expect(notUpdatedDocs).toHaveLength(1)
@@ -2743,6 +2909,7 @@ test.suite({ config: './config.ts' })('database', () => {
           data: {
             title: 'not updated',
           },
+          overrideAccess: true,
         })
       }
 
@@ -2773,6 +2940,7 @@ test.suite({ config: './config.ts' })('database', () => {
             equals: 'updated',
           },
         },
+        overrideAccess: true,
       })
 
       expect(docs).toHaveLength(5)
@@ -2788,6 +2956,7 @@ test.suite({ config: './config.ts' })('database', () => {
             equals: 'not updated',
           },
         },
+        overrideAccess: true,
       })
 
       expect(notUpdatedDocs).toHaveLength(6)
@@ -2818,6 +2987,7 @@ test.suite({ config: './config.ts' })('database', () => {
             number: i,
             title: 'not updated',
           },
+          overrideAccess: true,
         })
       }
 
@@ -2853,6 +3023,7 @@ test.suite({ config: './config.ts' })('database', () => {
             equals: 'updated',
           },
         },
+        overrideAccess: true,
       })
 
       expect(docs).toHaveLength(5)
@@ -2885,6 +3056,7 @@ test.suite({ config: './config.ts' })('database', () => {
             number: i,
             title: 'not updated',
           },
+          overrideAccess: true,
         })
       }
 
@@ -2900,6 +3072,7 @@ test.suite({ config: './config.ts' })('database', () => {
             exists: true,
           },
         },
+        overrideAccess: true,
       })
 
       expect(result?.docs.length).toBe(5)
@@ -2920,6 +3093,7 @@ test.suite({ config: './config.ts' })('database', () => {
             equals: 'updated',
           },
         },
+        overrideAccess: true,
       })
 
       expect(docs).toHaveLength(5)
@@ -2952,6 +3126,7 @@ test.suite({ config: './config.ts' })('database', () => {
             number: i,
             title: 'not updated',
           },
+          overrideAccess: true,
         })
       }
 
@@ -2987,6 +3162,7 @@ test.suite({ config: './config.ts' })('database', () => {
             equals: 'updated',
           },
         },
+        overrideAccess: true,
       })
 
       expect(docs).toHaveLength(5)
@@ -3021,6 +3197,7 @@ test.suite({ config: './config.ts' })('database', () => {
             number: i,
             title: 'not updated',
           },
+          overrideAccess: true,
         })
       }
 
@@ -3036,6 +3213,7 @@ test.suite({ config: './config.ts' })('database', () => {
             exists: true,
           },
         },
+        overrideAccess: true,
       })
 
       expect(result?.docs?.length).toBe(5)
@@ -3056,6 +3234,7 @@ test.suite({ config: './config.ts' })('database', () => {
             equals: 'updated',
           },
         },
+        overrideAccess: true,
       })
 
       expect(docs).toHaveLength(5)
@@ -3082,6 +3261,7 @@ test.suite({ config: './config.ts' })('database', () => {
           data: {
             title: 'not updated',
           },
+          overrideAccess: true,
         })
       }
 
@@ -3112,6 +3292,7 @@ test.suite({ config: './config.ts' })('database', () => {
             equals: 'updated',
           },
         },
+        overrideAccess: true,
       })
 
       expect(docs).toHaveLength(5)
@@ -3136,6 +3317,7 @@ test.suite({ config: './config.ts' })('database', () => {
           data: {
             title: 'not updated',
           },
+          overrideAccess: true,
         })
       }
 
@@ -3166,6 +3348,7 @@ test.suite({ config: './config.ts' })('database', () => {
             equals: 'updated',
           },
         },
+        overrideAccess: true,
       })
 
       expect(docs).toHaveLength(5)
@@ -3249,6 +3432,7 @@ test.suite({ config: './config.ts' })('database', () => {
             // @ts-expect-error
             title: undefined,
           },
+          overrideAccess: true,
         })
       } catch (e: any) {
         errorMessage = e.message
@@ -3272,6 +3456,7 @@ test.suite({ config: './config.ts' })('database', () => {
             },
             title: 'Title',
           },
+          overrideAccess: true,
         })
       } catch (e: any) {
         expect(e.message).toMatch(
@@ -3296,6 +3481,7 @@ test.suite({ config: './config.ts' })('database', () => {
               text: undefined,
             },
           },
+          overrideAccess: true,
         })
       } catch (e: any) {
         expect(e.data?.errors?.[0]?.path).toBe('groupWithinUnnamedTab.text')
@@ -3514,6 +3700,7 @@ test.suite({ config: './config.ts' })('database', () => {
           city: 'Berlin',
           country: 'Germany',
         },
+        overrideAccess: true,
       })
 
       const tableName = payload.db.schemaName ? `"${payload.db.schemaName}"."places"` : 'places'
@@ -3575,6 +3762,7 @@ test.suite({ config: './config.ts' })('database', () => {
           city: 'A',
           country: 'B',
         },
+        overrideAccess: true,
       })
 
       await expect(
@@ -3584,6 +3772,7 @@ test.suite({ config: './config.ts' })('database', () => {
             city: 'C',
             country: 'B',
           },
+          overrideAccess: true,
         }),
       ).resolves.toBeTruthy()
 
@@ -3594,6 +3783,7 @@ test.suite({ config: './config.ts' })('database', () => {
             city: 'A',
             country: 'D',
           },
+          overrideAccess: true,
         }),
       ).resolves.toBeTruthy()
 
@@ -3604,6 +3794,7 @@ test.suite({ config: './config.ts' })('database', () => {
             city: 'A',
             country: 'B',
           },
+          overrideAccess: true,
         }),
       ).rejects.toBeTruthy()
     })
@@ -3614,11 +3805,13 @@ test.suite({ config: './config.ts' })('database', () => {
       const createRes = await payload.create({
         collection: 'fields-persistance',
         data: { array: [], text: 'asd', textHooked: 'asd' },
+        overrideAccess: true,
       })
 
       const resLocal = await payload.findByID({
         id: createRes.id,
         collection: 'fields-persistance',
+        overrideAccess: true,
       })
 
       const resDb = (await payload.db.findOne({
@@ -3644,6 +3837,7 @@ test.suite({ config: './config.ts' })('database', () => {
           textWithinRow: '2',
           textWithinTabs: '3',
         },
+        overrideAccess: true,
       })
 
       expect(res.textWithinCollapsible).toBeUndefined()
@@ -3663,6 +3857,7 @@ test.suite({ config: './config.ts' })('database', () => {
             },
           ],
         },
+        overrideAccess: true,
       })
 
       const resDb = (await payload.db.findOne({
@@ -3678,29 +3873,32 @@ test.suite({ config: './config.ts' })('database', () => {
     })
 
     test('should allow virtual field with reference', async ({ payload }) => {
-      const post = await payload.create({ collection: 'posts', data: { title: 'my-title' } })
+      const post = await payload.create({ collection: 'posts', data: { title: 'my-title' }, overrideAccess: true })
       const { id } = await payload.create({
         collection: 'virtual-relations',
         data: { post: post.id },
         depth: 0,
+        overrideAccess: true,
       })
 
-      const doc = await payload.findByID({ id, collection: 'virtual-relations', depth: 0 })
+      const doc = await payload.findByID({ id, collection: 'virtual-relations', depth: 0, overrideAccess: true })
       expect(doc.postTitle).toBe('my-title')
       const draft = await payload.find({
         collection: 'virtual-relations',
         depth: 0,
         where: { id: { equals: id } },
+        overrideAccess: true,
       })
       expect(draft.docs[0]?.postTitle).toBe('my-title')
     })
 
     test('should not break when using select', async ({ payload }) => {
-      const post = await payload.create({ collection: 'posts', data: { title: 'my-title-10' } })
+      const post = await payload.create({ collection: 'posts', data: { title: 'my-title-10' }, overrideAccess: true })
       const { id } = await payload.create({
         collection: 'virtual-relations',
         data: { post: post.id },
         depth: 0,
+        overrideAccess: true,
       })
 
       const doc = await payload.findByID({
@@ -3708,19 +3906,21 @@ test.suite({ config: './config.ts' })('database', () => {
         collection: 'virtual-relations',
         depth: 0,
         select: { postTitle: true },
+        overrideAccess: true,
       })
       expect(doc.postTitle).toBe('my-title-10')
     })
 
     test('should respect hidden: true for virtual fields with reference', async ({ payload }) => {
-      const post = await payload.create({ collection: 'posts', data: { title: 'my-title-3' } })
+      const post = await payload.create({ collection: 'posts', data: { title: 'my-title-3' }, overrideAccess: true })
       const { id } = await payload.create({
         collection: 'virtual-relations',
         data: { post: post.id },
         depth: 0,
+        overrideAccess: true,
       })
 
-      const doc = await payload.findByID({ id, collection: 'virtual-relations', depth: 0 })
+      const doc = await payload.findByID({ id, collection: 'virtual-relations', depth: 0, overrideAccess: true })
       expect(doc.postTitleHidden).toBeUndefined()
 
       const doc_show = await payload.findByID({
@@ -3728,38 +3928,42 @@ test.suite({ config: './config.ts' })('database', () => {
         collection: 'virtual-relations',
         depth: 0,
         showHiddenFields: true,
+        overrideAccess: true,
       })
       expect(doc_show.postTitleHidden).toBe('my-title-3')
     })
 
     test('should allow virtual field as reference to ID', async ({ payload }) => {
-      const post = await payload.create({ collection: 'posts', data: { title: 'my-title' } })
+      const post = await payload.create({ collection: 'posts', data: { title: 'my-title' }, overrideAccess: true })
       const { id } = await payload.create({
         collection: 'virtual-relations',
         data: { post: post.id },
         depth: 0,
+        overrideAccess: true,
       })
 
-      const docDepth2 = await payload.findByID({ id, collection: 'virtual-relations' })
+      const docDepth2 = await payload.findByID({ id, collection: 'virtual-relations', overrideAccess: true })
       expect(docDepth2.postID).toBe(post.id)
-      const docDepth0 = await payload.findByID({ id, collection: 'virtual-relations', depth: 0 })
+      const docDepth0 = await payload.findByID({ id, collection: 'virtual-relations', depth: 0, overrideAccess: true })
       expect(docDepth0.postID).toBe(post.id)
     })
 
     test('should allow virtual field as reference to custom ID', async ({ payload }) => {
-      const customID = await payload.create({ collection: 'custom-ids', data: {} })
+      const customID = await payload.create({ collection: 'custom-ids', data: {}, overrideAccess: true })
       const { id } = await payload.create({
         collection: 'virtual-relations',
         data: { customID: customID.id },
         depth: 0,
+        overrideAccess: true,
       })
 
-      const docDepth2 = await payload.findByID({ id, collection: 'virtual-relations' })
+      const docDepth2 = await payload.findByID({ id, collection: 'virtual-relations', overrideAccess: true })
       expect(docDepth2.customIDValue).toBe(customID.id)
       const docDepth0 = await payload.findByID({
         id,
         collection: 'virtual-relations',
         depth: 0,
+        overrideAccess: true,
       })
       expect(docDepth0.customIDValue).toBe(customID.id)
     })
@@ -3768,20 +3972,23 @@ test.suite({ config: './config.ts' })('database', () => {
       const category = await payload.create({
         collection: 'categories',
         data: { title: 'category-3' },
+        overrideAccess: true,
       })
       const post = await payload.create({
         collection: 'posts',
         data: { category: category.id, title: 'my-title-3' },
+        overrideAccess: true,
       })
       const { id } = await payload.create({
         collection: 'virtual-relations',
         data: { post: post.id },
         depth: 0,
+        overrideAccess: true,
       })
 
-      const docDepth2 = await payload.findByID({ id, collection: 'virtual-relations' })
+      const docDepth2 = await payload.findByID({ id, collection: 'virtual-relations', overrideAccess: true })
       expect(docDepth2.postCategoryID).toBe(category.id)
-      const docDepth0 = await payload.findByID({ id, collection: 'virtual-relations', depth: 0 })
+      const docDepth0 = await payload.findByID({ id, collection: 'virtual-relations', depth: 0, overrideAccess: true })
       expect(docDepth0.postCategoryID).toBe(category.id)
     })
 
@@ -3789,6 +3996,7 @@ test.suite({ config: './config.ts' })('database', () => {
       const post = await payload.create({
         collection: 'posts',
         data: { localized: 'localized en', title: 'my-title' },
+        overrideAccess: true,
       })
 
       await payload.update({
@@ -3796,42 +4004,47 @@ test.suite({ config: './config.ts' })('database', () => {
         collection: 'posts',
         data: { localized: 'localized es' },
         locale: 'es',
+        overrideAccess: true,
       })
 
       const { id } = await payload.create({
         collection: 'virtual-relations',
         data: { post: post.id },
         depth: 0,
+        overrideAccess: true,
       })
 
-      let doc = await payload.findByID({ id, collection: 'virtual-relations', depth: 0 })
+      let doc = await payload.findByID({ id, collection: 'virtual-relations', depth: 0, overrideAccess: true })
       expect(doc.postLocalized).toBe('localized en')
 
-      doc = await payload.findByID({ id, collection: 'virtual-relations', depth: 0, locale: 'es' })
+      doc = await payload.findByID({ id, collection: 'virtual-relations', depth: 0, locale: 'es', overrideAccess: true })
       expect(doc.postLocalized).toBe('localized es')
     })
 
     test('should allow to query by a virtual field with reference', async ({ payload }) => {
-      await payload.delete({ collection: 'posts', where: {} })
-      await payload.delete({ collection: 'virtual-relations', where: {} })
-      const post_1 = await payload.create({ collection: 'posts', data: { title: 'Dan' } })
-      const post_2 = await payload.create({ collection: 'posts', data: { title: 'Mr.Dan' } })
+      await payload.delete({ collection: 'posts', where: {}, overrideAccess: true })
+      await payload.delete({ collection: 'virtual-relations', where: {}, overrideAccess: true })
+      const post_1 = await payload.create({ collection: 'posts', data: { title: 'Dan' }, overrideAccess: true })
+      const post_2 = await payload.create({ collection: 'posts', data: { title: 'Mr.Dan' }, overrideAccess: true })
 
       const doc_1 = await payload.create({
         collection: 'virtual-relations',
         data: { post: post_1.id },
         depth: 0,
+        overrideAccess: true,
       })
       const doc_2 = await payload.create({
         collection: 'virtual-relations',
         data: { post: post_2.id },
         depth: 0,
+        overrideAccess: true,
       })
 
       const { docs: ascDocs } = await payload.find({
         collection: 'virtual-relations',
         depth: 0,
         sort: 'postTitle',
+        overrideAccess: true,
       })
 
       expect(ascDocs[0]?.id).toBe(doc_1.id)
@@ -3842,6 +4055,7 @@ test.suite({ config: './config.ts' })('database', () => {
         collection: 'virtual-relations',
         depth: 0,
         sort: '-postTitle',
+        overrideAccess: true,
       })
 
       expect(descDocs[1]?.id).toBe(doc_1.id)
@@ -3853,12 +4067,14 @@ test.suite({ config: './config.ts' })('database', () => {
       const category = await payload.create({
         collection: 'categories',
         data: { title: '1-category' },
+        overrideAccess: true,
       })
       const post = await payload.create({
         collection: 'posts',
         data: { category: category.id, title: '1-post' },
+        overrideAccess: true,
       })
-      const doc = await payload.create({ collection: 'virtual-relations', data: { post: post.id } })
+      const doc = await payload.create({ collection: 'virtual-relations', data: { post: post.id }, overrideAccess: true })
       expect(doc.postCategoryTitle).toBe('1-category')
     })
 
@@ -3866,18 +4082,21 @@ test.suite({ config: './config.ts' })('database', () => {
       const category = await payload.create({
         collection: 'categories',
         data: { title: '3-category' },
+        overrideAccess: true,
       })
       const post = await payload.create({
         collection: 'posts',
         data: { category: category.id, title: '3-post' },
+        overrideAccess: true,
       })
-      const doc = await payload.create({ collection: 'virtual-relations', data: { post: post.id } })
+      const doc = await payload.create({ collection: 'virtual-relations', data: { post: post.id }, overrideAccess: true })
 
       const docWithSelect = await payload.findByID({
         id: doc.id,
         collection: 'virtual-relations',
         depth: 0,
         select: { postCategoryTitle: true },
+        overrideAccess: true,
       })
       expect(docWithSelect.postCategoryTitle).toBe('3-category')
     })
@@ -3886,46 +4105,53 @@ test.suite({ config: './config.ts' })('database', () => {
       const category = await payload.create({
         collection: 'categories',
         data: { title: '2-category' },
+        overrideAccess: true,
       })
       const post = await payload.create({
         collection: 'posts',
         data: { category: category.id, title: '2-post' },
+        overrideAccess: true,
       })
-      const doc = await payload.create({ collection: 'virtual-relations', data: { post: post.id } })
+      const doc = await payload.create({ collection: 'virtual-relations', data: { post: post.id }, overrideAccess: true })
       const found = await payload.find({
         collection: 'virtual-relations',
         where: { postCategoryTitle: { equals: '2-category' } },
+        overrideAccess: true,
       })
       expect(found.docs).toHaveLength(1)
       expect(found.docs[0].id).toBe(doc.id)
     })
 
     test('should allow to query by virtual field 2x deep with draft:true', async ({ payload }) => {
-      await payload.delete({ collection: 'virtual-relations', where: {} })
+      await payload.delete({ collection: 'virtual-relations', where: {}, overrideAccess: true })
       const category = await payload.create({
         collection: 'categories',
         data: { title: '3-category' },
+        overrideAccess: true,
       })
       const post = await payload.create({
         collection: 'posts',
         data: { category: category.id, title: '3-post' },
+        overrideAccess: true,
       })
-      const doc = await payload.create({ collection: 'virtual-relations', data: { post: post.id } })
+      const doc = await payload.create({ collection: 'virtual-relations', data: { post: post.id }, overrideAccess: true })
       const found = await payload.find({
         collection: 'virtual-relations',
         draft: true,
         where: { postCategoryTitle: { equals: '3-category' } },
+        overrideAccess: true,
       })
       expect(found.docs).toHaveLength(1)
       expect(found.docs[0].id).toBe(doc.id)
     })
 
     test('should allow referenced virtual field in globals', async ({ payload }) => {
-      const post = await payload.create({ collection: 'posts', data: { title: 'post' } })
+      const post = await payload.create({ collection: 'posts', data: { title: 'post' }, overrideAccess: true })
       const globalData = await payload.updateGlobal({
         slug: 'virtual-relation-global',
         data: { post: post.id },
         depth: 0,
+        overrideAccess: true,
       })
       expect(globalData.postTitle).toBe('post')
     })
@@ -3933,11 +4159,12 @@ test.suite({ config: './config.ts' })('database', () => {
     test('should allow referenced virtual field in collection update response', async ({
       payload,
     }) => {
-      const post = await payload.create({ collection: 'posts', data: { title: 'post-updated' } })
+      const post = await payload.create({ collection: 'posts', data: { title: 'post-updated' }, overrideAccess: true })
       const doc = await payload.create({
         collection: 'virtual-relations',
         data: {},
         depth: 0,
+        overrideAccess: true,
       })
 
       const updated = await payload.update({
@@ -3945,6 +4172,7 @@ test.suite({ config: './config.ts' })('database', () => {
         id: doc.id,
         data: { post: post.id },
         depth: 0,
+        overrideAccess: true,
       })
 
       expect(updated.postTitle).toBe('post-updated')
@@ -3953,36 +4181,43 @@ test.suite({ config: './config.ts' })('database', () => {
     test('should allow to sort by a virtual field with a reference to an ID', async ({
       payload,
     }) => {
-      await payload.delete({ collection: 'virtual-relations', where: {} })
+      await payload.delete({ collection: 'virtual-relations', where: {}, overrideAccess: true })
       const category_1 = await payload.create({
         collection: 'categories-custom-id',
         data: { id: 1 },
+        overrideAccess: true,
       })
       const category_2 = await payload.create({
         collection: 'categories-custom-id',
         data: { id: 2 },
+        overrideAccess: true,
       })
       const post_1 = await payload.create({
         collection: 'posts',
         data: { categoryCustomID: category_1.id, title: 'p-1' },
+        overrideAccess: true,
       })
       const post_2 = await payload.create({
         collection: 'posts',
         data: { categoryCustomID: category_2.id, title: 'p-2' },
+        overrideAccess: true,
       })
       const virtual_1 = await payload.create({
         collection: 'virtual-relations',
         data: { post: post_1.id },
+        overrideAccess: true,
       })
       const virtual_2 = await payload.create({
         collection: 'virtual-relations',
         data: { post: post_2.id },
+        overrideAccess: true,
       })
 
       const res = (
         await payload.find({
           collection: 'virtual-relations',
           sort: 'postCategoryCustomID',
+          overrideAccess: true,
         })
       ).docs
       expect(res[0].id).toBe(virtual_1.id)
@@ -3992,6 +4227,7 @@ test.suite({ config: './config.ts' })('database', () => {
         await payload.find({
           collection: 'virtual-relations',
           sort: '-postCategoryCustomID',
+          overrideAccess: true,
         })
       ).docs
       expect(res2[1].id).toBe(virtual_1.id)
@@ -4009,21 +4245,24 @@ test.suite({ config: './config.ts' })('database', () => {
         collection: 'users',
         limit: 1,
         where: { email: { equals: devUser.email } },
+        overrideAccess: true,
       })
       if (existingUsers.length === 0) {
-        await payload.create({ collection: 'users', data: devUser })
+        await payload.create({ collection: 'users', data: devUser, overrideAccess: true })
       }
       await restClient.login({ slug: 'users', credentials: devUser })
 
-      const post_1 = await payload.create({ collection: 'posts', data: { title: 'A' } })
-      const post_2 = await payload.create({ collection: 'posts', data: { title: 'B' } })
+      const post_1 = await payload.create({ collection: 'posts', data: { title: 'A' }, overrideAccess: true })
+      const post_2 = await payload.create({ collection: 'posts', data: { title: 'B' }, overrideAccess: true })
       const doc_1 = await payload.create({
         collection: 'virtual-relations',
         data: { post: post_1 },
+        overrideAccess: true,
       })
       const doc_2 = await payload.create({
         collection: 'virtual-relations',
         data: { post: post_2 },
+        overrideAccess: true,
       })
 
       const queryDesc = `query {
@@ -4048,6 +4287,7 @@ test.suite({ config: './config.ts' })('database', () => {
         collection: 'virtual-relations',
         sort: '-postTitle',
         where: { id: { in: [doc_1.id, doc_2.id] } },
+        overrideAccess: true,
       })
 
       expect(graphqlDesc[0].id).toBe(doc_2.id)
@@ -4077,6 +4317,7 @@ test.suite({ config: './config.ts' })('database', () => {
         collection: 'virtual-relations',
         sort: 'postTitle',
         where: { id: { in: [doc_1.id, doc_2.id] } },
+        overrideAccess: true,
       })
 
       expect(graphqlAsc[1].id).toBe(doc_2.id)
@@ -4086,14 +4327,16 @@ test.suite({ config: './config.ts' })('database', () => {
     })
 
     test('should allow to sort by a virtual field without error', async ({ payload }) => {
-      await payload.delete({ collection: fieldsPersistanceSlug, where: {} })
+      await payload.delete({ collection: fieldsPersistanceSlug, where: {}, overrideAccess: true })
       await payload.create({
         collection: fieldsPersistanceSlug,
         data: {},
+        overrideAccess: true,
       })
       const { docs } = await payload.find({
         collection: fieldsPersistanceSlug,
         sort: '-textHooked',
+        overrideAccess: true,
       })
       expect(docs).toHaveLength(1)
     })
@@ -4109,17 +4352,18 @@ test.suite({ config: './config.ts' })('database', () => {
     })
 
     test('should the value populate with hasMany: true relationship field', async ({ payload }) => {
-      await payload.delete({ collection: 'categories', where: {} })
-      await payload.delete({ collection: 'posts', where: {} })
-      await payload.delete({ collection: 'virtual-relations', where: {} })
+      await payload.delete({ collection: 'categories', where: {}, overrideAccess: true })
+      await payload.delete({ collection: 'posts', where: {}, overrideAccess: true })
+      await payload.delete({ collection: 'virtual-relations', where: {}, overrideAccess: true })
 
-      const post1 = await payload.create({ collection: 'posts', data: { title: 'post 1' } })
-      const post2 = await payload.create({ collection: 'posts', data: { title: 'post 2' } })
+      const post1 = await payload.create({ collection: 'posts', data: { title: 'post 1' }, overrideAccess: true })
+      const post2 = await payload.create({ collection: 'posts', data: { title: 'post 2' }, overrideAccess: true })
 
       const res = await payload.create({
         collection: 'virtual-relations',
         data: { posts: [post1.id, post2.id] },
         depth: 0,
+        overrideAccess: true,
       })
       expect(res.postsTitles).toEqual(['post 1', 'post 2'])
     })
@@ -4127,27 +4371,31 @@ test.suite({ config: './config.ts' })('database', () => {
     test('should the value populate with nested hasMany: true relationship field', async ({
       payload,
     }) => {
-      await payload.delete({ collection: 'categories', where: {} })
-      await payload.delete({ collection: 'posts', where: {} })
-      await payload.delete({ collection: 'virtual-relations', where: {} })
+      await payload.delete({ collection: 'categories', where: {}, overrideAccess: true })
+      await payload.delete({ collection: 'posts', where: {}, overrideAccess: true })
+      await payload.delete({ collection: 'virtual-relations', where: {}, overrideAccess: true })
 
       const category_1 = await payload.create({
         collection: 'categories',
         data: { title: 'category 1' },
+        overrideAccess: true,
       })
       const category_2 = await payload.create({
         collection: 'categories',
         data: { title: 'category 2' },
+        overrideAccess: true,
       })
       const post1 = await payload.create({
         collection: 'posts',
         data: { categories: [category_1.id, category_2.id], title: 'post 1' },
+        overrideAccess: true,
       })
 
       const res = await payload.create({
         collection: 'virtual-relations',
         data: { post: post1.id },
         depth: 0,
+        overrideAccess: true,
       })
       expect(res.postCategoriesTitles).toEqual(['category 1', 'category 2'])
     })
@@ -4158,16 +4406,19 @@ test.suite({ config: './config.ts' })('database', () => {
       const tenant = await payload.create({
         collection: 'virtual-linked-tenants',
         data: { slug: 'my-tenant' },
+        overrideAccess: true,
       })
 
       const project = await payload.create({
         collection: 'virtual-linked-projects',
         data: {},
+        overrideAccess: true,
       })
 
       await payload.create({
         collection: 'virtual-linked-roles',
         data: { project: project.id, tenant: tenant.id },
+        overrideAccess: true,
       })
 
       const result = await payload.find({
@@ -4188,6 +4439,7 @@ test.suite({ config: './config.ts' })('database', () => {
         // @ts-expect-error hardcoding a number and expecting that it will convert to string
         text: 1,
       },
+      overrideAccess: true,
     })
 
     expect(result.text).toStrictEqual('1')
@@ -4201,6 +4453,7 @@ test.suite({ config: './config.ts' })('database', () => {
         // @ts-expect-error passing strings when numbers are expected
         numbersHasMany: ['10', '20', '30'],
       },
+      overrideAccess: true,
     })
 
     expect(result.numbersHasMany).toEqual([10, 20, 30])
@@ -4215,6 +4468,7 @@ test.suite({ config: './config.ts' })('database', () => {
         title: 'testing-date-field',
         publishDate: testDate,
       },
+      overrideAccess: true,
     })
 
     // Dates should be stored as ISO strings
@@ -4225,6 +4479,7 @@ test.suite({ config: './config.ts' })('database', () => {
     const retrieved = await payload.findByID({
       collection: postsSlug,
       id: result.id,
+      overrideAccess: true,
     })
 
     expect(typeof retrieved.publishDate).toBe('string')
@@ -4255,6 +4510,7 @@ test.suite({ config: './config.ts' })('database', () => {
       payload.find({
         collection: 'fields-persistance',
         where: { text: { equals: 'asd' } },
+        overrideAccess: true,
       }),
     ).rejects.toThrow(QueryError)
   })
@@ -4271,6 +4527,7 @@ test.suite({ config: './config.ts' })('database', () => {
       invalidDoc = await payload.create({
         collection: 'relation-b',
         data: { relationship: invalidId, title: 'invalid' },
+        overrideAccess: true,
       })
     } catch (error) {
       // instanceof checks don't work with libsql
@@ -4281,6 +4538,7 @@ test.suite({ config: './config.ts' })('database', () => {
 
     const relationBDocs = await payload.find({
       collection: 'relation-b',
+      overrideAccess: true,
     })
 
     expect(relationBDocs.docs).toHaveLength(0)
@@ -4393,9 +4651,9 @@ test.suite({ config: './config.ts' })('database', () => {
   })
 
   test('should enforce unique ids on db level even after delete', async ({ payload }) => {
-    const { id } = await payload.create({ collection: postsSlug, data: { title: 'ASD' } })
-    await payload.delete({ id, collection: postsSlug })
-    const { id: id_2 } = await payload.create({ collection: postsSlug, data: { title: 'ASD' } })
+    const { id } = await payload.create({ collection: postsSlug, data: { title: 'ASD' }, overrideAccess: true })
+    await payload.delete({ id, collection: postsSlug, overrideAccess: true })
+    const { id: id_2 } = await payload.create({ collection: postsSlug, data: { title: 'ASD' }, overrideAccess: true })
     expect(id_2).not.toBe(id)
   })
 
@@ -4435,6 +4693,7 @@ test.suite({ config: './config.ts' })('database', () => {
     let result = (await payload.updateGlobal({
       slug: 'global-3',
       data: { text: 'this is global-3' },
+      overrideAccess: true,
     })) as { globalType: string } & Global2
 
     expect(result.text).toBe('this is global-3')
@@ -4449,6 +4708,7 @@ test.suite({ config: './config.ts' })('database', () => {
     result = (await payload.updateGlobal({
       slug: 'global-3',
       data: { text: 'this is global-3 but updated' },
+      overrideAccess: true,
     })) as { globalType: string } & Global2
 
     expect(result.text).toBe('this is global-3 but updated')
@@ -4464,6 +4724,7 @@ test.suite({ config: './config.ts' })('database', () => {
       data: {
         title: 'post 1',
       },
+      overrideAccess: true,
     })
 
     const doc2 = await payload.create({
@@ -4471,6 +4732,7 @@ test.suite({ config: './config.ts' })('database', () => {
       data: {
         title: 'post 2',
       },
+      overrideAccess: true,
     })
 
     const query1 = await payload.find({
@@ -4482,6 +4744,7 @@ test.suite({ config: './config.ts' })('database', () => {
           not_in: [],
         },
       },
+      overrideAccess: true,
     })
 
     const query2 = await payload.find({
@@ -4493,6 +4756,7 @@ test.suite({ config: './config.ts' })('database', () => {
           not_in: [],
         },
       },
+      overrideAccess: true,
     })
 
     const query3 = await payload.find({
@@ -4507,6 +4771,7 @@ test.suite({ config: './config.ts' })('database', () => {
           },
         ],
       },
+      overrideAccess: true,
     })
 
     expect(query1.totalDocs).toEqual(1)
@@ -4546,6 +4811,7 @@ test.suite({ config: './config.ts' })('database', () => {
     let payloadRes: any = await payload.findByID({
       id: res!.insertedId.toHexString(),
       collection: postsSlug,
+      overrideAccess: true,
     })
 
     expect(payloadRes.id).toBe(res!.insertedId.toHexString())
@@ -4561,6 +4827,7 @@ test.suite({ config: './config.ts' })('database', () => {
     payloadRes = await payload.findByID({
       id: res!.insertedId.toHexString(),
       collection: postsSlug,
+      overrideAccess: true,
     })
 
     expect(payloadRes.id).toBe(res!.insertedId.toHexString())
@@ -4571,7 +4838,7 @@ test.suite({ config: './config.ts' })('database', () => {
   })
 
   test('should not crash when the version field is not selected', async ({ payload }) => {
-    const customID = await payload.create({ collection: 'custom-ids', data: {} })
+    const customID = await payload.create({ collection: 'custom-ids', data: {}, overrideAccess: true })
     const res = await payload.db.queryDrafts({
       collection: 'custom-ids',
       select: { parent: true },
@@ -4585,9 +4852,10 @@ test.suite({ config: './config.ts' })('database', () => {
     await payload.updateGlobal({
       slug: 'header',
       data: { itemsLvl1: [{ itemsLvl2: [{ itemsLvl3: [{ itemsLvl4: [{ label: 'label' }] }] }] }] },
+      overrideAccess: true,
     })
 
-    const header = await payload.findGlobal({ slug: 'header' })
+    const header = await payload.findGlobal({ slug: 'header', overrideAccess: true })
 
     expect(header.itemsLvl1[0]?.itemsLvl2[0]?.itemsLvl3[0]?.itemsLvl4[0]?.label).toBe('label')
   })
@@ -4596,10 +4864,12 @@ test.suite({ config: './config.ts' })('database', () => {
     const category = await payload.create({
       collection: 'categories',
       data: { title: 'new-category' },
+      overrideAccess: true,
     })
     const post = await payload.create({
       collection: 'posts',
       data: { category: category.id, title: 'new-post' },
+      overrideAccess: true,
     })
 
     const result_1 = await payload.count({
@@ -4609,6 +4879,7 @@ test.suite({ config: './config.ts' })('database', () => {
           equals: 'new-category',
         },
       },
+      overrideAccess: true,
     })
 
     expect(result_1.totalDocs).toBe(1)
@@ -4620,6 +4891,7 @@ test.suite({ config: './config.ts' })('database', () => {
           equals: 'non-existing-category',
         },
       },
+      overrideAccess: true,
     })
 
     expect(result_2.totalDocs).toBe(0)
@@ -4632,6 +4904,7 @@ test.suite({ config: './config.ts' })('database', () => {
         testBlocks: [{ blockType: 'cta', text: 'text' }],
         testBlocksLocalized: [{ blockType: 'cta', text: 'text-localized' }],
       },
+      overrideAccess: true,
     })
 
     expect(res.testBlocks[0]?.text).toBe('text')
@@ -4639,27 +4912,32 @@ test.suite({ config: './config.ts' })('database', () => {
   })
 
   test('should support in with null', async ({ payload }) => {
-    await payload.delete({ collection: 'posts', where: {} })
+    await payload.delete({ collection: 'posts', where: {}, overrideAccess: true })
     const post_1 = await payload.create({
       collection: 'posts',
       data: { text: 'text-1', title: 'a' },
+      overrideAccess: true,
     })
     const post_2 = await payload.create({
       collection: 'posts',
       data: { text: 'text-2', title: 'a' },
+      overrideAccess: true,
     })
     const post_3 = await payload.create({
       collection: 'posts',
       data: { text: 'text-3', title: 'a' },
+      overrideAccess: true,
     })
     const post_null = await payload.create({
       collection: 'posts',
       data: { text: null, title: 'a' },
+      overrideAccess: true,
     })
 
     const { docs } = await payload.find({
       collection: 'posts',
       where: { text: { in: ['text-1', 'text-3', null] } },
+      overrideAccess: true,
     })
     expect(docs).toHaveLength(3)
     expect(docs[0].id).toBe(post_null.id)
@@ -4673,6 +4951,7 @@ test.suite({ config: './config.ts' })('database', () => {
       data: {
         slugField: 'unique-text',
       },
+      overrideAccess: true,
     })
 
     try {
@@ -4681,6 +4960,7 @@ test.suite({ config: './config.ts' })('database', () => {
         data: {
           slugField: 'unique-text',
         },
+        overrideAccess: true,
       })
     } catch (e) {
       const error = e as ValidationError
@@ -4695,6 +4975,7 @@ test.suite({ config: './config.ts' })('database', () => {
       data: {
         slugField: 'optimized-unique-1',
       },
+      overrideAccess: true,
     })
 
     const doc2 = await payload.create({
@@ -4702,6 +4983,7 @@ test.suite({ config: './config.ts' })('database', () => {
       data: {
         slugField: 'optimized-unique-2',
       },
+      overrideAccess: true,
     })
 
     // This update goes through the optimized path (shouldUseOptimizedUpsertRow) in db-drizzle
@@ -4713,6 +4995,7 @@ test.suite({ config: './config.ts' })('database', () => {
         data: {
           slugField: 'optimized-unique-1', // Try to set to doc1's unique value
         },
+        overrideAccess: true,
       })
     } catch (e) {
       const error = e as ValidationError
@@ -4731,6 +5014,7 @@ test.suite({ config: './config.ts' })('database', () => {
         text: 'other text (should not be nuked)',
         title: 'hello',
       },
+      overrideAccess: true,
     })
     const res = (await payload.db.updateOne({
       collection: 'posts',
@@ -4760,6 +5044,7 @@ test.suite({ config: './config.ts' })('database', () => {
         text: 'other text (should not be nuked)',
         title: 'hello',
       },
+      overrideAccess: true,
     })
     const post2 = await payload.create({
       collection: 'posts',
@@ -4770,6 +5055,7 @@ test.suite({ config: './config.ts' })('database', () => {
         text: 'other text 2 (should not be nuked)',
         title: 'hello',
       },
+      overrideAccess: true,
     })
 
     const res = (await payload.db.updateMany({
@@ -4827,18 +5113,20 @@ test.suite({ config: './config.ts' })('database', () => {
     const category = await payload.create({
       collection: 'categories',
       data: { title: 'category123' },
+      overrideAccess: true,
     })
     const res = await payload.find({
       collection: 'categories',
       draft: true,
       where: { id: { like: typeof category.id === 'number' ? `${category.id}` : category.id } },
+      overrideAccess: true,
     })
     expect(res.docs).toHaveLength(1)
     expect(res.docs[0].id).toBe(category.id)
   })
 
   test('should allow incremental number update', async ({ payload }) => {
-    const post = await payload.create({ collection: 'posts', data: { number: 1, title: 'post' } })
+    const post = await payload.create({ collection: 'posts', data: { number: 1, title: 'post' }, overrideAccess: true })
 
     const res = (await payload.db.updateOne({
       collection: 'posts',
@@ -4878,6 +5166,7 @@ test.suite({ config: './config.ts' })('database', () => {
           number: 10,
           title: 'post',
         },
+        overrideAccess: true,
       })
 
       const res = (await payload.db.updateOne({
@@ -4915,6 +5204,7 @@ test.suite({ config: './config.ts' })('database', () => {
           ],
           title: 'post',
         },
+        overrideAccess: true,
       })
 
       const res = (await payload.db.updateOne({
@@ -4948,6 +5238,7 @@ test.suite({ config: './config.ts' })('database', () => {
           ],
           title: 'post',
         },
+        overrideAccess: true,
       })
 
       const res = (await payload.db.updateOne({
@@ -4994,6 +5285,7 @@ test.suite({ config: './config.ts' })('database', () => {
           ],
           title: 'post',
         },
+        overrideAccess: true,
       })
 
       const res = (await payload.db.updateOne({
@@ -5040,6 +5332,7 @@ test.suite({ config: './config.ts' })('database', () => {
           ],
           title: 'post',
         },
+        overrideAccess: true,
       })
 
       const res = (await payload.db.updateOne({
@@ -5081,6 +5374,7 @@ test.suite({ config: './config.ts' })('database', () => {
           ],
           title: 'post',
         },
+        overrideAccess: true,
       })
 
       const res = (await payload.db.updateOne({
@@ -5143,6 +5437,7 @@ test.suite({ config: './config.ts' })('database', () => {
           ],
           title: 'post',
         },
+        overrideAccess: true,
       })
 
       const res = (await payload.db.updateOne({
@@ -5192,10 +5487,12 @@ test.suite({ config: './config.ts' })('database', () => {
       const cat1 = await payload.create({
         collection: 'categories',
         data: { title: 'Category 1' },
+        overrideAccess: true,
       })
       const cat2 = await payload.create({
         collection: 'categories',
         data: { title: 'Category 2' },
+        overrideAccess: true,
       })
 
       // Create a post with initial relationship
@@ -5206,6 +5503,7 @@ test.suite({ config: './config.ts' })('database', () => {
           title: 'Test Post',
         },
         depth: 0,
+        overrideAccess: true,
       })
 
       expect(post.categories).toHaveLength(1)
@@ -5234,14 +5532,17 @@ test.suite({ config: './config.ts' })('database', () => {
       const cat1 = await payload.create({
         collection: 'categories',
         data: { title: 'Category 1' },
+        overrideAccess: true,
       })
       const cat2 = await payload.create({
         collection: 'categories',
         data: { title: 'Category 2' },
+        overrideAccess: true,
       })
       const cat3 = await payload.create({
         collection: 'categories',
         data: { title: 'Category 3' },
+        overrideAccess: true,
       })
 
       // Create post with initial relationship
@@ -5251,6 +5552,7 @@ test.suite({ config: './config.ts' })('database', () => {
           categories: [cat1.id],
           title: 'Test Post',
         },
+        overrideAccess: true,
       })
 
       // Append multiple relationships using $push
@@ -5277,10 +5579,12 @@ test.suite({ config: './config.ts' })('database', () => {
       const cat1 = await payload.create({
         collection: 'categories',
         data: { title: 'Category 1' },
+        overrideAccess: true,
       })
       const cat2 = await payload.create({
         collection: 'categories',
         data: { title: 'Category 2' },
+        overrideAccess: true,
       })
 
       // Create post with initial relationships
@@ -5290,6 +5594,7 @@ test.suite({ config: './config.ts' })('database', () => {
           categories: [cat1.id, cat2.id],
           title: 'Test Post',
         },
+        overrideAccess: true,
       })
 
       // Try to append existing relationship - should not create duplicates
@@ -5315,10 +5620,12 @@ test.suite({ config: './config.ts' })('database', () => {
       const cat1 = await payload.create({
         collection: 'categories',
         data: { title: 'Category 1' },
+        overrideAccess: true,
       })
       const cat2 = await payload.create({
         collection: 'categories',
         data: { title: 'Category 2' },
+        overrideAccess: true,
       })
 
       // Create multiple posts with initial relationships
@@ -5328,6 +5635,7 @@ test.suite({ config: './config.ts' })('database', () => {
           categories: [cat1.id],
           title: 'Post 1',
         },
+        overrideAccess: true,
       })
       const post2 = await payload.create({
         collection: 'posts',
@@ -5335,6 +5643,7 @@ test.suite({ config: './config.ts' })('database', () => {
           categories: [cat1.id],
           title: 'Post 2',
         },
+        overrideAccess: true,
       })
 
       // Append cat2 to all posts using updateMany
@@ -5364,10 +5673,12 @@ test.suite({ config: './config.ts' })('database', () => {
       const category = await payload.create({
         collection: 'categories',
         data: { title: 'Test Category' },
+        overrideAccess: true,
       })
       const simple = await payload.create({
         collection: 'simple',
         data: { text: 'Test Simple' },
+        overrideAccess: true,
       })
 
       // Create post with initial polymorphic relationship
@@ -5382,7 +5693,8 @@ test.suite({ config: './config.ts' })('database', () => {
           ],
           title: 'Test Post',
         },
-        depth: 0, // Don't populate relationships
+        depth: 0,
+        overrideAccess: true, // Don't populate relationships
       })
 
       expect(post.polymorphicRelations).toHaveLength(1)
@@ -5425,6 +5737,7 @@ test.suite({ config: './config.ts' })('database', () => {
       const category = await payload.create({
         collection: 'categories',
         data: { title: 'Test Category' },
+        overrideAccess: true,
       })
 
       // Create post with polymorphic relationship
@@ -5440,6 +5753,7 @@ test.suite({ config: './config.ts' })('database', () => {
           title: 'Test Post',
         },
         depth: 0,
+        overrideAccess: true,
       })
 
       // Try to append the same relationship - should not create duplicates
@@ -5470,10 +5784,12 @@ test.suite({ config: './config.ts' })('database', () => {
       const category1 = await payload.create({
         collection: 'categories',
         data: { title: 'Category 1' },
+        overrideAccess: true,
       })
       const category2 = await payload.create({
         collection: 'categories',
         data: { title: 'Category 2' },
+        overrideAccess: true,
       })
 
       // Create post with localized polymorphic relationships
@@ -5490,6 +5806,7 @@ test.suite({ config: './config.ts' })('database', () => {
         },
         depth: 0,
         locale: 'en',
+        overrideAccess: true,
       })
 
       // Append relationship using $push with correct localized structure
@@ -5528,11 +5845,13 @@ test.suite({ config: './config.ts' })('database', () => {
       const category1 = await payload.create({
         collection: 'categories',
         data: { title: 'Category 1' },
+        overrideAccess: true,
       })
 
       const category2 = await payload.create({
         collection: 'categories',
         data: { title: 'Category 2' },
+        overrideAccess: true,
       })
 
       // Create a post with nested localized polymorphic relationship
@@ -5550,6 +5869,7 @@ test.suite({ config: './config.ts' })('database', () => {
           title: 'Test Nested $push',
         },
         locale: 'en',
+        overrideAccess: true,
       })
 
       // Use low-level API to push new items
@@ -5576,6 +5896,7 @@ test.suite({ config: './config.ts' })('database', () => {
         collection: 'posts',
         depth: 0,
         locale: 'en',
+        overrideAccess: true,
       })
 
       expect(result.testNestedGroup?.nestedLocalizedPolymorphicRelation).toHaveLength(2)
@@ -5598,10 +5919,12 @@ test.suite({ config: './config.ts' })('database', () => {
       const cat1 = await payload.create({
         collection: 'categories',
         data: { title: 'Category 1' },
+        overrideAccess: true,
       })
       const cat2 = await payload.create({
         collection: 'categories',
         data: { title: 'Category 2' },
+        overrideAccess: true,
       })
 
       // Create post with relationships
@@ -5611,6 +5934,7 @@ test.suite({ config: './config.ts' })('database', () => {
           categories: [cat1.id, cat2.id],
           title: 'Test Post',
         },
+        overrideAccess: true,
       })
 
       expect(post.categories).toHaveLength(2)
@@ -5635,14 +5959,17 @@ test.suite({ config: './config.ts' })('database', () => {
       const cat1 = await payload.create({
         collection: 'categories',
         data: { title: 'Category 1' },
+        overrideAccess: true,
       })
       const cat2 = await payload.create({
         collection: 'categories',
         data: { title: 'Category 2' },
+        overrideAccess: true,
       })
       const cat3 = await payload.create({
         collection: 'categories',
         data: { title: 'Category 3' },
+        overrideAccess: true,
       })
 
       // Create post with relationships
@@ -5652,6 +5979,7 @@ test.suite({ config: './config.ts' })('database', () => {
           categories: [cat1.id, cat2.id, cat3.id],
           title: 'Test Post',
         },
+        overrideAccess: true,
       })
 
       expect(post.categories).toHaveLength(3)
@@ -5676,14 +6004,17 @@ test.suite({ config: './config.ts' })('database', () => {
       const cat1 = await payload.create({
         collection: 'categories',
         data: { title: 'Category 1' },
+        overrideAccess: true,
       })
       const cat2 = await payload.create({
         collection: 'categories',
         data: { title: 'Category 2' },
+        overrideAccess: true,
       })
       const cat3 = await payload.create({
         collection: 'categories',
         data: { title: 'Category 3' },
+        overrideAccess: true,
       })
 
       // Create multiple posts with relationships
@@ -5693,6 +6024,7 @@ test.suite({ config: './config.ts' })('database', () => {
           categories: [cat1.id, cat2.id, cat3.id],
           title: 'Post 1',
         },
+        overrideAccess: true,
       })
       const post2 = await payload.create({
         collection: 'posts',
@@ -5700,6 +6032,7 @@ test.suite({ config: './config.ts' })('database', () => {
           categories: [cat1.id, cat2.id, cat3.id],
           title: 'Post 2',
         },
+        overrideAccess: true,
       })
 
       // Remove cat1 and cat3 from all posts using updateMany
@@ -5730,10 +6063,12 @@ test.suite({ config: './config.ts' })('database', () => {
       const category1 = await payload.create({
         collection: 'categories',
         data: { title: 'Test Category 1' },
+        overrideAccess: true,
       })
       const category2 = await payload.create({
         collection: 'categories',
         data: { title: 'Test Category 2' },
+        overrideAccess: true,
       })
 
       // Create post with multiple polymorphic relationships
@@ -5753,6 +6088,7 @@ test.suite({ config: './config.ts' })('database', () => {
           title: 'Test Post',
         },
         depth: 0,
+        overrideAccess: true,
       })
 
       expect(post.polymorphicRelations).toHaveLength(2)
@@ -5785,14 +6121,17 @@ test.suite({ config: './config.ts' })('database', () => {
       const category1 = await payload.create({
         collection: 'categories',
         data: { title: 'Test Category 1' },
+        overrideAccess: true,
       })
       const category2 = await payload.create({
         collection: 'categories',
         data: { title: 'Test Category 2' },
+        overrideAccess: true,
       })
       const simple = await payload.create({
         collection: 'simple',
         data: { text: 'Test Simple' },
+        overrideAccess: true,
       })
 
       // Create post with multiple polymorphic relationships
@@ -5807,6 +6146,7 @@ test.suite({ config: './config.ts' })('database', () => {
           title: 'Test Post',
         },
         depth: 0,
+        overrideAccess: true,
       })
 
       expect(post.polymorphicRelations).toHaveLength(3)
@@ -5837,14 +6177,17 @@ test.suite({ config: './config.ts' })('database', () => {
       const category1 = await payload.create({
         collection: 'categories',
         data: { title: 'Category 1' },
+        overrideAccess: true,
       })
       const category2 = await payload.create({
         collection: 'categories',
         data: { title: 'Category 2' },
+        overrideAccess: true,
       })
       const category3 = await payload.create({
         collection: 'categories',
         data: { title: 'Category 3' },
+        overrideAccess: true,
       })
 
       // Create post with multiple localized polymorphic relationships
@@ -5860,6 +6203,7 @@ test.suite({ config: './config.ts' })('database', () => {
         },
         depth: 0,
         locale: 'en',
+        overrideAccess: true,
       })
 
       // Remove relationships using $remove with correct localized structure
@@ -5900,16 +6244,19 @@ test.suite({ config: './config.ts' })('database', () => {
       const category1 = await payload.create({
         collection: 'categories',
         data: { title: 'Category 1' },
+        overrideAccess: true,
       })
 
       const category2 = await payload.create({
         collection: 'categories',
         data: { title: 'Category 2' },
+        overrideAccess: true,
       })
 
       const simple1 = await payload.create({
         collection: 'simple',
         data: { text: 'Simple 1' },
+        overrideAccess: true,
       })
 
       // Create a post with multiple items in nested localized polymorphic relationship
@@ -5935,6 +6282,7 @@ test.suite({ config: './config.ts' })('database', () => {
           title: 'Test Nested $remove',
         },
         locale: 'en',
+        overrideAccess: true,
       })
 
       // Use low-level API to remove items
@@ -5959,6 +6307,7 @@ test.suite({ config: './config.ts' })('database', () => {
         collection: 'posts',
         depth: 0,
         locale: 'en',
+        overrideAccess: true,
       })
 
       expect(result.testNestedGroup?.nestedLocalizedPolymorphicRelation).toHaveLength(1)
@@ -5986,6 +6335,7 @@ test.suite({ config: './config.ts' })('database', () => {
         ],
         title: 'title',
       },
+      overrideAccess: true,
     })
 
     expect(res.blocks).toHaveLength(1)
@@ -6032,6 +6382,7 @@ test.suite({ config: './config.ts' })('database', () => {
       id: res?.insertedId?.toHexString() as string,
       collection: 'blocks-docs',
       locale: 'en',
+      overrideAccess: true,
     })
     expect(doc.testBlocks).toHaveLength(1)
     expect(doc.testBlocks[0].id).toBe('1')
@@ -6057,6 +6408,7 @@ test.suite({ config: './config.ts' })('database', () => {
         testBlocks: [{ blockType: 'cta', text: 'text' }],
         testBlocksLocalized: [{ blockType: 'cta', text: 'text-localized' }],
       },
+      overrideAccess: true,
     })
     expect(res.testBlocks[0]?.text).toBe('text')
     expect(res.testBlocksLocalized[0]?.text).toBe('text-localized')
@@ -6068,6 +6420,7 @@ test.suite({ config: './config.ts' })('database', () => {
         testBlocksLocalized: [{ blockType: 'cta', text: 'text-localized-es' }],
       },
       locale: 'es',
+      overrideAccess: true,
     })
     expect(res_es.testBlocks[0]?.text).toBe('text_updated')
     expect(res_es.testBlocksLocalized[0]?.text).toBe('text-localized-es')
@@ -6075,6 +6428,7 @@ test.suite({ config: './config.ts' })('database', () => {
       id: res.id,
       collection: 'blocks-docs',
       locale: 'all',
+      overrideAccess: true,
     })
     expect(res_all.testBlocks[0]?.text).toBe('text_updated')
     expect(res_all.testBlocksLocalized.es[0]?.text).toBe('text-localized-es')
@@ -6112,7 +6466,7 @@ test.suite({ config: './config.ts' })('database', () => {
     'ensure mongodb respects collation when using collection in the config',
     async ({ payload }) => {
       // Clear any existing documents
-      await payload.delete({ collection: 'simple', where: {} })
+      await payload.delete({ collection: 'simple', where: {}, overrideAccess: true })
 
       const expectedUnsortedItems = ['Євген', 'Віктор', 'Роман']
       const expectedSortedItems = ['Віктор', 'Євген', 'Роман']
@@ -6121,22 +6475,26 @@ test.suite({ config: './config.ts' })('database', () => {
         collection: 'simple',
         locale: 'uk',
         data: { text: 'Роман' },
+        overrideAccess: true,
       })
       const simple_2 = await payload.create({
         collection: 'simple',
         locale: 'uk',
         data: { text: 'Віктор' },
+        overrideAccess: true,
       })
       const simple_3 = await payload.create({
         collection: 'simple',
         locale: 'uk',
         data: { text: 'Євген' },
+        overrideAccess: true,
       })
 
       const results = await payload.find({
         collection: 'simple',
         locale: 'uk',
         sort: 'text',
+        overrideAccess: true,
       })
 
       const initialMappedResults = results.docs.map((doc) => doc.text)
@@ -6149,6 +6507,7 @@ test.suite({ config: './config.ts' })('database', () => {
         collection: 'simple',
         locale: 'uk',
         sort: 'text',
+        overrideAccess: true,
       })
 
       const collatedMappedResults = resultsWithCollation.docs.map((doc) => doc.text)
@@ -6163,7 +6522,7 @@ test.suite({ config: './config.ts' })('database', () => {
     'ensure mongodb collation works with draft pagination without sort',
     async ({ payload }) => {
       // Clear any existing documents
-      await payload.delete({ collection: 'categories', where: {} })
+      await payload.delete({ collection: 'categories', where: {}, overrideAccess: true })
 
       // Create 15 draft documents
       const createdIds: (number | string)[] = []
@@ -6172,6 +6531,7 @@ test.suite({ config: './config.ts' })('database', () => {
           collection: 'categories',
           data: { name: `Category ${i}` },
           draft: true,
+          overrideAccess: true,
         })
         createdIds.push(doc.id)
       }
@@ -6184,6 +6544,7 @@ test.suite({ config: './config.ts' })('database', () => {
         collection: 'categories',
         limit: 10,
         draft: true,
+        overrideAccess: true,
         // No sort parameter
       })
 
@@ -6202,7 +6563,7 @@ test.suite({ config: './config.ts' })('database', () => {
 
       // Clean up
       for (const id of createdIds) {
-        await payload.delete({ collection: 'categories', id })
+        await payload.delete({ collection: 'categories', id, overrideAccess: true })
       }
 
       // Reset collation

--- a/test/database/migrate-to-blocks-as-json/int.spec.ts
+++ b/test/database/migrate-to-blocks-as-json/int.spec.ts
@@ -41,6 +41,7 @@ test.suite({ db: 'drizzle' })('migrateToBlocksAsJSON', () => {
         name: 'Related Item 1',
       },
       depth: 0,
+      overrideAccess: true,
     })
 
     // Seed many documents to test batching (250 documents to ensure multiple batches with default size of 100)
@@ -59,6 +60,7 @@ test.suite({ db: 'drizzle' })('migrateToBlocksAsJSON', () => {
             },
           ],
         },
+        overrideAccess: true,
       })
       batchPosts.push(batchPost.id)
     }
@@ -79,6 +81,7 @@ test.suite({ db: 'drizzle' })('migrateToBlocksAsJSON', () => {
           },
         ],
       },
+      overrideAccess: true,
     })
 
     const versionedPost = await payload.create({
@@ -95,6 +98,7 @@ test.suite({ db: 'drizzle' })('migrateToBlocksAsJSON', () => {
           },
         ],
       },
+      overrideAccess: true,
     })
 
     // create another version of post
@@ -112,6 +116,7 @@ test.suite({ db: 'drizzle' })('migrateToBlocksAsJSON', () => {
           },
         ],
       },
+      overrideAccess: true,
     })
 
     // and more
@@ -121,6 +126,7 @@ test.suite({ db: 'drizzle' })('migrateToBlocksAsJSON', () => {
       data: {
         title: 'Versioned Post 1 - Updated Again',
       },
+      overrideAccess: true,
     })
 
     await payload.updateGlobal({
@@ -133,6 +139,7 @@ test.suite({ db: 'drizzle' })('migrateToBlocksAsJSON', () => {
           },
         ],
       },
+      overrideAccess: true,
     })
 
     await payload.updateGlobal({
@@ -145,6 +152,7 @@ test.suite({ db: 'drizzle' })('migrateToBlocksAsJSON', () => {
           },
         ],
       },
+      overrideAccess: true,
     })
 
     await payload.updateGlobal({
@@ -157,6 +165,7 @@ test.suite({ db: 'drizzle' })('migrateToBlocksAsJSON', () => {
           },
         ],
       },
+      overrideAccess: true,
     })
 
     const currentConfig = readFileSync(path.resolve(dirname, 'config.ts'), 'utf-8')
@@ -194,6 +203,7 @@ test.suite({ db: 'drizzle' })('migrateToBlocksAsJSON', () => {
       collection: 'posts',
       id: post.id,
       depth: 0,
+      overrideAccess: true,
     })
 
     expect(updatedPost.content).toEqual([
@@ -212,12 +222,14 @@ test.suite({ db: 'drizzle' })('migrateToBlocksAsJSON', () => {
       collection: 'posts-versioned',
       id: versionedPost.id,
       depth: 0,
+      overrideAccess: true,
     })
 
     // Verify all batch posts were migrated
     const { totalDocs: batchPostsTotal } = await migratedPayload.find({
       // @ts-expect-error not generated
       collection: 'posts-batches',
+      overrideAccess: true,
       limit: 0,
     })
     expect(batchPostsTotal).toBe(1000)
@@ -227,6 +239,7 @@ test.suite({ db: 'drizzle' })('migrateToBlocksAsJSON', () => {
       // @ts-expect-error not generated
       collection: 'posts-batches',
       id: batchPosts[500], // Check middle post
+      overrideAccess: true,
       depth: 0,
     })
     expect(sampleBatchPost.title).toBe('Batch Post 501')
@@ -255,6 +268,7 @@ test.suite({ db: 'drizzle' })('migrateToBlocksAsJSON', () => {
       limit: 0,
       sort: 'createdAt',
       depth: 0,
+      overrideAccess: true,
     })
 
     expect(updatedVersions.totalDocs).toBe(3)
@@ -284,6 +298,7 @@ test.suite({ db: 'drizzle' })('migrateToBlocksAsJSON', () => {
     const updatedGlobal = await migratedPayload.findGlobal({
       slug: 'global',
       depth: 0,
+      overrideAccess: true,
     })
 
     expect(updatedGlobal.content).toEqual([
@@ -298,6 +313,7 @@ test.suite({ db: 'drizzle' })('migrateToBlocksAsJSON', () => {
     const updatedVersionedGlobal = await migratedPayload.findGlobal({
       slug: 'global-versioned',
       depth: 0,
+      overrideAccess: true,
     })
 
     expect(updatedVersionedGlobal.content).toEqual([

--- a/test/database/pg-replica/int.spec.ts
+++ b/test/database/pg-replica/int.spec.ts
@@ -88,7 +88,7 @@ test.suite({ db: (adapter) => adapter === 'postgres-read-replicas' })(
       test('should set lastWriteTimestamp after a create', async () => {
         adapter.lastWriteTimestamp = undefined
 
-        await payload.create({ collection: 'posts', data: { title: 'write-tracking' } })
+        await payload.create({ collection: 'posts', data: { title: 'write-tracking' }, overrideAccess: true })
 
         expect(adapter.lastWriteTimestamp).toBeDefined()
         expect(typeof adapter.lastWriteTimestamp).toBe('number')
@@ -96,19 +96,19 @@ test.suite({ db: (adapter) => adapter === 'postgres-read-replicas' })(
       })
 
       test('should set lastWriteTimestamp after an update', async () => {
-        const doc = await payload.create({ collection: 'posts', data: { title: 'before-update' } })
+        const doc = await payload.create({ collection: 'posts', data: { title: 'before-update' }, overrideAccess: true })
         adapter.lastWriteTimestamp = undefined
 
-        await payload.update({ collection: 'posts', id: doc.id, data: { title: 'after-update' } })
+        await payload.update({ collection: 'posts', id: doc.id, data: { title: 'after-update' }, overrideAccess: true })
 
         expect(adapter.lastWriteTimestamp).toBeDefined()
       })
 
       test('should set lastWriteTimestamp after a delete', async () => {
-        const doc = await payload.create({ collection: 'posts', data: { title: 'to-delete' } })
+        const doc = await payload.create({ collection: 'posts', data: { title: 'to-delete' }, overrideAccess: true })
         adapter.lastWriteTimestamp = undefined
 
-        await payload.delete({ collection: 'posts', id: doc.id })
+        await payload.delete({ collection: 'posts', id: doc.id, overrideAccess: true })
 
         expect(adapter.lastWriteTimestamp).toBeDefined()
       })
@@ -119,20 +119,21 @@ test.suite({ db: (adapter) => adapter === 'postgres-read-replicas' })(
         const doc = await payload.create({
           collection: 'posts',
           data: { title: 'find-after-create' },
+          overrideAccess: true,
         })
 
-        const found = await payload.findByID({ collection: 'posts', id: doc.id })
+        const found = await payload.findByID({ collection: 'posts', id: doc.id, overrideAccess: true })
 
         expect(found).toBeDefined()
         expect(found.title).toBe('find-after-create')
       })
 
       test('should find updated data immediately after updating', async () => {
-        const doc = await payload.create({ collection: 'posts', data: { title: 'original' } })
+        const doc = await payload.create({ collection: 'posts', data: { title: 'original' }, overrideAccess: true })
 
-        await payload.update({ collection: 'posts', id: doc.id, data: { title: 'updated' } })
+        await payload.update({ collection: 'posts', id: doc.id, data: { title: 'updated' }, overrideAccess: true })
 
-        const found = await payload.findByID({ collection: 'posts', id: doc.id })
+        const found = await payload.findByID({ collection: 'posts', id: doc.id, overrideAccess: true })
 
         expect(found.title).toBe('updated')
       })
@@ -140,26 +141,28 @@ test.suite({ db: (adapter) => adapter === 'postgres-read-replicas' })(
       test('should return correct count immediately after creating documents', async () => {
         const unique = `count-test-${Date.now()}`
 
-        await payload.create({ collection: 'posts', data: { title: unique } })
-        await payload.create({ collection: 'posts', data: { title: unique } })
-        await payload.create({ collection: 'posts', data: { title: unique } })
+        await payload.create({ collection: 'posts', data: { title: unique }, overrideAccess: true })
+        await payload.create({ collection: 'posts', data: { title: unique }, overrideAccess: true })
+        await payload.create({ collection: 'posts', data: { title: unique }, overrideAccess: true })
 
         const result = await payload.count({
           collection: 'posts',
           where: { title: { equals: unique } },
+          overrideAccess: true,
         })
 
         expect(result.totalDocs).toBe(3)
       })
 
       test('should not find a document after deleting it', async () => {
-        const doc = await payload.create({ collection: 'posts', data: { title: 'delete-me' } })
+        const doc = await payload.create({ collection: 'posts', data: { title: 'delete-me' }, overrideAccess: true })
 
-        await payload.delete({ collection: 'posts', id: doc.id })
+        await payload.delete({ collection: 'posts', id: doc.id, overrideAccess: true })
 
         const result = await payload.find({
           collection: 'posts',
           where: { id: { equals: doc.id } },
+          overrideAccess: true,
         })
 
         expect(result.docs).toHaveLength(0)
@@ -172,7 +175,7 @@ test.suite({ db: (adapter) => adapter === 'postgres-read-replicas' })(
         adapter.readReplicasAfterWriteInterval = 0
 
         // Create a doc — this sets lastWriteTimestamp
-        await payload.create({ collection: 'posts', data: { title: 'interval-zero' } })
+        await payload.create({ collection: 'posts', data: { title: 'interval-zero' }, overrideAccess: true })
 
         // With interval=0, the window is effectively disabled:
         // Date.now() - lastWriteTimestamp >= 0 is NOT < 0
@@ -191,7 +194,7 @@ test.suite({ db: (adapter) => adapter === 'postgres-read-replicas' })(
     test.describe('expired write window falls back to replica routing', () => {
       test('should route to replica when lastWriteTimestamp is old', async () => {
         // Create a doc so the table has data
-        const doc = await payload.create({ collection: 'posts', data: { title: 'old-write' } })
+        const doc = await payload.create({ collection: 'posts', data: { title: 'old-write' }, overrideAccess: true })
 
         // Simulate an old write (outside the window)
         adapter.lastWriteTimestamp = Date.now() - 10_000
@@ -199,7 +202,7 @@ test.suite({ db: (adapter) => adapter === 'postgres-read-replicas' })(
         // This read should go through adapter.drizzle (replica-wrapped).
         // With real replication in Docker, the replica should have caught up
         // by now, so the read still succeeds.
-        const found = await payload.findByID({ collection: 'posts', id: doc.id })
+        const found = await payload.findByID({ collection: 'posts', id: doc.id, overrideAccess: true })
 
         expect(found).toBeDefined()
         expect(found.title).toBe('old-write')
@@ -211,6 +214,7 @@ test.suite({ db: (adapter) => adapter === 'postgres-read-replicas' })(
         // This exercises createVersion which previously lacked getPrimaryDb,
         // causing the read-back after insert to hit a stale replica
         const doc = await (payload as any).create({
+          overrideAccess: true,
           collection: 'posts',
           data: { title: 'versioned-doc', _status: 'draft' },
           draft: true,
@@ -220,6 +224,7 @@ test.suite({ db: (adapter) => adapter === 'postgres-read-replicas' })(
         expect(doc.title).toBe('versioned-doc')
 
         const versions = await (payload as any).findVersions({
+          overrideAccess: true,
           collection: 'posts',
           where: { parent: { equals: doc.id } },
         })
@@ -229,6 +234,7 @@ test.suite({ db: (adapter) => adapter === 'postgres-read-replicas' })(
 
       test('should update a draft and create a new version without errors', async () => {
         const doc = await (payload as any).create({
+          overrideAccess: true,
           collection: 'posts',
           data: { title: 'draft-original', _status: 'draft' },
           draft: true,
@@ -236,6 +242,7 @@ test.suite({ db: (adapter) => adapter === 'postgres-read-replicas' })(
 
         // This triggers updateOne (has getPrimaryDb) + createVersion (now fixed)
         const updated = await (payload as any).update({
+          overrideAccess: true,
           collection: 'posts',
           id: doc.id,
           data: { title: 'draft-updated' },
@@ -245,6 +252,7 @@ test.suite({ db: (adapter) => adapter === 'postgres-read-replicas' })(
         expect(updated.title).toBe('draft-updated')
 
         const versions = await (payload as any).findVersions({
+          overrideAccess: true,
           collection: 'posts',
           where: { parent: { equals: doc.id } },
         })
@@ -254,12 +262,14 @@ test.suite({ db: (adapter) => adapter === 'postgres-read-replicas' })(
 
       test('should restore a version without errors', async () => {
         const doc = await (payload as any).create({
+          overrideAccess: true,
           collection: 'posts',
           data: { title: 'restore-v1', _status: 'draft' },
           draft: true,
         })
 
         await (payload as any).update({
+          overrideAccess: true,
           collection: 'posts',
           id: doc.id,
           data: { title: 'restore-v2' },
@@ -267,6 +277,7 @@ test.suite({ db: (adapter) => adapter === 'postgres-read-replicas' })(
         })
 
         const versions = await (payload as any).findVersions({
+          overrideAccess: true,
           collection: 'posts',
           where: { parent: { equals: doc.id } },
           sort: '-updatedAt',
@@ -276,6 +287,7 @@ test.suite({ db: (adapter) => adapter === 'postgres-read-replicas' })(
 
         // restoreVersion triggers updateVersion (now fixed)
         const restored = await (payload as any).restoreVersion({
+          overrideAccess: true,
           collection: 'posts',
           id: firstVersion.id,
         })
@@ -288,6 +300,7 @@ test.suite({ db: (adapter) => adapter === 'postgres-read-replicas' })(
       test('should create and update a global without errors', async () => {
         // First update creates the global row (createGlobal, now fixed)
         const result = await (payload as any).updateGlobal({
+          overrideAccess: true,
           slug: 'settings',
           data: { siteTitle: 'My Site' },
         })
@@ -297,6 +310,7 @@ test.suite({ db: (adapter) => adapter === 'postgres-read-replicas' })(
 
         // Second update uses updateGlobal path (also fixed)
         const updated = await (payload as any).updateGlobal({
+          overrideAccess: true,
           slug: 'settings',
           data: { siteTitle: 'Updated Site' },
         })
@@ -307,6 +321,7 @@ test.suite({ db: (adapter) => adapter === 'postgres-read-replicas' })(
       test('should create and update a versioned global without errors', async () => {
         // This exercises createGlobalVersion (now fixed)
         const result = await (payload as any).updateGlobal({
+          overrideAccess: true,
           slug: 'nav',
           data: { label: 'Home' },
         })
@@ -315,6 +330,7 @@ test.suite({ db: (adapter) => adapter === 'postgres-read-replicas' })(
         expect(result.label).toBe('Home')
 
         const versions = await (payload as any).findGlobalVersions({
+          overrideAccess: true,
           slug: 'nav',
         })
 
@@ -322,6 +338,7 @@ test.suite({ db: (adapter) => adapter === 'postgres-read-replicas' })(
 
         // Update again to exercise updateGlobalVersion path
         const updated = await (payload as any).updateGlobal({
+          overrideAccess: true,
           slug: 'nav',
           data: { label: 'Updated Home' },
         })
@@ -335,12 +352,14 @@ test.suite({ db: (adapter) => adapter === 'postgres-read-replicas' })(
         const doc = await payload.create({
           collection: 'posts',
           data: { title: 'to-delete-replica-test' },
+          overrideAccess: true,
         })
 
         // deleteOne reads the doc before deleting (now uses getPrimaryDb)
         const deleted = await payload.delete({
           collection: 'posts',
           id: doc.id,
+          overrideAccess: true,
         })
 
         expect(deleted).toBeDefined()

--- a/test/database/postgres-logs.int.spec.ts
+++ b/test/database/postgres-logs.int.spec.ts
@@ -15,6 +15,7 @@ test.suite({ config: './config.postgreslogs.ts', db: (adapter) => adapter.starts
           text: 'Some title',
           number: 5,
         },
+        overrideAccess: true,
       })
 
       // Count every console log
@@ -45,6 +46,7 @@ test.suite({ config: './config.postgreslogs.ts', db: (adapter) => adapter.starts
           title: 'Some title',
           number: 5,
         },
+        overrideAccess: true,
       })
 
       // Count every console log
@@ -73,6 +75,7 @@ test.suite({ config: './config.postgreslogs.ts', db: (adapter) => adapter.starts
           title: 'Some title',
           number: 5,
         },
+        overrideAccess: true,
       })
       await payload.create({
         collection: 'posts',
@@ -80,6 +83,7 @@ test.suite({ config: './config.postgreslogs.ts', db: (adapter) => adapter.starts
           title: 'Some title 2',
           number: 5,
         },
+        overrideAccess: true,
       })
       await payload.create({
         collection: 'posts',
@@ -87,6 +91,7 @@ test.suite({ config: './config.postgreslogs.ts', db: (adapter) => adapter.starts
           title: 'Some title 2',
           number: 5,
         },
+        overrideAccess: true,
       })
       // Count every console log
       const consoleCount = vitest.spyOn(console, 'log').mockImplementation(() => {})
@@ -101,6 +106,7 @@ test.suite({ config: './config.postgreslogs.ts', db: (adapter) => adapter.starts
 
       const allPosts = await payload.find({
         collection: 'posts',
+        overrideAccess: true,
       })
 
       expect(allPosts.docs).toHaveLength(0)
@@ -115,6 +121,7 @@ test.suite({ config: './config.postgreslogs.ts', db: (adapter) => adapter.starts
           title: 'Some title',
           number: 5,
         },
+        overrideAccess: true,
       })
       await payload.create({
         collection: 'posts',
@@ -122,6 +129,7 @@ test.suite({ config: './config.postgreslogs.ts', db: (adapter) => adapter.starts
           title: 'Some title 2',
           number: 5,
         },
+        overrideAccess: true,
       })
       await payload.create({
         collection: 'posts',
@@ -129,6 +137,7 @@ test.suite({ config: './config.postgreslogs.ts', db: (adapter) => adapter.starts
           title: 'Some title 2',
           number: 5,
         },
+        overrideAccess: true,
       })
       // Count every console log
       const consoleCount = vitest.spyOn(console, 'log').mockImplementation(() => {})
@@ -145,6 +154,7 @@ test.suite({ config: './config.postgreslogs.ts', db: (adapter) => adapter.starts
 
       const allPosts = await payload.find({
         collection: 'posts',
+        overrideAccess: true,
       })
 
       expect(allPosts.docs).toHaveLength(1)
@@ -162,6 +172,7 @@ test.suite({ config: './config.postgreslogs.ts', db: (adapter) => adapter.starts
               text: 'bulk-delete',
               number: i,
             },
+            overrideAccess: true,
           })
         }
 
@@ -173,6 +184,7 @@ test.suite({ config: './config.postgreslogs.ts', db: (adapter) => adapter.starts
           where: {
             text: { equals: 'bulk-delete' },
           },
+          overrideAccess: true,
         })
 
         const queryCount = consoleCount.mock.calls.length
@@ -200,6 +212,7 @@ test.suite({ config: './config.postgreslogs.ts', db: (adapter) => adapter.starts
           ],
           title: 'post',
         },
+        overrideAccess: true,
       })
       const consoleCount = vitest.spyOn(console, 'log').mockImplementation(() => {})
 

--- a/test/database/postgres-operator-handlers.int.spec.ts
+++ b/test/database/postgres-operator-handlers.int.spec.ts
@@ -279,11 +279,12 @@ test.suite({ db: (adapter) => adapter.startsWith('postgres') })(
       )
       activePayloads.push(payload)
 
-      await payload.create({ collection: 'accent-items', data: { title: 'Ácido' } })
+      await payload.create({ collection: 'accent-items', data: { title: 'Ácido' }, overrideAccess: true })
 
       const result = await payload.find({
         collection: 'accent-items',
         where: { title: { contains: 'acido' } },
+        overrideAccess: true,
       })
 
       expect(result.docs).toHaveLength(0)
@@ -345,6 +346,7 @@ test.suite({ db: (adapter) => adapter.startsWith('postgres') })(
           const doc = await payload.create({
             collection: 'accent-items',
             data: { title: word },
+            overrideAccess: true,
           })
           seeded[word] = doc.id
         }
@@ -352,6 +354,7 @@ test.suite({ db: (adapter) => adapter.startsWith('postgres') })(
         await payload.create({
           collection: 'accent-items',
           data: { title: 'Apple' },
+          overrideAccess: true,
         })
 
         richDoc = await payload.create({
@@ -366,6 +369,7 @@ test.suite({ db: (adapter) => adapter.startsWith('postgres') })(
             tags: [{ value: 'Ácido tag' }],
             tagsText: ['Ácido hasMany tag'],
           },
+          overrideAccess: true,
         })
 
         await payload.update({
@@ -373,6 +377,7 @@ test.suite({ db: (adapter) => adapter.startsWith('postgres') })(
           id: richDoc.id,
           data: { localizedTitle: 'Ácido' },
           locale: 'es',
+          overrideAccess: true,
         })
 
         await payload.update({
@@ -380,6 +385,7 @@ test.suite({ db: (adapter) => adapter.startsWith('postgres') })(
           id: richDoc.id,
           data: { localizedTitle: 'Acido' },
           locale: 'en',
+          overrideAccess: true,
         })
       })
 
@@ -391,6 +397,7 @@ test.suite({ db: (adapter) => adapter.startsWith('postgres') })(
         const result = await payload.find({
           collection: 'accent-items',
           where: { title: { contains: 'acido' } },
+          overrideAccess: true,
         })
 
         expect(result.docs.map((doc: any) => doc.id)).toEqual(
@@ -402,6 +409,7 @@ test.suite({ db: (adapter) => adapter.startsWith('postgres') })(
         const result = await payload.find({
           collection: 'accent-items',
           where: { title: { like: 'nino' } },
+          overrideAccess: true,
         })
 
         expect(result.docs.map((doc: any) => doc.id)).toEqual([seeded['Niño']])
@@ -411,6 +419,7 @@ test.suite({ db: (adapter) => adapter.startsWith('postgres') })(
         const result = await payload.find({
           collection: 'accent-items',
           where: { title: { not_like: 'nino' } },
+          overrideAccess: true,
         })
 
         const ids = result.docs.map((doc: any) => doc.id)
@@ -422,6 +431,7 @@ test.suite({ db: (adapter) => adapter.startsWith('postgres') })(
         const result = await payload.find({
           collection: 'accent-items',
           where: { title: { contains: 'ACIDO' } },
+          overrideAccess: true,
         })
 
         expect(result.docs.map((doc: any) => doc.id)).toEqual(
@@ -433,6 +443,7 @@ test.suite({ db: (adapter) => adapter.startsWith('postgres') })(
         const result = await payload.find({
           collection: 'accent-items',
           where: { title: { like: 'acido apple' } },
+          overrideAccess: true,
         })
 
         expect(result.docs.map((doc: any) => doc.id)).toEqual([richDoc.id])
@@ -443,6 +454,7 @@ test.suite({ db: (adapter) => adapter.startsWith('postgres') })(
           collection: 'accent-items',
           locale: 'es',
           where: { localizedTitle: { contains: 'acido' } },
+          overrideAccess: true,
         })
 
         expect(result.docs.map((doc: any) => doc.id)).toEqual([richDoc.id])
@@ -452,6 +464,7 @@ test.suite({ db: (adapter) => adapter.startsWith('postgres') })(
         const result = await payload.find({
           collection: 'accent-items',
           where: { 'group.note': { contains: 'acido' } },
+          overrideAccess: true,
         })
 
         expect(result.docs.map((doc: any) => doc.id)).toEqual([richDoc.id])
@@ -461,6 +474,7 @@ test.suite({ db: (adapter) => adapter.startsWith('postgres') })(
         const result = await payload.find({
           collection: 'accent-items',
           where: { 'tags.value': { contains: 'acido' } },
+          overrideAccess: true,
         })
 
         expect(result.docs.map((doc: any) => doc.id)).toEqual([richDoc.id])
@@ -470,6 +484,7 @@ test.suite({ db: (adapter) => adapter.startsWith('postgres') })(
         const result = await payload.find({
           collection: 'accent-items',
           where: { 'sections.value': { contains: 'acido' } },
+          overrideAccess: true,
         })
 
         expect(result.docs.map((doc: any) => doc.id)).toEqual([richDoc.id])
@@ -479,6 +494,7 @@ test.suite({ db: (adapter) => adapter.startsWith('postgres') })(
         const result = await payload.find({
           collection: 'accent-items',
           where: { tagsText: { contains: 'acido' } },
+          overrideAccess: true,
         })
 
         expect(result.docs.map((doc: any) => doc.id)).toEqual([richDoc.id])
@@ -488,12 +504,14 @@ test.suite({ db: (adapter) => adapter.startsWith('postgres') })(
         const equalsResult = await payload.find({
           collection: 'accent-items',
           where: { score: { equals: 42 } },
+          overrideAccess: true,
         })
         expect(equalsResult.docs.map((doc: any) => doc.id)).toEqual([richDoc.id])
 
         const existsResult = await payload.find({
           collection: 'accent-items',
           where: { score: { exists: false } },
+          overrideAccess: true,
         })
         expect(existsResult.docs.map((doc: any) => doc.id)).not.toContain(richDoc.id)
       })
@@ -509,6 +527,7 @@ test.suite({ db: (adapter) => adapter.startsWith('postgres') })(
           await payload.find({
             collection: 'accent-items',
             where: { scores: { contains: 2 } },
+            overrideAccess: true,
           })
         } catch (error) {
           thrown = error
@@ -522,6 +541,7 @@ test.suite({ db: (adapter) => adapter.startsWith('postgres') })(
         const result = await payload.find({
           collection: 'accent-items',
           where: { related: { equals: seeded['Ácido'] } },
+          overrideAccess: true,
         })
 
         expect(result.docs.map((doc: any) => doc.id)).toEqual([richDoc.id])
@@ -531,11 +551,13 @@ test.suite({ db: (adapter) => adapter.startsWith('postgres') })(
         await payload.create({
           collection: 'accent-custom-id-items',
           data: { id: 'acido-slug-ácido', title: 'Ácido slug' },
+          overrideAccess: true,
         })
 
         const result = await payload.find({
           collection: 'accent-custom-id-items',
           where: { id: { contains: 'acido-slug-acido' } },
+          overrideAccess: true,
         })
 
         expect(result.docs).toHaveLength(1)
@@ -559,7 +581,7 @@ test.suite({ db: (adapter) => adapter.startsWith('postgres') })(
         )
         activePayloads.push(payload)
 
-        const doc = await payload.create({ collection: 'accent-items', data: { title: 'Ácido' } })
+        const doc = await payload.create({ collection: 'accent-items', data: { title: 'Ácido' }, overrideAccess: true })
 
         // Postgres cannot ILIKE a native `uuid` column at all - a pre-existing limitation
         // unrelated to this feature. The PgUUID guard means a `contains` query against the id
@@ -570,6 +592,7 @@ test.suite({ db: (adapter) => adapter.startsWith('postgres') })(
           await payload.find({
             collection: 'accent-items',
             where: { id: { contains: String(doc.id).slice(0, 8) } },
+            overrideAccess: true,
           })
         } catch (error) {
           thrown = error
@@ -581,6 +604,7 @@ test.suite({ db: (adapter) => adapter.startsWith('postgres') })(
         const exactMatch = await payload.find({
           collection: 'accent-items',
           where: { id: { equals: doc.id } },
+          overrideAccess: true,
         })
         expect(exactMatch.docs).toHaveLength(1)
       },
@@ -610,11 +634,12 @@ test.suite({ db: (adapter) => adapter.startsWith('postgres') })(
       )
       activePayloads.push(payload)
 
-      await payload.create({ collection: 'accent-items', data: { title: 'HELLO' } })
+      await payload.create({ collection: 'accent-items', data: { title: 'HELLO' }, overrideAccess: true })
 
       const result = await payload.find({
         collection: 'accent-items',
         where: { title: { contains: 'hello' } },
+        overrideAccess: true,
       })
 
       expect(result.docs).toHaveLength(1)
@@ -658,11 +683,12 @@ test.suite({ db: (adapter) => adapter.startsWith('postgres') })(
 
       process.env.PAYLOAD_FORCE_DRIZZLE_PUSH = 'false'
 
-      await payload.create({ collection: 'accent-items', data: { title: 'hello world' } })
+      await payload.create({ collection: 'accent-items', data: { title: 'hello world' }, overrideAccess: true })
 
       const result = await payload.find({
         collection: 'accent-items',
         where: { title: { contains: 'hello' } },
+        overrideAccess: true,
       })
 
       expect(receivedValue).toBe('%hello%')
@@ -700,12 +726,14 @@ test.suite({ db: (adapter) => adapter.startsWith('postgres') })(
       const withTitle = await payload.create({
         collection: 'accent-items',
         data: { title: 'hello' },
+        overrideAccess: true,
       })
-      const withoutTitle = await payload.create({ collection: 'accent-items', data: {} })
+      const withoutTitle = await payload.create({ collection: 'accent-items', data: {}, overrideAccess: true })
 
       const result = await payload.find({
         collection: 'accent-items',
         where: { title: { not_equals: 'something-else' } },
+        overrideAccess: true,
       })
 
       const ids = result.docs.map((doc: any) => doc.id)

--- a/test/database/postgres-vector.int.spec.ts
+++ b/test/database/postgres-vector.int.spec.ts
@@ -84,6 +84,7 @@ test.suite({ db: (adapter) => adapter.startsWith('postgres') })(
           embedding: [-5.2, 3.1, 0.2, 8.1, 3.5],
           title: 'apple',
         },
+        overrideAccess: true,
       })
 
       await payload.create({
@@ -92,6 +93,7 @@ test.suite({ db: (adapter) => adapter.startsWith('postgres') })(
           embedding: catEmbedding,
           title: 'cat',
         },
+        overrideAccess: true,
       })
 
       await payload.create({
@@ -100,6 +102,7 @@ test.suite({ db: (adapter) => adapter.startsWith('postgres') })(
           embedding: [-5.1, 2.9, 0.8, 7.9, 3.1],
           title: 'fruit',
         },
+        overrideAccess: true,
       })
 
       await payload.create({
@@ -108,6 +111,7 @@ test.suite({ db: (adapter) => adapter.startsWith('postgres') })(
           embedding: [1.7, -0.3, 6.9, 19.1, 21.1],
           title: 'dog',
         },
+        overrideAccess: true,
       })
 
       const similarity = sql<number>`1 - (${cosineDistance(payload.db.tables.posts.embedding, catEmbedding)})`
@@ -206,6 +210,7 @@ test.suite({ db: (adapter) => adapter.startsWith('postgres') })(
           embedding: '{2:1,4:2}/5',
           title: 'apple',
         },
+        overrideAccess: true,
       })
 
       await payload.create({
@@ -214,6 +219,7 @@ test.suite({ db: (adapter) => adapter.startsWith('postgres') })(
           embedding: catEmbedding,
           title: 'cat',
         },
+        overrideAccess: true,
       })
 
       await payload.create({
@@ -222,6 +228,7 @@ test.suite({ db: (adapter) => adapter.startsWith('postgres') })(
           embedding: '{2:4,4:6}/5',
           title: 'fruit',
         },
+        overrideAccess: true,
       })
 
       await payload.create({
@@ -230,6 +237,7 @@ test.suite({ db: (adapter) => adapter.startsWith('postgres') })(
           embedding: '{1:1,3:2,5:2}/5',
           title: 'dog',
         },
+        overrideAccess: true,
       })
 
       const distance = sql<number>`(${l2Distance(payload.db.tables.posts.embedding, catEmbedding)})`
@@ -318,6 +326,7 @@ test.suite({ db: (adapter) => adapter.startsWith('postgres') })(
           embedding: '01010',
           title: 'apple',
         },
+        overrideAccess: true,
       })
 
       await payload.create({
@@ -326,6 +335,7 @@ test.suite({ db: (adapter) => adapter.startsWith('postgres') })(
           embedding: '10101',
           title: 'cat',
         },
+        overrideAccess: true,
       })
 
       await payload.create({
@@ -334,6 +344,7 @@ test.suite({ db: (adapter) => adapter.startsWith('postgres') })(
           embedding: '11111',
           title: 'fruit',
         },
+        overrideAccess: true,
       })
 
       await payload.create({
@@ -342,6 +353,7 @@ test.suite({ db: (adapter) => adapter.startsWith('postgres') })(
           embedding: '10100',
           title: 'dog',
         },
+        overrideAccess: true,
       })
 
       const similarity = sql<number>`1 - (${jaccardDistance(payload.db.tables.posts.embedding, catEmbedding)})`

--- a/test/database/sqlite-bound-parameters-limit.int.spec.ts
+++ b/test/database/sqlite-bound-parameters-limit.int.spec.ts
@@ -31,6 +31,7 @@ test.suite({ config: './config.ts', db: (adapter) => adapter.startsWith('sqlite'
           collection: 'simple',
           pagination: false,
           where: { id: { in: IN } },
+          overrideAccess: true,
         }),
       ).rejects.toBeTruthy()
 
@@ -40,6 +41,7 @@ test.suite({ config: './config.ts', db: (adapter) => adapter.startsWith('sqlite'
           collection: 'simple',
           pagination: false,
           where: { id: { not_in: IN } },
+          overrideAccess: true,
         }),
       ).rejects.toBeTruthy()
 
@@ -51,6 +53,7 @@ test.suite({ config: './config.ts', db: (adapter) => adapter.startsWith('sqlite'
           collection: 'simple',
           pagination: false,
           where: { id: { in: IN } },
+          overrideAccess: true,
         }),
       ).resolves.toBeTruthy()
 
@@ -60,19 +63,21 @@ test.suite({ config: './config.ts', db: (adapter) => adapter.startsWith('sqlite'
           collection: 'simple',
           pagination: false,
           where: { id: { not_in: IN } },
+          overrideAccess: true,
         }),
       ).resolves.toBeTruthy()
 
       // Verify that "in" still works properly
 
       const docs = await Promise.all(
-        Array.from({ length: 300 }, () => payload.create({ collection: 'simple', data: {} })),
+        Array.from({ length: 300 }, () => payload.create({ collection: 'simple', data: {}, overrideAccess: true })),
       )
 
       const res = await payload.find({
         collection: 'simple',
         pagination: false,
         where: { id: { in: docs.map((e) => e.id) } },
+        overrideAccess: true,
       })
 
       expect(res.totalDocs).toBe(300)
@@ -92,6 +97,7 @@ test.suite({ config: './config.ts', db: (adapter) => adapter.startsWith('sqlite'
           text: 'Test',
         },
         locale: 'en',
+        overrideAccess: true,
       })
 
       const res = await payload.find({
@@ -106,6 +112,7 @@ test.suite({ config: './config.ts', db: (adapter) => adapter.startsWith('sqlite'
           },
         },
         locale: 'en',
+        overrideAccess: true,
       })
 
       expect(res.totalDocs).toBe(1)

--- a/test/dataloader/config.ts
+++ b/test/dataloader/config.ts
@@ -134,25 +134,30 @@ export default buildConfigWithDefaults({
         email: devUser.email,
         password: devUser.password,
       },
+      overrideAccess: true,
     })
 
     await payload.create({
       collection: 'posts',
       data: postDoc,
       user,
+      overrideAccess: true,
     })
 
     const tag = await payload.create({
       collection: 'itemTags',
       data: { name: 'tag1' },
+      overrideAccess: true,
     })
     const item = await payload.create({
       collection: 'items',
       data: { name: 'item1', itemTags: [tag.id] },
+      overrideAccess: true,
     })
     const shop = await payload.create({
       collection: 'shops',
       data: { name: 'shop1', items: [item.id] },
+      overrideAccess: true,
     })
   },
 })

--- a/test/dataloader/int.spec.ts
+++ b/test/dataloader/int.spec.ts
@@ -19,6 +19,7 @@ test.suite({ config: './config.ts' })('dataloader', () => {
         email: devUser.email,
         password: devUser.password,
       },
+      overrideAccess: true,
     })
 
     if (loginResult.token) {
@@ -97,6 +98,7 @@ test.suite({ config: './config.ts' })('dataloader', () => {
         data: {
           richText: buildDefaultEditorState({ text: 'relation a' }),
         },
+        overrideAccess: true,
       })
 
       const relationB = await payload.create({
@@ -105,6 +107,7 @@ test.suite({ config: './config.ts' })('dataloader', () => {
           relationship: relationA.id,
           richText: buildDefaultEditorState({ text: 'relation b' }),
         },
+        overrideAccess: true,
       })
 
       expect(relationA.id).toBeDefined()
@@ -128,12 +131,14 @@ test.suite({ config: './config.ts' })('dataloader', () => {
             ],
           }),
         },
+        overrideAccess: true,
       })
 
       const relationANoDepth = await payload.findByID({
         id: relationA.id,
         collection: 'relation-a',
         depth: 0,
+        overrideAccess: true,
       })
 
       expect(relationANoDepth.relationship).toStrictEqual(relationB.id)
@@ -142,6 +147,7 @@ test.suite({ config: './config.ts' })('dataloader', () => {
         id: relationA.id,
         collection: 'relation-a',
         depth: 4,
+        overrideAccess: true,
       })
 
       const innerMostRelationship =
@@ -162,6 +168,7 @@ test.suite({ config: './config.ts' })('dataloader', () => {
         collection: 'items' as CollectionSlug,
         req,
         depth: 0,
+        overrideAccess: true,
         where: {
           name: { exists: true },
         },

--- a/test/email-nodemailer/config.ts
+++ b/test/email-nodemailer/config.ts
@@ -28,6 +28,7 @@ export default buildConfigWithDefaults({
         email: devUser.email,
         password: devUser.password,
       },
+      overrideAccess: true,
     })
   },
 })

--- a/test/email-resend/config.ts
+++ b/test/email-resend/config.ts
@@ -35,6 +35,7 @@ export default buildConfigWithDefaults({
         email: devUser.email,
         password: devUser.password,
       },
+      overrideAccess: true,
     })
 
     const email = await payload.sendEmail({

--- a/test/email/config.ts
+++ b/test/email/config.ts
@@ -34,6 +34,7 @@ export default buildConfigWithDefaults({
         email: devUser.email,
         password: devUser.password,
       },
+      overrideAccess: true,
     })
 
     await payload.create({
@@ -41,6 +42,7 @@ export default buildConfigWithDefaults({
       data: {
         text: 'example post',
       },
+      overrideAccess: true,
     })
 
     const email = await payload.sendEmail({
@@ -56,6 +58,7 @@ export default buildConfigWithDefaults({
       collection: 'media',
       data: {},
       file: imageFile,
+      overrideAccess: true,
     })
   },
 })

--- a/test/embed/config.ts
+++ b/test/embed/config.ts
@@ -31,6 +31,7 @@ export default buildConfigWithDefaults({
         email: devUser.email,
         password: devUser.password,
       },
+      overrideAccess: true,
     })
   },
 })

--- a/test/endpoints/config.ts
+++ b/test/endpoints/config.ts
@@ -85,6 +85,7 @@ export default buildConfigWithDefaults({
         email: devUser.email,
         password: devUser.password,
       },
+      overrideAccess: true,
     })
   },
 })

--- a/test/evals/config.ts
+++ b/test/evals/config.ts
@@ -46,6 +46,7 @@ export default buildConfigWithDefaults({
         email: devUser.email,
         password: devUser.password,
       },
+      overrideAccess: true,
     })
   },
 })

--- a/test/evals/datasets/collections/codegen.ts
+++ b/test/evals/datasets/collections/codegen.ts
@@ -146,6 +146,7 @@ export const collectionsCodegenDataset: EvalCase[] = [
       const { docs } = await payload.find({
         collection: 'posts',
         where: { title: { equals: seededTitle } },
+        overrideAccess: true,
       })
       expect(docs).toHaveLength(1)
     },

--- a/test/evals/datasets/mcp.ts
+++ b/test/evals/datasets/mcp.ts
@@ -41,6 +41,7 @@ export const mcpDataset: EvalCase[] = [
       const { docs } = await payload.find({
         collection: 'media',
         where: { alt: { equals: 'Local checklist icon' } },
+        overrideAccess: true,
       })
       const media = docs[0]
 
@@ -101,6 +102,7 @@ export const mcpDataset: EvalCase[] = [
       const { docs } = await payload.find({
         collection: 'media',
         where: { alt: { equals: 'Checklist icon' } },
+        overrideAccess: true,
       })
       const media = docs[0]
 
@@ -141,10 +143,11 @@ export const mcpDataset: EvalCase[] = [
           mimetype: 'image/png',
           size: originalFile.length,
         },
+        overrideAccess: true,
       })
     },
     verify: async ({ audit, expect, payload, transcript }) => {
-      const { docs } = await payload.find({ collection: 'media' })
+      const { docs } = await payload.find({ collection: 'media', overrideAccess: true })
       const media = docs[0]
 
       expect(docs).toHaveLength(1)
@@ -176,6 +179,7 @@ export const mcpDataset: EvalCase[] = [
       const { docs } = await payload.find({
         collection: 'posts',
         where: { title: { equals: 'Created by Payload MCP eval' } },
+        overrideAccess: true,
       })
 
       expect(docs).toHaveLength(1)
@@ -202,6 +206,7 @@ export const mcpDataset: EvalCase[] = [
         where: {
           title: { in: ['First bulk MCP post', 'Second bulk MCP post'] },
         },
+        overrideAccess: true,
       })
       const createCalls = audit.filter(
         (event) => event.type === 'mcp-tool-call' && event.name === 'createDocuments',
@@ -238,11 +243,13 @@ export const mcpDataset: EvalCase[] = [
       await payload.create({
         collection: 'posts',
         data: { title: 'MCP Update Target' },
+        overrideAccess: true,
       })
     },
     verify: async ({ audit, expect, payload, transcript }) => {
       const { docs } = await payload.find({
         collection: 'posts',
+        overrideAccess: true,
       })
 
       expect(docs).toHaveLength(1)
@@ -264,16 +271,18 @@ export const mcpDataset: EvalCase[] = [
     input: 'Delete the post titled "MCP Delete Target".',
     setup: async ({ payload }) => {
       for (const title of ['MCP Delete Target', 'MCP Keep', 'MCP Update Target']) {
-        await payload.create({ collection: 'posts', data: { title } })
+        await payload.create({ collection: 'posts', data: { title }, overrideAccess: true })
       }
     },
     verify: async ({ audit, expect, payload, transcript }) => {
       const deletedPosts = await payload.find({
         collection: 'posts',
         where: { title: { equals: 'MCP Delete Target' } },
+        overrideAccess: true,
       })
       const remainingPosts = await payload.find({
         collection: 'posts',
+        overrideAccess: true,
       })
 
       expect(deletedPosts.docs).toHaveLength(0)
@@ -297,7 +306,10 @@ export const mcpDataset: EvalCase[] = [
     configPath: 'mcp/shared',
     input: 'Change the site tagline to "Updated through Payload MCP".',
     verify: async ({ audit, expect, payload, transcript }) => {
-      const settings = (await payload.findGlobal({ slug: 'site-settings' })) as {
+      const settings = (await payload.findGlobal({
+        slug: 'site-settings',
+        overrideAccess: true,
+      })) as {
         tagline?: unknown
       }
 
@@ -325,17 +337,20 @@ export const mcpDataset: EvalCase[] = [
       await payload.create({
         collection: 'authors',
         data: { name: 'Ada Lovelace' },
+        overrideAccess: true,
       })
     },
     verify: async ({ audit, expect, payload, transcript }) => {
       const { docs: authors } = await payload.find({
         collection: 'authors',
         where: { name: { equals: 'Ada Lovelace' } },
+        overrideAccess: true,
       })
       const { docs: posts } = await payload.find({
         collection: 'posts',
         depth: 0,
         where: { title: { equals: 'Relationship created by Payload MCP eval' } },
+        overrideAccess: true,
       })
       const author = authors[0] as Record<string, unknown> | undefined
       const post = posts[0] as Record<string, unknown> | undefined
@@ -367,6 +382,7 @@ export const mcpDataset: EvalCase[] = [
       const { docs } = await payload.find({
         collection: 'posts',
         where: { title: { equals: 'Lexical content created by Payload MCP eval' } },
+        overrideAccess: true,
       })
       const post = docs[0] as Record<string, unknown> | undefined
       const content = post?.content as DefaultTypedEditorState | undefined
@@ -417,6 +433,7 @@ export const mcpDataset: EvalCase[] = [
         collection: 'articles',
         data: { _status: 'published', title: 'MCP Draft Update Target' },
         locale: 'en',
+        overrideAccess: true,
       })
     },
     verify: async ({ audit, expect, payload, transcript }) => {
@@ -425,6 +442,7 @@ export const mcpDataset: EvalCase[] = [
         draft: true,
         locale: 'en',
         where: { title: { equals: 'MCP Draft Update Saved' } },
+        overrideAccess: true,
       })
       expect(draftArticles).toHaveLength(1)
 
@@ -434,6 +452,7 @@ export const mcpDataset: EvalCase[] = [
         collection: 'articles',
         draft: false,
         locale: 'en',
+        overrideAccess: true,
       })
 
       expect(publishedArticle.title).toBe('MCP Draft Update Target')
@@ -461,6 +480,7 @@ export const mcpDataset: EvalCase[] = [
         collection: 'articles',
         data: { _status: 'published', title: 'MCP Published Update Target' },
         locale: 'en',
+        overrideAccess: true,
       })
     },
     verify: async ({ audit, expect, payload, transcript }) => {
@@ -469,6 +489,7 @@ export const mcpDataset: EvalCase[] = [
         draft: false,
         locale: 'en',
         where: { title: { equals: 'MCP Published Update Saved' } },
+        overrideAccess: true,
       })
       const publishedArticle = publishedArticles[0]
 
@@ -496,6 +517,7 @@ export const mcpDataset: EvalCase[] = [
         collection: 'articles',
         data: { _status: 'published', title: 'MCP Unpublish Target' },
         locale: 'en',
+        overrideAccess: true,
       })
     },
     verify: async ({ audit, expect, payload, transcript }) => {
@@ -504,6 +526,7 @@ export const mcpDataset: EvalCase[] = [
         draft: false,
         locale: 'en',
         where: { title: { equals: 'MCP Unpublish Target' } },
+        overrideAccess: true,
       })
       const unpublishedArticle = unpublishedArticles[0]
 
@@ -530,6 +553,7 @@ export const mcpDataset: EvalCase[] = [
         collection: 'articles',
         data: { _status: 'published', title: 'MCP Published Read Target' },
         locale: 'en',
+        overrideAccess: true,
       })
 
       await payload.update({
@@ -538,6 +562,7 @@ export const mcpDataset: EvalCase[] = [
         data: { title: 'MCP Draft Must Not Be Read' },
         draft: true,
         locale: 'en',
+        overrideAccess: true,
       })
     },
     verify: async ({ audit, expect, payload, transcript }) => {
@@ -546,6 +571,7 @@ export const mcpDataset: EvalCase[] = [
         draft: false,
         locale: 'en',
         where: { title: { equals: 'MCP Published Read Target' } },
+        overrideAccess: true,
       })
       expect(publishedArticles).toHaveLength(1)
 
@@ -555,6 +581,7 @@ export const mcpDataset: EvalCase[] = [
         collection: 'articles',
         draft: true,
         locale: 'en',
+        overrideAccess: true,
       })
       const agentResponse = getFinalAgentResponse({ transcript })
 
@@ -587,6 +614,7 @@ export const mcpDataset: EvalCase[] = [
         collection: 'articles',
         data: { _status: 'published', title: 'MCP Draft Read Published Title' },
         locale: 'en',
+        overrideAccess: true,
       })
 
       await payload.update({
@@ -595,6 +623,7 @@ export const mcpDataset: EvalCase[] = [
         data: { title: 'MCP Draft Read Latest Title' },
         draft: true,
         locale: 'en',
+        overrideAccess: true,
       })
     },
     verify: async ({ audit, expect, payload, transcript }) => {
@@ -603,6 +632,7 @@ export const mcpDataset: EvalCase[] = [
         draft: true,
         locale: 'en',
         where: { title: { equals: 'MCP Draft Read Latest Title' } },
+        overrideAccess: true,
       })
       const storedDraft = draftArticles[0]
       const agentResponse = getFinalAgentResponse({ transcript })
@@ -635,6 +665,7 @@ export const mcpDataset: EvalCase[] = [
         collection: 'articles',
         data: { _status: 'published', title: 'MCP English Publish Target' },
         locale: 'en',
+        overrideAccess: true,
       })
 
       await payload.update({
@@ -644,6 +675,7 @@ export const mcpDataset: EvalCase[] = [
         draft: false,
         locale: 'es',
         publishAllLocales: false,
+        overrideAccess: true,
       })
       await payload.update({
         id: article.id,
@@ -651,6 +683,7 @@ export const mcpDataset: EvalCase[] = [
         data: { title: 'MCP Spanish Draft Title' },
         draft: true,
         locale: 'es',
+        overrideAccess: true,
       })
     },
     verify: async ({ audit, expect, payload, transcript }) => {
@@ -659,6 +692,7 @@ export const mcpDataset: EvalCase[] = [
         draft: false,
         locale: 'en',
         where: { title: { equals: 'MCP English Published Title' } },
+        overrideAccess: true,
       })
       expect(publishedEnglishArticles).toHaveLength(1)
 
@@ -668,12 +702,14 @@ export const mcpDataset: EvalCase[] = [
         collection: 'articles',
         draft: false,
         locale: 'es',
+        overrideAccess: true,
       })
       const draftSpanish = await payload.findByID({
         id: publishedEnglish!.id,
         collection: 'articles',
         draft: true,
         locale: 'es',
+        overrideAccess: true,
       })
 
       expect(publishedEnglish?.title).toBe('MCP English Published Title')
@@ -704,6 +740,7 @@ export const mcpDataset: EvalCase[] = [
         draft: true,
         locale: 'en',
         where: { title: { equals: 'MCP Newly Created Draft' } },
+        overrideAccess: true,
       })
       const article = docs[0]
 
@@ -730,6 +767,7 @@ export const mcpDataset: EvalCase[] = [
         draft: false,
         locale: 'en',
         where: { title: { equals: 'MCP Newly Created Published' } },
+        overrideAccess: true,
       })
       const article = docs[0]
 

--- a/test/field-access-context/config.ts
+++ b/test/field-access-context/config.ts
@@ -31,6 +31,7 @@ export default buildConfigWithDefaults({
         email: devUser.email,
         password: devUser.password,
       },
+      overrideAccess: true,
     })
   },
 })

--- a/test/field-access-context/int.spec.ts
+++ b/test/field-access-context/int.spec.ts
@@ -11,12 +11,12 @@ const parentIDs: (number | string)[] = []
 test.suite({ config: './config.ts' })('field access collection context', () => {
   test.afterEach(async ({ payload }) => {
     for (const id of parentIDs) {
-      await payload.delete({ id, collection: parentsSlug })
+      await payload.delete({ id, collection: parentsSlug, overrideAccess: true })
     }
     parentIDs.length = 0
 
     for (const id of childIDs) {
-      await payload.delete({ id, collection: childrenSlug })
+      await payload.delete({ id, collection: childrenSlug, overrideAccess: true })
     }
     childIDs.length = 0
 
@@ -72,6 +72,7 @@ test.suite({ config: './config.ts' })('field access collection context', () => {
         accessReadProbe: 'local read',
         title: 'local read parent',
       },
+      overrideAccess: true,
     })
     parentIDs.push(doc.id)
     resetAccessLog()
@@ -101,6 +102,7 @@ test.suite({ config: './config.ts' })('field access collection context', () => {
         accessReadProbe: 'rest read',
         title: 'rest read parent',
       },
+      overrideAccess: true,
     })
     parentIDs.push(doc.id)
     resetAccessLog()
@@ -127,6 +129,7 @@ test.suite({ config: './config.ts' })('field access collection context', () => {
         accessReadProbe: 'graphql read',
         title: 'graphql read parent',
       },
+      overrideAccess: true,
     })
     parentIDs.push(doc.id)
     resetAccessLog()
@@ -163,6 +166,7 @@ test.suite({ config: './config.ts' })('field access collection context', () => {
         childReadProbe: 'relationship child read',
         title: 'relationship child',
       },
+      overrideAccess: true,
     })
     childIDs.push(child.id)
 
@@ -172,6 +176,7 @@ test.suite({ config: './config.ts' })('field access collection context', () => {
         child: child.id,
         title: 'relationship parent',
       },
+      overrideAccess: true,
     })
     parentIDs.push(parent.id)
     resetAccessLog()
@@ -199,6 +204,7 @@ test.suite({ config: './config.ts' })('field access collection context', () => {
       data: {
         title: 'update parent',
       },
+      overrideAccess: true,
     })
     parentIDs.push(doc.id)
     resetAccessLog()
@@ -228,6 +234,7 @@ test.suite({ config: './config.ts' })('field access collection context', () => {
         distinctProbe: 'one',
         title: 'distinct one',
       },
+      overrideAccess: true,
     })
     parentIDs.push(firstDoc.id)
 
@@ -237,6 +244,7 @@ test.suite({ config: './config.ts' })('field access collection context', () => {
         distinctProbe: 'two',
         title: 'distinct two',
       },
+      overrideAccess: true,
     })
     parentIDs.push(secondDoc.id)
     resetAccessLog()
@@ -285,6 +293,7 @@ test.suite({ config: './config.ts' })('field access collection context', () => {
       data: {
         globalReadProbe: 'global read',
       },
+      overrideAccess: true,
     })
     resetAccessLog()
 
@@ -320,6 +329,7 @@ test.suite({ config: './config.ts' })('field access collection context', () => {
         childReadProbe: 'global relationship child',
         title: 'global relationship child',
       },
+      overrideAccess: true,
     })
     childIDs.push(child.id)
 
@@ -328,6 +338,7 @@ test.suite({ config: './config.ts' })('field access collection context', () => {
       data: {
         globalChild: child.id,
       },
+      overrideAccess: true,
     })
     resetAccessLog()
 

--- a/test/field-error-states/seed.ts
+++ b/test/field-error-states/seed.ts
@@ -9,5 +9,6 @@ export const seed = async (payload: Payload) => {
       email: devUser.email,
       password: devUser.password,
     },
+    overrideAccess: true,
   })
 }

--- a/test/field-paths/config.ts
+++ b/test/field-paths/config.ts
@@ -28,6 +28,7 @@ export const HooksConfig: Promise<SanitizedConfig> = buildConfigWithDefaults({
         email: devUser.email,
         password: devUser.password,
       },
+      overrideAccess: true,
     })
   },
 })

--- a/test/field-paths/e2e.spec.ts
+++ b/test/field-paths/e2e.spec.ts
@@ -45,6 +45,7 @@ test.describe('Field Paths', () => {
     const { id: docID } = await payload.create({
       collection: fieldPathsSlug,
       data: testDoc,
+      overrideAccess: true,
     })
 
     await page.goto(fieldPathsUrl.edit(docID))
@@ -56,6 +57,7 @@ test.describe('Field Paths', () => {
     const { id: docID } = await payload.create({
       collection: fieldPathsSlug,
       data: testDoc,
+      overrideAccess: true,
     })
 
     await navigateToDiffVersionView({

--- a/test/field-paths/int.spec.ts
+++ b/test/field-paths/int.spec.ts
@@ -46,12 +46,14 @@ test.suite({ config: './config.ts' })('Field Paths', () => {
       const originalDoc = await payload.create({
         collection: fieldPathsSlug,
         data: testDoc,
+        overrideAccess: true,
       })
 
       // duplicate the doc to ensure that the beforeDuplicate hook is run
       const doc = await payload.duplicate({
         id: originalDoc.id,
         collection: fieldPathsSlug,
+        overrideAccess: true,
       })
 
       const expectedDoc = {

--- a/test/field-perf/config.ts
+++ b/test/field-perf/config.ts
@@ -83,6 +83,7 @@ export default buildConfigWithDefaults({
         email: devUser.email,
         password: devUser.password,
       },
+      overrideAccess: true,
     })
 
     await payload.create({
@@ -107,6 +108,7 @@ export default buildConfigWithDefaults({
           ],
         })),
       },
+      overrideAccess: true,
     })
   },
 })

--- a/test/fields-relationship/e2e.spec.ts
+++ b/test/fields-relationship/e2e.spec.ts
@@ -108,6 +108,7 @@ describe('Relationship Field', () => {
       data: {
         name: 'relation',
       },
+      overrideAccess: true,
     })) as any
 
     anotherRelationOneDoc = (await payload.create({
@@ -115,6 +116,7 @@ describe('Relationship Field', () => {
       data: {
         name: 'relation',
       },
+      overrideAccess: true,
     })) as any
 
     relationTwoDoc = (await payload.create({
@@ -122,6 +124,7 @@ describe('Relationship Field', () => {
       data: {
         name: 'second-relation',
       },
+      overrideAccess: true,
     })) as any
 
     // Create restricted doc
@@ -130,6 +133,7 @@ describe('Relationship Field', () => {
       data: {
         name: 'restricted',
       },
+      overrideAccess: true,
     })) as any
 
     // Doc with useAsTitle
@@ -141,6 +145,7 @@ describe('Relationship Field', () => {
           title: 'relation-title',
         },
       },
+      overrideAccess: true,
     })) as any
 
     // Doc with useAsTitle for word boundary test
@@ -152,6 +157,7 @@ describe('Relationship Field', () => {
           title: 'word boundary search',
         },
       },
+      overrideAccess: true,
     })
 
     // Collection 1 Doc
@@ -160,6 +166,7 @@ describe('Relationship Field', () => {
       data: {
         name: 'One',
       },
+      overrideAccess: true,
     })) as any
 
     // Add restricted doc as relation
@@ -172,6 +179,7 @@ describe('Relationship Field', () => {
         relationshipRestricted: restrictedRelation.id,
         relationshipWithTitle: relationWithTitle.id,
       },
+      overrideAccess: true,
     })) as any
   })
 
@@ -293,6 +301,7 @@ describe('Relationship Field', () => {
         data: {
           name: `relation-one-${i}`,
         },
+        overrideAccess: true,
       })
       relationOneIDs.push(doc.id)
     }
@@ -304,6 +313,7 @@ describe('Relationship Field', () => {
         data: {
           name: `relation-two-${i}`,
         },
+        overrideAccess: true,
       })
       relationTwoIDs.push(doc.id)
     }
@@ -421,6 +431,7 @@ describe('Relationship Field', () => {
         data: {
           filter: 'Include me',
         },
+        overrideAccess: true,
       })
 
       // first ensure that filter options are applied in the edit view
@@ -457,6 +468,7 @@ describe('Relationship Field', () => {
         data: {
           filter: 'Include me',
         },
+        overrideAccess: true,
       })
 
       // First ensure that filter options are applied to the Edit View
@@ -518,6 +530,7 @@ describe('Relationship Field', () => {
         data: {
           name: 'include',
         },
+        overrideAccess: true,
       })) as any
 
       const { id: exclude } = (await payload.create({
@@ -525,6 +538,7 @@ describe('Relationship Field', () => {
         data: {
           name: 'exclude',
         },
+        overrideAccess: true,
       })) as any
 
       await loadCreatePage()
@@ -543,6 +557,7 @@ describe('Relationship Field', () => {
         data: {
           name: 'exclude',
         },
+        overrideAccess: true,
       })
 
       await loadCreatePage()
@@ -564,6 +579,7 @@ describe('Relationship Field', () => {
         data: {
           name: 'whatever',
         },
+        overrideAccess: true,
       })
 
       await loadCreatePage()
@@ -583,6 +599,7 @@ describe('Relationship Field', () => {
         data: {
           name: 'truth',
         },
+        overrideAccess: true,
       })
 
       await loadCreatePage()
@@ -640,12 +657,14 @@ describe('Relationship Field', () => {
       data: {
         name: 'Drawer ID Label',
       },
+      overrideAccess: true,
     })
     const doc = await payload.create({
       collection: slug,
       data: {
         relationship: relatedDoc.id,
       },
+      overrideAccess: true,
     })
     await payload.update({
       id: doc.id,
@@ -653,6 +672,7 @@ describe('Relationship Field', () => {
       data: {
         relationToSelf: doc.id,
       },
+      overrideAccess: true,
     })
 
     await page.goto(url.edit(doc.id))
@@ -690,10 +710,12 @@ describe('Relationship Field', () => {
       payload.delete({
         id: relatedDoc.id,
         collection: relationOneSlug,
+        overrideAccess: true,
       }),
       payload.delete({
         id: doc.id,
         collection: slug,
+        overrideAccess: true,
       }),
     ])
   })
@@ -777,6 +799,7 @@ describe('Relationship Field', () => {
         title: '',
       },
       draft: true,
+      overrideAccess: true,
     })
 
     await payload.update({
@@ -786,6 +809,7 @@ describe('Relationship Field', () => {
         title: 'Draft Only Title',
       },
       draft: true,
+      overrideAccess: true,
     })
 
     // Create the doc that holds the relationship to the draft-only related doc.
@@ -902,6 +926,7 @@ describe('Relationship Field', () => {
               },
             ],
           },
+          overrideAccess: true,
         })
       }
 
@@ -916,6 +941,7 @@ describe('Relationship Field', () => {
               },
             ],
           },
+          overrideAccess: true,
         })
       }
 
@@ -974,6 +1000,7 @@ describe('Relationship Field', () => {
               data: {
                 name: 'relation',
               },
+              overrideAccess: true,
             }),
           )
         }
@@ -988,6 +1015,7 @@ describe('Relationship Field', () => {
         data: {
           relationshipHasMany: relations,
         },
+        overrideAccess: true,
       })
     })
 
@@ -1018,6 +1046,7 @@ describe('Relationship Field', () => {
         data: {
           name: 'Doc to filter on',
         },
+        overrideAccess: true,
       })
 
       await payload.create({
@@ -1036,16 +1065,19 @@ describe('Relationship Field', () => {
             value: relatedDoc.id,
           },
         },
+        overrideAccess: true,
       })
 
       const cleanup = async () => {
         await payload.delete({
           id: relatedDoc.id,
           collection: slug,
+          overrideAccess: true,
         })
         await payload.delete({
           id: relatedDoc.id,
           collection: relationOneSlug,
+          overrideAccess: true,
         })
       }
 
@@ -1115,28 +1147,34 @@ describe('Relationship Field', () => {
       const relatedDoc1 = await payload.create({
         collection: relationOneSlug,
         data: { name: 'Related Doc 1' },
+        overrideAccess: true,
       })
       const relatedDoc2 = await payload.create({
         collection: relationOneSlug,
         data: { name: 'Related Doc 2' },
+        overrideAccess: true,
       })
       const relatedDoc3 = await payload.create({
         collection: relationOneSlug,
         data: { name: 'Related Doc 3' },
+        overrideAccess: true,
       })
 
       // Create main docs that reference different related docs
       const mainDoc1 = await payload.create({
         collection: slug,
         data: { relationship: relatedDoc1.id },
+        overrideAccess: true,
       })
       const mainDoc2 = await payload.create({
         collection: slug,
         data: { relationship: relatedDoc2.id },
+        overrideAccess: true,
       })
       const mainDoc3 = await payload.create({
         collection: slug,
         data: { relationship: relatedDoc3.id },
+        overrideAccess: true,
       })
 
       await page.goto(url.list)
@@ -1154,12 +1192,24 @@ describe('Relationship Field', () => {
       await expect(tableRow).toHaveCount(2)
 
       // Cleanup
-      await payload.delete({ id: String(mainDoc1.id), collection: slug })
-      await payload.delete({ id: String(mainDoc2.id), collection: slug })
-      await payload.delete({ id: String(mainDoc3.id), collection: slug })
-      await payload.delete({ id: String(relatedDoc1.id), collection: relationOneSlug })
-      await payload.delete({ id: String(relatedDoc2.id), collection: relationOneSlug })
-      await payload.delete({ id: String(relatedDoc3.id), collection: relationOneSlug })
+      await payload.delete({ id: String(mainDoc1.id), collection: slug, overrideAccess: true })
+      await payload.delete({ id: String(mainDoc2.id), collection: slug, overrideAccess: true })
+      await payload.delete({ id: String(mainDoc3.id), collection: slug, overrideAccess: true })
+      await payload.delete({
+        id: String(relatedDoc1.id),
+        collection: relationOneSlug,
+        overrideAccess: true,
+      })
+      await payload.delete({
+        id: String(relatedDoc2.id),
+        collection: relationOneSlug,
+        overrideAccess: true,
+      })
+      await payload.delete({
+        id: String(relatedDoc3.id),
+        collection: relationOneSlug,
+        overrideAccess: true,
+      })
     })
   })
 })
@@ -1179,6 +1229,7 @@ async function clearCollectionDocs(collectionSlug: CollectionSlug): Promise<void
     where: {
       id: { exists: true },
     },
+    overrideAccess: true,
   })
 }
 
@@ -1194,5 +1245,6 @@ async function createVersionedRelationshipFieldDoc(
       title,
       ...overrides,
     },
+    overrideAccess: true,
   }) as unknown as Promise<VersionedRelationshipField>
 }

--- a/test/fields-relationship/int.spec.ts
+++ b/test/fields-relationship/int.spec.ts
@@ -29,6 +29,7 @@ test.suite({ config: './config.ts' })('Relationship Fields', () => {
         data: {
           name: relatedDocName,
         },
+        overrideAccess: true,
       })
 
       const version1 = await payload.create({
@@ -40,6 +41,7 @@ test.suite({ config: './config.ts' })('Relationship Fields', () => {
             relationTo: collection1Slug,
           },
         },
+        overrideAccess: true,
       })
 
       const version2 = await payload.update({
@@ -48,6 +50,7 @@ test.suite({ config: './config.ts' })('Relationship Fields', () => {
         data: {
           title: 'Version 2 Title',
         },
+        overrideAccess: true,
       })
 
       const versions = await payload.findVersions({
@@ -59,6 +62,7 @@ test.suite({ config: './config.ts' })('Relationship Fields', () => {
         },
         sort: '-updatedAt',
         limit: 1,
+        overrideAccess: true,
       })
 
       version2ID = versions.docs[0].id
@@ -81,6 +85,7 @@ test.suite({ config: './config.ts' })('Relationship Fields', () => {
         collection: versionedRelationshipFieldSlug,
         id: version2ID,
         locale: 'all',
+        overrideAccess: true,
       })
 
       expect(version2Data.version.title).toEqual('Version 2 Title')

--- a/test/fields/collections/Array/e2e.spec.ts
+++ b/test/fields/collections/Array/e2e.spec.ts
@@ -336,6 +336,7 @@ describe('Array', () => {
         ],
         title: 'for test 1',
       },
+      overrideAccess: true,
     })
 
     await payload.create({
@@ -348,6 +349,7 @@ describe('Array', () => {
         ],
         title: 'for test 2',
       },
+      overrideAccess: true,
     })
 
     await payload.create({
@@ -366,6 +368,7 @@ describe('Array', () => {
         ],
         title: 'for test 3',
       },
+      overrideAccess: true,
     })
 
     const bulkText = 'Bulk update text'

--- a/test/fields/collections/Date/e2e.spec.ts
+++ b/test/fields/collections/Date/e2e.spec.ts
@@ -360,6 +360,7 @@ describe('Date', () => {
         docs: [existingDoc],
       } = await payload.find({
         collection: dateFieldsSlug,
+        overrideAccess: true,
       })
 
       await page.goto(url.edit(existingDoc!.id))
@@ -387,6 +388,7 @@ describe('Date', () => {
         docs: [existingDoc],
       } = await payload.find({
         collection: dateFieldsSlug,
+        overrideAccess: true,
       })
 
       await page.goto(url.edit(existingDoc!.id))
@@ -416,6 +418,7 @@ describe('Date', () => {
         docs: [existingDoc],
       } = await payload.find({
         collection: dateFieldsSlug,
+        overrideAccess: true,
       })
 
       await page.goto(url.edit(existingDoc!.id))
@@ -442,6 +445,7 @@ describe('Date', () => {
         docs: [existingDoc],
       } = await payload.find({
         collection: dateFieldsSlug,
+        overrideAccess: true,
       })
 
       await page.goto(url.edit(existingDoc!.id))
@@ -470,6 +474,7 @@ describe('Date', () => {
         docs: [existingDoc],
       } = await payload.find({
         collection: dateFieldsSlug,
+        overrideAccess: true,
       })
 
       await page.goto(url.edit(existingDoc!.id))
@@ -522,6 +527,7 @@ describe('Date', () => {
         docs: [existingDoc],
       } = await payload.find({
         collection: dateFieldsSlug,
+        overrideAccess: true,
       })
 
       await page.goto(url.edit(existingDoc!.id))
@@ -545,6 +551,7 @@ describe('Date', () => {
         docs: [existingDoc],
       } = await payload.find({
         collection: dateFieldsSlug,
+        overrideAccess: true,
       })
 
       await page.goto(url.edit(existingDoc!.id))
@@ -611,6 +618,7 @@ describe('Date', () => {
             equals: docID,
           },
         },
+        overrideAccess: true,
       })
 
       expect(existingDoc?.dayAndTimeWithTimezone).toEqual(expectedUTCValue)
@@ -700,6 +708,7 @@ describe('Date', () => {
         docs: [existingDoc],
       } = await payload.find({
         collection: dateFieldsSlug,
+        overrideAccess: true,
       })
 
       await page.goto(url.edit(existingDoc!.id))
@@ -774,6 +783,7 @@ const createTimezoneContextTests = (contextName: string, timezoneId: string) => 
         docs: [existingDoc],
       } = await payload.find({
         collection: dateFieldsSlug,
+        overrideAccess: true,
       })
 
       await page.goto(url.edit(existingDoc!.id))
@@ -885,6 +895,7 @@ const createTimezoneContextTests = (contextName: string, timezoneId: string) => 
             equals: docID,
           },
         },
+        overrideAccess: true,
       })
 
       expect(existingDoc?.dayAndTimeWithTimezone).toEqual(expectedUTCValue)
@@ -925,6 +936,7 @@ const createTimezoneContextTests = (contextName: string, timezoneId: string) => 
             equals: docID,
           },
         },
+        overrideAccess: true,
       })
 
       expect(existingDoc?.dayAndTimeWithTimezone).toEqual(expectedUTCValue)
@@ -965,6 +977,7 @@ const createTimezoneContextTests = (contextName: string, timezoneId: string) => 
             equals: docID,
           },
         },
+        overrideAccess: true,
       })
 
       expect(existingDoc?.dayAndTimeWithTimezone).toEqual(expectedUTCValue)
@@ -1016,6 +1029,7 @@ const createTimezoneContextTests = (contextName: string, timezoneId: string) => 
             equals: docID,
           },
         },
+        overrideAccess: true,
       })
 
       expect(existingDoc?.dayAndTimeWithTimezone).toEqual(expectedDateTimeUTCValue)
@@ -1068,6 +1082,7 @@ const createTimezoneContextTests = (contextName: string, timezoneId: string) => 
             equals: docID,
           },
         },
+        overrideAccess: true,
       })
 
       expect(existingDoc?.dayAndTimeWithTimezone).toEqual(expectedDateTimeUTCValue)
@@ -1085,6 +1100,7 @@ const createTimezoneContextTests = (contextName: string, timezoneId: string) => 
         docs: [existingDoc],
       } = await payload.find({
         collection: dateFieldsSlug,
+        overrideAccess: true,
       })
 
       await page.goto(url.edit(existingDoc!.id))
@@ -1114,6 +1130,7 @@ const createTimezoneContextTests = (contextName: string, timezoneId: string) => 
         docs: [updatedDoc],
       } = await payload.find({
         collection: dateFieldsSlug,
+        overrideAccess: true,
       })
 
       expect(updatedDoc?.dayAndTimeWithTimezoneFixed).toEqual(expectedUpdatedUTCValue)
@@ -1128,6 +1145,7 @@ const createTimezoneContextTests = (contextName: string, timezoneId: string) => 
         docs: [existingDoc],
       } = await payload.find({
         collection: dateFieldsSlug,
+        overrideAccess: true,
       })
 
       await page.goto(url.edit(existingDoc!.id))
@@ -1201,6 +1219,7 @@ const createTimezoneContextTests = (contextName: string, timezoneId: string) => 
               equals: docID,
             },
           },
+          overrideAccess: true,
         })
 
         // The UTC value should be identical regardless of browser timezone context
@@ -1259,6 +1278,7 @@ const createTimezoneContextTests = (contextName: string, timezoneId: string) => 
               equals: docID,
             },
           },
+          overrideAccess: true,
         })
 
         expect(existingDoc?.dateWithOffsetTimezone).toEqual(expectedUTCValue)
@@ -1320,6 +1340,7 @@ const createTimezoneContextTests = (contextName: string, timezoneId: string) => 
               equals: docID,
             },
           },
+          overrideAccess: true,
         })
 
         // Should have saved with the offset timezone
@@ -1338,6 +1359,7 @@ const createTimezoneContextTests = (contextName: string, timezoneId: string) => 
             dateWithOffsetTimezone: '2025-01-01T12:30:00.000Z',
             dateWithOffsetTimezone_tz: '+05:30',
           },
+          overrideAccess: true,
         })
 
         await page.goto(url.edit(doc.id))

--- a/test/fields/collections/Indexed/e2e.spec.ts
+++ b/test/fields/collections/Indexed/e2e.spec.ts
@@ -70,6 +70,7 @@ describe('Radio', () => {
         uniqueRequiredText: 'text',
         uniqueText,
       },
+      overrideAccess: true,
     })
 
     await payload.update({
@@ -79,6 +80,7 @@ describe('Radio', () => {
         localizedUniqueRequiredText: 'es text',
       },
       locale: 'es',
+      overrideAccess: true,
     })
 
     await gotoAndWaitForForm(page, url.create)

--- a/test/fields/collections/JSON/e2e.spec.ts
+++ b/test/fields/collections/JSON/e2e.spec.ts
@@ -76,6 +76,7 @@ describe('JSON', () => {
     const longDoc = await payload.create({
       collection: jsonFieldsSlug,
       data: { json: longJsonData },
+      overrideAccess: true,
     })
 
     // Create a document with short JSON (<100 chars)
@@ -84,6 +85,7 @@ describe('JSON', () => {
     const shortDoc = await payload.create({
       collection: jsonFieldsSlug,
       data: { json: shortJsonData },
+      overrideAccess: true,
     })
 
     await page.goto(url.list)
@@ -122,6 +124,7 @@ describe('JSON', () => {
     const doc = await payload.create({
       collection: jsonFieldsSlug,
       data: { json: slightlyLongJsonData },
+      overrideAccess: true,
     })
 
     await page.goto(url.list)
@@ -187,6 +190,7 @@ describe('JSON', () => {
           default: 'value',
         },
       },
+      overrideAccess: true,
     })
 
     await page.goto(url.edit(createdDoc.id))

--- a/test/fields/collections/Point/e2e.spec.ts
+++ b/test/fields/collections/Point/e2e.spec.ts
@@ -65,6 +65,7 @@ describe('Point', () => {
         localized: [4, 2],
         point: [5, 5],
       },
+      overrideAccess: true,
     })
     emptyGroupPoint = await payload.create({
       collection: pointFieldsSlug,
@@ -73,6 +74,7 @@ describe('Point', () => {
         localized: [3, -2],
         point: [5, 5],
       },
+      overrideAccess: true,
     })
   })
 

--- a/test/fields/collections/Relationship/e2e.spec.ts
+++ b/test/fields/collections/Relationship/e2e.spec.ts
@@ -218,6 +218,7 @@ describe('relationship', () => {
       data: {
         text: 'doc to be deleted',
       },
+      overrideAccess: true,
     })
     const doc = await payload.create({
       collection: relationshipFieldsSlug,
@@ -227,10 +228,12 @@ describe('relationship', () => {
           value: createdRelatedDoc.id,
         },
       },
+      overrideAccess: true,
     })
     await payload.delete({
       id: createdRelatedDoc.id,
       collection: textFieldsSlug,
+      overrideAccess: true,
     })
 
     await page.goto(url.edit(doc.id))
@@ -455,10 +458,12 @@ describe('relationship', () => {
           equals: 'some updated text value',
         },
       },
+      overrideAccess: true,
     })
 
     const relationshipDocuments = await payload.find({
       collection: relationshipFieldsSlug,
+      overrideAccess: true,
     })
 
     // The Seeded text document should now have a text field with value 'some updated text value',
@@ -1065,6 +1070,7 @@ describe('relationship', () => {
         },
         relationshipDrawer: textDoc.id,
       },
+      overrideAccess: true,
     })
 
     await page.goto(url.edit(doc.id))
@@ -1158,6 +1164,7 @@ async function createTextFieldDoc(overrides?: Partial<TextField>): Promise<TextF
       text: 'some text',
       ...overrides,
     },
+    overrideAccess: true,
   }) as unknown as Promise<TextField>
 }
 
@@ -1171,5 +1178,6 @@ async function createRelationshipFieldDoc(
       relationship,
       ...overrides,
     },
+    overrideAccess: true,
   }) as unknown as Promise<RelationshipField>
 }

--- a/test/fields/collections/Select/index.ts
+++ b/test/fields/collections/Select/index.ts
@@ -301,6 +301,7 @@ const SelectFields: CollectionConfig = {
           collection: selectFieldsSlug,
           limit: 0,
           req,
+          overrideAccess: true,
         })
 
         return data.disallowOption2

--- a/test/fields/int.spec.ts
+++ b/test/fields/int.spec.ts
@@ -54,6 +54,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         email: devUser.email,
         password: devUser.password,
       },
+      overrideAccess: true,
     })
   })
 
@@ -62,7 +63,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
 
     test.afterEach(async ({ payload }) => {
       for (const id of created) {
-        await payload.delete({ collection: 'slug-fields', id })
+        await payload.delete({ collection: 'slug-fields', id, overrideAccess: true })
       }
       created.length = 0
     })
@@ -71,6 +72,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
       const doc = await payload.create({
         collection: 'slug-fields',
         data: { title: 'My First Post' },
+        overrideAccess: true,
       })
       created.push(doc.id)
       expect(doc.slug).toBe('my-first-post')
@@ -80,6 +82,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
       const doc = await payload.create({
         collection: 'slug-fields',
         data: { title: 'My First Post', slug: 'custom-slug' },
+        overrideAccess: true,
       })
       created.push(doc.id)
       expect(doc.slug).toBe('custom-slug')
@@ -89,6 +92,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
       const doc = await payload.create({
         collection: 'slug-fields',
         data: { title: 'My First Post', slug: 'Hello World' },
+        overrideAccess: true,
       })
       created.push(doc.id)
       expect(doc.slug).toBe('hello-world')
@@ -98,6 +102,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
       const doc = await payload.create({
         collection: 'slug-fields',
         data: { title: 'Original Title' },
+        overrideAccess: true,
       })
       created.push(doc.id)
 
@@ -105,6 +110,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         collection: 'slug-fields',
         id: doc.id,
         data: { title: 'Changed Title', slug: 'manual-value' },
+        overrideAccess: true,
       })
       expect(updated.slug).toBe('manual-value')
 
@@ -112,6 +118,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         collection: 'slug-fields',
         id: doc.id,
         data: { title: 'Changed Title Again' },
+        overrideAccess: true,
       })
       expect(again.slug).toBe('manual-value')
     })
@@ -121,6 +128,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         collection: 'slug-fields',
         data: { title: 'Title', localizedTitle: 'English Title' },
         locale: 'en',
+        overrideAccess: true,
       })
       created.push(doc.id)
       expect(doc.localizedSlug).toBe('english-title')
@@ -131,6 +139,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         collection: 'slug-fields',
         id: doc.id,
         locale: 'all',
+        overrideAccess: true,
       })
       const localizedSlug = allLocales.localizedSlug as unknown as Record<string, string>
       expect(localizedSlug.en).toBe('english-title')
@@ -144,6 +153,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         collection: 'slug-fields',
         data: { title: 'Hello World' },
         locale: 'en',
+        overrideAccess: true,
       })
       created.push(doc.id)
 
@@ -153,6 +163,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         collection: 'slug-fields',
         id: doc.id,
         locale: 'all',
+        overrideAccess: true,
       })
       const shared = allLocales.localizedSharedSlug as unknown as Record<string, string>
       expect(shared.en).toBe('hello-world')
@@ -166,6 +177,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         collection: 'slug-fields',
         data: { title: 'Title', localizedTitle: 'English Title' },
         locale: 'en',
+        overrideAccess: true,
       })
       created.push(doc.id)
 
@@ -175,12 +187,14 @@ test.suite({ config: './config.ts' })('Fields', () => {
         id: doc.id,
         data: { localizedSlug: 'titulo-espanol' },
         locale: 'es',
+        overrideAccess: true,
       })
 
       const allLocales = await payload.findByID({
         collection: 'slug-fields',
         id: doc.id,
         locale: 'all',
+        overrideAccess: true,
       })
       const localizedSlug = allLocales.localizedSlug as unknown as Record<string, string>
       expect(localizedSlug.en).toBe('english-title')
@@ -193,6 +207,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
       const doc = await payload.create({
         collection: 'slug-fields',
         data: { title: 'No Source' },
+        overrideAccess: true,
       })
       created.push(doc.id)
       expect(doc.sourcelessSlug).toMatch(/^slug-field-\d+$/)
@@ -204,6 +219,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
       const doc = await payload.create({
         collection: 'slug-fields',
         data: { title: 'No Source', sourcelessSlug: 'Manual Value' },
+        overrideAccess: true,
       })
       created.push(doc.id)
       expect(doc.sourcelessSlug).toBe('manual-value')
@@ -214,6 +230,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         collection: 'slug-fields',
         data: { title: 'Title', localizedSlug: 'shared' },
         locale: 'en',
+        overrideAccess: true,
       })
       created.push(en.id)
       expect(en.localizedSlug).toBe('shared')
@@ -222,6 +239,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         collection: 'slug-fields',
         data: { title: 'Titulo', localizedSlug: 'shared' },
         locale: 'es',
+        overrideAccess: true,
       })
       created.push(es.id)
       expect(es.localizedSlug).toBe('shared')
@@ -234,6 +252,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         collection: 'slug-fields',
         data: { title: 'Title', localizedSlug: 'shared-across-self' },
         locale: 'en',
+        overrideAccess: true,
       })
       created.push(doc.id)
       expect(doc.localizedSlug).toBe('shared-across-self')
@@ -243,6 +262,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         id: doc.id,
         data: { localizedSlug: 'shared-across-self' },
         locale: 'es',
+        overrideAccess: true,
       })
       expect(es.localizedSlug).toBe('shared-across-self')
 
@@ -250,6 +270,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         collection: 'slug-fields',
         id: doc.id,
         locale: 'all',
+        overrideAccess: true,
       })
       const localizedSlug = allLocales.localizedSlug as unknown as Record<string, string>
       expect(localizedSlug.en).toBe('shared-across-self')
@@ -263,6 +284,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         collection: 'slug-fields',
         data: { title: 'First', localizedSlug: 'shared-localized' },
         locale: 'es',
+        overrideAccess: true,
       })
       created.push(first.id)
       expect(first.localizedSlug).toBe('shared-localized')
@@ -272,6 +294,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           collection: 'slug-fields',
           data: { title: 'Second', localizedSlug: 'shared-localized' },
           locale: 'es',
+          overrideAccess: true,
         }),
       ).rejects.toThrow()
     })
@@ -282,6 +305,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         collection: 'slug-fields',
         data: { title: 'A', localizedSlug: 'my-slug' },
         locale: 'en',
+        overrideAccess: true,
       })
       created.push(a.id)
       await payload.update({
@@ -289,6 +313,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         id: a.id,
         data: { localizedSlug: 'my-slugo' },
         locale: 'es',
+        overrideAccess: true,
       })
 
       // Doc B may take `my-slug` in es — it matches A's en value, but the es namespace is free.
@@ -296,14 +321,15 @@ test.suite({ config: './config.ts' })('Fields', () => {
         collection: 'slug-fields',
         data: { title: 'B', localizedSlug: 'my-slug' },
         locale: 'es',
+        overrideAccess: true,
       })
       created.push(b.id)
 
       const aLocales = (
-        await payload.findByID({ collection: 'slug-fields', id: a.id, locale: 'all' })
+        await payload.findByID({ collection: 'slug-fields', id: a.id, locale: 'all', overrideAccess: true })
       ).localizedSlug as unknown as Record<string, string>
       const bLocales = (
-        await payload.findByID({ collection: 'slug-fields', id: b.id, locale: 'all' })
+        await payload.findByID({ collection: 'slug-fields', id: b.id, locale: 'all', overrideAccess: true })
       ).localizedSlug as unknown as Record<string, string>
       expect(aLocales.en).toBe('my-slug')
       expect(aLocales.es).toBe('my-slugo')
@@ -315,6 +341,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           collection: 'slug-fields',
           data: { title: 'C', localizedSlug: 'my-slugo' },
           locale: 'es',
+          overrideAccess: true,
         }),
       ).rejects.toThrow()
     })
@@ -326,6 +353,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         collection: 'slug-fields',
         data: { title: 'First', localizedTitle: 'Shared Derived' },
         locale: 'es',
+        overrideAccess: true,
       })
       created.push(first.id)
       expect(first.localizedSlug).toBe('shared-derived')
@@ -334,6 +362,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         collection: 'slug-fields',
         data: { title: 'Second', localizedTitle: 'Shared Derived' },
         locale: 'es',
+        overrideAccess: true,
       })
       created.push(second.id)
       expect(second.localizedSlug).toBe('shared-derived-1')
@@ -346,6 +375,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         collection: 'slug-fields',
         data: { title: 'English', localizedTitle: 'Cross Locale' },
         locale: 'en',
+        overrideAccess: true,
       })
       created.push(en.id)
       expect(en.localizedSlug).toBe('cross-locale')
@@ -354,6 +384,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         collection: 'slug-fields',
         data: { title: 'Spanish', localizedTitle: 'Cross Locale' },
         locale: 'es',
+        overrideAccess: true,
       })
       created.push(es.id)
       expect(es.localizedSlug).toBe('cross-locale')
@@ -365,6 +396,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
       const original = await payload.create({
         collection: 'slug-fields',
         data: { title: 'My First Post' },
+        overrideAccess: true,
       })
       created.push(original.id)
       expect(original.slug).toBe('my-first-post')
@@ -372,6 +404,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
       const duplicate = await payload.duplicate({
         collection: 'slug-fields',
         id: original.id,
+        overrideAccess: true,
       })
       created.push(duplicate.id)
 
@@ -381,6 +414,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
       const secondDuplicate = await payload.duplicate({
         collection: 'slug-fields',
         id: original.id,
+        overrideAccess: true,
       })
       created.push(secondDuplicate.id)
       expect(secondDuplicate.slug).toBe('slug-field-2')
@@ -392,6 +426,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
       const doc = await payload.create({
         collection: 'slug-fields',
         data: { title: 'Fallthrough Title', slug: '!!!' },
+        overrideAccess: true,
       })
       created.push(doc.id)
       expect(doc.slug).toBe('fallthrough-title')
@@ -401,6 +436,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
       const first = await payload.create({
         collection: 'slug-fields',
         data: { title: 'First', slug: 'shared-slug' },
+        overrideAccess: true,
       })
       created.push(first.id)
       expect(first.slug).toBe('shared-slug')
@@ -409,6 +445,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         payload.create({
           collection: 'slug-fields',
           data: { title: 'Second', slug: 'shared-slug' },
+          overrideAccess: true,
         }),
       ).rejects.toThrow()
     })
@@ -417,16 +454,18 @@ test.suite({ config: './config.ts' })('Fields', () => {
       const a = await payload.create({
         collection: 'slug-fields',
         data: { title: 'Doc A', slug: 'doc-a' },
+        overrideAccess: true,
       })
       created.push(a.id)
       const b = await payload.create({
         collection: 'slug-fields',
         data: { title: 'Doc B', slug: 'doc-b' },
+        overrideAccess: true,
       })
       created.push(b.id)
 
       await expect(
-        payload.update({ collection: 'slug-fields', id: b.id, data: { slug: 'doc-a' } }),
+        payload.update({ collection: 'slug-fields', id: b.id, data: { slug: 'doc-a' }, overrideAccess: true }),
       ).rejects.toThrow()
     })
 
@@ -434,6 +473,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
       const doc = await payload.create({
         collection: 'slug-fields',
         data: { title: 'Stable', slug: 'stable-slug' },
+        overrideAccess: true,
       })
       created.push(doc.id)
 
@@ -443,6 +483,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         collection: 'slug-fields',
         id: doc.id,
         data: { slug: 'stable-slug' },
+        overrideAccess: true,
       })
       expect(updated.slug).toBe('stable-slug')
     })
@@ -457,6 +498,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         collection: 'slug-fields',
         data: { title: 'Taken' },
         locale: 'es',
+        overrideAccess: true,
       })
       created.push(taken.id)
       const takenSlug = taken.localizedSlug as string
@@ -483,6 +525,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
       const first = await payload.create({
         collection: 'slug-fields',
         data: { title: 'Shared Regen' },
+        overrideAccess: true,
       })
       created.push(first.id)
       expect(first.slug).toBe('shared-regen')
@@ -508,6 +551,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
       const doc = await payload.create({
         collection: 'slug-fields',
         data: { title: 'Own Slug' },
+        overrideAccess: true,
       })
       created.push(doc.id)
       expect(doc.slug).toBe('own-slug')
@@ -533,7 +577,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
 
       test.afterEach(async ({ payload }) => {
         for (const id of created) {
-          await payload.delete({ collection: 'slug-autosave', id })
+          await payload.delete({ collection: 'slug-autosave', id, overrideAccess: true })
         }
         created.length = 0
       })
@@ -543,6 +587,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           collection: 'slug-autosave',
           draft: true,
           data: { title: 'Draft One' },
+          overrideAccess: true,
         })
         created.push(draft.id)
         expect(draft.slug).toBe('draft-one')
@@ -555,6 +600,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           collection: 'slug-autosave',
           draft: true,
           data: {},
+          overrideAccess: true,
         })
         created.push(draft.id)
         expect(draft.slug).toBe('slug-autosave-1')
@@ -565,6 +611,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           collection: 'slug-autosave',
           id: draft.id,
           draft: true,
+          overrideAccess: true,
         })
         expect(latestDraft.slug).toBe('slug-autosave-1')
       })
@@ -576,6 +623,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           collection: 'slug-autosave',
           draft: true,
           data: { slug: '!!!' },
+          overrideAccess: true,
         })
         created.push(draft.id)
         expect(draft.slug).toBe('slug-autosave-1')
@@ -588,6 +636,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           collection: 'slug-autosave',
           draft: true,
           data: {},
+          overrideAccess: true,
         })
         created.push(first.id)
 
@@ -595,6 +644,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           collection: 'slug-autosave',
           draft: true,
           data: {},
+          overrideAccess: true,
         })
         created.push(second.id)
 
@@ -607,6 +657,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           collection: 'slug-autosave',
           draft: true,
           data: { title: 'First', slug: 'shared-draft-slug' },
+          overrideAccess: true,
         })
         created.push(first.id)
         expect(first.slug).toBe('shared-draft-slug')
@@ -616,6 +667,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             collection: 'slug-autosave',
             draft: true,
             data: { title: 'Second', slug: 'shared-draft-slug' },
+            overrideAccess: true,
           }),
         ).rejects.toThrow()
       })
@@ -627,12 +679,14 @@ test.suite({ config: './config.ts' })('Fields', () => {
           collection: 'slug-autosave',
           draft: true,
           data: { title: 'A', slug: 'draft-a' },
+          overrideAccess: true,
         })
         created.push(a.id)
         const b = await payload.create({
           collection: 'slug-autosave',
           draft: true,
           data: { title: 'B', slug: 'draft-b' },
+          overrideAccess: true,
         })
         created.push(b.id)
 
@@ -642,6 +696,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             id: b.id,
             draft: true,
             data: { slug: 'draft-a' },
+            overrideAccess: true,
           }),
         ).rejects.toThrow()
       })
@@ -654,6 +709,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           draft: true,
           data: { localizedTitle: 'One', localizedSlug: 'shared-draft-localized' },
           locale: 'en',
+          overrideAccess: true,
         })
         created.push(en.id)
         expect(en.localizedSlug).toBe('shared-draft-localized')
@@ -664,6 +720,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           draft: true,
           data: { localizedTitle: 'Uno', localizedSlug: 'shared-draft-localized' },
           locale: 'es',
+          overrideAccess: true,
         })
         created.push(es.id)
         expect(es.localizedSlug).toBe('shared-draft-localized')
@@ -675,6 +732,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             draft: true,
             data: { localizedTitle: 'Two', localizedSlug: 'shared-draft-localized' },
             locale: 'en',
+            overrideAccess: true,
           }),
         ).rejects.toThrow()
       })
@@ -687,6 +745,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           draft: true,
           data: {},
           locale: 'en',
+          overrideAccess: true,
         })
         created.push(draft.id)
         expect(draft.localizedSlug).toBe('slug-autosave-1')
@@ -697,6 +756,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           id: draft.id,
           draft: true,
           locale: 'en',
+          overrideAccess: true,
         })
         expect(latestDraft.localizedSlug).toBe('slug-autosave-1')
 
@@ -705,6 +765,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           id: draft.id,
           data: { _status: 'published' },
           locale: 'en',
+          overrideAccess: true,
         })
         expect(published.localizedSlug).toBe('slug-autosave-1')
       })
@@ -717,6 +778,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           draft: true,
           data: {},
           locale: 'en',
+          overrideAccess: true,
         })
         created.push(draft.id)
 
@@ -725,6 +787,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           id: draft.id,
           draft: true,
           locale: 'all',
+          overrideAccess: true,
         })
         const localizedSlug = allLocales.localizedSlug as unknown as Record<string, string>
         expect(localizedSlug.en).toMatch(/^slug-autosave-\d+$/)
@@ -739,6 +802,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           draft: true,
           data: {},
           locale: 'en',
+          overrideAccess: true,
         })
         created.push(en.id)
         expect(en.localizedSlug).toBe('slug-autosave-1')
@@ -750,6 +814,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           draft: true,
           data: {},
           locale: 'es',
+          overrideAccess: true,
         })
         expect(es.localizedSlug).toBe('slug-autosave-1')
       })
@@ -759,11 +824,12 @@ test.suite({ config: './config.ts' })('Fields', () => {
           collection: 'slug-autosave',
           draft: true,
           data: { title: 'Dup Me', slug: 'dup-me' },
+          overrideAccess: true,
         })
         created.push(original.id)
         expect(original.slug).toBe('dup-me')
 
-        const duplicate = await payload.duplicate({ collection: 'slug-autosave', id: original.id })
+        const duplicate = await payload.duplicate({ collection: 'slug-autosave', id: original.id, overrideAccess: true })
         created.push(duplicate.id)
 
         expect(duplicate.slug).not.toBe('dup-me')
@@ -777,6 +843,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           collection: 'slug-autosave',
           draft: true,
           data: { title: 'Draft One', slug: 'user-typed' },
+          overrideAccess: true,
         })
         created.push(draft.id)
         expect(draft.slug).toBe('user-typed')
@@ -787,6 +854,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           collection: 'slug-autosave',
           draft: true,
           data: { title: 'Draft One' },
+          overrideAccess: true,
         })
         created.push(draft.id)
         expect(draft.slug).toBe('draft-one')
@@ -796,6 +864,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           id: draft.id,
           draft: true,
           data: { title: 'Draft One Updated' },
+          overrideAccess: true,
         })
         expect(updated.slug).toBe('draft-one')
       })
@@ -805,6 +874,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           collection: 'slug-autosave',
           draft: true,
           data: { title: 'Draft One' },
+          overrideAccess: true,
         })
         created.push(draft.id)
 
@@ -813,6 +883,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           id: draft.id,
           draft: true,
           data: { title: 'Draft Two' },
+          overrideAccess: true,
         })
 
         const overwritten = await payload.update({
@@ -820,6 +891,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           id: draft.id,
           draft: true,
           data: { slug: 'human-chosen-slug' },
+          overrideAccess: true,
         })
         expect(overwritten.slug).toBe('human-chosen-slug')
 
@@ -828,6 +900,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           id: draft.id,
           draft: true,
           data: { title: 'Draft Three' },
+          overrideAccess: true,
         })
         expect(afterMoreEdits.slug).toBe('human-chosen-slug')
       })
@@ -837,6 +910,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           collection: 'slug-autosave',
           draft: true,
           data: { title: 'Draft One' },
+          overrideAccess: true,
         })
         created.push(draft.id)
         expect(draft.slug).toBe('draft-one')
@@ -846,12 +920,14 @@ test.suite({ config: './config.ts' })('Fields', () => {
           id: draft.id,
           draft: true,
           data: { title: 'Publishable Title' },
+          overrideAccess: true,
         })
 
         const published = await payload.update({
           collection: 'slug-autosave',
           id: draft.id,
           data: { _status: 'published', title: 'Publishable Title' },
+          overrideAccess: true,
         })
         expect(published.slug).toBe('draft-one')
 
@@ -859,6 +935,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           collection: 'slug-autosave',
           id: draft.id,
           data: { _status: 'published', title: 'Title Changed After Publish' },
+          overrideAccess: true,
         })
         expect(afterPublish.slug).toBe('draft-one')
       })
@@ -871,7 +948,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
 
     test.afterEach(async ({ payload }) => {
       for (const id of created) {
-        await payload.delete({ collection, id })
+        await payload.delete({ collection, id, overrideAccess: true })
       }
       created.length = 0
     })
@@ -883,6 +960,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
       const hidden = await payload.create({
         collection,
         data: { title: 'REST shared title' },
+        overrideAccess: true,
       })
       created.push(hidden.id)
 
@@ -902,6 +980,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
       const hidden = await payload.create({
         collection,
         data: { title: 'Shared title' },
+        overrideAccess: true,
       })
       created.push(hidden.id)
 
@@ -923,10 +1002,12 @@ test.suite({ config: './config.ts' })('Fields', () => {
       const hidden = await payload.create({
         collection,
         data: { slug: 'shared-slug', title: 'Hidden' },
+        overrideAccess: true,
       })
       const editable = await payload.create({
         collection,
         data: { slug: 'editable-slug', title: 'Editable' },
+        overrideAccess: true,
       })
       created.push(hidden.id, editable.id)
 
@@ -947,6 +1028,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         collection,
         data: { localizedTitle: 'Localized title', title: 'Hidden' },
         locale: 'en',
+        overrideAccess: true,
       })
       created.push(hidden.id)
 
@@ -964,11 +1046,13 @@ test.suite({ config: './config.ts' })('Fields', () => {
         collection,
         id: createdWithAccess.id,
         locale: 'all',
+        overrideAccess: true,
       })
       const hiddenLocales = await payload.findByID({
         collection,
         id: hidden.id,
         locale: 'all',
+        overrideAccess: true,
       })
       const localizedSlug = allLocales.localizedSlug as unknown as Record<string, string>
       const hiddenLocalizedSlug = hiddenLocales.localizedSlug as unknown as Record<string, string>
@@ -981,6 +1065,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
       const hidden = await payload.create({
         collection,
         data: { title: 'Hidden' },
+        overrideAccess: true,
       })
       created.push(hidden.id)
 
@@ -1002,6 +1087,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
       const hidden = await payload.create({
         collection,
         data: { title: 'Shared title' },
+        overrideAccess: true,
       })
       created.push(hidden.id)
 
@@ -1023,6 +1109,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
       doc = await payload.create({
         collection: 'text-fields',
         data: { text },
+        overrideAccess: true,
       })
     })
 
@@ -1038,6 +1125,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
       const { dependentOnFieldWithDefaultValue, fieldWithDefaultValue } = await payload.create({
         collection: 'text-fields',
         data: { text },
+        overrideAccess: true,
       })
 
       expect(fieldWithDefaultValue).toEqual(dependentOnFieldWithDefaultValue)
@@ -1052,6 +1140,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         },
         collection: 'text-fields',
         data: { text: 'required' },
+        overrideAccess: true,
       })
 
       expect(text.defaultValueFromReq).toBe('from-context')
@@ -1066,11 +1155,13 @@ test.suite({ config: './config.ts' })('Fields', () => {
           text,
         },
         locale: 'en',
+        overrideAccess: true,
       })
       const localizedDoc = await payload.findByID({
         id,
         collection: 'text-fields',
         locale: 'all',
+        overrideAccess: true,
       })
 
       // @ts-expect-error
@@ -1089,12 +1180,14 @@ test.suite({ config: './config.ts' })('Fields', () => {
           },
         },
         locale: 'all',
+        overrideAccess: true,
       })
 
       const allLocales = await payload.findByID({
         id: doc.id,
         collection: 'text-fields',
         locale: 'all',
+        overrideAccess: true,
       })
 
       // @ts-expect-error
@@ -1102,7 +1195,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
       // @ts-expect-error
       expect(allLocales.localizedRequiredText.es).toEqual('Spanish text')
 
-      await payload.delete({ collection: 'text-fields', id: doc.id })
+      await payload.delete({ collection: 'text-fields', id: doc.id, overrideAccess: true })
     })
 
     test('should query hasMany in', async ({ payload }) => {
@@ -1112,6 +1205,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           hasMany: ['one', 'five'],
           text: 'required',
         },
+        overrideAccess: true,
       })
 
       const miss = await payload.create({
@@ -1120,6 +1214,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           hasMany: ['two'],
           text: 'required',
         },
+        overrideAccess: true,
       })
 
       const { docs } = await payload.find({
@@ -1129,6 +1224,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             in: ['one'],
           },
         },
+        overrideAccess: true,
       })
 
       const hitResult = docs.find(({ id: findID }) => hit.id === findID)
@@ -1139,7 +1235,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
     })
 
     test('should query multiple hasMany fields', async ({ payload }) => {
-      await payload.delete({ collection: 'text-fields', where: {} })
+      await payload.delete({ collection: 'text-fields', where: {}, overrideAccess: true })
       const hit = await payload.create({
         collection: 'text-fields',
         data: {
@@ -1147,6 +1243,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           hasManySecond: ['4'],
           text: 'required',
         },
+        overrideAccess: true,
       })
 
       const miss = await payload.create({
@@ -1156,6 +1253,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           hasManySecond: ['4'],
           text: 'required',
         },
+        overrideAccess: true,
       })
 
       const { docs } = await payload.find({
@@ -1166,6 +1264,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             equals: '4',
           },
         },
+        overrideAccess: true,
       })
 
       const hitResult = docs.find(({ id: findID }) => hit.id === findID)
@@ -1182,6 +1281,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           hasMany: ['apple pie', 'banana bread', 'cherry tart'],
           text: 'required',
         },
+        overrideAccess: true,
       })
 
       const miss = await payload.create({
@@ -1190,6 +1290,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           hasMany: ['orange juice', 'grape soda'],
           text: 'required',
         },
+        overrideAccess: true,
       })
 
       const { docs } = await payload.find({
@@ -1199,6 +1300,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             contains: 'banana',
           },
         },
+        overrideAccess: true,
       })
 
       const hitResult = docs.find(({ id: findID }) => hit.id === findID)
@@ -1207,8 +1309,8 @@ test.suite({ config: './config.ts' })('Fields', () => {
       expect(hitResult).toBeDefined()
       expect(missResult).toBeFalsy()
 
-      await payload.delete({ collection: 'text-fields', id: hit.id })
-      await payload.delete({ collection: 'text-fields', id: miss.id })
+      await payload.delete({ collection: 'text-fields', id: hit.id, overrideAccess: true })
+      await payload.delete({ collection: 'text-fields', id: miss.id, overrideAccess: true })
     })
 
     test('should query hasMany with contains operator - array value', async ({ payload }) => {
@@ -1218,6 +1320,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           hasMany: ['apple pie', 'banana bread'],
           text: 'required',
         },
+        overrideAccess: true,
       })
 
       const hit2 = await payload.create({
@@ -1226,6 +1329,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           hasMany: ['cherry tart', 'grape soda'],
           text: 'required',
         },
+        overrideAccess: true,
       })
 
       const miss = await payload.create({
@@ -1234,6 +1338,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           hasMany: ['orange juice', 'lemon water'],
           text: 'required',
         },
+        overrideAccess: true,
       })
 
       const { docs } = await payload.find({
@@ -1243,6 +1348,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             contains: ['banana', 'cherry'],
           },
         },
+        overrideAccess: true,
       })
 
       const hit1Result = docs.find(({ id: findID }) => hit1.id === findID)
@@ -1253,9 +1359,9 @@ test.suite({ config: './config.ts' })('Fields', () => {
       expect(hit2Result).toBeDefined()
       expect(missResult).toBeFalsy()
 
-      await payload.delete({ collection: 'text-fields', id: hit1.id })
-      await payload.delete({ collection: 'text-fields', id: hit2.id })
-      await payload.delete({ collection: 'text-fields', id: miss.id })
+      await payload.delete({ collection: 'text-fields', id: hit1.id, overrideAccess: true })
+      await payload.delete({ collection: 'text-fields', id: hit2.id, overrideAccess: true })
+      await payload.delete({ collection: 'text-fields', id: miss.id, overrideAccess: true })
     })
 
     test('should query like on value', async ({ payload }) => {
@@ -1264,6 +1370,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         data: {
           text: 'dog',
         },
+        overrideAccess: true,
       })
 
       const hit = await payload.create({
@@ -1271,6 +1378,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         data: {
           text: 'cat',
         },
+        overrideAccess: true,
       })
 
       const { docs } = await payload.find({
@@ -1280,6 +1388,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             like: 'cat',
           },
         },
+        overrideAccess: true,
       })
 
       const hitResult = docs.find(({ id: findID }) => hit.id === findID)
@@ -1295,6 +1404,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         data: {
           text: 'dog-unique-test',
         },
+        overrideAccess: true,
       })
 
       const miss = await payload.create({
@@ -1302,6 +1412,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         data: {
           text: 'cat-unique-test',
         },
+        overrideAccess: true,
       })
 
       const { docs } = await payload.find({
@@ -1311,6 +1422,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             not_like: 'cat-unique-test',
           },
         },
+        overrideAccess: true,
       })
 
       const hitResult = docs.find(({ id: findID }) => hit.id === findID)
@@ -1331,6 +1443,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             },
           ],
         },
+        overrideAccess: true,
       })
 
       const docSecond = await payload.create({
@@ -1343,6 +1456,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             },
           ],
         },
+        overrideAccess: true,
       })
 
       const resEqualsFull = await payload.find({
@@ -1353,6 +1467,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           },
         },
         sort: '-createdAt',
+        overrideAccess: true,
       })
 
       expect(resEqualsFull.docs.find((res) => res.id === docFirst.id)).toBeDefined()
@@ -1368,6 +1483,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           },
         },
         sort: '-createdAt',
+        overrideAccess: true,
       })
 
       expect(resEqualsFirst.docs.find((res) => res.id === docFirst.id)).toBeDefined()
@@ -1383,6 +1499,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           },
         },
         sort: '-createdAt',
+        overrideAccess: true,
       })
 
       expect(resContainsSecond.docs.find((res) => res.id === docFirst.id)).toBeUndefined()
@@ -1398,6 +1515,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           },
         },
         sort: '-createdAt',
+        overrideAccess: true,
       })
 
       expect(resInSecond.docs.find((res) => res.id === docFirst.id)).toBeUndefined()
@@ -1418,6 +1536,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             },
           ],
         },
+        overrideAccess: true,
       })
 
       const docSecond = await payload.create({
@@ -1431,6 +1550,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             },
           ],
         },
+        overrideAccess: true,
       })
 
       const resEqualsFull = await payload.find({
@@ -1441,6 +1561,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           },
         },
         sort: '-createdAt',
+        overrideAccess: true,
       })
 
       expect(resEqualsFull.docs.find((res) => res.id === docFirst.id)).toBeDefined()
@@ -1456,6 +1577,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           },
         },
         sort: '-createdAt',
+        overrideAccess: true,
       })
 
       expect(resEqualsFirst.docs.find((res) => res.id === docFirst.id)).toBeDefined()
@@ -1471,6 +1593,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           },
         },
         sort: '-createdAt',
+        overrideAccess: true,
       })
 
       expect(resContainsSecond.docs.find((res) => res.id === docFirst.id)).toBeUndefined()
@@ -1486,6 +1609,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           },
         },
         sort: '-createdAt',
+        overrideAccess: true,
       })
 
       expect(resInSecond.docs.find((res) => res.id === docFirst.id)).toBeUndefined()
@@ -1501,6 +1625,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           text: 'hasMany deletion test',
           hasMany: ['one', 'two', 'three'],
         },
+        overrideAccess: true,
       })
 
       await payload.update({
@@ -1509,11 +1634,13 @@ test.suite({ config: './config.ts' })('Fields', () => {
         data: {
           hasMany: [],
         },
+        overrideAccess: true,
       })
 
       const resultingDoc = await payload.findByID({
         collection: textFieldsSlug,
         id: createdDocId,
+        overrideAccess: true,
       })
 
       expect(resultingDoc.hasMany).toHaveLength(0)
@@ -1538,12 +1665,14 @@ test.suite({ config: './config.ts' })('Fields', () => {
         data: {
           text: textDocText,
         },
+        overrideAccess: true,
       })
       otherTextDoc = await payload.create({
         collection: 'text-fields',
         data: {
           text: otherTextDocText,
         },
+        overrideAccess: true,
       })
       const relationship = { relationTo: 'text-fields', value: textDoc.id }
       parent = await payload.create({
@@ -1552,6 +1681,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           relationship,
           text: relationshipText,
         },
+        overrideAccess: true,
       })
 
       child = await payload.create({
@@ -1561,6 +1691,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           relationship,
           text: relationshipText,
         },
+        overrideAccess: true,
       })
 
       grandChild = await payload.create({
@@ -1570,6 +1701,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           relationship,
           text: relationshipText,
         },
+        overrideAccess: true,
       })
 
       selfReferencing = await payload.create({
@@ -1578,6 +1710,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           relationship,
           text: relationshipText,
         },
+        overrideAccess: true,
       })
 
       relationshipInArray = await payload.create({
@@ -1590,6 +1723,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           ],
           relationship,
         },
+        overrideAccess: true,
       })
     })
 
@@ -1599,6 +1733,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         where: {
           relationToSelf: { equals: parent.id },
         },
+        overrideAccess: true,
       })
 
       const grandChildResult = await payload.find({
@@ -1606,16 +1741,19 @@ test.suite({ config: './config.ts' })('Fields', () => {
         where: {
           relationToSelf: { equals: child.id },
         },
+        overrideAccess: true,
       })
 
       const anyChildren = await payload.find({
         collection: relationshipFieldsSlug,
+        overrideAccess: true,
       })
       const allChildren = await payload.find({
         collection: relationshipFieldsSlug,
         where: {
           'relationToSelf.text': { equals: relationshipText },
         },
+        overrideAccess: true,
       })
 
       expect(childResult.docs[0].id).toStrictEqual(child.id)
@@ -1636,6 +1774,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             },
           ],
         },
+        overrideAccess: true,
       })
 
       expect(result.docs).toHaveLength(1)
@@ -1646,10 +1785,12 @@ test.suite({ config: './config.ts' })('Fields', () => {
       const row = await payload.create({
         collection: 'row-fields',
         data: { title: 'some-title', id: 'custom-row-id' },
+        overrideAccess: true,
       })
       const textDoc = await payload.create({
         collection: 'text-fields',
         data: { text: 'asd' },
+        overrideAccess: true,
       })
 
       const rel = await payload.create({
@@ -1659,6 +1800,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           relationToRow: row.id,
           relationToRowMany: [row.id],
         },
+        overrideAccess: true,
       })
 
       const result = await payload.find({
@@ -1667,6 +1809,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           'relationToRow.title': { equals: 'some-title' },
           'relationToRowMany.title': { equals: 'some-title' },
         },
+        overrideAccess: true,
       })
 
       expect(result.docs[0].id).toBe(rel.id)
@@ -1685,6 +1828,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             id: 'some-id',
             title: '',
           },
+          overrideAccess: true,
         }),
       ).rejects.toThrow('The following field is invalid: Title within a row')
     })
@@ -1698,6 +1842,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
       doc = await payload.create({
         collection: 'date-fields',
         data: dateDoc,
+        overrideAccess: true,
       })
     })
 
@@ -1710,6 +1855,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             greater_than_equal: tenMinutesAgo,
           },
         },
+        overrideAccess: true,
       })
 
       expect(docs.map(({ id }) => id)).toContain(doc.id)
@@ -1724,6 +1870,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             greater_than_equal: tenMinutesAgo,
           },
         },
+        overrideAccess: true,
       })
 
       expect(result.docs[0].id).toEqual(doc.id)
@@ -1738,6 +1885,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             greater_than_equal: tenMinutesLater,
           },
         },
+        overrideAccess: true,
       })
 
       expect(result.totalDocs).toBe(0)
@@ -1752,6 +1900,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             less_than: tenMinutesLater,
           },
         },
+        overrideAccess: true,
       })
 
       expect(result.docs[0].id).toEqual(doc.id)
@@ -1766,6 +1915,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             less_than: tenMinutesAgo,
           },
         },
+        overrideAccess: true,
       })
 
       expect(result.totalDocs).toBe(0)
@@ -1780,6 +1930,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             in: [new Date(doc.createdAt)],
           },
         },
+        overrideAccess: true,
       })
 
       expect(result.docs[0].id).toBe(doc.id)
@@ -1794,6 +1945,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             in: [tenMinutesAgo],
           },
         },
+        overrideAccess: true,
       })
 
       expect(result.totalDocs).toBe(0)
@@ -1821,17 +1973,19 @@ test.suite({ config: './config.ts' })('Fields', () => {
     })
 
     test('should query a date field inside an array field', async ({ payload }) => {
-      await payload.delete({ collection: 'date-fields', where: {} })
+      await payload.delete({ collection: 'date-fields', where: {}, overrideAccess: true })
       for (const doc of dataSample) {
         await payload.create({
           collection: 'date-fields',
           data: doc,
+          overrideAccess: true,
         })
       }
 
       const res = await payload.find({
         collection: 'date-fields',
         where: { 'array.date': { greater_than: new Date('2025-06-01').toISOString() } },
+        overrideAccess: true,
       })
 
       const filter = (doc: any) =>
@@ -1859,11 +2013,13 @@ test.suite({ config: './config.ts' })('Fields', () => {
           selectHasManyLocalized: ['one', 'two'],
         },
         locale: 'en',
+        overrideAccess: true,
       })
       doc = await payload.findByID({
         id,
         collection: 'select-fields',
         locale: 'all',
+        overrideAccess: true,
       })
     })
 
@@ -1877,6 +2033,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         data: {
           selectHasMany: ['one', 'two'],
         },
+        overrideAccess: true,
       })
 
       const updatedDoc = await payload.update({
@@ -1885,6 +2042,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         data: {
           select: 'one',
         },
+        overrideAccess: true,
       })
 
       expect(Array.isArray(updatedDoc.selectHasMany)).toBe(true)
@@ -1897,6 +2055,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         data: {
           selectHasMany: ['one', 'two'],
         },
+        overrideAccess: true,
       })
 
       const updatedDoc = await payload.update({
@@ -1905,6 +2064,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         data: {
           selectHasMany: [],
         },
+        overrideAccess: true,
       })
 
       expect(updatedDoc.selectHasMany).toHaveLength(0)
@@ -1916,6 +2076,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         data: {
           selectHasMany: ['one', 'four'],
         },
+        overrideAccess: true,
       })
 
       const miss = await payload.create({
@@ -1923,6 +2084,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         data: {
           selectHasMany: ['three'],
         },
+        overrideAccess: true,
       })
 
       const { docs } = await payload.find({
@@ -1932,6 +2094,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             in: ['one'],
           },
         },
+        overrideAccess: true,
       })
 
       const hitResult = docs.find(({ id: findID }) => hit.id === findID)
@@ -1945,6 +2108,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
       const doc = await payload.create({
         collection: 'select-fields',
         data: { array: [{ selectHasMany: ['one', 'two'] }] },
+        overrideAccess: true,
       })
 
       expect(doc.array[0].selectHasMany).toStrictEqual(['one', 'two'])
@@ -1960,6 +2124,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             },
           ],
         },
+        overrideAccess: true,
       })
 
       expect(upd.array[0].selectHasMany).toStrictEqual(['six'])
@@ -1969,6 +2134,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
       const doc = await payload.create({
         collection: 'select-fields',
         data: { array: [{ group: { selectHasMany: ['one', 'two'] } }] },
+        overrideAccess: true,
       })
 
       expect(doc.array[0].group.selectHasMany).toStrictEqual(['one', 'two'])
@@ -1984,6 +2150,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             },
           ],
         },
+        overrideAccess: true,
       })
 
       expect(upd.array[0].group.selectHasMany).toStrictEqual(['six'])
@@ -1993,6 +2160,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
       const base = await payload.create({
         collection: 'select-versions-fields',
         data: { hasMany: ['a', 'b'] },
+        overrideAccess: true,
       })
 
       expect(base.hasMany).toStrictEqual(['a', 'b'])
@@ -2001,6 +2169,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         collection: 'select-versions-fields',
         data: { array: [{ hasManyArr: ['a', 'b'] }] },
         draft: true,
+        overrideAccess: true,
       })
 
       expect(array.array[0]?.hasManyArr).toStrictEqual(['a', 'b'])
@@ -2008,6 +2177,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
       const block = await payload.create({
         collection: 'select-versions-fields',
         data: { blocks: [{ blockType: 'block', hasManyBlocks: ['a', 'b'] }] },
+        overrideAccess: true,
       })
 
       expect(block.blocks[0]?.hasManyBlocks).toStrictEqual(['a', 'b'])
@@ -2017,6 +2187,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
       let data = await payload.create({
         collection: 'select-versions-fields',
         data: { hasMany: ['a', 'b', 'c'] },
+        overrideAccess: true,
       })
       expect(data.hasMany).toStrictEqual(['a', 'b', 'c'])
 
@@ -2025,6 +2196,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         collection: 'select-versions-fields',
         data: { hasMany: ['a'] },
         draft: true,
+        overrideAccess: true,
       })
       expect(data.hasMany).toStrictEqual(['a'])
 
@@ -2034,6 +2206,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         data: { hasMany: ['a', 'b', 'c', 'd'] },
         draft: true,
         autosave: true,
+        overrideAccess: true,
       })
       expect(data.hasMany).toStrictEqual(['a', 'b', 'c', 'd'])
 
@@ -2043,6 +2216,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         data: { hasMany: ['a'] },
         draft: true,
         autosave: true,
+        overrideAccess: true,
       })
       expect(data.hasMany).toStrictEqual(['a'])
     })
@@ -2057,6 +2231,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             disallowOption1: true,
             selectWithFilteredOptions: 'one',
           },
+          overrideAccess: true,
         })
 
         expect(result).toBeFalsy()
@@ -2072,6 +2247,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           disallowOption1: true,
           selectWithFilteredOptions: 'two',
         },
+        overrideAccess: true,
       })
 
       expect(result).toBeTruthy()
@@ -2087,6 +2263,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             disallowOption2: true,
             selectAsyncFilterOptions: 'one',
           },
+          overrideAccess: true,
         }),
       ).rejects.toThrow('The following field is invalid: Select with async filtered options')
 
@@ -2096,6 +2273,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           disallowOption2: true,
           selectAsyncFilterOptions: 'two',
         },
+        overrideAccess: true,
       })
 
       expect(result).toBeTruthy()
@@ -2112,6 +2290,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           data: {
             selectHasMany: ['one', 'two', 'one', 'two', 'one'],
           },
+          overrideAccess: true,
         })
       } catch (e) {
         error = e as ValidationError
@@ -2129,6 +2308,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
       doc = await payload.create({
         collection: 'number-fields',
         data: numberDoc,
+        overrideAccess: true,
       })
     })
 
@@ -2150,6 +2330,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           data: {
             min: 5,
           },
+          overrideAccess: true,
         }),
       ).rejects.toThrow('The following field is invalid: Min')
     })
@@ -2160,6 +2341,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           data: {
             max: 15,
           },
+          overrideAccess: true,
         }),
       ).rejects.toThrow('The following field is invalid: Max')
     })
@@ -2171,6 +2353,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           data: {
             positiveNumber: -5,
           },
+          overrideAccess: true,
         }),
       ).rejects.toThrow('The following field is invalid: Positive Number')
     })
@@ -2182,6 +2365,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           data: {
             negativeNumber: 5,
           },
+          overrideAccess: true,
         }),
       ).rejects.toThrow('The following field is invalid: Negative Number')
     })
@@ -2192,6 +2376,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           data: {
             decimalMin: -0.25,
           },
+          overrideAccess: true,
         }),
       ).rejects.toThrow('The following field is invalid: Decimal Min')
     })
@@ -2203,6 +2388,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           data: {
             decimalMax: 1.5,
           },
+          overrideAccess: true,
         }),
       ).rejects.toThrow('The following field is invalid: Decimal Max')
     })
@@ -2214,11 +2400,13 @@ test.suite({ config: './config.ts' })('Fields', () => {
           localizedHasMany,
         },
         locale: 'en',
+        overrideAccess: true,
       })
       const localizedDoc = await payload.findByID({
         id,
         collection: 'number-fields',
         locale: 'all',
+        overrideAccess: true,
       })
 
       // @ts-expect-error
@@ -2231,6 +2419,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         data: {
           hasMany: [5, 10],
         },
+        overrideAccess: true,
       })
 
       const miss = await payload.create({
@@ -2238,6 +2427,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         data: {
           hasMany: [13],
         },
+        overrideAccess: true,
       })
 
       const { docs } = await payload.find({
@@ -2247,6 +2437,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             in: [5],
           },
         },
+        overrideAccess: true,
       })
 
       const hitResult = docs.find(({ id: findID }) => hit.id === findID)
@@ -2262,6 +2453,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         data: {
           number: null,
         },
+        overrideAccess: true,
       })
 
       const numbersExist = await payload.find({
@@ -2271,6 +2463,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             exists: true,
           },
         },
+        overrideAccess: true,
       })
 
       // Verify that documents with number field are found (at least the seeded ones)
@@ -2283,6 +2476,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             exists: false,
           },
         },
+        overrideAccess: true,
       })
 
       // Verify we find at least the document we just created with null
@@ -2296,6 +2490,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         data: {
           localizedHasMany: [1, 2, 3],
         },
+        overrideAccess: true,
       })
 
       await payload.update({
@@ -2304,11 +2499,13 @@ test.suite({ config: './config.ts' })('Fields', () => {
         data: {
           localizedHasMany: [],
         },
+        overrideAccess: true,
       })
 
       const resultingDoc = await payload.findByID({
         collection: numberFieldsSlug,
         id: createdDocId,
+        overrideAccess: true,
       })
 
       expect(resultingDoc.localizedHasMany).toHaveLength(0)
@@ -2325,6 +2522,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           },
         ],
       },
+      overrideAccess: true,
     })
 
     const docSecond = await payload.create({
@@ -2336,6 +2534,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           },
         ],
       },
+      overrideAccess: true,
     })
 
     const resEqualsFull = await payload.find({
@@ -2345,6 +2544,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           equals: 10,
         },
       },
+      overrideAccess: true,
     })
 
     expect(resEqualsFull.docs.find((res) => res.id === docFirst.id)).toBeDefined()
@@ -2359,6 +2559,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           equals: 30,
         },
       },
+      overrideAccess: true,
     })
 
     expect(resEqualsFirst.docs.find((res) => res.id === docFirst.id)).toBeDefined()
@@ -2373,6 +2574,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           in: [40],
         },
       },
+      overrideAccess: true,
     })
 
     expect(resInSecond.docs.find((res) => res.id === docFirst.id)).toBeUndefined()
@@ -2392,6 +2594,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           },
         ],
       },
+      overrideAccess: true,
     })
 
     const docSecond = await payload.create({
@@ -2404,6 +2607,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           },
         ],
       },
+      overrideAccess: true,
     })
 
     const resEqualsFull = await payload.find({
@@ -2413,6 +2617,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           equals: 10,
         },
       },
+      overrideAccess: true,
     })
 
     expect(resEqualsFull.docs.find((res) => res.id === docFirst.id)).toBeDefined()
@@ -2427,6 +2632,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           equals: 30,
         },
       },
+      overrideAccess: true,
     })
 
     expect(resEqualsFirst.docs.find((res) => res.id === docFirst.id)).toBeDefined()
@@ -2441,6 +2647,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           in: [40],
         },
       },
+      overrideAccess: true,
     })
 
     expect(resInSecond.docs.find((res) => res.id === docFirst.id)).toBeUndefined()
@@ -2541,6 +2748,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
       const findDoc = await payload.find({
         collection: 'point-fields',
         pagination: false,
+        overrideAccess: true,
       })
       ;[doc] = findDoc.docs
     })
@@ -2552,6 +2760,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
       const find = await payload.find({
         collection: 'point-fields',
         pagination: false,
+        overrideAccess: true,
       })
 
       ;[doc] = find.docs
@@ -2572,6 +2781,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           localized,
           point,
         },
+        overrideAccess: true,
       })
 
       expect(doc.point).toEqual(point)
@@ -2596,6 +2806,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           localized: uniqueLocalized,
           point: uniquePoint,
         },
+        overrideAccess: true,
       })
 
       // Now make sure we can't create a duplicate (since 'localized' is a unique field)
@@ -2607,6 +2818,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             localized: uniqueLocalized,
             point: uniquePoint,
           },
+          overrideAccess: true,
         }),
       ).rejects.toThrow(Error)
 
@@ -2616,6 +2828,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           data: {
             min: 5,
           },
+          overrideAccess: true,
         }),
       ).rejects.toThrow('The following field is invalid: Min')
 
@@ -2641,6 +2854,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           localized: uniqueLocalized,
           point: uniquePoint,
         },
+        overrideAccess: true,
       })
 
       // try to update the required field to null
@@ -2651,6 +2865,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             point: null,
           },
           id: doc.id,
+          overrideAccess: true,
         }),
       ).rejects.toThrow('The following field is invalid: Location')
     })
@@ -2672,6 +2887,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           localized: uniqueLocalized,
           point: uniquePoint,
         },
+        overrideAccess: true,
       })
 
       expect(doc.localized).toEqual(uniqueLocalized)
@@ -2683,6 +2899,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           localized: null,
         },
         id: doc.id,
+        overrideAccess: true,
       })
 
       expect(updatedDoc.localized).toEqual(undefined)
@@ -2696,6 +2913,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
       const res = await payload.create({
         collection: 'point-fields',
         data: { point, camelCasePoint: [7, -7] },
+        overrideAccess: true,
       })
       expect(res.camelCasePoint).toEqual([7, -7])
     })
@@ -2710,6 +2928,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             exists: true,
           },
         },
+        overrideAccess: true,
       })
     })
 
@@ -2720,6 +2939,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           checkbox: true,
           checkboxNotRequired: false,
         },
+        overrideAccess: true,
       })
 
       const existsFalseDoc = await payload.create({
@@ -2727,6 +2947,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         data: {
           checkbox: true,
         },
+        overrideAccess: true,
       })
 
       const existsFalse = await payload.find({
@@ -2736,6 +2957,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             exists: false,
           },
         },
+        overrideAccess: true,
       })
       expect(existsFalse.totalDocs).toBe(1)
       expect(existsFalse.docs[0]?.id).toEqual(existsFalseDoc.id)
@@ -2747,6 +2969,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             exists: true,
           },
         },
+        overrideAccess: true,
       })
       expect(existsTrue.totalDocs).toBe(1)
       expect(existsTrue.docs[0]?.id).toEqual(existsTrueDoc.id)
@@ -2764,6 +2987,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             exists: true,
           },
         },
+        overrideAccess: true,
       })
     })
 
@@ -2776,11 +3000,13 @@ test.suite({ config: './config.ts' })('Fields', () => {
       await payload.create({
         collection: 'indexed-fields',
         data,
+        overrideAccess: true,
       })
       expect(async () => {
         const result = await payload.create({
           collection: 'indexed-fields',
           data,
+          overrideAccess: true,
         })
         return result.error
       }).toBeDefined()
@@ -2792,6 +3018,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
       const textDoc = await payload.create({
         collection: 'text-fields',
         data: { text: 'unique-test-hasMany-false-' + Date.now() },
+        overrideAccess: true,
       })
 
       const firstDoc = await payload
@@ -2803,6 +3030,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             uniqueRequiredText: 'unique-3-' + Date.now(),
             uniqueRelationship: textDoc.id,
           },
+          overrideAccess: true,
         })
         // Skip mongodb unique error because it threats localizedUniqueRequriedText.es as undefined
         .then((doc) =>
@@ -2811,6 +3039,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             collection: 'indexed-fields',
             data: { localizedUniqueRequiredText: 'unique-20-' + Date.now() },
             id: doc.id,
+            overrideAccess: true,
           }),
         )
 
@@ -2823,6 +3052,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             uniqueRequiredText: 'unique-10-' + Date.now(),
             uniqueRelationship: textDoc.id,
           },
+          overrideAccess: true,
         }),
       ).rejects.toBeTruthy()
     })
@@ -2833,6 +3063,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
       const textDoc = await payload.create({
         collection: 'text-fields',
         data: { text: 'unique-test-hasMany-true-' + Date.now() },
+        overrideAccess: true,
       })
 
       const firstDoc = await payload
@@ -2844,6 +3075,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             uniqueRequiredText: 'unique-hasMany3-' + Date.now(),
             uniqueHasManyRelationship: [textDoc.id],
           },
+          overrideAccess: true,
         })
         // Skip mongodb unique error because it threats localizedUniqueRequriedText.es as undefined
         .then((doc) =>
@@ -2852,6 +3084,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             collection: 'indexed-fields',
             data: { localizedUniqueRequiredText: 'unique-hasMany40-' + Date.now() },
             id: doc.id,
+            overrideAccess: true,
           }),
         )
 
@@ -2865,6 +3098,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             uniqueRequiredText: 'unique-hasMany55-' + Date.now(),
             uniqueHasManyRelationship_2: [textDoc.id],
           },
+          overrideAccess: true,
         })
         // Skip mongodb unique error because it threats localizedUniqueRequriedText.es as undefined
         .then((doc) =>
@@ -2873,6 +3107,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             collection: 'indexed-fields',
             data: { localizedUniqueRequiredText: 'unique-hasMany30-' + Date.now() },
             id: doc.id,
+            overrideAccess: true,
           }),
         )
 
@@ -2885,6 +3120,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             uniqueRequiredText: 'unique-hasMany10-' + Date.now(),
             uniqueHasManyRelationship: [textDoc.id],
           },
+          overrideAccess: true,
         }),
       ).rejects.toBeTruthy()
     })
@@ -2895,6 +3131,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
       const textDoc = await payload.create({
         collection: 'text-fields',
         data: { text: 'unique-test-poly-' + Date.now() },
+        overrideAccess: true,
       })
 
       const firstDoc = await payload
@@ -2906,6 +3143,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             uniqueRequiredText: 'unique-poly3-' + Date.now(),
             uniquePolymorphicRelationship: { relationTo: 'text-fields', value: textDoc.id },
           },
+          overrideAccess: true,
         })
         // Skip mongodb unique error because it threats localizedUniqueRequriedText.es as undefined
         .then((doc) =>
@@ -2914,6 +3152,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             collection: 'indexed-fields',
             data: { localizedUniqueRequiredText: 'unique-poly20-' + Date.now() },
             id: doc.id,
+            overrideAccess: true,
           }),
         )
 
@@ -2927,6 +3166,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             uniqueRequiredText: 'unique-poly55-' + Date.now(),
             uniquePolymorphicRelationship_2: { relationTo: 'text-fields', value: textDoc.id },
           },
+          overrideAccess: true,
         })
         // Skip mongodb unique error because it threats localizedUniqueRequriedText.es as undefined
         .then((doc) =>
@@ -2935,6 +3175,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             collection: 'indexed-fields',
             data: { localizedUniqueRequiredText: 'unique-poly100-' + Date.now() },
             id: doc.id,
+            overrideAccess: true,
           }),
         )
 
@@ -2947,6 +3188,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             uniqueRequiredText: 'unique-poly10-' + Date.now(),
             uniquePolymorphicRelationship: { relationTo: 'text-fields', value: textDoc.id },
           },
+          overrideAccess: true,
         }),
       ).rejects.toBeTruthy()
     })
@@ -2957,6 +3199,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
       const textDoc = await payload.create({
         collection: 'text-fields',
         data: { text: 'unique-test-poly-hasMany-' + Date.now() },
+        overrideAccess: true,
       })
 
       const firstDoc = await payload
@@ -2970,6 +3213,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
               { relationTo: 'text-fields', value: textDoc.id },
             ],
           },
+          overrideAccess: true,
         })
         .then((doc) =>
           payload.update({
@@ -2977,6 +3221,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             collection: 'indexed-fields',
             data: { localizedUniqueRequiredText: 'unique-polyMany100-' + Date.now() },
             id: doc.id,
+            overrideAccess: true,
           }),
         )
 
@@ -2992,6 +3237,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
               { relationTo: 'text-fields', value: textDoc.id },
             ],
           },
+          overrideAccess: true,
         })
         // Skip mongodb unique error because it threats localizedUniqueRequriedText.es as undefined
         .then((doc) =>
@@ -3000,6 +3246,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             collection: 'indexed-fields',
             data: { localizedUniqueRequiredText: 'unique-polyMany300-' + Date.now() },
             id: doc.id,
+            overrideAccess: true,
           }),
         )
 
@@ -3014,6 +3261,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
               { relationTo: 'text-fields', value: textDoc.id },
             ],
           },
+          overrideAccess: true,
         }),
       ).rejects.toBeTruthy()
     })
@@ -3031,6 +3279,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
       const doc = await payload.create({
         collection: 'indexed-fields',
         data,
+        overrideAccess: true,
       })
       // Update spanish so we do not run into the unique constraint for other locales
       await payload.update({
@@ -3040,11 +3289,13 @@ test.suite({ config: './config.ts' })('Fields', () => {
           localizedUniqueRequiredText: 'es1-' + timestamp,
         },
         locale: 'es',
+        overrideAccess: true,
       })
       data.uniqueRequiredText = 'b-' + timestamp
       const result = await payload.create({
         collection: 'indexed-fields',
         data: { ...data, localizedUniqueRequiredText: 'en2-' + timestamp },
+        overrideAccess: true,
       })
 
       expect(result.id).toBeDefined()
@@ -3059,10 +3310,12 @@ test.suite({ config: './config.ts' })('Fields', () => {
       const doc = await payload.create({
         collection: 'indexed-fields',
         data,
+        overrideAccess: true,
       })
       const result = await payload.duplicate({
         id: doc.id,
         collection: 'indexed-fields',
+        overrideAccess: true,
       })
 
       expect(result.id).not.toEqual(doc.id)
@@ -3078,6 +3331,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
       doc = await payload.create({
         collection,
         data: {},
+        overrideAccess: true,
       })
     })
 
@@ -3085,6 +3339,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
       const docWithIDs = (await payload.create({
         collection: groupFieldsSlug,
         data: namedGroupDoc,
+        overrideAccess: true,
       })) as Partial<GroupField>
       expect(docWithIDs.group.subGroup.arrayWithinGroup[0].id).toBeDefined()
     })
@@ -3110,6 +3365,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             },
           ],
         },
+        overrideAccess: true,
       })
 
       const spanish = await payload.update({
@@ -3125,12 +3381,14 @@ test.suite({ config: './config.ts' })('Fields', () => {
           ],
         },
         locale: 'es',
+        overrideAccess: true,
       })
 
       const result = await payload.findByID({
         id: doc.id,
         collection,
         locale: 'all',
+        overrideAccess: true,
       })
 
       expect(doc.items[0].localizedText).toStrictEqual('test')
@@ -3157,6 +3415,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             },
           ],
         },
+        overrideAccess: true,
       })
 
       const res = await payload.update({
@@ -3184,6 +3443,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             },
           ],
         },
+        overrideAccess: true,
       })
 
       expect(res.nestedArrayLocalized).toHaveLength(3)
@@ -3212,11 +3472,13 @@ test.suite({ config: './config.ts' })('Fields', () => {
             },
           ],
         },
+        overrideAccess: true,
       })
 
       const result = await payload.findByID({
         id: doc.id,
         collection,
+        overrideAccess: true,
       })
 
       expect(result.items[0]).toMatchObject({
@@ -3241,6 +3503,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         data: {
           localized,
         },
+        overrideAccess: true,
       })
 
       const enDoc = await payload.update({
@@ -3250,6 +3513,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           localized: [{ text: enText }],
         },
         locale: 'en',
+        overrideAccess: true,
       })
 
       const esDoc = await payload.update({
@@ -3259,12 +3523,14 @@ test.suite({ config: './config.ts' })('Fields', () => {
           localized: [{ text: esText }],
         },
         locale: 'es',
+        overrideAccess: true,
       })
 
       const allLocales = (await payload.findByID({
         id,
         collection,
         locale: 'all',
+        overrideAccess: true,
       })) as unknown as {
         localized: {
           en: unknown
@@ -3291,6 +3557,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           ],
           localized: [{ text: 'a' }],
         },
+        overrideAccess: true,
       })
 
       // left join collection_items + left join collection_items_locales
@@ -3317,6 +3584,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             },
           ],
         },
+        overrideAccess: true,
       })
 
       expect(res.id).toBe(doc.id)
@@ -3340,6 +3608,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
               },
             ],
           },
+          overrideAccess: true,
         }),
       ).rejects.toThrow('The following field is invalid: Items 1 > Sub Array 1 > Second text field')
     })
@@ -3362,6 +3631,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
               },
             ],
           },
+          overrideAccess: true,
         }),
       ).rejects.toThrow('The following field is invalid: Items 1 > Sub Array 1 > Text In Row')
     })
@@ -3384,7 +3654,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
     })
 
     test.options({ db: 'mongo' })('should query exists true', async ({ payload }) => {
-      await payload.delete({ collection: 'array-fields', where: {} })
+      await payload.delete({ collection: 'array-fields', where: {}, overrideAccess: true })
 
       const withoutCollapsed = await payload.create({
         collection: 'array-fields',
@@ -3400,6 +3670,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             },
           ],
         },
+        overrideAccess: true,
       })
       const withCollapsed = await payload.create({
         collection: 'array-fields',
@@ -3416,6 +3687,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           ],
           items: [{ text: 'with-collapsed' }],
         },
+        overrideAccess: true,
       })
 
       const res = await payload.find({
@@ -3425,6 +3697,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             exists: true,
           },
         },
+        overrideAccess: true,
       })
 
       expect(res.totalDocs).toBe(1)
@@ -3432,7 +3705,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
     })
 
     test.options({ db: 'mongo' })('should query exists false', async ({ payload }) => {
-      await payload.delete({ collection: 'array-fields', where: {} })
+      await payload.delete({ collection: 'array-fields', where: {}, overrideAccess: true })
 
       const withoutCollapsed = await payload.create({
         collection: 'array-fields',
@@ -3448,6 +3721,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             },
           ],
         },
+        overrideAccess: true,
       })
       const withCollapsed = await payload.create({
         collection: 'array-fields',
@@ -3464,6 +3738,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           ],
           items: [{ text: 'with-collapsed' }],
         },
+        overrideAccess: true,
       })
 
       const res = await payload.find({
@@ -3473,6 +3748,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             exists: false,
           },
         },
+        overrideAccess: true,
       })
 
       expect(res.totalDocs).toBe(1)
@@ -3503,6 +3779,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           ],
           localized: [{ text: 'req' }],
         },
+        overrideAccess: true,
       })
 
       // Verify richText is returned as an object, not a string
@@ -3514,6 +3791,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
       const found = await payload.findByID({
         collection,
         id: doc.id,
+        overrideAccess: true,
       })
 
       expect(found.items[0].richTextField).toBeDefined()
@@ -3528,6 +3806,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           // @ts-expect-error testing null in array
           items: [null, { text: 'required', localizedText: 'valid' }],
         },
+        overrideAccess: true,
       })
 
       // The null should be stripped; the valid row should survive intact.
@@ -3543,6 +3822,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
       document = await payload.create({
         collection: groupFieldsSlug,
         data: {},
+        overrideAccess: true,
       })
     })
 
@@ -3567,6 +3847,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           insideUnnamedGroup: 'Hello world',
           deeplyNestedGroup: { insideNestedUnnamedGroup: 'Secondfield' },
         },
+        overrideAccess: true,
       })
       expect(groupDoc).toMatchObject({
         id: expect.anything(),
@@ -3616,6 +3897,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             text,
           },
         },
+        overrideAccess: true,
       })
       const miss = await payload.create({
         collection: groupFieldsSlug,
@@ -3624,12 +3906,14 @@ test.suite({ config: './config.ts' })('Fields', () => {
             text: 'do not find this',
           },
         },
+        overrideAccess: true,
       })
       const result = await payload.find({
         collection: groupFieldsSlug,
         where: {
           'localizedGroup.text': { equals: text },
         },
+        overrideAccess: true,
       })
 
       const resultIDs = result.docs.map(({ id }) => id)
@@ -3658,6 +3942,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             ],
           },
         },
+        overrideAccess: true,
       })
 
       expect(res.camelCaseGroup.array[0].text).toBe('text')
@@ -3674,6 +3959,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             array: [{ text: 'text-en' }],
           },
         },
+        overrideAccess: true,
       })
 
       expect(doc.localizedGroupArr.array[0].text).toBe('text-en')
@@ -3687,6 +3973,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             array: [{ text: 'text-es' }],
           },
         },
+        overrideAccess: true,
       })
 
       expect(esDoc.localizedGroupArr.array[0].text).toBe('text-es')
@@ -3695,6 +3982,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         collection: 'group-fields',
         id: doc.id,
         locale: 'all',
+        overrideAccess: true,
       })
 
       expect(allDoc.localizedGroupArr.en.array[0].text).toBe('text-en')
@@ -3713,6 +4001,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             select: ['one', 'two'],
           },
         },
+        overrideAccess: true,
       })
 
       expect(doc.localizedGroupSelect.select).toStrictEqual(['one', 'two'])
@@ -3726,6 +4015,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             select: ['one'],
           },
         },
+        overrideAccess: true,
       })
 
       expect(esDoc.localizedGroupSelect.select).toStrictEqual(['one'])
@@ -3734,6 +4024,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         collection: 'group-fields',
         id: doc.id,
         locale: 'all',
+        overrideAccess: true,
       })
 
       expect(allDoc.localizedGroupSelect.en.select).toStrictEqual(['one', 'two'])
@@ -3746,11 +4037,13 @@ test.suite({ config: './config.ts' })('Fields', () => {
       const rel_1 = await payload.create({
         collection: 'email-fields',
         data: { email: 'pro123@gmail.com' },
+        overrideAccess: true,
       })
 
       const rel_2 = await payload.create({
         collection: 'email-fields',
         data: { email: 'frank@gmail.com' },
+        overrideAccess: true,
       })
 
       const doc = await payload.create({
@@ -3762,6 +4055,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             email: rel_1.id,
           },
         },
+        overrideAccess: true,
       })
 
       expect(doc.localizedGroupRel.email).toBe(rel_1.id)
@@ -3776,6 +4070,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             email: rel_2.id,
           },
         },
+        overrideAccess: true,
       })
 
       expect(upd.localizedGroupRel.email).toBe(rel_2.id)
@@ -3785,6 +4080,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         id: doc.id,
         locale: 'all',
         depth: 0,
+        overrideAccess: true,
       })
 
       expect(docAll.localizedGroupRel.en.email).toBe(rel_1.id)
@@ -3797,11 +4093,13 @@ test.suite({ config: './config.ts' })('Fields', () => {
       const rel_1 = await payload.create({
         collection: 'email-fields',
         data: { email: 'pro123@gmail.com' },
+        overrideAccess: true,
       })
 
       const rel_2 = await payload.create({
         collection: 'email-fields',
         data: { email: 'frank@gmail.com' },
+        overrideAccess: true,
       })
 
       const doc = await payload.create({
@@ -3813,6 +4111,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             email: [rel_1.id],
           },
         },
+        overrideAccess: true,
       })
 
       expect(doc.localizedGroupManyRel.email).toStrictEqual([rel_1.id])
@@ -3827,6 +4126,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             email: [rel_2.id],
           },
         },
+        overrideAccess: true,
       })
 
       expect(upd.localizedGroupManyRel.email).toStrictEqual([rel_2.id])
@@ -3836,6 +4136,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         id: doc.id,
         locale: 'all',
         depth: 0,
+        overrideAccess: true,
       })
 
       expect(docAll.localizedGroupManyRel.en.email).toStrictEqual([rel_1.id])
@@ -3848,11 +4149,13 @@ test.suite({ config: './config.ts' })('Fields', () => {
       const rel_1 = await payload.create({
         collection: 'email-fields',
         data: { email: 'pro123@gmail.com' },
+        overrideAccess: true,
       })
 
       const rel_2 = await payload.create({
         collection: 'email-fields',
         data: { email: 'frank@gmail.com' },
+        overrideAccess: true,
       })
 
       const doc = await payload.create({
@@ -3867,6 +4170,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             },
           },
         },
+        overrideAccess: true,
       })
 
       expect(doc.localizedGroupPolyRel.email).toStrictEqual({
@@ -3887,6 +4191,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             },
           },
         },
+        overrideAccess: true,
       })
 
       expect(upd.localizedGroupPolyRel.email).toStrictEqual({
@@ -3899,6 +4204,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         id: doc.id,
         locale: 'all',
         depth: 0,
+        overrideAccess: true,
       })
 
       expect(docAll.localizedGroupPolyRel.en.email).toStrictEqual({
@@ -3917,11 +4223,13 @@ test.suite({ config: './config.ts' })('Fields', () => {
       const rel_1 = await payload.create({
         collection: 'email-fields',
         data: { email: 'pro123@gmail.com' },
+        overrideAccess: true,
       })
 
       const rel_2 = await payload.create({
         collection: 'email-fields',
         data: { email: 'frank@gmail.com' },
+        overrideAccess: true,
       })
 
       const doc = await payload.create({
@@ -3938,6 +4246,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             ],
           },
         },
+        overrideAccess: true,
       })
 
       expect(doc.localizedGroupPolyHasManyRel.email).toStrictEqual([
@@ -3962,6 +4271,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             ],
           },
         },
+        overrideAccess: true,
       })
 
       expect(upd.localizedGroupPolyHasManyRel.email).toStrictEqual([
@@ -3976,6 +4286,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         id: doc.id,
         locale: 'all',
         depth: 0,
+        overrideAccess: true,
       })
 
       expect(docAll.localizedGroupPolyHasManyRel.en.email).toStrictEqual([
@@ -4000,6 +4311,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
       document = await payload.create({
         collection: tabsFieldsSlug,
         data: tabsDoc,
+        overrideAccess: true,
       })
     })
 
@@ -4007,6 +4319,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
       const testDoc1 = await payload.findByID({
         id: document.id,
         collection: tabsFieldsSlug,
+        overrideAccess: true,
       })
 
       await reload(payload.config, payload, true)
@@ -4014,6 +4327,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
       const testDoc2 = await payload.findByID({
         id: document.id,
         collection: tabsFieldsSlug,
+        overrideAccess: true,
       })
 
       expect(testDoc1.id).toStrictEqual(testDoc2.id)
@@ -4036,6 +4350,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         id: document.id,
         collection: tabsFieldsSlug,
         locale: 'all',
+        overrideAccess: true,
       })
       expect(document.localizedTab.en.text).toStrictEqual(localizedTextValue)
     })
@@ -4053,6 +4368,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
       const newDocument = await payload.create({
         collection: tabsFieldsSlug,
         data: tabsDoc,
+        overrideAccess: true,
       })
       expect(newDocument.hooksTab.beforeValidate).toBe(true)
       expect(newDocument.hooksTab.beforeChange).toBe(true)
@@ -4064,6 +4380,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
       const doc = await payload.create({
         collection: groupFieldsSlug,
         data: namedGroupDoc,
+        overrideAccess: true,
       })
 
       expect(doc.potentiallyEmptyGroup).toBeDefined()
@@ -4094,6 +4411,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             ],
           },
         },
+        overrideAccess: true,
       })
 
       expect(res.camelCaseTab.array[0].text).toBe('text')
@@ -4120,6 +4438,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
               },
             ],
           },
+          overrideAccess: true,
         }),
       ).rejects.toThrow('The following field is invalid: Tab with Array > Array 3 > Text')
     })
@@ -4129,6 +4448,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
     test('should retrieve doc with blocks', async ({ payload }) => {
       const blockFields = await payload.find({
         collection: 'block-fields',
+        overrideAccess: true,
       })
 
       expect(blockFields.docs[0].blocks[0].blockType).toEqual(blocksDoc.blocks[0].blockType)
@@ -4156,6 +4476,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
               like: 'fun',
             },
           },
+          overrideAccess: true,
         })
 
         expect(blockFieldsSuccess.docs).toHaveLength(1)
@@ -4167,6 +4488,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
               like: 'funny',
             },
           },
+          overrideAccess: true,
         })
 
         expect(blockFieldsFail.docs).toHaveLength(0)
@@ -4184,6 +4506,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
               like: 'fun',
             },
           },
+          overrideAccess: true,
         })
 
         expect(blockFieldsSuccess.docs).toHaveLength(1)
@@ -4195,6 +4518,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
               like: 'funny',
             },
           },
+          overrideAccess: true,
         })
 
         expect(blockFieldsFail.docs).toHaveLength(0)
@@ -4212,6 +4536,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
               like: 'fun',
             },
           },
+          overrideAccess: true,
         })
 
         expect(blockFieldsSuccess.docs).toHaveLength(1)
@@ -4223,6 +4548,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
               like: 'funny',
             },
           },
+          overrideAccess: true,
         })
 
         expect(blockFieldsFail.docs).toHaveLength(0)
@@ -4240,6 +4566,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             },
           ],
         },
+        overrideAccess: true,
       })
       await payload.create({
         collection: 'block-fields',
@@ -4251,6 +4578,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             },
           ],
         },
+        overrideAccess: true,
       })
       await payload.create({
         collection: 'block-fields',
@@ -4262,6 +4590,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             },
           ],
         },
+        overrideAccess: true,
       })
 
       const blockFields = await payload.find({
@@ -4289,6 +4618,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         data: {
           text: 'test',
         },
+        overrideAccess: true,
       })
       const blockDoc = await payload.create({
         collection: blockFieldsSlug,
@@ -4300,12 +4630,14 @@ test.suite({ config: './config.ts' })('Fields', () => {
             },
           ],
         },
+        overrideAccess: true,
       })
       const result = await payload.find({
         collection: blockFieldsSlug,
         where: {
           'relationshipBlocks.relationship': { equals: textDoc.id },
         },
+        overrideAccess: true,
       })
 
       expect(result.docs).toHaveLength(1)
@@ -4325,6 +4657,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             },
           ],
         },
+        overrideAccess: true,
       })
       const miss = await payload.create({
         collection: blockFieldsSlug,
@@ -4342,6 +4675,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             },
           ],
         },
+        overrideAccess: true,
       })
 
       const { docs: equalsDocs } = await payload.find({
@@ -4356,6 +4690,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             },
           ],
         },
+        overrideAccess: true,
       })
 
       const { docs: inDocs } = await payload.find({
@@ -4363,6 +4698,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         where: {
           'blocks.blockType': { in: ['content'] },
         },
+        overrideAccess: true,
       })
 
       const equalsHitResult = equalsDocs.find(({ id }) => id === hit.id)
@@ -4391,6 +4727,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             },
           ],
         },
+        overrideAccess: true,
       })
 
       expect(result.blocksWithLocalizedArray[0].array[0].text).toEqual('localized')
@@ -4402,6 +4739,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
       const blockFields = await payload.find({
         collection: 'block-fields',
         locale: 'all',
+        overrideAccess: true,
       })
 
       // Find the document that has the localizedReferences field from the seed
@@ -4421,6 +4759,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
       const blockFields = await payload.find({
         collection: 'block-fields',
         locale: 'all',
+        overrideAccess: true,
       })
 
       // Find the document that has the localizedReferencesLocalizedBlock field from the seed
@@ -4449,6 +4788,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             },
           ],
         },
+        overrideAccess: true,
       })
 
       // The null should be stripped; the valid block should survive intact.
@@ -4473,6 +4813,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
               },
             },
           },
+          overrideAccess: true,
         }),
       ).rejects.toThrow(
         'The following field is invalid: Collapsible Field > Group > Sub Group > Required Text Within Sub Group',
@@ -4488,6 +4829,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         data: {
           json,
         },
+        overrideAccess: true,
       })
 
       expect(doc.json).toStrictEqual({ foo: 'bar' })
@@ -4500,6 +4842,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           data: {
             json: '{ bad input: true }',
           },
+          overrideAccess: true,
         }),
       ).rejects.toThrow('The following field is invalid: Json')
     })
@@ -4511,6 +4854,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           data: {
             json: { foo: 'bad' },
           },
+          overrideAccess: true,
         }),
       ).rejects.toThrow('The following field is invalid: Json')
     })
@@ -4523,6 +4867,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             state: {},
           },
         },
+        overrideAccess: true,
       })
 
       expect(jsonFieldsDoc.json.state).toEqual({})
@@ -4535,6 +4880,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             state: {},
           },
         },
+        overrideAccess: true,
       })
 
       expect(updatedJsonFieldsDoc.json.state).toEqual({})
@@ -4554,6 +4900,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
               exists: true,
             },
           },
+          overrideAccess: true,
         })
 
         fooBar = await payload.create({
@@ -4561,6 +4908,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           data: {
             json: { foo: 'foobar', number: 5 },
           },
+          overrideAccess: true,
         })
 
         bazBar = await payload.create({
@@ -4568,6 +4916,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           data: {
             json: { baz: 'bar', number: 10 },
           },
+          overrideAccess: true,
         })
 
         // Create content for array 'in' and 'not_in' queries
@@ -4580,6 +4929,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
                 isEven: i % 2 === 0,
               },
             },
+            overrideAccess: true,
           })
         }
       })
@@ -4590,6 +4940,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           where: {
             'json.foo': { like: 'bar' },
           },
+          overrideAccess: true,
         })
 
         const docIDs = docs.map(({ id }) => id)
@@ -4604,6 +4955,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           where: {
             'json.baz': { not_like: 'bar' },
           },
+          overrideAccess: true,
         })
 
         const docIDs = docs.map(({ id }) => id)
@@ -4618,6 +4970,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           where: {
             'json.foo': { equals: 'foobar' },
           },
+          overrideAccess: true,
         })
 
         const notEquals = await payload.find({
@@ -4625,6 +4978,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           where: {
             'json.foo': { equals: 'bar' },
           },
+          overrideAccess: true,
         })
 
         const docIDs = docs.map(({ id }) => id)
@@ -4640,6 +4994,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           where: {
             'json.number': { equals: 5 },
           },
+          overrideAccess: true,
         })
 
         const docIDs = docs.map(({ id }) => id)
@@ -4654,6 +5009,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           where: {
             'json.foo': { exists: true },
           },
+          overrideAccess: true,
         })
 
         const docIDs = docs.map(({ id }) => id)
@@ -4666,12 +5022,14 @@ test.suite({ config: './config.ts' })('Fields', () => {
         const nullJSON = await payload.create({
           collection: 'json-fields',
           data: {},
+          overrideAccess: true,
         })
         const hasJSON = await payload.create({
           collection: 'json-fields',
           data: {
             json: [],
           },
+          overrideAccess: true,
         })
 
         const docsExistsFalse = await payload.find({
@@ -4679,12 +5037,14 @@ test.suite({ config: './config.ts' })('Fields', () => {
           where: {
             json: { exists: false },
           },
+          overrideAccess: true,
         })
         const docsExistsTrue = await payload.find({
           collection: 'json-fields',
           where: {
             json: { exists: true },
           },
+          overrideAccess: true,
         })
 
         const existFalseIDs = docsExistsFalse.docs.map(({ id }) => id)
@@ -4703,6 +5063,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           data: {
             select: 'one',
           },
+          overrideAccess: true,
         })
 
         const existsResult = await payload.find({
@@ -4711,6 +5072,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             id: { equals: id },
             select: { exists: true },
           },
+          overrideAccess: true,
         })
 
         expect(existsResult.docs).toHaveLength(1)
@@ -4721,6 +5083,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             id: { equals: id },
             select: { exists: false },
           },
+          overrideAccess: true,
         })
 
         expect(existsFalseResult.docs).toHaveLength(0)
@@ -4731,6 +5094,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           data: {
             select: null,
           },
+          overrideAccess: true,
         })
 
         const existsTrueResult = await payload.find({
@@ -4739,6 +5103,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             id: { equals: id },
             select: { exists: true },
           },
+          overrideAccess: true,
         })
 
         expect(existsTrueResult.docs).toHaveLength(0)
@@ -4749,6 +5114,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             id: { equals: id },
             select: { exists: false },
           },
+          overrideAccess: true,
         })
 
         expect(result.docs).toHaveLength(1)
@@ -4760,6 +5126,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           where: {
             'json.value': { in: [1, 3] },
           },
+          overrideAccess: true,
         })
 
         const docIDs = docs.map(({ json }) => json.value)
@@ -4775,6 +5142,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           where: {
             'json.value': { not_in: [1, 3] },
           },
+          overrideAccess: true,
         })
 
         const docIDs = docs.map(({ json }) => json.value)
@@ -4800,6 +5168,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
               },
             ],
           },
+          overrideAccess: true,
         })
 
         const docIDs = docs.map(({ json }) => json.value)
@@ -4830,6 +5199,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
               ],
             },
           },
+          overrideAccess: true,
         })
 
         const { docs } = await payload.find({
@@ -4863,6 +5233,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
               },
             ],
           },
+          overrideAccess: true,
         })
 
         expect(docs).toHaveLength(1)
@@ -4878,6 +5249,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           data: {
             json: { doc: { value: docId, relationTo: collectionSlug } },
           },
+          overrideAccess: true,
         })
 
         // different ID, same relationTo — should NOT match the and query
@@ -4886,6 +5258,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           data: {
             json: { doc: { value: '99', relationTo: collectionSlug } },
           },
+          overrideAccess: true,
         })
 
         // same ID, different relationTo — should NOT match the and query
@@ -4894,6 +5267,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           data: {
             json: { doc: { value: docId, relationTo: 'other' } },
           },
+          overrideAccess: true,
         })
 
         const { docs: equalsDocs } = await payload.find({
@@ -4901,6 +5275,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           where: {
             'json.doc.value': { equals: docId },
           },
+          overrideAccess: true,
         })
 
         expect(equalsDocs.map(({ id }) => id)).toContain(matchingDoc.id)
@@ -4910,6 +5285,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           where: {
             'json.doc.value': { exists: true },
           },
+          overrideAccess: true,
         })
 
         expect(existsDocs.map(({ id }) => id)).toContain(matchingDoc.id)
@@ -4925,6 +5301,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
               { 'json.doc.relationTo': { equals: collectionSlug } },
             ],
           },
+          overrideAccess: true,
         })
 
         expect(andDocs).toHaveLength(1)
@@ -4938,6 +5315,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             where: {
               'json.select from': { equals: 5 },
             },
+            overrideAccess: true,
           }),
         ).rejects.toBeTruthy()
 
@@ -4947,6 +5325,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             where: {
               'json."unsafe"': { equals: 5 },
             },
+            overrideAccess: true,
           }),
         ).rejects.toBeTruthy()
 
@@ -4956,6 +5335,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             where: {
               'json.(unsafe"': { equals: 5 },
             },
+            overrideAccess: true,
           }),
         ).rejects.toBeTruthy()
 
@@ -4965,6 +5345,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             where: {
               'json.unsafe="': { equals: 5 },
             },
+            overrideAccess: true,
           }),
         ).rejects.toBeTruthy()
       })
@@ -4978,6 +5359,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
               where: {
                 'json.value': { equals: 'select(' },
               },
+              overrideAccess: true,
             }),
           ).rejects.toBeTruthy()
 
@@ -4987,6 +5369,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
               where: {
                 'json.value': { equals: '"unsafe' },
               },
+              overrideAccess: true,
             }),
           ).rejects.toBeTruthy()
 
@@ -4996,6 +5379,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
               where: {
                 'json.value': { equals: `'unsafe` },
               },
+              overrideAccess: true,
             }),
           ).rejects.toBeTruthy()
 
@@ -5005,6 +5389,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
               where: {
                 'json.value': { equals: `unsafe\\` },
               },
+              overrideAccess: true,
             }),
           ).rejects.toBeTruthy()
 
@@ -5014,6 +5399,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
               where: {
                 'json.value': { equals: `unsafe=` },
               },
+              overrideAccess: true,
             }),
           ).rejects.toBeTruthy()
         },
@@ -5038,6 +5424,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
               where: {
                 [path]: { equals: 'test' },
               },
+              overrideAccess: true,
             }),
           ).rejects.toBeTruthy()
         }
@@ -5049,6 +5436,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           where: {
             'json.valid_key': { equals: 'test' },
           },
+          overrideAccess: true,
         })
 
         expect(result.docs).toBeDefined()
@@ -5065,6 +5453,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             in: [],
           },
         },
+        overrideAccess: true,
       })
 
       expect(query.docs).toBeDefined()
@@ -5075,7 +5464,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
 
       test.afterEach(async ({ payload }) => {
         for (const id of createdIDs) {
-          await payload.delete({ collection: 'relationship-fields', id })
+          await payload.delete({ collection: 'relationship-fields', id, overrideAccess: true })
         }
         createdIDs.length = 0
       })
@@ -5090,11 +5479,13 @@ test.suite({ config: './config.ts' })('Fields', () => {
         const text1 = await payload.create({
           collection: 'text-fields',
           data: { text: 'Text 1' },
+          overrideAccess: true,
         })
 
         const text2 = await payload.create({
           collection: 'text-fields',
           data: { text: 'Text 2' },
+          overrideAccess: true,
         })
 
         const relDoc = await payload.create({
@@ -5103,6 +5494,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             relationshipHasMany: [text1.id, text2.id],
             relationship: { relationTo: 'text-fields', value: text1.id },
           },
+          overrideAccess: true,
         })
         createdIDs.push(relDoc.id)
 
@@ -5114,6 +5506,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
               equals: [text1.id, text2.id],
             },
           },
+          overrideAccess: true,
         })
 
         expect(result.docs).toHaveLength(1)
@@ -5127,6 +5520,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
               equals: [text1.id],
             },
           },
+          overrideAccess: true,
         })
 
         expect(noMatchResult.docs).toHaveLength(0)
@@ -5142,12 +5536,14 @@ test.suite({ config: './config.ts' })('Fields', () => {
         const text1 = await payload.create({
           collection: 'text-fields',
           data: { text: 'Text 1' },
+          overrideAccess: true,
         })
 
         // @ts-expect-error - items field typing issue
         const array1 = await payload.create({
           collection: 'array-fields',
           data: { items: [{ text: 'Array 1' }] },
+          overrideAccess: true,
         })
 
         const relDoc = await payload.create({
@@ -5159,6 +5555,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             ],
             relationship: { relationTo: 'text-fields', value: text1.id },
           },
+          overrideAccess: true,
         })
         createdIDs.push(relDoc.id)
 
@@ -5173,6 +5570,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
               ],
             },
           },
+          overrideAccess: true,
         })
 
         expect(result.docs).toHaveLength(1)
@@ -5186,6 +5584,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
               equals: [{ relationTo: 'text-fields', value: text1.id }],
             },
           },
+          overrideAccess: true,
         })
 
         expect(noMatchResult.docs).toHaveLength(0)
@@ -5201,16 +5600,19 @@ test.suite({ config: './config.ts' })('Fields', () => {
         const text1 = await payload.create({
           collection: 'text-fields',
           data: { text: 'Text 1' },
+          overrideAccess: true,
         })
 
         const text2 = await payload.create({
           collection: 'text-fields',
           data: { text: 'Text 2' },
+          overrideAccess: true,
         })
 
         const text3 = await payload.create({
           collection: 'text-fields',
           data: { text: 'Text 3' },
+          overrideAccess: true,
         })
 
         const relDoc1 = await payload.create({
@@ -5219,6 +5621,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             relationshipHasMany: [text1.id, text2.id],
             relationship: { relationTo: 'text-fields', value: text1.id },
           },
+          overrideAccess: true,
         })
         createdIDs.push(relDoc1.id)
 
@@ -5228,6 +5631,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             relationshipHasMany: [text3.id],
             relationship: { relationTo: 'text-fields', value: text3.id },
           },
+          overrideAccess: true,
         })
         createdIDs.push(relDoc2.id)
 
@@ -5239,6 +5643,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
               not_equals: [text1.id, text2.id],
             },
           },
+          overrideAccess: true,
         })
 
         const docIDs = result.docs.map((doc) => doc.id)
@@ -5254,6 +5659,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
               not_equals: [text3.id],
             },
           },
+          overrideAccess: true,
         })
 
         const noMatchDocIDs = noMatchResult.docs.map((doc) => doc.id)
@@ -5272,17 +5678,20 @@ test.suite({ config: './config.ts' })('Fields', () => {
         const text1 = await payload.create({
           collection: 'text-fields',
           data: { text: 'Text 1' },
+          overrideAccess: true,
         })
 
         // @ts-expect-error - items field typing issue
         const array1 = await payload.create({
           collection: 'array-fields',
           data: { items: [{ text: 'Array 1' }] },
+          overrideAccess: true,
         })
 
         const text2 = await payload.create({
           collection: 'text-fields',
           data: { text: 'Text 2' },
+          overrideAccess: true,
         })
 
         const relDoc1 = await payload.create({
@@ -5294,6 +5703,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             ],
             relationship: { relationTo: 'text-fields', value: text1.id },
           },
+          overrideAccess: true,
         })
         createdIDs.push(relDoc1.id)
 
@@ -5303,6 +5713,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             relationHasManyPolymorphic: [{ relationTo: 'text-fields', value: text2.id }],
             relationship: { relationTo: 'text-fields', value: text2.id },
           },
+          overrideAccess: true,
         })
         createdIDs.push(relDoc2.id)
 
@@ -5317,6 +5728,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
               ],
             },
           },
+          overrideAccess: true,
         })
 
         const docIDs = result.docs.map((doc) => doc.id)
@@ -5332,6 +5744,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
               not_equals: [{ relationTo: 'text-fields', value: text2.id }],
             },
           },
+          overrideAccess: true,
         })
 
         const noMatchDocIDs = noMatchResult.docs.map((doc) => doc.id)
@@ -5346,6 +5759,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         const text1 = await payload.create({
           collection: 'text-fields',
           data: { text: 'Text 1' },
+          overrideAccess: true,
         })
 
         const relDoc = await payload.create({
@@ -5354,6 +5768,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             relationshipHasMany: [text1.id],
             relationship: { relationTo: 'text-fields', value: text1.id },
           },
+          overrideAccess: true,
         })
         createdIDs.push(relDoc.id)
 
@@ -5365,6 +5780,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
                 equals: [text1.id],
               },
             },
+            overrideAccess: true,
           })
 
           expect(equalsResult.docs.some((doc) => doc.id === relDoc.id)).toBe(true)
@@ -5376,11 +5792,12 @@ test.suite({ config: './config.ts' })('Fields', () => {
                 not_equals: [text1.id],
               },
             },
+            overrideAccess: true,
           })
 
           expect(notEqualsResult.docs.some((doc) => doc.id === relDoc.id)).toBe(false)
         } finally {
-          await payload.delete({ collection: 'text-fields', id: text1.id })
+          await payload.delete({ collection: 'text-fields', id: text1.id, overrideAccess: true })
         }
       })
 
@@ -5395,11 +5812,13 @@ test.suite({ config: './config.ts' })('Fields', () => {
         const text1 = await payload.create({
           collection: 'text-fields',
           data: { text: 'Text 1' },
+          overrideAccess: true,
         })
 
         const text2 = await payload.create({
           collection: 'text-fields',
           data: { text: 'Text 2' },
+          overrideAccess: true,
         })
 
         // relDocWithNull has no relationshipDrawer set (null)
@@ -5408,6 +5827,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           data: {
             relationship: { relationTo: 'text-fields', value: text1.id },
           },
+          overrideAccess: true,
         })
         createdIDs.push(relDocWithNull.id)
 
@@ -5423,12 +5843,13 @@ test.suite({ config: './config.ts' })('Fields', () => {
                 not_equals: [text2.id],
               },
             },
+            overrideAccess: true,
           })
 
           expect(result.docs.some((doc) => doc.id === relDocWithNull.id)).toBe(true)
         } finally {
-          await payload.delete({ collection: 'text-fields', id: text1.id })
-          await payload.delete({ collection: 'text-fields', id: text2.id })
+          await payload.delete({ collection: 'text-fields', id: text1.id, overrideAccess: true })
+          await payload.delete({ collection: 'text-fields', id: text2.id, overrideAccess: true })
         }
       })
     })
@@ -5441,6 +5862,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         data: {
           select: 'one',
         },
+        overrideAccess: true,
       })
 
       const existsResult = await payload.find({
@@ -5449,6 +5871,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           id: { equals: id },
           select: { exists: true },
         },
+        overrideAccess: true,
       })
 
       expect(existsResult.docs).toHaveLength(1)
@@ -5459,6 +5882,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           id: { equals: id },
           select: { exists: false },
         },
+        overrideAccess: true,
       })
 
       expect(existsFalseResult.docs).toHaveLength(0)
@@ -5469,6 +5893,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         data: {
           select: null,
         },
+        overrideAccess: true,
       })
 
       const existsTrueResult = await payload.find({
@@ -5477,6 +5902,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           id: { equals: id },
           select: { exists: true },
         },
+        overrideAccess: true,
       })
 
       expect(existsTrueResult.docs).toHaveLength(0)
@@ -5487,6 +5913,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           id: { equals: id },
           select: { exists: false },
         },
+        overrideAccess: true,
       })
 
       expect(result.docs).toHaveLength(1)
@@ -5501,6 +5928,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         await payload.delete({
           collection: customIDNestedSlug,
           id,
+          overrideAccess: true,
         })
       }
       createdIDs.length = 0
@@ -5517,6 +5945,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           title: 'Test Document',
           description: 'Testing nested custom ID field',
         },
+        overrideAccess: true,
       })
 
       expect(doc.id).toBe(customID)
@@ -5533,11 +5962,13 @@ test.suite({ config: './config.ts' })('Fields', () => {
           id: customID,
           title: 'Another Test',
         },
+        overrideAccess: true,
       })
 
       const retrieved = await payload.findByID({
         collection: customIDNestedSlug,
         id: customID,
+        overrideAccess: true,
       })
 
       expect(retrieved.id).toBe(customID)
@@ -5554,6 +5985,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           id: customID,
           title: 'Original Title',
         },
+        overrideAccess: true,
       })
 
       const updated = await payload.update({
@@ -5562,6 +5994,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         data: {
           title: 'Updated Title',
         },
+        overrideAccess: true,
       })
 
       expect(updated.id).toBe(customID)
@@ -5579,6 +6012,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           dateWithOffsetTimezone_tz: '+05:30',
         },
         draft: true,
+        overrideAccess: true,
       })
 
       expect(doc.dateWithOffsetTimezone).toEqual('2027-08-12T04:30:00.000Z')
@@ -5594,6 +6028,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           dateWithMixedTimezones_tz: 'America/New_York',
         },
         draft: true,
+        overrideAccess: true,
       })
 
       expect(doc.dateWithMixedTimezones_tz).toEqual('America/New_York')
@@ -5604,6 +6039,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
         data: {
           dateWithMixedTimezones_tz: '+05:30',
         },
+        overrideAccess: true,
       })
 
       expect(updated.dateWithMixedTimezones_tz).toEqual('+05:30')
@@ -5618,6 +6054,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           dateWithOffsetTimezone_tz: '+05:30',
         },
         draft: true,
+        overrideAccess: true,
       })
 
       await payload.create({
@@ -5628,6 +6065,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           dateWithOffsetTimezone_tz: '-08:00',
         },
         draft: true,
+        overrideAccess: true,
       })
 
       const indiaTimezoneResults = await payload.find({
@@ -5637,6 +6075,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             equals: '+05:30',
           },
         },
+        overrideAccess: true,
       })
 
       expect(indiaTimezoneResults.docs.length).toBeGreaterThanOrEqual(1)
@@ -5654,6 +6093,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           dateWithMixedTimezones_tz: 'America/New_York',
         },
         draft: true,
+        overrideAccess: true,
       })
 
       expect(doc.dateWithMixedTimezones_tz).toEqual('America/New_York')
@@ -5667,6 +6107,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           dateWithMixedTimezones_tz: '+05:30',
         },
         draft: true,
+        overrideAccess: true,
       })
 
       expect(doc2.dateWithMixedTimezones_tz).toEqual('+05:30')
@@ -5682,6 +6123,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           dateWithOffsetTimezone_tz: '+05:30',
         },
         draft: true,
+        overrideAccess: true,
       })
 
       expect(doc1.dateWithOffsetTimezone_tz).toEqual('+05:30')
@@ -5695,6 +6137,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           dateWithOffsetTimezone_tz: '-08:00',
         },
         draft: true,
+        overrideAccess: true,
       })
 
       expect(doc2.dateWithOffsetTimezone_tz).toEqual('-08:00')
@@ -5708,6 +6151,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           dateWithOffsetTimezone_tz: '+00:00',
         },
         draft: true,
+        overrideAccess: true,
       })
 
       expect(doc3.dateWithOffsetTimezone_tz).toEqual('+00:00')
@@ -5727,6 +6171,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             dateWithOffsetTimezone_tz: '+05:30',
           },
           draft: true,
+          overrideAccess: true,
         })
 
         const query = `
@@ -5762,6 +6207,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             dateWithOffsetTimezone_tz: '-08:00',
           },
           draft: true,
+          overrideAccess: true,
         })
 
         const query = `
@@ -5791,6 +6237,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             dateWithMixedTimezones_tz: 'America/New_York',
           },
           draft: true,
+          overrideAccess: true,
         })
 
         const query = `
@@ -5893,6 +6340,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             dateWithOffsetTimezone_tz: '+05:30',
           },
           draft: true,
+          overrideAccess: true,
         })
 
         const mutation = `
@@ -5930,6 +6378,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             dateWithMixedTimezones: '2027-08-12T14:00:00.000Z',
             dateWithMixedTimezones_tz: 'America/New_York',
           },
+          overrideAccess: true,
         })
 
         const mutation = `
@@ -5968,6 +6417,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             dateWithMixedTimezones_tz: '+05:30',
           },
           draft: true,
+          overrideAccess: true,
         })
 
         const mutation = `
@@ -6005,6 +6455,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             dateWithOffsetTimezone_tz: '+05:30',
           },
           draft: true,
+          overrideAccess: true,
         })
 
         await payload.create({
@@ -6015,6 +6466,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
             dateWithOffsetTimezone_tz: '-08:00',
           },
           draft: true,
+          overrideAccess: true,
         })
 
         const query = `
@@ -6097,6 +6549,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           dateWithTimezoneWithDisabledColumns_tz: 'America/New_York',
         },
         draft: true,
+        overrideAccess: true,
       })
 
       expect(doc.dateWithTimezoneWithDisabledColumns_tz).toEqual('America/New_York')
@@ -6129,6 +6582,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           dateWithTimezoneNoDefault: '2027-08-12T14:00:00.000Z',
         },
         draft: true,
+        overrideAccess: true,
       })
 
       expect(doc.dateWithTimezoneNoDefault_tz).toBeFalsy()
@@ -6144,6 +6598,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
           dateWithMixedTimezones: '2027-08-12T14:00:00.000Z',
         },
         draft: true,
+        overrideAccess: true,
       })
 
       expect(doc.dateWithMixedTimezones_tz).toEqual('America/New_York')

--- a/test/folders/config.ts
+++ b/test/folders/config.ts
@@ -72,6 +72,7 @@ export default buildConfigWithDefaults({
         email: devUser.email,
         password: devUser.password,
       },
+      overrideAccess: true,
     })
     await seed(payload)
   },

--- a/test/folders/seed.ts
+++ b/test/folders/seed.ts
@@ -18,162 +18,189 @@ export const seed = async (payload: Payload): Promise<void> => {
   const documentation = await payload.create({
     collection: folderSlug,
     data: { name: 'Documentation', folderType: ['posts'] },
+    overrideAccess: true,
   })
 
   // Documentation > Getting Started
   const gettingStarted = await payload.create({
     collection: folderSlug,
     data: { name: 'Getting Started', folder: documentation.id, folderType: ['posts'] },
+    overrideAccess: true,
   })
 
   // Documentation > SDKs (container)
   const sdks = await payload.create({
     collection: folderSlug,
     data: { name: 'SDKs', folder: documentation.id, folderType: ['posts'] },
+    overrideAccess: true,
   })
 
   // Documentation > SDKs > JavaScript
   const sdkJs = await payload.create({
     collection: folderSlug,
     data: { name: 'JavaScript', folder: sdks.id, folderType: ['posts'] },
+    overrideAccess: true,
   })
 
   // Documentation > SDKs > iOS
   const sdkIos = await payload.create({
     collection: folderSlug,
     data: { name: 'iOS', folder: sdks.id, folderType: ['posts'] },
+    overrideAccess: true,
   })
 
   // Documentation > SDKs > Python
   await payload.create({
     collection: folderSlug,
     data: { name: 'Python', folder: sdks.id, folderType: ['posts'] },
+    overrideAccess: true,
   })
 
   // Documentation > SDKs > React Native
   await payload.create({
     collection: folderSlug,
     data: { name: 'React Native', folder: sdks.id, folderType: ['posts'] },
+    overrideAccess: true,
   })
 
   // Documentation > Features (container)
   const features = await payload.create({
     collection: folderSlug,
     data: { name: 'Features', folder: documentation.id, folderType: ['posts'] },
+    overrideAccess: true,
   })
 
   // Documentation > Features > Funnels
   const funnels = await payload.create({
     collection: folderSlug,
     data: { name: 'Funnels', folder: features.id, folderType: ['posts'] },
+    overrideAccess: true,
   })
 
   // Documentation > Features > Cohorts
   await payload.create({
     collection: folderSlug,
     data: { name: 'Cohorts', folder: features.id, folderType: ['posts'] },
+    overrideAccess: true,
   })
 
   // Documentation > Features > Retention
   const retention = await payload.create({
     collection: folderSlug,
     data: { name: 'Retention', folder: features.id, folderType: ['posts', 'media'] },
+    overrideAccess: true,
   })
 
   // Documentation > Features > Dashboards
   await payload.create({
     collection: folderSlug,
     data: { name: 'Dashboards', folder: features.id, folderType: ['posts', 'media'] },
+    overrideAccess: true,
   })
 
   // Root: Marketing
   const marketing = await payload.create({
     collection: folderSlug,
     data: { name: 'Marketing', folderType: ['posts', 'media'] },
+    overrideAccess: true,
   })
 
   // Marketing > Blog (container)
   const blog = await payload.create({
     collection: folderSlug,
     data: { name: 'Blog', folder: marketing.id, folderType: ['posts'] },
+    overrideAccess: true,
   })
 
   // Marketing > Blog > Product Updates
   const productUpdates = await payload.create({
     collection: folderSlug,
     data: { name: 'Product Updates', folder: blog.id, folderType: ['posts'] },
+    overrideAccess: true,
   })
 
   // Marketing > Blog > Engineering
   const engineering = await payload.create({
     collection: folderSlug,
     data: { name: 'Engineering', folder: blog.id, folderType: ['posts'] },
+    overrideAccess: true,
   })
 
   // Marketing > Blog > Customer Stories
   await payload.create({
     collection: folderSlug,
     data: { name: 'Customer Stories', folder: blog.id, folderType: ['posts'] },
+    overrideAccess: true,
   })
 
   // Marketing > Landing Pages
   await payload.create({
     collection: folderSlug,
     data: { name: 'Landing Pages', folder: marketing.id, folderType: ['posts', 'media'] },
+    overrideAccess: true,
   })
 
   // Marketing > Case Studies
   const caseStudies = await payload.create({
     collection: folderSlug,
     data: { name: 'Case Studies', folder: marketing.id, folderType: ['posts', 'media'] },
+    overrideAccess: true,
   })
 
   // Marketing > Brand Assets (media only)
   const brandAssets = await payload.create({
     collection: folderSlug,
     data: { name: 'Brand Assets', folder: marketing.id, folderType: ['media'] },
+    overrideAccess: true,
   })
 
   // Root: Product
   const product = await payload.create({
     collection: folderSlug,
     data: { name: 'Product', folderType: ['posts'] },
+    overrideAccess: true,
   })
 
   // Product > Changelog
   const changelog = await payload.create({
     collection: folderSlug,
     data: { name: 'Changelog', folder: product.id, folderType: ['posts'] },
+    overrideAccess: true,
   })
 
   // Product > Roadmap
   await payload.create({
     collection: folderSlug,
     data: { name: 'Roadmap', folder: product.id, folderType: ['posts'] },
+    overrideAccess: true,
   })
 
   // Root: Legal
   const legal = await payload.create({
     collection: folderSlug,
     data: { name: 'Legal', folderType: ['posts'] },
+    overrideAccess: true,
   })
 
   // Legal > Privacy
   const privacy = await payload.create({
     collection: folderSlug,
     data: { name: 'Privacy', folder: legal.id, folderType: ['posts'] },
+    overrideAccess: true,
   })
 
   // Legal > Terms
   const terms = await payload.create({
     collection: folderSlug,
     data: { name: 'Terms', folder: legal.id, folderType: ['posts'] },
+    overrideAccess: true,
   })
 
   // Root: Shared (no folderType restriction - for testing)
   const shared = await payload.create({
     collection: folderSlug,
     data: { name: 'Shared' },
+    overrideAccess: true,
   })
 
   // ============================================
@@ -187,6 +214,7 @@ export const seed = async (payload: Payload): Promise<void> => {
       folder: documentation.id,
       title: 'Documentation Overview',
     },
+    overrideAccess: true,
   })
 
   // Getting Started docs
@@ -196,6 +224,7 @@ export const seed = async (payload: Payload): Promise<void> => {
       folder: gettingStarted.id,
       title: 'Quick Start Guide',
     },
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -204,6 +233,7 @@ export const seed = async (payload: Payload): Promise<void> => {
       folder: gettingStarted.id,
       title: 'Installing Beacon Analytics',
     },
+    overrideAccess: true,
   })
 
   // SDKs (container)
@@ -213,6 +243,7 @@ export const seed = async (payload: Payload): Promise<void> => {
       folder: sdks.id,
       title: 'SDK Comparison Guide',
     },
+    overrideAccess: true,
   })
 
   // SDK docs
@@ -222,6 +253,7 @@ export const seed = async (payload: Payload): Promise<void> => {
       folder: sdkJs.id,
       title: 'JavaScript SDK Reference',
     },
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -230,6 +262,7 @@ export const seed = async (payload: Payload): Promise<void> => {
       folder: sdkIos.id,
       title: 'iOS SDK Reference',
     },
+    overrideAccess: true,
   })
 
   // Note: Python and React Native SDKs don't have stored refs, create inline
@@ -238,6 +271,7 @@ export const seed = async (payload: Payload): Promise<void> => {
       collection: folderSlug,
       limit: 1,
       where: { name: { equals: 'Python' } },
+      overrideAccess: true,
     })
   ).docs[0]
 
@@ -248,6 +282,7 @@ export const seed = async (payload: Payload): Promise<void> => {
         folder: pythonSdk.id,
         title: 'Python SDK Reference',
       },
+      overrideAccess: true,
     })
   }
 
@@ -256,6 +291,7 @@ export const seed = async (payload: Payload): Promise<void> => {
       collection: folderSlug,
       limit: 1,
       where: { name: { equals: 'React Native' } },
+      overrideAccess: true,
     })
   ).docs[0]
 
@@ -266,6 +302,7 @@ export const seed = async (payload: Payload): Promise<void> => {
         folder: reactNativeSdk.id,
         title: 'React Native SDK Reference',
       },
+      overrideAccess: true,
     })
   }
 
@@ -276,6 +313,7 @@ export const seed = async (payload: Payload): Promise<void> => {
       folder: features.id,
       title: 'Features Overview',
     },
+    overrideAccess: true,
   })
 
   // Feature sub-folders
@@ -285,6 +323,7 @@ export const seed = async (payload: Payload): Promise<void> => {
       folder: funnels.id,
       title: 'Building Your First Funnel',
     },
+    overrideAccess: true,
   })
 
   // Cohorts folder
@@ -293,6 +332,7 @@ export const seed = async (payload: Payload): Promise<void> => {
       collection: folderSlug,
       limit: 1,
       where: { name: { equals: 'Cohorts' } },
+      overrideAccess: true,
     })
   ).docs[0]
 
@@ -303,6 +343,7 @@ export const seed = async (payload: Payload): Promise<void> => {
         folder: cohorts.id,
         title: 'Understanding Cohort Analysis',
       },
+      overrideAccess: true,
     })
   }
 
@@ -312,6 +353,7 @@ export const seed = async (payload: Payload): Promise<void> => {
       folder: retention.id,
       title: 'Retention Metrics Guide',
     },
+    overrideAccess: true,
   })
 
   // Dashboards folder
@@ -320,6 +362,7 @@ export const seed = async (payload: Payload): Promise<void> => {
       collection: folderSlug,
       limit: 1,
       where: { name: { equals: 'Dashboards' } },
+      overrideAccess: true,
     })
   ).docs[0]
 
@@ -330,6 +373,7 @@ export const seed = async (payload: Payload): Promise<void> => {
         folder: dashboards.id,
         title: 'Creating Custom Dashboards',
       },
+      overrideAccess: true,
     })
   }
 
@@ -340,6 +384,7 @@ export const seed = async (payload: Payload): Promise<void> => {
       folder: marketing.id,
       title: 'Marketing Resources Hub',
     },
+    overrideAccess: true,
   })
 
   // Blog (container)
@@ -349,6 +394,7 @@ export const seed = async (payload: Payload): Promise<void> => {
       folder: blog.id,
       title: 'Blog Editorial Guidelines',
     },
+    overrideAccess: true,
   })
 
   // Blog sub-folders
@@ -358,6 +404,7 @@ export const seed = async (payload: Payload): Promise<void> => {
       folder: productUpdates.id,
       title: 'March 2024 Product Update',
     },
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -366,6 +413,7 @@ export const seed = async (payload: Payload): Promise<void> => {
       folder: engineering.id,
       title: 'How We Built Real-Time Analytics',
     },
+    overrideAccess: true,
   })
 
   // Customer Stories folder
@@ -374,6 +422,7 @@ export const seed = async (payload: Payload): Promise<void> => {
       collection: folderSlug,
       limit: 1,
       where: { name: { equals: 'Customer Stories' } },
+      overrideAccess: true,
     })
   ).docs[0]
 
@@ -384,6 +433,7 @@ export const seed = async (payload: Payload): Promise<void> => {
         folder: customerStories.id,
         title: 'How Acme Corp Increased Retention by 40%',
       },
+      overrideAccess: true,
     })
   }
 
@@ -393,6 +443,7 @@ export const seed = async (payload: Payload): Promise<void> => {
       collection: folderSlug,
       limit: 1,
       where: { name: { equals: 'Landing Pages' } },
+      overrideAccess: true,
     })
   ).docs[0]
 
@@ -403,6 +454,7 @@ export const seed = async (payload: Payload): Promise<void> => {
         folder: landingPages.id,
         title: 'Enterprise Landing Page Copy',
       },
+      overrideAccess: true,
     })
   }
 
@@ -413,6 +465,7 @@ export const seed = async (payload: Payload): Promise<void> => {
       folder: caseStudies.id,
       title: 'TechStart Case Study',
     },
+    overrideAccess: true,
   })
 
   // Brand Assets (media only) - add media
@@ -425,6 +478,7 @@ export const seed = async (payload: Payload): Promise<void> => {
       folder: brandAssets.id,
     },
     file: imageFile,
+    overrideAccess: true,
   })
 
   // Product (root)
@@ -434,6 +488,7 @@ export const seed = async (payload: Payload): Promise<void> => {
       folder: product.id,
       title: 'Product Team Updates',
     },
+    overrideAccess: true,
   })
 
   // Changelog
@@ -443,6 +498,7 @@ export const seed = async (payload: Payload): Promise<void> => {
       folder: changelog.id,
       title: 'v2.5.0 Release Notes',
     },
+    overrideAccess: true,
   })
 
   // Roadmap folder
@@ -451,6 +507,7 @@ export const seed = async (payload: Payload): Promise<void> => {
       collection: folderSlug,
       limit: 1,
       where: { name: { equals: 'Roadmap' } },
+      overrideAccess: true,
     })
   ).docs[0]
 
@@ -461,6 +518,7 @@ export const seed = async (payload: Payload): Promise<void> => {
         folder: roadmap.id,
         title: 'Q2 2024 Roadmap',
       },
+      overrideAccess: true,
     })
   }
 
@@ -471,6 +529,7 @@ export const seed = async (payload: Payload): Promise<void> => {
       folder: legal.id,
       title: 'Legal Overview',
     },
+    overrideAccess: true,
   })
 
   // Legal sub-folders
@@ -480,6 +539,7 @@ export const seed = async (payload: Payload): Promise<void> => {
       folder: privacy.id,
       title: 'Privacy Policy',
     },
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -488,6 +548,7 @@ export const seed = async (payload: Payload): Promise<void> => {
       folder: terms.id,
       title: 'Terms of Service',
     },
+    overrideAccess: true,
   })
 
   // Shared (no folder restriction)
@@ -497,6 +558,7 @@ export const seed = async (payload: Payload): Promise<void> => {
       folder: shared.id,
       title: 'Internal: Content Style Guide',
     },
+    overrideAccess: true,
   })
 
   payload.logger.info('Beacon Analytics seed data created:')

--- a/test/folders/seed/index.ts
+++ b/test/folders/seed/index.ts
@@ -1,10 +1,9 @@
 import type { Config, Payload } from 'payload'
 
-import { folderSlug } from '../shared.js'
-
 import type { Post } from '../payload-types.js'
 
 import { devUser } from '../../credentials.js'
+import { folderSlug } from '../shared.js'
 
 async function createPost(
   payload: Payload,
@@ -16,6 +15,7 @@ async function createPost(
       title,
       folder,
     },
+    overrideAccess: true,
   })
 }
 
@@ -29,6 +29,7 @@ async function createFolder(
       name,
       folder,
     },
+    overrideAccess: true,
   })
 }
 
@@ -39,6 +40,7 @@ export const seed: NonNullable<Config['onInit']> = async (payload) => {
       email: devUser.email,
       password: devUser.password,
     },
+    overrideAccess: true,
   })
 
   for (let i = 0; i < 12; i++) {

--- a/test/form-state/config.ts
+++ b/test/form-state/config.ts
@@ -30,6 +30,7 @@ export default buildConfigWithDefaults({
         email: devUser.email,
         password: devUser.password,
       },
+      overrideAccess: true,
     })
 
     await payload.create({
@@ -37,6 +38,7 @@ export default buildConfigWithDefaults({
       data: {
         title: 'example post',
       },
+      overrideAccess: true,
     })
   },
 })

--- a/test/form-state/e2e.spec.ts
+++ b/test/form-state/e2e.spec.ts
@@ -438,6 +438,7 @@ test.describe('Form State', () => {
       data: {
         title: 'Initial Title',
       },
+      overrideAccess: true,
     })
 
     await page.goto(autosavePostsUrl.edit(doc.id))
@@ -584,6 +585,7 @@ test.describe('Form State', () => {
       data: {
         title: 'Initial Title',
       },
+      overrideAccess: true,
     })
 
     await page.goto(autosavePostsUrl.edit(autosavePost.id))
@@ -848,5 +850,6 @@ async function createPost(overrides?: Partial<Post>): Promise<Post> {
       title: 'Post Title',
       ...overrides,
     },
+    overrideAccess: true,
   }) as unknown as Promise<Post>
 }

--- a/test/form-state/int.spec.ts
+++ b/test/form-state/int.spec.ts
@@ -48,6 +48,7 @@ test.suite({ config: './config.ts' })('Form State', () => {
       data: {
         title: 'Test Post',
       },
+      overrideAccess: true,
     })
 
     const { state } = await buildFormState({
@@ -106,6 +107,7 @@ test.suite({ config: './config.ts' })('Form State', () => {
       data: {
         title: 'Test Post',
       },
+      overrideAccess: true,
     })
 
     const { state } = await buildFormState({
@@ -238,6 +240,7 @@ test.suite({ config: './config.ts' })('Form State', () => {
       data: {
         showField: false,
       },
+      overrideAccess: true,
     })
 
     const { state: stateHidden } = await buildFormState({
@@ -266,6 +269,7 @@ test.suite({ config: './config.ts' })('Form State', () => {
       data: {
         showField: true,
       },
+      overrideAccess: true,
     })
 
     const { state: stateVisible } = await buildFormState({
@@ -288,8 +292,8 @@ test.suite({ config: './config.ts' })('Form State', () => {
     expect(stateVisible?.conditionalCustomField).toHaveProperty('customComponents')
     expect(stateVisible?.conditionalCustomField?.customComponents?.Field).toBeDefined()
 
-    await payload.delete({ collection: conditionsSlug, id: hiddenDoc.id })
-    await payload.delete({ collection: conditionsSlug, id: visibleDoc.id })
+    await payload.delete({ collection: conditionsSlug, id: hiddenDoc.id, overrideAccess: true })
+    await payload.delete({ collection: conditionsSlug, id: visibleDoc.id, overrideAccess: true })
   })
 
   test('should preserve values of fields nested inside a row hidden by admin.condition', async ({
@@ -303,6 +307,7 @@ test.suite({ config: './config.ts' })('Form State', () => {
         showField: false,
         conditionalRowField: 'value in db',
       },
+      overrideAccess: true,
     })
 
     const { state: stateHidden } = await buildFormState({
@@ -328,7 +333,7 @@ test.suite({ config: './config.ts' })('Form State', () => {
     // `withCondition` (rather than rendering an empty, visible row).
     expect(stateHidden?.['_index-2']?.passesCondition).toBe(false)
 
-    await payload.delete({ collection: conditionsSlug, id: hiddenDoc.id })
+    await payload.delete({ collection: conditionsSlug, id: hiddenDoc.id, overrideAccess: true })
   })
 
   test('should preserve values of fields nested inside a collapsible hidden by admin.condition', async ({
@@ -342,6 +347,7 @@ test.suite({ config: './config.ts' })('Form State', () => {
         showField: false,
         conditionalCollapsibleField: 'collapsible db value',
       },
+      overrideAccess: true,
     })
 
     const { state: stateHidden } = await buildFormState({
@@ -364,7 +370,7 @@ test.suite({ config: './config.ts' })('Form State', () => {
     // nested field's value must survive even though the collapsible is hidden.
     expect(stateHidden?.conditionalCollapsibleField?.value).toBe('collapsible db value')
 
-    await payload.delete({ collection: conditionsSlug, id: hiddenDoc.id })
+    await payload.delete({ collection: conditionsSlug, id: hiddenDoc.id, overrideAccess: true })
   })
 
   test('should render custom Field component when admin.condition flips from false to true via onChange', async ({
@@ -377,6 +383,7 @@ test.suite({ config: './config.ts' })('Form State', () => {
       data: {
         showField: false,
       },
+      overrideAccess: true,
     })
 
     const { state: initialState } = await buildFormState({
@@ -421,7 +428,7 @@ test.suite({ config: './config.ts' })('Form State', () => {
     expect(flippedState?.conditionalCustomField).toHaveProperty('customComponents')
     expect(flippedState?.conditionalCustomField?.customComponents?.Field).toBeDefined()
 
-    await payload.delete({ collection: conditionsSlug, id: doc.id })
+    await payload.delete({ collection: conditionsSlug, id: doc.id, overrideAccess: true })
   })
 
   test('should add `addedByServer` flag to fields that originate on the server', async ({
@@ -440,6 +447,7 @@ test.suite({ config: './config.ts' })('Form State', () => {
           },
         ],
       },
+      overrideAccess: true,
     })
 
     const { state } = await buildFormState({
@@ -1314,6 +1322,7 @@ test.suite({ config: './config.ts' })('Form State', () => {
         title: 'Test Post',
         array: [], // Empty array - this should result in rows: [] in form state
       },
+      overrideAccess: true,
     })
 
     const { state } = await buildFormState({
@@ -1353,6 +1362,7 @@ test.suite({ config: './config.ts' })('Form State', () => {
       data: {
         title: 'Test Post',
       },
+      overrideAccess: true,
     })
 
     const { state } = await buildFormState({
@@ -1373,6 +1383,6 @@ test.suite({ config: './config.ts' })('Form State', () => {
 
     expect(state.selectWithAsyncFilterOptions?.selectFilterOptions).toStrictEqual(['allowed'])
 
-    await payload.delete({ collection: postsSlug, id: postData.id })
+    await payload.delete({ collection: postsSlug, id: postData.id, overrideAccess: true })
   })
 })

--- a/test/globals/config.ts
+++ b/test/globals/config.ts
@@ -137,6 +137,7 @@ export default buildConfigWithDefaults({
         email: devUser.email,
         password: devUser.password,
       },
+      overrideAccess: true,
     })
 
     await payload.updateGlobal({
@@ -144,6 +145,7 @@ export default buildConfigWithDefaults({
       data: {
         title: 'hello',
       },
+      overrideAccess: true,
     })
   },
 })

--- a/test/globals/int.spec.ts
+++ b/test/globals/int.spec.ts
@@ -73,6 +73,7 @@ test.suite({ config: './config.ts' })('globals', () => {
           },
         },
         slug,
+        overrideAccess: true,
       })
 
       expect(createdJSON.json.state).toEqual({})
@@ -85,6 +86,7 @@ test.suite({ config: './config.ts' })('globals', () => {
       const doc = await payload.updateGlobal({
         data,
         slug,
+        overrideAccess: true,
       })
       expect(doc).toMatchObject(data)
     })
@@ -97,9 +99,11 @@ test.suite({ config: './config.ts' })('globals', () => {
       await payload.updateGlobal({
         data,
         slug,
+        overrideAccess: true,
       })
       const doc = await payload.findGlobal({
         slug,
+        overrideAccess: true,
       })
 
       expect(doc.globalType).toEqual(slug)
@@ -130,6 +134,7 @@ test.suite({ config: './config.ts' })('globals', () => {
         },
         locale: englishLocale,
         slug: arraySlug,
+        overrideAccess: true,
       })
 
       await payload.updateGlobal({
@@ -138,16 +143,19 @@ test.suite({ config: './config.ts' })('globals', () => {
         },
         locale: spanishLocale,
         slug: arraySlug,
+        overrideAccess: true,
       })
 
       const en = await payload.findGlobal({
         locale: englishLocale,
         slug: arraySlug,
+        overrideAccess: true,
       })
 
       const es = await payload.findGlobal({
         locale: spanishLocale,
         slug: arraySlug,
+        overrideAccess: true,
       })
 
       expect(en).toMatchObject(localized.en)
@@ -179,6 +187,7 @@ test.suite({ config: './config.ts' })('globals', () => {
           enabled: true,
         },
         slug: accessControlSlug,
+        overrideAccess: true,
       })
 
       const hasAccess = await payload.findGlobal({
@@ -194,6 +203,7 @@ test.suite({ config: './config.ts' })('globals', () => {
     }) => {
       const defaultValueGlobal = await payload.findGlobal({
         slug: defaultValueSlug,
+        overrideAccess: true,
       })
 
       expect(defaultValueGlobal.text).toStrictEqual('test')
@@ -227,6 +237,7 @@ test.suite({ config: './config.ts' })('globals', () => {
       await payload.updateGlobal({
         data,
         slug,
+        overrideAccess: true,
       })
 
       const query = `query {

--- a/test/graphql/config.ts
+++ b/test/graphql/config.ts
@@ -122,6 +122,7 @@ export default buildConfigWithDefaults({
         email: devUser.email,
         password: devUser.password,
       },
+      overrideAccess: true,
     })
   },
 })

--- a/test/graphql/int.spec.ts
+++ b/test/graphql/int.spec.ts
@@ -60,6 +60,7 @@ test.suite({ config: './config.ts' })('graphql', () => {
         data: {
           title: 'example post',
         },
+        overrideAccess: true,
       })
       await payload.update({
         collection: 'posts',
@@ -67,6 +68,7 @@ test.suite({ config: './config.ts' })('graphql', () => {
         data: {
           relationToSelf: post.id,
         },
+        overrideAccess: true,
       })
 
       const query = `query {
@@ -99,6 +101,7 @@ test.suite({ config: './config.ts' })('graphql', () => {
           title: 'example post',
           'hyphenated-name': 'example-hyphenated-name',
         },
+        overrideAccess: true,
       })
 
       const query = `query {
@@ -117,7 +120,7 @@ test.suite({ config: './config.ts' })('graphql', () => {
     })
 
     test('should not error because of non nullable fields', async ({ payload, restClient }) => {
-      await payload.delete({ collection: 'posts', where: {} })
+      await payload.delete({ collection: 'posts', where: {}, overrideAccess: true })
 
       // this is an array if any errors
       const res_1 = await restClient
@@ -141,6 +144,7 @@ query {
       await payload.create({
         collection: 'posts',
         data: { title: 'any-title' },
+        overrideAccess: true,
       })
 
       const res_2 = await restClient
@@ -173,6 +177,7 @@ query {
             },
           ],
         },
+        overrideAccess: true,
       })
 
       // Query without select: true
@@ -227,6 +232,7 @@ query {
       await payload.delete({
         collection: 'posts',
         id: createdPost.id,
+        overrideAccess: true,
       })
     })
 
@@ -239,6 +245,7 @@ query {
         data: {
           title: 'Post 1',
         },
+        overrideAccess: true,
       })
 
       await payload.updateGlobal({
@@ -251,6 +258,7 @@ query {
             },
           ],
         },
+        overrideAccess: true,
       })
 
       const query = `query {
@@ -275,6 +283,7 @@ query {
       await payload.delete({
         collection: 'posts',
         id: post1.id,
+        overrideAccess: true,
       })
 
       const afterDelete = await restClient

--- a/test/group-by/e2e.spec.ts
+++ b/test/group-by/e2e.spec.ts
@@ -65,6 +65,7 @@ test.describe('Group By', () => {
         email: devUser.email,
         password: devUser.password,
       },
+      overrideAccess: true,
     })
   })
 
@@ -266,6 +267,7 @@ test.describe('Group By', () => {
         category: null,
         title: 'My Post',
       },
+      overrideAccess: true,
     })
 
     await page.goto(url.list)
@@ -286,6 +288,7 @@ test.describe('Group By', () => {
         date: null,
         title: 'My Post',
       },
+      overrideAccess: true,
     })
 
     await page.goto(url.list)
@@ -307,6 +310,7 @@ test.describe('Group By', () => {
           checkbox: null,
           title: 'Null Post',
         },
+        overrideAccess: true,
       }),
       await payload.create({
         collection: postsSlug,
@@ -314,6 +318,7 @@ test.describe('Group By', () => {
           checkbox: true,
           title: 'True Post',
         },
+        overrideAccess: true,
       }),
       await payload.create({
         collection: postsSlug,
@@ -321,6 +326,7 @@ test.describe('Group By', () => {
           checkbox: false,
           title: 'False Post',
         },
+        overrideAccess: true,
       }),
     ])
 
@@ -977,6 +983,7 @@ test.describe('Group By', () => {
         ...data,
         deletedAt: new Date().toISOString(), // Set the post as trashed
       },
+      overrideAccess: true,
     }) as unknown as Promise<Post>
   }
 
@@ -1045,6 +1052,7 @@ test.describe('Group By', () => {
           title: 'Virtual Field Cell Test',
           where: {},
         },
+        overrideAccess: true,
         user,
       })
 
@@ -1084,6 +1092,7 @@ test.describe('Group By', () => {
           title: presetTitle,
           where: {},
         },
+        overrideAccess: true,
         user,
       })
 

--- a/test/group-by/seed.ts
+++ b/test/group-by/seed.ts
@@ -1,8 +1,8 @@
 import type { Payload } from 'payload'
 
-import { devUser } from '../credentials.js'
-import { executePromises } from '../__helpers/shared/executePromises.js'
 import { seedDB } from '../__helpers/shared/clearAndSeed/seed.js'
+import { executePromises } from '../__helpers/shared/executePromises.js'
+import { devUser } from '../credentials.js'
 import { categoriesSlug } from './collections/Categories/index.js'
 import { pagesSlug } from './collections/Pages/index.js'
 import { postsSlug } from './collections/Posts/index.js'
@@ -28,12 +28,14 @@ export const seed = async (_payload: Payload) => {
             data: {
               title: 'Category 1',
             },
+            overrideAccess: true,
           }),
           _payload.create({
             collection: categoriesSlug,
             data: {
               title: 'Category 2',
             },
+            overrideAccess: true,
           }),
         ])
 
@@ -45,6 +47,7 @@ export const seed = async (_payload: Payload) => {
               data: {
                 title: `Page ${index + 1}`,
               },
+              overrideAccess: true,
             }),
           ),
         )
@@ -58,6 +61,7 @@ export const seed = async (_payload: Payload) => {
                 page: pages[index]!.id,
                 title: `Post ${index + 1}`,
               },
+              overrideAccess: true,
             }),
           ),
         )
@@ -68,6 +72,7 @@ export const seed = async (_payload: Payload) => {
             category: category1.id,
             title: 'Find me',
           },
+          overrideAccess: true,
         })
 
         await _payload.create({
@@ -76,12 +81,14 @@ export const seed = async (_payload: Payload) => {
             category: category2.id,
             title: 'Find me',
           },
+          overrideAccess: true,
         })
 
         // Get the first post for polymorphic relationships
         const firstPost = await _payload.find({
           collection: postsSlug,
           limit: 1,
+          overrideAccess: true,
         })
 
         // Create relationship test documents
@@ -96,6 +103,7 @@ export const seed = async (_payload: Payload) => {
               },
               title: 'Poly HasOne (Category)',
             },
+            overrideAccess: true,
           }),
 
           // Document with PolyHasOneRelationship to post
@@ -108,6 +116,7 @@ export const seed = async (_payload: Payload) => {
               },
               title: 'Poly HasOne (Post)',
             },
+            overrideAccess: true,
           }),
 
           // Document with PolyHasManyRelationship to both categories and posts
@@ -130,6 +139,7 @@ export const seed = async (_payload: Payload) => {
               ],
               title: 'Poly HasMany (Mixed)',
             },
+            overrideAccess: true,
           }),
 
           // Document with MonoHasOneRelationship
@@ -139,6 +149,7 @@ export const seed = async (_payload: Payload) => {
               MonoHasOneRelationship: category1.id,
               title: 'Mono HasOne',
             },
+            overrideAccess: true,
           }),
 
           // Document with MonoHasManyRelationship
@@ -148,6 +159,7 @@ export const seed = async (_payload: Payload) => {
               MonoHasManyRelationship: [category1.id, category2.id],
               title: 'Mono HasMany',
             },
+            overrideAccess: true,
           }),
 
           // Documents with no relationships (for "No Value" testing)
@@ -156,6 +168,7 @@ export const seed = async (_payload: Payload) => {
             data: {
               title: 'No Relationships 1',
             },
+            overrideAccess: true,
           }),
 
           _payload.create({
@@ -163,6 +176,7 @@ export const seed = async (_payload: Payload) => {
             data: {
               title: 'No Relationships 2',
             },
+            overrideAccess: true,
           }),
         ])
       },

--- a/test/hierarchy/config.ts
+++ b/test/hierarchy/config.ts
@@ -288,6 +288,7 @@ export default buildConfigWithDefaults({
         email: devUser.email,
         password: devUser.password,
       },
+      overrideAccess: true,
     })
     await seed(payload)
   },

--- a/test/hierarchy/e2e.spec.ts
+++ b/test/hierarchy/e2e.spec.ts
@@ -82,10 +82,12 @@ test.describe('Hierarchy Sidebar', () => {
   test.afterAll(async () => {
     // Clean up created documents
     for (const id of createdOrgIds) {
-      await payload.delete({ id, collection: 'organizations' }).catch(() => {})
+      await payload
+        .delete({ id, collection: 'organizations', overrideAccess: true })
+        .catch(() => {})
     }
     for (const id of createdDeptIds) {
-      await payload.delete({ id, collection: 'departments' }).catch(() => {})
+      await payload.delete({ id, collection: 'departments', overrideAccess: true }).catch(() => {})
     }
   })
 
@@ -162,9 +164,14 @@ test.describe('Hierarchy Sidebar', () => {
       const prefs = await payload.find({
         collection: 'payload-preferences',
         where: { key: { equals: 'hierarchy-tree-divisions' } },
+        overrideAccess: true,
       })
       for (const pref of prefs.docs) {
-        await payload.delete({ id: pref.id, collection: 'payload-preferences' })
+        await payload.delete({
+          id: pref.id,
+          collection: 'payload-preferences',
+          overrideAccess: true,
+        })
       }
 
       await page.goto(`${serverURL}/admin`)
@@ -313,6 +320,7 @@ test.describe('Hierarchy Sidebar', () => {
       testOrg = await payload.create({
         collection: 'organizations',
         data: { title: 'Selection Test Org' },
+        overrideAccess: true,
       })
       createdOrgIds.push(testOrg.id)
     })
@@ -442,9 +450,14 @@ test.describe('Hierarchy Sidebar', () => {
       const prefs = await payload.find({
         collection: 'payload-preferences',
         where: { key: { equals: 'hierarchy-tree-folders' } },
+        overrideAccess: true,
       })
       for (const pref of prefs.docs) {
-        await payload.delete({ id: pref.id, collection: 'payload-preferences' })
+        await payload.delete({
+          id: pref.id,
+          collection: 'payload-preferences',
+          overrideAccess: true,
+        })
       }
     })
 
@@ -456,10 +469,15 @@ test.describe('Hierarchy Sidebar', () => {
           collection: 'organizations',
           draft: true,
           where: { title: { equals: organizationTitle } },
+          overrideAccess: true,
         })
 
         for (const organization of createdOrganizations.docs) {
-          await payload.delete({ id: organization.id, collection: 'organizations' })
+          await payload.delete({
+            id: organization.id,
+            collection: 'organizations',
+            overrideAccess: true,
+          })
         }
       })
 
@@ -471,6 +489,7 @@ test.describe('Hierarchy Sidebar', () => {
           collection: 'folders',
           limit: 1,
           where: { name: { equals: 'Orgs and Products' } },
+          overrideAccess: true,
         })
         const multiTypeFolder = multiTypeFolders.docs[0]
 
@@ -497,6 +516,7 @@ test.describe('Hierarchy Sidebar', () => {
               depth: 0,
               draft: true,
               where: { title: { equals: organizationTitle } },
+              overrideAccess: true,
             })
 
             return autosavedOrganizations.docs[0]?.parentFolder
@@ -647,9 +667,14 @@ test.describe('Hierarchy Sidebar', () => {
       const createdFolder = await payload.find({
         collection: 'folders',
         where: { name: { equals: newFolderName } },
+        overrideAccess: true,
       })
       if (createdFolder.docs[0]) {
-        await payload.delete({ id: createdFolder.docs[0].id, collection: 'folders' })
+        await payload.delete({
+          id: createdFolder.docs[0].id,
+          collection: 'folders',
+          overrideAccess: true,
+        })
       }
     })
 
@@ -702,9 +727,14 @@ test.describe('Hierarchy Sidebar', () => {
       const createdFolder = await payload.find({
         collection: 'folders',
         where: { name: { equals: newFolderName } },
+        overrideAccess: true,
       })
       if (createdFolder.docs[0]) {
-        await payload.delete({ id: createdFolder.docs[0].id, collection: 'folders' })
+        await payload.delete({
+          id: createdFolder.docs[0].id,
+          collection: 'folders',
+          overrideAccess: true,
+        })
       }
     })
   })
@@ -729,11 +759,13 @@ test.describe('Hierarchy Sidebar', () => {
       parentFolder = await payload.create({
         collection: 'folders',
         data: { name: parentFolderName },
+        overrideAccess: true,
       })
 
       childFolder = await payload.create({
         collection: 'folders',
         data: { name: childFolderName, parentFolder: parentFolder.id },
+        overrideAccess: true,
       })
 
       // Create a product with the child folder selected
@@ -744,19 +776,26 @@ test.describe('Hierarchy Sidebar', () => {
           name: `Product In Child Folder ${uniqueSuffix}`,
           parentFolder: childFolder.id as number,
         },
+        overrideAccess: true,
       })
     })
 
     test.afterAll(async () => {
       // Clean up in reverse order of dependencies
       if (productWithFolder?.id) {
-        await payload.delete({ id: productWithFolder.id, collection: 'products' }).catch(() => {})
+        await payload
+          .delete({ id: productWithFolder.id, collection: 'products', overrideAccess: true })
+          .catch(() => {})
       }
       if (childFolder?.id) {
-        await payload.delete({ id: childFolder.id, collection: 'folders' }).catch(() => {})
+        await payload
+          .delete({ id: childFolder.id, collection: 'folders', overrideAccess: true })
+          .catch(() => {})
       }
       if (parentFolder?.id) {
-        await payload.delete({ id: parentFolder.id, collection: 'folders' }).catch(() => {})
+        await payload
+          .delete({ id: parentFolder.id, collection: 'folders', overrideAccess: true })
+          .catch(() => {})
       }
     })
 

--- a/test/hierarchy/int.spec.ts
+++ b/test/hierarchy/int.spec.ts
@@ -65,12 +65,12 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
   test.describe('Tree Data Generation', () => {
     test.beforeEach(async ({ payload }) => {
       // Clear existing data before each test
-      await payload.delete({ collection: 'organizations', where: {} })
+      await payload.delete({ collection: 'organizations', where: {}, overrideAccess: true })
     })
 
     test.afterEach(async ({ payload }) => {
       // Clean up data after each test
-      await payload.delete({ collection: 'organizations', where: {} })
+      await payload.delete({ collection: 'organizations', where: {}, overrideAccess: true })
     })
 
     test('should compute correct paths for root document', async ({ payload }) => {
@@ -81,6 +81,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
           parent: null,
           title: 'Root Page',
         },
+        overrideAccess: true,
       })
 
       expect(rootPage._h_slugPath).toBe('root-page')
@@ -95,6 +96,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
           parent: null,
           title: 'Root',
         },
+        overrideAccess: true,
       })
 
       // Create child
@@ -105,6 +107,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
           parent: rootPage.id,
           title: 'Child',
         },
+        overrideAccess: true,
       })
 
       expect(childPage._h_slugPath).toBe('root/child')
@@ -118,6 +121,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
           parent: childPage.id,
           title: 'Grandchild',
         },
+        overrideAccess: true,
       })
 
       expect(grandchildPage._h_slugPath).toBe('root/child/grandchild')
@@ -129,21 +133,25 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
       const rootPage = await payload.create({
         collection: 'organizations',
         data: { parent: null, title: 'Root' },
+        overrideAccess: true,
       })
 
       const anotherRoot = await payload.create({
         collection: 'organizations',
         data: { parent: null, title: 'Another Root' },
+        overrideAccess: true,
       })
 
       const childPage = await payload.create({
         collection: 'organizations',
         data: { parent: rootPage.id, title: 'Child' },
+        overrideAccess: true,
       })
 
       const grandchildPage = await payload.create({
         collection: 'organizations',
         data: { parent: childPage.id, title: 'Grandchild' },
+        overrideAccess: true,
       })
 
       // Move child to another root
@@ -152,6 +160,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         collection: 'organizations',
         context: { computeHierarchyPaths: true },
         data: { parent: anotherRoot.id },
+        overrideAccess: true,
       })
 
       // Check child path reflects new parent
@@ -163,6 +172,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         id: grandchildPage.id,
         collection: 'organizations',
         context: { computeHierarchyPaths: true },
+        overrideAccess: true,
       })
 
       expect(updatedGrandchild._h_slugPath).toBe('another-root/child/grandchild')
@@ -174,11 +184,13 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
       const rootPage = await payload.create({
         collection: 'organizations',
         data: { parent: null, title: 'Root' },
+        overrideAccess: true,
       })
 
       const childPage = await payload.create({
         collection: 'organizations',
         data: { parent: rootPage.id, title: 'Child' },
+        overrideAccess: true,
       })
 
       // Update root title
@@ -186,6 +198,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         id: rootPage.id,
         collection: 'organizations',
         data: { title: 'Updated Root' },
+        overrideAccess: true,
       })
 
       // Check child paths automatically reflect change (walks up parent chain)
@@ -193,6 +206,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         id: childPage.id,
         collection: 'organizations',
         context: { computeHierarchyPaths: true },
+        overrideAccess: true,
       })
 
       expect(updatedChild._h_slugPath).toBe('updated-root/child')
@@ -204,11 +218,13 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
       const rootPage = await payload.create({
         collection: 'organizations',
         data: { parent: null, title: 'Root' },
+        overrideAccess: true,
       })
 
       const childPage = await payload.create({
         collection: 'organizations',
         data: { parent: rootPage.id, title: 'Child' },
+        overrideAccess: true,
       })
 
       // Move child to root
@@ -217,6 +233,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         collection: 'organizations',
         context: { computeHierarchyPaths: true },
         data: { parent: null },
+        overrideAccess: true,
       })
 
       expect(updatedChild._h_slugPath).toBe('child')
@@ -226,17 +243,18 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
 
   test.describe('Circular Reference Prevention', () => {
     test.beforeEach(async ({ payload }) => {
-      await payload.delete({ collection: 'organizations', where: {} })
+      await payload.delete({ collection: 'organizations', where: {}, overrideAccess: true })
     })
 
     test.afterEach(async ({ payload }) => {
-      await payload.delete({ collection: 'organizations', where: {} })
+      await payload.delete({ collection: 'organizations', where: {}, overrideAccess: true })
     })
 
     test('should prevent self-referential parent', async ({ payload }) => {
       const page = await payload.create({
         collection: 'organizations',
         data: { parent: null, title: 'Test Page' },
+        overrideAccess: true,
       })
 
       await expect(
@@ -244,6 +262,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
           id: page.id,
           collection: 'organizations',
           data: { parent: page.id },
+          overrideAccess: true,
         }),
       ).rejects.toThrow('Document cannot be its own parent')
     })
@@ -252,11 +271,13 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
       const parentPage = await payload.create({
         collection: 'organizations',
         data: { parent: null, title: 'Parent' },
+        overrideAccess: true,
       })
 
       const childPage = await payload.create({
         collection: 'organizations',
         data: { parent: parentPage.id, title: 'Child' },
+        overrideAccess: true,
       })
 
       await expect(
@@ -264,6 +285,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
           id: parentPage.id,
           collection: 'organizations',
           data: { parent: childPage.id },
+          overrideAccess: true,
         }),
       ).rejects.toThrow('Cannot move folder into its own subfolder')
     })
@@ -272,16 +294,19 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
       const grandparent = await payload.create({
         collection: 'organizations',
         data: { parent: null, title: 'Grandparent' },
+        overrideAccess: true,
       })
 
       const parent = await payload.create({
         collection: 'organizations',
         data: { parent: grandparent.id, title: 'Parent' },
+        overrideAccess: true,
       })
 
       const child = await payload.create({
         collection: 'organizations',
         data: { parent: parent.id, title: 'Child' },
+        overrideAccess: true,
       })
 
       await expect(
@@ -289,6 +314,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
           id: grandparent.id,
           collection: 'organizations',
           data: { parent: child.id },
+          overrideAccess: true,
         }),
       ).rejects.toThrow('Cannot move folder into its own subfolder')
     })
@@ -297,16 +323,19 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
       const page1 = await payload.create({
         collection: 'organizations',
         data: { parent: null, title: 'Page 1' },
+        overrideAccess: true,
       })
 
       const page2 = await payload.create({
         collection: 'organizations',
         data: { parent: null, title: 'Page 2' },
+        overrideAccess: true,
       })
 
       const child = await payload.create({
         collection: 'organizations',
         data: { parent: page1.id, title: 'Child' },
+        overrideAccess: true,
       })
 
       // Moving child from page1 to page2 should work
@@ -316,6 +345,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         context: { computeHierarchyPaths: true },
         data: { parent: page2.id },
         depth: 0,
+        overrideAccess: true,
       })
 
       expect(updated.parent).toBe(page2.id)
@@ -326,23 +356,25 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
   test.describe('Query Patterns', () => {
     test.beforeEach(async ({ payload }) => {
       // Clear existing data before each test
-      await payload.delete({ collection: 'organizations', where: {} })
+      await payload.delete({ collection: 'organizations', where: {}, overrideAccess: true })
     })
 
     test.afterEach(async ({ payload }) => {
       // Clean up data after each test
-      await payload.delete({ collection: 'organizations', where: {} })
+      await payload.delete({ collection: 'organizations', where: {}, overrideAccess: true })
     })
 
     test('should find root documents by querying parent field', async ({ payload }) => {
       const root = await payload.create({
         collection: 'organizations',
         data: { parent: null, title: 'Root' },
+        overrideAccess: true,
       })
 
       await payload.create({
         collection: 'organizations',
         data: { parent: root.id, title: 'Child 1' },
+        overrideAccess: true,
       })
 
       const roots = await payload.find({
@@ -350,6 +382,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         where: {
           parent: { equals: null },
         },
+        overrideAccess: true,
       })
 
       expect(roots.docs).toHaveLength(1)
@@ -360,21 +393,25 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
       const root = await payload.create({
         collection: 'organizations',
         data: { parent: null, title: 'Root' },
+        overrideAccess: true,
       })
 
       const child1 = await payload.create({
         collection: 'organizations',
         data: { parent: root.id, title: 'Child 1' },
+        overrideAccess: true,
       })
 
       const child2 = await payload.create({
         collection: 'organizations',
         data: { parent: root.id, title: 'Child 2' },
+        overrideAccess: true,
       })
 
       await payload.create({
         collection: 'organizations',
         data: { parent: child1.id, title: 'Grandchild 1' },
+        overrideAccess: true,
       })
 
       const directChildren = await payload.find({
@@ -382,6 +419,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         where: {
           parent: { equals: root.id },
         },
+        overrideAccess: true,
       })
 
       expect(directChildren.docs).toHaveLength(2)
@@ -393,11 +431,11 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
 
   test.describe('Custom Field Names', () => {
     test.beforeEach(async ({ payload }) => {
-      await payload.delete({ collection: 'departments', where: {} })
+      await payload.delete({ collection: 'departments', where: {}, overrideAccess: true })
     })
 
     test.afterEach(async ({ payload }) => {
-      await payload.delete({ collection: 'departments', where: {} })
+      await payload.delete({ collection: 'departments', where: {}, overrideAccess: true })
     })
 
     test('should use custom field names for path fields', async ({ payload }) => {
@@ -405,6 +443,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         collection: 'departments',
         context: { computeHierarchyPaths: true },
         data: { deptName: 'Engineering' },
+        overrideAccess: true,
       })
 
       expect(parentDept._breadcrumbSlug).toBe('engineering')
@@ -417,6 +456,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
           deptName: 'Frontend',
           parentDept: parentDept.id,
         },
+        overrideAccess: true,
       })
 
       expect(childDept._breadcrumbSlug).toBe('engineering/frontend')
@@ -427,12 +467,12 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
   test.describe('Deep Nesting', () => {
     test.beforeEach(async ({ payload }) => {
       // Clear existing data before each test
-      await payload.delete({ collection: 'organizations', where: {} })
+      await payload.delete({ collection: 'organizations', where: {}, overrideAccess: true })
     })
 
     test.afterEach(async ({ payload }) => {
       // Clean up data after each test
-      await payload.delete({ collection: 'organizations', where: {} })
+      await payload.delete({ collection: 'organizations', where: {}, overrideAccess: true })
     })
 
     test('should handle deeply nested structures', async ({ payload }) => {
@@ -447,6 +487,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
             parent: currentParent?.id || null,
             title: `Level ${i}`,
           },
+          overrideAccess: true,
         })
       }
 
@@ -470,12 +511,14 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
       const parent = await payload.create({
         collection: 'organizations',
         data: { parent: null, title: 'Products' },
+        overrideAccess: true,
       })
 
       // Publish child
       const child = await payload.create({
         collection: 'organizations',
         data: { _status: 'published', parent: parent.id, title: 'Clothing' },
+        overrideAccess: true,
       })
 
       // Create draft with different title
@@ -484,18 +527,21 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         collection: 'organizations',
         data: { title: 'Apparel' },
         draft: true,
+        overrideAccess: true,
       })
 
       // Move parent
       const grandParent = await payload.create({
         collection: 'organizations',
         data: { _status: 'published', parent: null, title: 'Categories' },
+        overrideAccess: true,
       })
 
       await payload.update({
         id: parent.id,
         collection: 'organizations',
         data: { _status: 'published', parent: grandParent.id },
+        overrideAccess: true,
       })
 
       // Paths are computed on read - published version uses published title
@@ -504,6 +550,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         collection: 'organizations',
         context: { computeHierarchyPaths: true },
         draft: false,
+        overrideAccess: true,
       })
 
       expect(publishedChild._h_slugPath).toBe('categories/products/clothing')
@@ -514,6 +561,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         collection: 'organizations',
         context: { computeHierarchyPaths: true },
         draft: true,
+        overrideAccess: true,
       })
 
       expect(draftChild._h_slugPath).toBe('categories/products/apparel')
@@ -523,22 +571,26 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
       const parent = await payload.create({
         collection: 'organizations',
         data: { _status: 'published', parent: null, title: 'Services' },
+        overrideAccess: true,
       })
 
       const child = await payload.create({
         collection: 'organizations',
         data: { _status: 'published', parent: parent.id, title: 'Consulting' },
+        overrideAccess: true,
       })
 
       const newParent = await payload.create({
         collection: 'organizations',
         data: { parent: null, title: 'Offerings' },
+        overrideAccess: true,
       })
 
       await payload.update({
         id: parent.id,
         collection: 'organizations',
         data: { parent: newParent.id },
+        overrideAccess: true,
       })
 
       // Path is computed from current parent chain
@@ -546,6 +598,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         id: child.id,
         collection: 'organizations',
         context: { computeHierarchyPaths: true },
+        overrideAccess: true,
       })
 
       expect(publishedChild._h_slugPath).toBe('offerings/services/consulting')
@@ -557,6 +610,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         collection: 'organizations',
         context: { computeHierarchyPaths: true },
         draft: true,
+        overrideAccess: true,
       })
 
       expect(draftChild._h_slugPath).toBe('offerings/services/consulting')
@@ -568,18 +622,21 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         collection: 'organizations',
         data: { parent: null, title: 'Future' },
         draft: true,
+        overrideAccess: true,
       })
 
       const child = await payload.create({
         collection: 'organizations',
         data: { parent: parent1.id, title: 'Plans' },
         draft: true,
+        overrideAccess: true,
       })
 
       const newParent = await payload.create({
         collection: 'organizations',
         data: { parent: null, title: 'Roadmap' },
         draft: true,
+        overrideAccess: true,
       })
 
       await payload.update({
@@ -587,6 +644,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         collection: 'organizations',
         data: { parent: newParent.id },
         draft: true,
+        overrideAccess: true,
       })
 
       // Path is computed from current draft parent chain
@@ -595,6 +653,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         collection: 'organizations',
         context: { computeHierarchyPaths: true },
         draft: true,
+        overrideAccess: true,
       })
 
       expect(draftChild._h_slugPath).toBe('roadmap/future/plans')
@@ -605,22 +664,26 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
       const parent = await payload.create({
         collection: 'organizations',
         data: { parent: null, title: 'Electronics' },
+        overrideAccess: true,
       })
 
       const child = await payload.create({
         collection: 'organizations',
         data: { parent: parent.id, title: 'Phones' },
+        overrideAccess: true,
       })
 
       const newParent = await payload.create({
         collection: 'organizations',
         data: { parent: null, title: 'Tech' },
+        overrideAccess: true,
       })
 
       await payload.update({
         id: parent.id,
         collection: 'organizations',
         data: { parent: newParent.id },
+        overrideAccess: true,
       })
 
       // Path is computed from current parent chain
@@ -628,6 +691,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         id: child.id,
         collection: 'organizations',
         context: { computeHierarchyPaths: true },
+        overrideAccess: true,
       })
 
       expect(updatedChild._h_slugPath).toBe('tech/electronics/phones')
@@ -643,6 +707,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
           name: 'Clothing',
           parent: null,
         },
+        overrideAccess: true,
       })
 
       // Update parent for Spanish
@@ -651,6 +716,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         collection: 'products',
         data: { name: 'Ropa' },
         locale: 'es',
+        overrideAccess: true,
       })
 
       // Update parent for German
@@ -659,6 +725,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         collection: 'products',
         data: { name: 'Kleidung' },
         locale: 'de',
+        overrideAccess: true,
       })
 
       // Create child with default locale (en)
@@ -668,6 +735,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
           name: 'Shirts',
           parent: parent.id,
         },
+        overrideAccess: true,
       })
 
       // Update child for Spanish
@@ -676,6 +744,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         collection: 'products',
         data: { name: 'Camisas' },
         locale: 'es',
+        overrideAccess: true,
       })
 
       // Update child for German
@@ -684,6 +753,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         collection: 'products',
         data: { name: 'Hemden' },
         locale: 'de',
+        overrideAccess: true,
       })
 
       // Fetch with locale: 'all' to get all locales
@@ -692,6 +762,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         collection: 'products',
         context: { computeHierarchyPaths: true },
         locale: 'all',
+        overrideAccess: true,
       })
 
       // Verify paths are localized
@@ -716,6 +787,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
           name: 'Clothing',
           parent: null,
         },
+        overrideAccess: true,
       })
 
       await payload.update({
@@ -723,6 +795,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         collection: 'products',
         data: { name: 'Ropa' },
         locale: 'es',
+        overrideAccess: true,
       })
 
       await payload.update({
@@ -730,6 +803,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         collection: 'products',
         data: { name: 'Kleidung' },
         locale: 'de',
+        overrideAccess: true,
       })
 
       // Create child with default locale (en)
@@ -739,6 +813,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
           name: 'Shirts',
           parent: parent.id,
         },
+        overrideAccess: true,
       })
 
       await payload.update({
@@ -746,6 +821,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         collection: 'products',
         data: { name: 'Camisas' },
         locale: 'es',
+        overrideAccess: true,
       })
 
       await payload.update({
@@ -753,6 +829,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         collection: 'products',
         data: { name: 'Hemden' },
         locale: 'de',
+        overrideAccess: true,
       })
 
       // Create new parent with default locale (en)
@@ -762,6 +839,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
           name: 'Apparel',
           parent: null,
         },
+        overrideAccess: true,
       })
 
       await payload.update({
@@ -769,6 +847,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         collection: 'products',
         data: { name: 'Indumentaria' },
         locale: 'es',
+        overrideAccess: true,
       })
 
       await payload.update({
@@ -776,6 +855,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         collection: 'products',
         data: { name: 'Bekleidung' },
         locale: 'de',
+        overrideAccess: true,
       })
 
       // Move parent under newParent
@@ -783,6 +863,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         id: parent.id,
         collection: 'products',
         data: { parent: newParent.id },
+        overrideAccess: true,
       })
 
       // Fetch child with all locales
@@ -791,6 +872,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         collection: 'products',
         context: { computeHierarchyPaths: true },
         locale: 'all',
+        overrideAccess: true,
       })
 
       expect(updatedChild._h_slugPath).toEqual({
@@ -814,6 +896,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
           name: 'Clothing',
           parent: null,
         },
+        overrideAccess: true,
       })
 
       await payload.update({
@@ -821,6 +904,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         collection: 'products',
         data: { name: 'Ropa' },
         locale: 'es',
+        overrideAccess: true,
       })
 
       await payload.update({
@@ -828,6 +912,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         collection: 'products',
         data: { name: 'Kleidung' },
         locale: 'de',
+        overrideAccess: true,
       })
 
       // Create child with default locale (en)
@@ -837,6 +922,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
           name: 'Shirts',
           parent: parent.id,
         },
+        overrideAccess: true,
       })
 
       await payload.update({
@@ -844,6 +930,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         collection: 'products',
         data: { name: 'Camisas' },
         locale: 'es',
+        overrideAccess: true,
       })
 
       await payload.update({
@@ -851,6 +938,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         collection: 'products',
         data: { name: 'Hemden' },
         locale: 'de',
+        overrideAccess: true,
       })
 
       // Update parent title for all locales
@@ -859,6 +947,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         collection: 'products',
         data: { name: 'Apparel' },
         locale: 'en',
+        overrideAccess: true,
       })
 
       await payload.update({
@@ -866,6 +955,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         collection: 'products',
         data: { name: 'Indumentaria' },
         locale: 'es',
+        overrideAccess: true,
       })
 
       await payload.update({
@@ -873,6 +963,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         collection: 'products',
         data: { name: 'Bekleidung' },
         locale: 'de',
+        overrideAccess: true,
       })
 
       // Fetch child with all locales
@@ -881,6 +972,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         collection: 'products',
         context: { computeHierarchyPaths: true },
         locale: 'all',
+        overrideAccess: true,
       })
 
       expect(updatedChild._h_slugPath).toEqual({
@@ -904,6 +996,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
           name: 'Clothing',
           parent: null,
         },
+        overrideAccess: true,
       })
 
       await payload.update({
@@ -911,6 +1004,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         collection: 'products',
         data: { name: 'Ropa' },
         locale: 'es',
+        overrideAccess: true,
       })
 
       await payload.update({
@@ -918,6 +1012,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         collection: 'products',
         data: { name: 'Kleidung' },
         locale: 'de',
+        overrideAccess: true,
       })
 
       // Create child with default locale (en)
@@ -927,6 +1022,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
           name: 'Shirts',
           parent: parent.id,
         },
+        overrideAccess: true,
       })
 
       await payload.update({
@@ -934,6 +1030,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         collection: 'products',
         data: { name: 'Camisas' },
         locale: 'es',
+        overrideAccess: true,
       })
 
       await payload.update({
@@ -941,6 +1038,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         collection: 'products',
         data: { name: 'Hemden' },
         locale: 'de',
+        overrideAccess: true,
       })
 
       // Publish
@@ -950,6 +1048,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         data: { _status: 'published' },
         draft: false,
         publishAllLocales: true,
+        overrideAccess: true,
       })
 
       // Create draft with different title for each locale
@@ -967,6 +1066,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
           },
           draft: true,
           locale,
+          overrideAccess: true,
         })
       }
 
@@ -977,6 +1077,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
           name: 'Apparel',
           parent: null,
         },
+        overrideAccess: true,
       })
 
       await payload.update({
@@ -984,6 +1085,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         collection: 'products',
         data: { name: 'Indumentaria' },
         locale: 'es',
+        overrideAccess: true,
       })
 
       await payload.update({
@@ -991,6 +1093,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         collection: 'products',
         data: { name: 'Bekleidung' },
         locale: 'de',
+        overrideAccess: true,
       })
 
       // Move parent under newParent
@@ -998,6 +1101,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         id: parent.id,
         collection: 'products',
         data: { parent: newParent.id },
+        overrideAccess: true,
       })
 
       // Verify published version
@@ -1006,6 +1110,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         collection: 'products',
         context: { computeHierarchyPaths: true },
         locale: 'all',
+        overrideAccess: true,
       })
 
       expect(publishedChild._h_slugPath).toEqual({
@@ -1021,6 +1126,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         context: { computeHierarchyPaths: true },
         draft: true,
         locale: 'all',
+        overrideAccess: true,
       })
 
       expect(draftChild._h_slugPath).toEqual({
@@ -1040,6 +1146,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         },
         draft: true,
         locale: 'en',
+        overrideAccess: true,
       })
 
       // Update other locales for parent
@@ -1049,6 +1156,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         data: { name: 'Futuro' },
         draft: true,
         locale: 'es',
+        overrideAccess: true,
       })
       await payload.update({
         id: parent.id,
@@ -1056,6 +1164,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         data: { name: 'Zukunft' },
         draft: true,
         locale: 'de',
+        overrideAccess: true,
       })
 
       // Create child as draft
@@ -1067,6 +1176,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         },
         draft: true,
         locale: 'en',
+        overrideAccess: true,
       })
 
       // Update other locales for child
@@ -1076,6 +1186,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         data: { name: 'Planes' },
         draft: true,
         locale: 'es',
+        overrideAccess: true,
       })
       await payload.update({
         id: child.id,
@@ -1083,6 +1194,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         data: { name: 'Pläne' },
         draft: true,
         locale: 'de',
+        overrideAccess: true,
       })
 
       // Create new parent (published) with default locale
@@ -1092,6 +1204,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
           name: 'Roadmap',
           parent: null,
         },
+        overrideAccess: true,
       })
 
       await payload.update({
@@ -1099,6 +1212,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         collection: 'products',
         data: { name: 'Hoja de Ruta' },
         locale: 'es',
+        overrideAccess: true,
       })
 
       await payload.update({
@@ -1106,6 +1220,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         collection: 'products',
         data: { name: 'Fahrplan' },
         locale: 'de',
+        overrideAccess: true,
       })
 
       // Move parent
@@ -1115,6 +1230,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         data: { parent: newParent.id },
         draft: true,
         locale: 'en',
+        overrideAccess: true,
       })
 
       const draftChild = await payload.findByID({
@@ -1123,6 +1239,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         context: { computeHierarchyPaths: true },
         draft: true,
         locale: 'all',
+        overrideAccess: true,
       })
 
       expect(draftChild._h_slugPath).toEqual({
@@ -1141,11 +1258,11 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
 
   test.describe('Ancestor Cache Performance', () => {
     test.beforeEach(async ({ payload }) => {
-      await payload.delete({ collection: 'organizations', where: {} })
+      await payload.delete({ collection: 'organizations', where: {}, overrideAccess: true })
     })
 
     test.afterEach(async ({ payload }) => {
-      await payload.delete({ collection: 'organizations', where: {} })
+      await payload.delete({ collection: 'organizations', where: {}, overrideAccess: true })
     })
 
     test('should cache ancestors when computing paths for multiple documents', async ({
@@ -1155,11 +1272,13 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
       const root = await payload.create({
         collection: 'organizations',
         data: { parent: null, title: 'Root' },
+        overrideAccess: true,
       })
 
       const category = await payload.create({
         collection: 'organizations',
         data: { parent: root.id, title: 'Category' },
+        overrideAccess: true,
       })
 
       const childIds: Array<number | string> = []
@@ -1168,6 +1287,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         const child = await payload.create({
           collection: 'organizations',
           data: { parent: category.id, title: `Child ${i}` },
+          overrideAccess: true,
         })
         childIds.push(child.id)
       }
@@ -1189,6 +1309,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         where: {
           id: { in: childIds },
         },
+        overrideAccess: true,
       })
 
       expect(results.docs.length).toBe(5)
@@ -1217,16 +1338,19 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
       const root = await payload.create({
         collection: 'organizations',
         data: { parent: null, title: 'Products' },
+        overrideAccess: true,
       })
 
       const cat1 = await payload.create({
         collection: 'organizations',
         data: { parent: root.id, title: 'Electronics' },
+        overrideAccess: true,
       })
 
       const cat2 = await payload.create({
         collection: 'organizations',
         data: { parent: root.id, title: 'Clothing' },
+        overrideAccess: true,
       })
 
       const childIds: Array<number | string> = []
@@ -1236,6 +1360,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         const child = await payload.create({
           collection: 'organizations',
           data: { parent: cat1.id, title: `Product E${i}` },
+          overrideAccess: true,
         })
         childIds.push(child.id)
       }
@@ -1245,6 +1370,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         const child = await payload.create({
           collection: 'organizations',
           data: { parent: cat2.id, title: `Product C${i}` },
+          overrideAccess: true,
         })
         childIds.push(child.id)
       }
@@ -1264,6 +1390,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
         where: {
           id: { in: childIds },
         },
+        overrideAccess: true,
       })
 
       const stats = cacheStats
@@ -1284,7 +1411,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
 
     test.afterEach(async ({ payload }) => {
       for (const id of createdPageIds) {
-        await payload.delete({ collection: 'pages', id }).catch(() => {})
+        await payload.delete({ collection: 'pages', id, overrideAccess: true }).catch(() => {})
       }
       createdPageIds.length = 0
     })
@@ -1299,6 +1426,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
           slug: 'about-us', // Different from title
           title: 'About Our Company', // Would slugify to 'about-our-company'
         },
+        overrideAccess: true,
       })
       createdPageIds.push(page.id)
 
@@ -1316,6 +1444,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
           slug: 'home',
           title: 'Home Page',
         },
+        overrideAccess: true,
       })
       createdPageIds.push(rootPage.id)
 
@@ -1328,6 +1457,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
           slug: 'services',
           title: 'Our Services',
         },
+        overrideAccess: true,
       })
       createdPageIds.push(childPage.id)
 
@@ -1345,6 +1475,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
           slug: '', // Empty slug
           title: 'Contact Us',
         },
+        overrideAccess: true,
       })
       createdPageIds.push(page.id)
 
@@ -1361,7 +1492,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
       // Delete in reverse order (children before parents)
       for (const id of [...createdOrgIds].reverse()) {
         try {
-          await payload.delete({ collection: 'organizations', id })
+          await payload.delete({ collection: 'organizations', id, overrideAccess: true })
         } catch {
           // Ignore if already deleted
         }
@@ -1374,6 +1505,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
       const parent = await payload.create({
         collection: 'organizations',
         data: { parent: null, title: 'Parent Org' },
+        overrideAccess: true,
       })
       createdOrgIds.push(parent.id)
 
@@ -1381,6 +1513,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
       const child = await payload.create({
         collection: 'organizations',
         data: { parent: parent.id, title: 'Child Org' },
+        overrideAccess: true,
       })
       createdOrgIds.push(child.id)
 
@@ -1392,6 +1525,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
           _h_slugPath: true,
           _h_titlePath: true,
         },
+        overrideAccess: true,
       })
 
       // Should have full paths (not flat paths)
@@ -1404,6 +1538,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
       const parent = await payload.create({
         collection: 'organizations',
         data: { parent: null, title: 'Hidden Parent' },
+        overrideAccess: true,
       })
       createdOrgIds.push(parent.id)
 
@@ -1411,6 +1546,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
       const child = await payload.create({
         collection: 'organizations',
         data: { parent: parent.id, title: 'Hidden Child' },
+        overrideAccess: true,
       })
       createdOrgIds.push(child.id)
 
@@ -1422,6 +1558,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
           _h_slugPath: true,
           _h_titlePath: true,
         },
+        overrideAccess: true,
       })
 
       // Paths should be computed correctly
@@ -1437,6 +1574,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
       const parent = await payload.create({
         collection: 'organizations',
         data: { parent: null, title: 'Explicit Parent' },
+        overrideAccess: true,
       })
       createdOrgIds.push(parent.id)
 
@@ -1444,6 +1582,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
       const child = await payload.create({
         collection: 'organizations',
         data: { parent: parent.id, title: 'Explicit Child' },
+        overrideAccess: true,
       })
       createdOrgIds.push(child.id)
 
@@ -1455,6 +1594,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
           _h_slugPath: true,
           title: true,
         },
+        overrideAccess: true,
       })
 
       // Paths should be computed correctly
@@ -1472,18 +1612,21 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
       const level1 = await payload.create({
         collection: 'organizations',
         data: { parent: null, title: 'Level 1' },
+        overrideAccess: true,
       })
       createdOrgIds.push(level1.id)
 
       const level2 = await payload.create({
         collection: 'organizations',
         data: { parent: level1.id, title: 'Level 2' },
+        overrideAccess: true,
       })
       createdOrgIds.push(level2.id)
 
       const level3 = await payload.create({
         collection: 'organizations',
         data: { parent: level2.id, title: 'Level 3' },
+        overrideAccess: true,
       })
       createdOrgIds.push(level3.id)
 
@@ -1495,6 +1638,7 @@ test.suite({ config: './config.ts' })('Hierarchy', () => {
           _h_slugPath: true,
           _h_titlePath: true,
         },
+        overrideAccess: true,
       })
 
       // Should have full 3-level path

--- a/test/hierarchy/seed.ts
+++ b/test/hierarchy/seed.ts
@@ -13,119 +13,150 @@ export async function seed(payload: Payload): Promise<void> {
   const alphaDivision = await payload.create({
     collection: divisionsSlug,
     data: { title: 'Alpha Division' },
+    overrideAccess: true,
   })
 
   await payload.create({
     collection: divisionsSlug,
     data: { parent: alphaDivision.id, title: 'Alpha Child 1' },
+    overrideAccess: true,
   })
   await payload.create({
     collection: divisionsSlug,
     data: { parent: alphaDivision.id, title: 'Alpha Child 2' },
+    overrideAccess: true,
   })
   await payload.create({
     collection: divisionsSlug,
     data: { parent: alphaDivision.id, title: 'Alpha Child 3' },
+    overrideAccess: true,
   })
   await payload.create({
     collection: divisionsSlug,
     data: { parent: alphaDivision.id, title: 'Alpha Child 4' },
+    overrideAccess: true,
   })
 
-  await payload.create({ collection: divisionsSlug, data: { title: 'Beta Division' } })
-  await payload.create({ collection: divisionsSlug, data: { title: 'Gamma Division' } })
+  await payload.create({
+    collection: divisionsSlug,
+    data: { title: 'Beta Division' },
+    overrideAccess: true,
+  })
+  await payload.create({
+    collection: divisionsSlug,
+    data: { title: 'Gamma Division' },
+    overrideAccess: true,
+  })
 
   // Create organization hierarchy
   const acmeCorp = await payload.create({
     collection: organizationsSlug,
     data: { title: 'Acme Corp' },
+    overrideAccess: true,
   })
 
   await payload.create({
     collection: organizationsSlug,
     data: { title: 'Beta Corp' },
+    overrideAccess: true,
   })
 
   await payload.create({
     collection: organizationsSlug,
     data: { title: 'Gamma Corp' },
+    overrideAccess: true,
   })
 
   const engineeringDiv = await payload.create({
     collection: organizationsSlug,
     data: { parent: acmeCorp.id, title: 'Engineering Division' },
+    overrideAccess: true,
   })
 
   await payload.create({
     collection: organizationsSlug,
     data: { parent: engineeringDiv.id, title: 'Frontend Team' },
+    overrideAccess: true,
   })
 
   await payload.create({
     collection: organizationsSlug,
     data: { parent: engineeringDiv.id, title: 'Backend Team' },
+    overrideAccess: true,
   })
 
   await payload.create({
     collection: organizationsSlug,
     data: { parent: acmeCorp.id, title: 'Marketing Division' },
+    overrideAccess: true,
   })
 
   await payload.create({
     collection: organizationsSlug,
     data: { parent: acmeCorp.id, title: 'Zeta Division' },
+    overrideAccess: true,
   })
 
   // Create department hierarchy (tests custom field names)
   const hrDept = await payload.create({
     collection: departmentsSlug,
     data: { deptName: 'Human Resources' },
+    overrideAccess: true,
   })
 
   await payload.create({
     collection: departmentsSlug,
     data: { deptName: 'Recruiting', parentDept: hrDept.id },
+    overrideAccess: true,
   })
 
   await payload.create({
     collection: departmentsSlug,
     data: { deptName: 'Benefits', parentDept: hrDept.id },
+    overrideAccess: true,
   })
 
   const financeDept = await payload.create({
     collection: departmentsSlug,
     data: { deptName: 'Finance' },
+    overrideAccess: true,
   })
 
   await payload.create({
     collection: departmentsSlug,
     data: { deptName: 'Accounting', parentDept: financeDept.id },
+    overrideAccess: true,
   })
 
   // Create product hierarchy (tests localization)
   const electronicsCategory = await payload.create({
     collection: productsSlug,
     data: { name: 'Electronics' },
+    overrideAccess: true,
   })
 
   const computersCategory = await payload.create({
     collection: productsSlug,
     data: { name: 'Computers', parent: electronicsCategory.id },
+    overrideAccess: true,
   })
 
   await payload.create({
     collection: productsSlug,
     data: { name: 'Laptops', parent: computersCategory.id },
+    overrideAccess: true,
   })
 
   await payload.create({
     collection: productsSlug,
     data: { name: 'Desktops', parent: computersCategory.id },
+    overrideAccess: true,
   })
 
   await payload.create({
     collection: productsSlug,
     data: { name: 'Phones', parent: electronicsCategory.id },
+    overrideAccess: true,
   })
 
   // Create folder hierarchy (tests collectionSpecific filter)
@@ -133,26 +164,31 @@ export async function seed(payload: Payload): Promise<void> {
   const generalFolder = await payload.create({
     collection: foldersSlug,
     data: { name: 'General' }, // No restriction - accepts all types
+    overrideAccess: true,
   })
 
   await payload.create({
     collection: foldersSlug,
     data: { allowedTypes: [organizationsSlug], name: 'Orgs Only' },
+    overrideAccess: true,
   })
 
   await payload.create({
     collection: foldersSlug,
     data: { allowedTypes: [productsSlug], name: 'Products Only' },
+    overrideAccess: true,
   })
 
   await payload.create({
     collection: foldersSlug,
     data: { allowedTypes: [organizationsSlug, productsSlug], name: 'Orgs and Products' },
+    overrideAccess: true,
   })
 
   // Nested folder
   await payload.create({
     collection: foldersSlug,
     data: { name: 'Subfolder', parentFolder: generalFolder.id },
+    overrideAccess: true,
   })
 }

--- a/test/hooks/collections/ContextHooks/index.ts
+++ b/test/hooks/collections/ContextHooks/index.ts
@@ -57,6 +57,7 @@ const ContextHooks: CollectionConfig = {
           context: {
             triggerAfterChange: false, // Make sure we don't trigger afterChange again and again in an infinite loop. This should be done via context and not a potential disableHooks property, as we want to specifically test the context functionality here
           },
+          overrideAccess: true,
         })
       },
     ],

--- a/test/hooks/collections/Users/afterLoginHook.ts
+++ b/test/hooks/collections/Users/afterLoginHook.ts
@@ -8,5 +8,6 @@ export const afterLoginHook: CollectionAfterLoginHook = async ({ req, user }) =>
       afterLoginHook: true,
     },
     req,
+    overrideAccess: true,
   })
 }

--- a/test/hooks/collections/Users/index.ts
+++ b/test/hooks/collections/Users/index.ts
@@ -19,10 +19,12 @@ export const seedHooksUsers = async (payload: Payload) => {
   await payload.create({
     collection: hooksUsersSlug,
     data: devUser,
+    overrideAccess: true,
   })
   await payload.create({
     collection: hooksUsersSlug,
     data: regularUser,
+    overrideAccess: true,
   })
 }
 

--- a/test/hooks/config.ts
+++ b/test/hooks/config.ts
@@ -87,6 +87,7 @@ export const HooksConfig: Promise<SanitizedConfig> = buildConfigWithDefaults({
         fieldBeforeChange: false,
         fieldBeforeValidate: false,
       },
+      overrideAccess: true,
     })
   },
 })

--- a/test/hooks/e2e.spec.ts
+++ b/test/hooks/e2e.spec.ts
@@ -82,6 +82,7 @@ describe('Hooks', () => {
         data: {
           title: 'some title',
         },
+        overrideAccess: true,
       })
 
       await page.goto(beforeDeleteURL.list)
@@ -108,6 +109,7 @@ describe('Hooks', () => {
               where: {
                 id: { equals: doc.id },
               },
+              overrideAccess: true,
             })
             return docs.totalDocs
           },
@@ -118,6 +120,7 @@ describe('Hooks', () => {
       await payload.delete({
         id: doc.id,
         collection: 'before-delete-hooks',
+        overrideAccess: true,
       })
     })
 
@@ -127,6 +130,7 @@ describe('Hooks', () => {
         data: {
           title: 'some title',
         },
+        overrideAccess: true,
       })
 
       await page.goto(beforeDeleteURL.edit(doc.id))
@@ -149,6 +153,7 @@ describe('Hooks', () => {
               where: {
                 id: { equals: doc.id },
               },
+              overrideAccess: true,
             })
             return docs.totalDocs
           },
@@ -159,6 +164,7 @@ describe('Hooks', () => {
       await payload.delete({
         id: doc.id,
         collection: 'before-delete-hooks',
+        overrideAccess: true,
       })
     })
 
@@ -168,6 +174,7 @@ describe('Hooks', () => {
         data: {
           title: 'some title',
         },
+        overrideAccess: true,
       })
 
       await page.goto(beforeDelete2URL.list)
@@ -189,6 +196,7 @@ describe('Hooks', () => {
       await payload.delete({
         id: doc.id,
         collection: 'before-delete-2-hooks',
+        overrideAccess: true,
       })
     })
 
@@ -198,6 +206,7 @@ describe('Hooks', () => {
         data: {
           title: 'some title',
         },
+        overrideAccess: true,
       })
 
       await page.goto(beforeDelete2URL.edit(doc.id))
@@ -215,6 +224,7 @@ describe('Hooks', () => {
       await payload.delete({
         id: doc.id,
         collection: 'before-delete-2-hooks',
+        overrideAccess: true,
       })
     })
   })
@@ -230,5 +240,6 @@ async function clearCollectionDocs(collectionSlug: CollectionSlug): Promise<void
     where: {
       id: { exists: true },
     },
+    overrideAccess: true,
   })
 }

--- a/test/hooks/int.spec.ts
+++ b/test/hooks/int.spec.ts
@@ -36,6 +36,7 @@ test.suite({ config: './config.ts' })('Hooks', () => {
           localizedTransform: [2, 8],
           transform: [2, 8],
         },
+        overrideAccess: true,
       })
 
       expect(doc.transform).toBeDefined()
@@ -60,6 +61,7 @@ test.suite({ config: './config.ts' })('Hooks', () => {
       doc = await payload.create({
         collection: hooksSlug,
         data,
+        overrideAccess: true,
       })
     })
 
@@ -81,6 +83,7 @@ test.suite({ config: './config.ts' })('Hooks', () => {
         id: doc.id,
         collection: hooksSlug,
         data,
+        overrideAccess: true,
       })
 
       expect(doc.collectionAfterChange).toBeTruthy()
@@ -99,6 +102,7 @@ test.suite({ config: './config.ts' })('Hooks', () => {
       doc = await payload.findByID({
         id: doc.id,
         collection: hooksSlug,
+        overrideAccess: true,
       })
 
       expect(doc.collectionAfterRead).toBeTruthy()
@@ -117,6 +121,7 @@ test.suite({ config: './config.ts' })('Hooks', () => {
           },
           text: 'ok',
         },
+        overrideAccess: true,
       })
 
       expect(document.group.subGroup.afterRead).toEqual(generatedAfterReadText)
@@ -129,6 +134,7 @@ test.suite({ config: './config.ts' })('Hooks', () => {
         data: {
           title: 'Hello',
         },
+        overrideAccess: true,
       })
 
       const document = await payload.create({
@@ -146,11 +152,13 @@ test.suite({ config: './config.ts' })('Hooks', () => {
           },
           text: 'ok',
         },
+        overrideAccess: true,
       })
 
       const retrievedDoc = await payload.findByID({
         id: document.id,
         collection: nestedAfterReadHooksSlug,
+        overrideAccess: true,
       })
 
       expect(retrievedDoc.group.array[0].shouldPopulate.title).toEqual(relation.title)
@@ -165,11 +173,13 @@ test.suite({ config: './config.ts' })('Hooks', () => {
         data: {
           text: 'ok',
         },
+        overrideAccess: true,
       })
 
       const retrievedDoc = await payload.findByID({
         id: document.id,
         collection: chainingHooksSlug,
+        overrideAccess: true,
       })
 
       expect(retrievedDoc.text).toEqual('ok!!')
@@ -181,10 +191,12 @@ test.suite({ config: './config.ts' })('Hooks', () => {
         data: {
           text: 'ok',
         },
+        overrideAccess: true,
       })
 
       const { docs: retrievedDocs } = await payload.find({
         collection: chainingHooksSlug,
+        overrideAccess: true,
       })
 
       expect(retrievedDocs[0].text).toEqual('ok!!')
@@ -197,12 +209,14 @@ test.suite({ config: './config.ts' })('Hooks', () => {
           data: {
             title: 'Title',
           },
+          overrideAccess: true,
         }),
         await payload.create({
           collection: afterOperationSlug,
           data: {
             title: 'Title',
           },
+          overrideAccess: true,
         }),
       ])
 
@@ -211,6 +225,7 @@ test.suite({ config: './config.ts' })('Hooks', () => {
 
       const findResult = await payload.find({
         collection: afterOperationSlug,
+        overrideAccess: true,
       })
 
       expect(findResult.docs).toHaveLength(2)
@@ -224,6 +239,7 @@ test.suite({ config: './config.ts' })('Hooks', () => {
           data: {
             title: 'Title',
           },
+          overrideAccess: true,
         }),
         await payload.update({
           id: doc2.id,
@@ -231,6 +247,7 @@ test.suite({ config: './config.ts' })('Hooks', () => {
           data: {
             title: 'Title',
           },
+          overrideAccess: true,
         }),
       ])
 
@@ -239,6 +256,7 @@ test.suite({ config: './config.ts' })('Hooks', () => {
 
       const findResult2 = await payload.find({
         collection: afterOperationSlug,
+        overrideAccess: true,
       })
 
       expect(findResult2.docs).toHaveLength(2)
@@ -252,11 +270,13 @@ test.suite({ config: './config.ts' })('Hooks', () => {
         data: {
           value: 'wrongvalue',
         },
+        overrideAccess: true,
       })
 
       const retrievedDoc = await payload.findByID({
         id: document.id,
         collection: contextHooksSlug,
+        overrideAccess: true,
       })
 
       expect(retrievedDoc.value).toEqual('secret')
@@ -271,11 +291,13 @@ test.suite({ config: './config.ts' })('Hooks', () => {
         data: {
           value: 'wrongvalue',
         },
+        overrideAccess: true,
       })
 
       const retrievedDoc = await payload.findByID({
         id: document.id,
         collection: contextHooksSlug,
+        overrideAccess: true,
       })
 
       expect(retrievedDoc.value).toEqual('data from Local API')
@@ -284,6 +306,7 @@ test.suite({ config: './config.ts' })('Hooks', () => {
     test('should pass context from Local API to global hooks', async ({ payload }) => {
       const globalDocument = await payload.findGlobal({
         slug: dataHooksGlobalSlug,
+        overrideAccess: true,
       })
 
       expect(globalDocument.field_globalAndField).not.toEqual('data from Local API context')
@@ -293,6 +316,7 @@ test.suite({ config: './config.ts' })('Hooks', () => {
         context: {
           field_beforeChange_GlobalAndField_override: 'data from Local API context',
         },
+        overrideAccess: true,
       })
       expect(globalDocumentWithContext.field_globalAndField).toEqual('data from Local API context')
     })
@@ -313,6 +337,7 @@ test.suite({ config: './config.ts' })('Hooks', () => {
       const retrievedDoc = await payload.findByID({
         collection: contextHooksSlug,
         id: doc.id,
+        overrideAccess: true,
       })
 
       expect(retrievedDoc.value).toEqual('data from REST API')
@@ -332,6 +357,7 @@ test.suite({ config: './config.ts' })('Hooks', () => {
             ],
           },
         },
+        overrideAccess: true,
       })
 
       const updatedDoc = await payload.update({
@@ -347,6 +373,7 @@ test.suite({ config: './config.ts' })('Hooks', () => {
             ],
           },
         },
+        overrideAccess: true,
       })
 
       expect(updatedDoc).toBeDefined()
@@ -360,6 +387,7 @@ test.suite({ config: './config.ts' })('Hooks', () => {
         data: {
           title: 'Relation for nested afterChange',
         },
+        overrideAccess: true,
       })
 
       // this collection will throw an error if previousValue is not defined in nested afterChange hook
@@ -446,6 +474,7 @@ test.suite({ config: './config.ts' })('Hooks', () => {
             },
           },
         },
+        overrideAccess: true,
       })
 
       await expect(
@@ -455,6 +484,7 @@ test.suite({ config: './config.ts' })('Hooks', () => {
           data: {
             text: 'updated',
           },
+          overrideAccess: true,
         }),
       ).resolves.not.toThrow()
     })
@@ -474,6 +504,7 @@ test.suite({ config: './config.ts' })('Hooks', () => {
           password: devUser.password,
           roles: ['admin'],
         },
+        overrideAccess: true,
       })
 
       const { token } = await payload.login({
@@ -482,6 +513,7 @@ test.suite({ config: './config.ts' })('Hooks', () => {
           email: hookUser.email,
           password: devUser.password,
         },
+        overrideAccess: true,
       })
 
       hookUserToken = token
@@ -494,11 +526,13 @@ test.suite({ config: './config.ts' })('Hooks', () => {
           email: devUser.email,
           password: devUser.password,
         },
+        overrideAccess: true,
       })
 
       const result = await payload.findByID({
         id: user.id,
         collection: hooksUsersSlug,
+        overrideAccess: true,
       })
 
       expect(user).toBeDefined()
@@ -515,6 +549,7 @@ test.suite({ config: './config.ts' })('Hooks', () => {
           roles: ['admin'],
           afterLoginHook: false,
         },
+        overrideAccess: true,
       })
 
       expect(resetUser.afterLoginHook).toStrictEqual(false)
@@ -525,6 +560,7 @@ test.suite({ config: './config.ts' })('Hooks', () => {
           email: resetUser.email,
         },
         disableEmail: true,
+        overrideAccess: true,
       })
 
       const { user } = await payload.resetPassword({
@@ -542,6 +578,7 @@ test.suite({ config: './config.ts' })('Hooks', () => {
       const result = await payload.findByID({
         id: user.id,
         collection: hooksUsersSlug,
+        overrideAccess: true,
       })
 
       expect(result.afterLoginHook).toStrictEqual(true)
@@ -552,6 +589,7 @@ test.suite({ config: './config.ts' })('Hooks', () => {
         payload.login({
           collection: hooksUsersSlug,
           data: { email: regularUser.email, password: regularUser.password },
+          overrideAccess: true,
         }),
       ).rejects.toThrow(AuthenticationError)
     })
@@ -592,6 +630,7 @@ test.suite({ config: './config.ts' })('Hooks', () => {
       const doc = await payload.create({
         collection: dataHooksSlug,
         data: {},
+        overrideAccess: true,
       })
 
       expect(JSON.parse(doc.collection_beforeOperation_collection)).toStrictEqual(
@@ -618,6 +657,7 @@ test.suite({ config: './config.ts' })('Hooks', () => {
       const foundDoc = await payload.findByID({
         id: doc.id,
         collection: dataHooksSlug,
+        overrideAccess: true,
       })
 
       expect(JSON.parse(foundDoc.collection_beforeRead_collection)).toStrictEqual(
@@ -638,6 +678,7 @@ test.suite({ config: './config.ts' })('Hooks', () => {
       const doc = await payload.create({
         collection: dataHooksSlug,
         data: {},
+        overrideAccess: true,
       })
 
       const collectionAndField = JSON.stringify(sanitizedHooksCollection) + JSON.stringify(field)
@@ -654,6 +695,7 @@ test.suite({ config: './config.ts' })('Hooks', () => {
       const doc = await payload.updateGlobal({
         slug: dataHooksGlobalSlug,
         data: {},
+        overrideAccess: true,
       })
 
       expect(JSON.parse(doc.global_beforeChange_global)).toStrictEqual(sanitizedHooksGlobal)
@@ -663,6 +705,7 @@ test.suite({ config: './config.ts' })('Hooks', () => {
       // beforeRead is only run for findOne operations
       const foundDoc = await payload.findGlobal({
         slug: dataHooksGlobalSlug,
+        overrideAccess: true,
       })
 
       expect(JSON.parse(foundDoc.global_beforeRead_global)).toStrictEqual(sanitizedHooksGlobal)
@@ -685,6 +728,7 @@ test.suite({ config: './config.ts' })('Hooks', () => {
       const doc = await payload.updateGlobal({
         slug: dataHooksGlobalSlug,
         data: {},
+        overrideAccess: true,
       })
 
       const globalAndFieldString = globalString + fieldString
@@ -709,6 +753,7 @@ test.suite({ config: './config.ts' })('Hooks', () => {
         data: {
           selection: 'b',
         },
+        overrideAccess: true,
       })
 
       const updateResult = await payload.update({
@@ -720,6 +765,7 @@ test.suite({ config: './config.ts' })('Hooks', () => {
         context: {
           beforeValidateTest: true,
         },
+        overrideAccess: true,
       })
 
       expect(updateResult).toBeDefined()
@@ -735,6 +781,7 @@ test.suite({ config: './config.ts' })('Hooks', () => {
       await payload.create({
         collection: beforeOperationSlug,
         data: {},
+        overrideAccess: true,
       })
 
       expect(getLastOperation()).toEqual('create')
@@ -744,12 +791,14 @@ test.suite({ config: './config.ts' })('Hooks', () => {
       const doc = await payload.create({
         collection: beforeOperationSlug,
         data: {},
+        overrideAccess: true,
       })
 
       await payload.update({
         id: doc.id,
         collection: beforeOperationSlug,
         data: {},
+        overrideAccess: true,
       })
 
       expect(getLastOperation()).toEqual('update')
@@ -759,12 +808,14 @@ test.suite({ config: './config.ts' })('Hooks', () => {
       const doc = await payload.create({
         collection: beforeOperationSlug,
         data: {},
+        overrideAccess: true,
       })
 
       await payload.update({
         id: doc.id,
         collection: beforeOperationSlug,
         data: {},
+        overrideAccess: true,
       })
 
       expect(getLastOperation()).toEqual('update')
@@ -774,11 +825,13 @@ test.suite({ config: './config.ts' })('Hooks', () => {
       const doc = await payload.create({
         collection: beforeOperationSlug,
         data: {},
+        overrideAccess: true,
       })
 
       await payload.findByID({
         id: doc.id,
         collection: beforeOperationSlug,
+        overrideAccess: true,
       })
 
       expect(getLastOperation()).toEqual('read')
@@ -788,12 +841,14 @@ test.suite({ config: './config.ts' })('Hooks', () => {
       await payload.create({
         collection: beforeOperationSlug,
         data: {},
+        overrideAccess: true,
       })
 
       clearLastOperation()
 
       await payload.find({
         collection: beforeOperationSlug,
+        overrideAccess: true,
       })
 
       expect(getLastOperation()).toEqual('read')
@@ -805,19 +860,23 @@ test.suite({ config: './config.ts' })('Hooks', () => {
       await payload.create({
         collection: beforeOperationSlug,
         data: { category: 'test1' },
+        overrideAccess: true,
       })
       await payload.create({
         collection: beforeOperationSlug,
         data: { category: 'test2' },
+        overrideAccess: true,
       })
       await payload.create({
         collection: beforeOperationSlug,
         data: { category: 'test1' },
+        overrideAccess: true,
       })
 
       await payload.findDistinct({
         collection: beforeOperationSlug,
         field: 'category',
+        overrideAccess: true,
       })
 
       expect(getLastOperation()).toEqual('readDistinct')
@@ -827,11 +886,13 @@ test.suite({ config: './config.ts' })('Hooks', () => {
       const doc = await payload.create({
         collection: beforeOperationSlug,
         data: {},
+        overrideAccess: true,
       })
 
       await payload.delete({
         id: doc.id,
         collection: beforeOperationSlug,
+        overrideAccess: true,
       })
 
       expect(getLastOperation()).toEqual('delete')
@@ -841,11 +902,13 @@ test.suite({ config: './config.ts' })('Hooks', () => {
       const doc = await payload.create({
         collection: beforeOperationSlug,
         data: {},
+        overrideAccess: true,
       })
 
       await payload.delete({
         id: doc.id,
         collection: beforeOperationSlug,
+        overrideAccess: true,
       })
 
       expect(getLastOperation()).toEqual('delete')
@@ -855,10 +918,12 @@ test.suite({ config: './config.ts' })('Hooks', () => {
       await payload.create({
         collection: beforeOperationSlug,
         data: {},
+        overrideAccess: true,
       })
 
       await payload.count({
         collection: beforeOperationSlug,
+        overrideAccess: true,
       })
 
       expect(getLastOperation()).toEqual('count')
@@ -868,6 +933,7 @@ test.suite({ config: './config.ts' })('Hooks', () => {
       const doc = await payload.create({
         collection: beforeOperationSlug,
         data: {},
+        overrideAccess: true,
       })
 
       await payload.countVersions({
@@ -877,6 +943,7 @@ test.suite({ config: './config.ts' })('Hooks', () => {
             equals: doc.id,
           },
         },
+        overrideAccess: true,
       })
 
       expect(getLastOperation()).toEqual('countVersions')
@@ -886,6 +953,7 @@ test.suite({ config: './config.ts' })('Hooks', () => {
       const doc = await payload.create({
         collection: beforeOperationSlug,
         data: {},
+        overrideAccess: true,
       })
 
       await payload.findVersions({
@@ -895,6 +963,7 @@ test.suite({ config: './config.ts' })('Hooks', () => {
             equals: doc.id,
           },
         },
+        overrideAccess: true,
       })
 
       expect(getLastOperation()).toEqual('read')
@@ -904,6 +973,7 @@ test.suite({ config: './config.ts' })('Hooks', () => {
       const doc = await payload.create({
         collection: beforeOperationSlug,
         data: { category: 'v1' },
+        overrideAccess: true,
       })
 
       // Update to create a version
@@ -911,6 +981,7 @@ test.suite({ config: './config.ts' })('Hooks', () => {
         id: doc.id,
         collection: beforeOperationSlug,
         data: { category: 'v2' },
+        overrideAccess: true,
       })
 
       const versions = await payload.findVersions({
@@ -920,6 +991,7 @@ test.suite({ config: './config.ts' })('Hooks', () => {
             equals: doc.id,
           },
         },
+        overrideAccess: true,
       })
 
       expect(versions.docs.length).toBeGreaterThan(0)
@@ -927,6 +999,7 @@ test.suite({ config: './config.ts' })('Hooks', () => {
       await payload.findVersionByID({
         collection: beforeOperationSlug,
         id: versions.docs[0]!.id,
+        overrideAccess: true,
       })
 
       expect(getLastOperation()).toEqual('read')
@@ -936,6 +1009,7 @@ test.suite({ config: './config.ts' })('Hooks', () => {
       const doc = await payload.create({
         collection: beforeOperationSlug,
         data: { category: 'v1' },
+        overrideAccess: true,
       })
 
       // Update to create a version
@@ -943,6 +1017,7 @@ test.suite({ config: './config.ts' })('Hooks', () => {
         id: doc.id,
         collection: beforeOperationSlug,
         data: { category: 'v2' },
+        overrideAccess: true,
       })
 
       const versions = await payload.findVersions({
@@ -952,6 +1027,7 @@ test.suite({ config: './config.ts' })('Hooks', () => {
             equals: doc.id,
           },
         },
+        overrideAccess: true,
       })
 
       expect(versions.docs.length).toBeGreaterThan(0)
@@ -959,6 +1035,7 @@ test.suite({ config: './config.ts' })('Hooks', () => {
       await payload.restoreVersion({
         collection: beforeOperationSlug,
         id: versions.docs[0]!.id,
+        overrideAccess: true,
       })
 
       expect(getLastOperation()).toEqual('restoreVersion')
@@ -972,11 +1049,13 @@ test.suite({ config: './config.ts' })('Hooks', () => {
         data: {
           title: 'test',
         },
+        overrideAccess: true,
       })
 
       const docFromFind = await payload.findByID({
         collection: afterReadSlug,
         id: createdDoc.id,
+        overrideAccess: true,
       })
 
       const { docs } = await payload.find({
@@ -986,6 +1065,7 @@ test.suite({ config: './config.ts' })('Hooks', () => {
             equals: createdDoc.id,
           },
         },
+        overrideAccess: true,
       })
 
       const docFromFindMany = docs[0]
@@ -1001,7 +1081,7 @@ test.suite({ config: './config.ts' })('Hooks', () => {
 
     test.afterEach(async ({ payload }) => {
       for (const id of createdIDs) {
-        await payload.delete({ collection: overrideAccessSlug, id })
+        await payload.delete({ collection: overrideAccessSlug, id, overrideAccess: true })
       }
       createdIDs.length = 0
     })
@@ -1110,6 +1190,7 @@ test.suite({ config: './config.ts' })('Hooks', () => {
       const doc = await payload.create({
         collection: overrideAccessSlug,
         data: { title: 'Test Default' },
+        overrideAccess: true,
       })
 
       createdIDs.push(doc.id)
@@ -1117,6 +1198,7 @@ test.suite({ config: './config.ts' })('Hooks', () => {
       const result = await payload.findByID({
         collection: overrideAccessSlug,
         id: doc.id,
+        overrideAccess: true,
       })
 
       expect(result.beforeReadCalled).toBe(true)

--- a/test/i18n/config.ts
+++ b/test/i18n/config.ts
@@ -125,6 +125,7 @@ export default buildConfigWithDefaults({
         email: devUser.email,
         password: devUser.password,
       },
+      overrideAccess: true,
     })
   },
 })

--- a/test/i18n/e2e.spec.ts
+++ b/test/i18n/e2e.spec.ts
@@ -203,6 +203,7 @@ describe('i18n', () => {
         data: {
           i18nFieldLabel: 'Test',
         },
+        overrideAccess: true,
       })
 
       // set language to Spanish

--- a/test/joins/e2e.spec.ts
+++ b/test/joins/e2e.spec.ts
@@ -88,6 +88,7 @@ describe('Join Field', () => {
           equals: 'example',
         },
       },
+      overrideAccess: true,
     })
 
     if (!docs[0]) {
@@ -96,7 +97,12 @@ describe('Join Field', () => {
 
     ;({ id: categoryID } = docs[0])
 
-    const folder = await payload.find({ collection: 'folders', depth: 0, sort: 'createdAt' })
+    const folder = await payload.find({
+      collection: 'folders',
+      depth: 0,
+      sort: 'createdAt',
+      overrideAccess: true,
+    })
     rootParentID = folder.docs[0]!.id
   })
 
@@ -127,6 +133,7 @@ describe('Join Field', () => {
     const result = await payload.find({
       collection: categoriesSlug,
       limit: 1,
+      overrideAccess: true,
     })
     const category = result.docs[0]
 
@@ -141,6 +148,7 @@ describe('Join Field', () => {
         category: category.id,
         title: 'a',
       },
+      overrideAccess: true,
     })
 
     await payload.create({
@@ -149,6 +157,7 @@ describe('Join Field', () => {
         category: category.id,
         title: 'b',
       },
+      overrideAccess: true,
     })
 
     await payload.create({
@@ -157,6 +166,7 @@ describe('Join Field', () => {
         category: category.id,
         title: 'z',
       },
+      overrideAccess: true,
     })
 
     await navigateToDoc(page, categoriesURL)
@@ -523,6 +533,7 @@ describe('Join Field', () => {
         category: categoryID as string,
         title,
       },
+      overrideAccess: true,
     })
 
     await page.goto(categoriesURL.edit(categoryID))
@@ -577,6 +588,7 @@ describe('Join Field', () => {
         title,
         category: categoryID as string,
       },
+      overrideAccess: true,
     })
 
     await page.goto(categoriesURL.edit(categoryID))
@@ -632,6 +644,7 @@ describe('Join Field', () => {
       data: {
         title: 'Test Category (With Versions)',
       },
+      overrideAccess: true,
     })
 
     await payload.create({
@@ -640,6 +653,7 @@ describe('Join Field', () => {
         categoryVersion: categoryVersionsDoc.id,
         title: 'Test Post',
       },
+      overrideAccess: true,
     })
 
     await page.goto(categoriesVersionsURL.edit(categoryVersionsDoc.id))
@@ -868,7 +882,7 @@ describe('Join Field', () => {
   })
 
   test('should render create-first-user with when users collection has a join field and hide it', async () => {
-    await payload.delete({ collection: 'users', where: {} })
+    await payload.delete({ collection: 'users', where: {}, overrideAccess: true })
     const url = new AdminUrlUtil(serverURL, 'users')
     await page.goto(url.admin + '/create-first-user')
     await expect(page.locator('.field-type.join')).toBeHidden()
@@ -905,6 +919,7 @@ describe('Join Field', () => {
       data: {
         title: 'Category Versions',
       },
+      overrideAccess: true,
     })
 
     const versionDoc = await payload.create({
@@ -913,6 +928,7 @@ describe('Join Field', () => {
         categoryVersion: categoryVersionsDoc.id,
         title: 'Version 1',
       },
+      overrideAccess: true,
     })
 
     await payload.update({
@@ -922,6 +938,7 @@ describe('Join Field', () => {
         title: 'Version 1 - Draft',
       },
       draft: true,
+      overrideAccess: true,
     })
 
     await page.goto(categoriesVersionsURL.edit(categoryVersionsDoc.id))

--- a/test/joins/int.spec.ts
+++ b/test/joins/int.spec.ts
@@ -52,6 +52,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
         name: 'paginate example',
         group: {},
       },
+      overrideAccess: true,
     })
 
     otherCategory = await payload.create({
@@ -60,6 +61,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
         name: 'otherCategory',
         group: {},
       },
+      overrideAccess: true,
     })
 
     // create an upload
@@ -70,6 +72,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
       collection: uploadsSlug,
       data: {},
       file: imageFile,
+      overrideAccess: true,
     })
 
     categoryID = idToString(category.id, payload)
@@ -129,6 +132,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
         },
       },
       collection: categoriesSlug,
+      overrideAccess: true,
     })
 
     expect(categoryWithPosts.group.relatedPosts.docs).toHaveLength(10)
@@ -147,6 +151,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
       },
       select: {},
       collection: categoriesSlug,
+      overrideAccess: true,
     })
 
     expect(Object.keys(categoryWithPosts)).toStrictEqual(['id'])
@@ -166,6 +171,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
         },
       },
       collection: categoriesSlug,
+      overrideAccess: true,
     })
 
     expect(categoryWithPosts).toStrictEqual({
@@ -189,6 +195,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
         },
       },
       collection: categoriesSlug,
+      overrideAccess: true,
     })
 
     expect(categoryWithPosts.group.relatedPosts?.totalDocs).toBe(15)
@@ -204,6 +211,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
         },
       },
       collection: categoriesSlug,
+      overrideAccess: true,
     })
 
     expect(categoryWithPosts.group.relatedPosts?.totalDocs).toBe(15)
@@ -216,6 +224,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
       joins: {
         hasManyPosts: { limit: 1, count: true },
       },
+      overrideAccess: true,
     })
 
     expect(res.hasManyPosts?.totalDocs).toBe(15)
@@ -226,6 +235,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
       limit: 1,
       collection: postsSlug,
       depth: 2,
+      overrideAccess: true,
     })
 
     expect(docs[0].category.id).toBeDefined()
@@ -237,6 +247,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
     const { docs } = await payload.find({
       limit: 1,
       collection: postsSlug,
+      overrideAccess: true,
     })
 
     expect(docs[0].group.camelCaseCategory.id).toBeDefined()
@@ -248,6 +259,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
     const categoryWithPosts = await payload.findByID({
       id: category.id,
       collection: categoriesSlug,
+      overrideAccess: true,
     })
 
     expect(categoryWithPosts.arrayPosts.docs).toBeDefined()
@@ -258,6 +270,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
     const categoryWithPosts = await payload.findByID({
       id: category.id,
       collection: categoriesSlug,
+      overrideAccess: true,
     })
 
     expect(categoryWithPosts.arrayHasManyPosts.docs).toBeDefined()
@@ -268,6 +281,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
     const categoryWithPosts = await payload.findByID({
       id: category.id,
       collection: categoriesSlug,
+      overrideAccess: true,
     })
 
     expect(categoryWithPosts.localizedArrayPosts.docs).toBeDefined()
@@ -278,6 +292,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
     const categoryWithPosts = await payload.findByID({
       id: category.id,
       collection: categoriesSlug,
+      overrideAccess: true,
     })
 
     expect(categoryWithPosts.blocksPosts.docs).toBeDefined()
@@ -287,6 +302,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
     const { docs } = await payload.find({
       limit: 1,
       collection: postsSlug,
+      overrideAccess: true,
     })
 
     expect(docs[0].upload.id).toBeDefined()
@@ -297,6 +313,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
     const categoryWithPosts = await payload.findByID({
       collection: categoriesSlug,
       id: category.id,
+      overrideAccess: true,
     })
     expect(categoryWithPosts.polymorphic.docs[0]).toHaveProperty('id')
     expect(categoryWithPosts.polymorphics.docs[0]).toHaveProperty('id')
@@ -312,6 +329,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
       data: {
         name: 'sharedFolder',
       },
+      overrideAccess: true,
     })
 
     await payload.create({
@@ -321,6 +339,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
         _h_folders: folderDoc.id,
       },
       depth: 0,
+      overrideAccess: true,
     })
 
     await payload.create({
@@ -330,6 +349,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
         _h_folders: folderDoc.id,
       },
       depth: 0,
+      overrideAccess: true,
     })
 
     const result = await payload.find({
@@ -359,6 +379,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
           equals: folderDoc.id,
         },
       },
+      overrideAccess: true,
     })
 
     expect(result.docs[0]?.children.docs).toHaveLength(1)
@@ -371,6 +392,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
         name: 'scopedFolder',
         folderType: ['folderPoly1', 'folderPoly2'],
       },
+      overrideAccess: true,
     })
 
     await payload.create({
@@ -380,6 +402,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
         folderType: ['folderPoly1'],
         _h_folders: folderDoc.id,
       },
+      overrideAccess: true,
     })
 
     const findFolder = await payload.find({
@@ -409,19 +432,21 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
           },
         },
       },
+      overrideAccess: true,
     })
 
     expect(findFolder?.docs[0]?.children?.docs).toHaveLength(1)
   })
 
   test('should query where with exists for hasMany select fields', async ({ payload }) => {
-    await payload.delete({ collection: 'folders', where: {} })
+    await payload.delete({ collection: 'folders', where: {}, overrideAccess: true })
     const folderDoc = await payload.create({
       collection: 'folders',
       data: {
         name: 'scopedFolder',
         folderType: ['folderPoly1', 'folderPoly2'],
       },
+      overrideAccess: true,
     })
 
     await payload.create({
@@ -431,6 +456,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
         folderType: ['folderPoly1'],
         _h_folders: folderDoc.id,
       },
+      overrideAccess: true,
     })
 
     const findFolder = await payload.find({
@@ -469,6 +495,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
           },
         },
       },
+      overrideAccess: true,
     })
 
     expect(findFolder?.docs[0]?.children?.docs).toHaveLength(1)
@@ -488,6 +515,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
         },
       },
       collection: categoriesSlug,
+      overrideAccess: true,
     })
 
     expect(categoryWithPosts.relatedPosts.docs).toHaveLength(1)
@@ -498,6 +526,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
     const categoryWithPosts = await payload.findByID({
       id: category.id,
       collection: categoriesSlug,
+      overrideAccess: true,
     })
 
     // relatedPosts join has defaultSort: '-title', defaultLimit: 5
@@ -514,6 +543,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
           sort: 'title',
         },
       },
+      overrideAccess: true,
     })
 
     // ascending sort overrides defaultSort: '-title'
@@ -526,6 +556,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
       where: {
         id: { equals: category.id },
       },
+      overrideAccess: true,
     })
 
     const [categoryWithPosts] = result.docs
@@ -541,12 +572,14 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
       where: {
         id: { equals: category.id },
       },
+      overrideAccess: true,
     })
     const otherResult = await payload.find({
       collection: categoriesSlug,
       where: {
         id: { equals: otherCategory.id },
       },
+      overrideAccess: true,
     })
 
     const [categoryWithPosts] = result.docs
@@ -594,12 +627,14 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
       where: {
         id: { equals: category.id },
       },
+      overrideAccess: true,
     })
     const otherResultEn = await payload.find({
       collection: categoriesSlug,
       where: {
         id: { equals: otherCategory.id },
       },
+      overrideAccess: true,
     })
 
     const [categoryWithPostsEn] = resultEn.docs
@@ -618,6 +653,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
       where: {
         id: { equals: category.id },
       },
+      overrideAccess: true,
     })
     const otherResultEs = await payload.find({
       collection: categoriesSlug,
@@ -625,6 +661,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
       where: {
         id: { equals: otherCategory.id },
       },
+      overrideAccess: true,
     })
 
     const [categoryWithPostsEs] = resultEs.docs
@@ -644,6 +681,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
           in: [post_1.id, post_2.id],
         },
       },
+      overrideAccess: true,
     })
   })
 
@@ -653,6 +691,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
       data: {
         name: 'category with post',
       },
+      overrideAccess: true,
     })
 
     await createPost(
@@ -668,6 +707,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
       where: {
         id: { equals: category.id },
       },
+      overrideAccess: true,
     })
 
     expect(result.docs[0].id).toStrictEqual(category.id)
@@ -681,6 +721,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
         data: {
           name: 'category with filtered post',
         },
+        overrideAccess: true,
       })
 
       await createPost(
@@ -704,6 +745,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
       categoryWithFilteredPost = await payload.findByID({
         id: categoryWithFilteredPost.id,
         collection: categoriesSlug,
+        overrideAccess: true,
       })
     })
 
@@ -724,6 +766,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
             },
           },
         },
+        overrideAccess: true,
       })
 
       expect(categoryWithFilteredPost.filtered.docs).toHaveLength(0)
@@ -740,6 +783,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
         data: {
           name: 'localized category',
         },
+        overrideAccess: true,
       })
       const post1 = await payload.create({
         collection: 'localized-posts',
@@ -748,6 +792,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
           title: 'english post 1',
           category: localizedCategory.id,
         },
+        overrideAccess: true,
       })
       await payload.update({
         collection: 'localized-posts',
@@ -757,6 +802,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
           title: 'spanish post',
           category: localizedCategory.id,
         },
+        overrideAccess: true,
       })
       await payload.create({
         collection: 'localized-posts',
@@ -765,6 +811,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
           title: 'english post 2',
           category: localizedCategory.id,
         },
+        overrideAccess: true,
       })
     })
 
@@ -775,11 +822,13 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
         id: localizedCategory.id,
         collection: 'localized-categories',
         locale: 'en',
+        overrideAccess: true,
       })
       const esCategory = await payload.findByID({
         id: localizedCategory.id,
         collection: 'localized-categories',
         locale: 'es',
+        overrideAccess: true,
       })
       expect(enCategory.relatedPosts.docs).toHaveLength(2)
       expect(esCategory.relatedPosts.docs).toHaveLength(1)
@@ -788,19 +837,20 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
 
   test.describe('Joins with versions', () => {
     test.afterEach(async ({ payload }) => {
-      await payload.delete({ collection: 'versions', where: {} })
-      await payload.delete({ collection: 'categories-versions', where: {} })
+      await payload.delete({ collection: 'versions', where: {}, overrideAccess: true })
+      await payload.delete({ collection: 'categories-versions', where: {}, overrideAccess: true })
     })
 
     test('should populate joins when versions on both sides draft false', async ({ payload }) => {
-      const category = await payload.create({ collection: 'categories-versions', data: {} })
+      const category = await payload.create({ collection: 'categories-versions', data: {}, overrideAccess: true })
 
       const version = await payload.create({
         collection: 'versions',
         data: { title: 'version', categoryVersion: category.id },
+        overrideAccess: true,
       })
 
-      const res = await payload.find({ collection: 'categories-versions', draft: false })
+      const res = await payload.find({ collection: 'categories-versions', draft: false, overrideAccess: true })
 
       expect(res.docs[0].relatedVersions.docs[0].id).toBe(version.id)
     })
@@ -808,14 +858,15 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
     test('should populate joins with hasMany relationships when versions on both sides draft false', async ({
       payload,
     }) => {
-      const category = await payload.create({ collection: 'categories-versions', data: {} })
+      const category = await payload.create({ collection: 'categories-versions', data: {}, overrideAccess: true })
 
       const version = await payload.create({
         collection: 'versions',
         data: { title: 'version', categoryVersions: [category.id] },
+        overrideAccess: true,
       })
 
-      const res = await payload.find({ collection: 'categories-versions', draft: false })
+      const res = await payload.find({ collection: 'categories-versions', draft: false, overrideAccess: true })
 
       expect(res.docs[0].relatedVersionsMany.docs[0].id).toBe(version.id)
     })
@@ -823,16 +874,18 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
     test('should populate joins with hasMany relationships when versions on both sides draft true payload.db.queryDrafts', async ({
       payload,
     }) => {
-      const category = await payload.create({ collection: 'categories-versions', data: {} })
+      const category = await payload.create({ collection: 'categories-versions', data: {}, overrideAccess: true })
 
       const version = await payload.create({
         collection: 'versions',
         data: { title: 'version', categoryVersion: category.id },
+        overrideAccess: true,
       })
 
       const res = await payload.find({
         collection: 'categories-versions',
         draft: true,
+        overrideAccess: true,
       })
 
       expect(res.docs[0].relatedVersions.docs[0].id).toBe(version.id)
@@ -845,12 +898,14 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
         collection: 'categories-versions',
         data: { _status: 'draft' },
         draft: true,
+        overrideAccess: true,
       })
 
       const version = await payload.create({
         collection: 'versions',
         data: { title: 'original-title', _status: 'draft', categoryVersion: category.id },
         draft: true,
+        overrideAccess: true,
       })
 
       await payload.update({
@@ -858,11 +913,13 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
         id: version.id,
         data: { title: 'updated-title' },
         draft: true,
+        overrideAccess: true,
       })
 
       const res = await payload.find({
         collection: 'categories-versions',
         draft: true,
+        overrideAccess: true,
       })
 
       expect(res.docs[0].relatedVersions.docs[0].id).toBe(version.id)
@@ -872,16 +929,18 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
     test('should populate joins when versions on both sides draft true payload.db.queryDrafts', async ({
       payload,
     }) => {
-      const category = await payload.create({ collection: 'categories-versions', data: {} })
+      const category = await payload.create({ collection: 'categories-versions', data: {}, overrideAccess: true })
 
       const version = await payload.create({
         collection: 'versions',
         data: { categoryVersions: [category.id], title: 'version' },
+        overrideAccess: true,
       })
 
       const res = await payload.find({
         collection: 'categories-versions',
         draft: true,
+        overrideAccess: true,
       })
 
       expect(res.docs[0].relatedVersionsMany.docs[0].id).toBe(version.id)
@@ -998,6 +1057,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
         data: {
           name: 'restricted category',
         },
+        overrideAccess: true,
       })
       await createPost(
         { payload },
@@ -1308,12 +1368,14 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
         collection: 'categories-versions',
         data: { _status: 'draft' },
         draft: true,
+        overrideAccess: true,
       })
 
       const version = await payload.create({
         collection: 'versions',
         data: { _status: 'draft', title: 'original-title', categoryVersion: category.id },
         draft: true,
+        overrideAccess: true,
       })
 
       await payload.update({
@@ -1321,6 +1383,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
         draft: true,
         id: version.id,
         data: { title: 'updated-title' },
+        overrideAccess: true,
       })
 
       const query = `query {
@@ -1486,7 +1549,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
     payload,
     restClient,
   }) => {
-    const allCategories = await payload.find({ collection: categoriesSlug, pagination: false })
+    const allCategories = await payload.find({ collection: categoriesSlug, pagination: false, overrideAccess: true })
 
     const allCategoriesByIds = await restClient
       .GET(`/categories`, {
@@ -1506,16 +1569,18 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
   test('should join with singular collection name', async ({ payload }) => {
     const {
       docs: [category],
-    } = await payload.find({ collection: categoriesSlug, limit: 1, depth: 0 })
+    } = await payload.find({ collection: categoriesSlug, limit: 1, depth: 0, overrideAccess: true })
 
     const singular = await payload.create({
       collection: 'singular',
       data: { category: category.id },
+      overrideAccess: true,
     })
 
     const categoryWithJoins = await payload.findByID({
       collection: categoriesSlug,
       id: category.id,
+      overrideAccess: true,
     })
 
     expect((categoryWithJoins.singulars.docs[0] as Singular).id).toBe(singular.id)
@@ -1534,6 +1599,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
       joins: {
         relatedPosts: false,
       },
+      overrideAccess: true,
     })
 
     // removed from the result
@@ -1574,12 +1640,13 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
 
   test('should have correct totalDocs', async ({ payload }) => {
     for (let i = 0; i < 50; i++) {
-      await payload.create({ collection: categoriesSlug, data: { name: 'totalDocs' } })
+      await payload.create({ collection: categoriesSlug, data: { name: 'totalDocs' }, overrideAccess: true })
     }
 
     const count = await payload.count({
       collection: categoriesSlug,
       where: { name: { equals: 'totalDocs' } },
+      overrideAccess: true,
     })
     expect(count.totalDocs).toBe(50)
 
@@ -1587,40 +1654,44 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
       collection: categoriesSlug,
       limit: 5,
       where: { name: { equals: 'totalDocs' } },
+      overrideAccess: true,
     })
     expect(find.totalDocs).toBe(50)
     expect(find.docs).toHaveLength(5)
 
-    await payload.delete({ collection: categoriesSlug, where: { name: { equals: 'totalDocs' } } })
+    await payload.delete({ collection: categoriesSlug, where: { name: { equals: 'totalDocs' } }, overrideAccess: true })
   })
 
   test('should self join', async ({ payload }) => {
-    const doc_1 = await payload.create({ collection: 'self-joins', data: {} })
-    const doc_2 = await payload.create({ collection: 'self-joins', data: { rel: doc_1 }, depth: 0 })
+    const doc_1 = await payload.create({ collection: 'self-joins', data: {}, overrideAccess: true })
+    const doc_2 = await payload.create({ collection: 'self-joins', data: { rel: doc_1 }, depth: 0, overrideAccess: true })
 
-    const data = await payload.findByID({ collection: 'self-joins', id: doc_1.id, depth: 1 })
+    const data = await payload.findByID({ collection: 'self-joins', id: doc_1.id, depth: 1, overrideAccess: true })
 
     expect((data.joins.docs[0] as TypeWithID).id).toBe(doc_2.id)
   })
 
   test('should populate joins on depth 2', async ({ payload }) => {
-    const depthJoin_2 = await payload.create({ collection: 'depth-joins-2', data: {}, depth: 0 })
+    const depthJoin_2 = await payload.create({ collection: 'depth-joins-2', data: {}, depth: 0, overrideAccess: true })
     const depthJoin_1 = await payload.create({
       collection: 'depth-joins-1',
       data: { rel: depthJoin_2 },
       depth: 0,
+      overrideAccess: true,
     })
 
     const depthJoin_3 = await payload.create({
       collection: 'depth-joins-3',
       data: { rel: depthJoin_1 },
       depth: 0,
+      overrideAccess: true,
     })
 
     const data = await payload.findByID({
       collection: 'depth-joins-2',
       id: depthJoin_2.id,
       depth: 2,
+      overrideAccess: true,
     })
 
     const joinedDoc = data.joins.docs[0] as DepthJoins1
@@ -1638,6 +1709,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
         collection: 'multiple-collections-parents',
         depth: 0,
         data: {},
+        overrideAccess: true,
       })
 
       const child_1 = await payload.create({
@@ -1647,6 +1719,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
           parent,
           title: 'doc-1',
         },
+        overrideAccess: true,
       })
 
       const child_2 = await payload.create({
@@ -1656,12 +1729,14 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
           parent,
           title: 'doc-2',
         },
+        overrideAccess: true,
       })
 
       parent = await payload.findByID({
         collection: 'multiple-collections-parents',
         id: parent.id,
         depth: 0,
+        overrideAccess: true,
       })
 
       expect(parent.children.docs[0].value).toBe(child_2.id)
@@ -1673,6 +1748,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
         collection: 'multiple-collections-parents',
         id: parent.id,
         depth: 1,
+        overrideAccess: true,
       })
 
       expect(parent.children.docs[0].value.id).toBe(child_2.id)
@@ -1691,6 +1767,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
             sort: 'title',
           },
         },
+        overrideAccess: true,
       })
 
       expect(parent.children.docs).toHaveLength(1)
@@ -1706,6 +1783,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
             sort: 'title',
           },
         },
+        overrideAccess: true,
       })
 
       expect(parent.children.docs).toHaveLength(2)
@@ -1721,6 +1799,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
             sort: 'title',
           },
         },
+        overrideAccess: true,
       })
 
       expect(parent.children.docs[0]?.value.title).toBe('doc-1')
@@ -1735,6 +1814,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
             sort: '-title',
           },
         },
+        overrideAccess: true,
       })
 
       expect(parent.children.docs[0]?.value.title).toBe('doc-2')
@@ -1754,6 +1834,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
             },
           },
         },
+        overrideAccess: true,
       })
 
       expect(parent.children?.docs).toHaveLength(1)
@@ -1773,6 +1854,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
             },
           },
         },
+        overrideAccess: true,
       })
 
       // WHERE by relationTo with overrideAccess:false
@@ -1805,6 +1887,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
             count: true,
           },
         },
+        overrideAccess: true,
       })
 
       expect(parent.children?.totalDocs).toBe(2)
@@ -1824,6 +1907,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
             },
           },
         },
+        overrideAccess: true,
       })
 
       expect(parent.children?.totalDocs).toBe(1)
@@ -1831,14 +1915,16 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
   })
 
   test('should support where querying by a top level join field', async ({ payload }) => {
-    const category = await payload.create({ collection: 'categories', data: {} })
+    const category = await payload.create({ collection: 'categories', data: {}, overrideAccess: true })
     await payload.create({
       collection: 'posts',
       data: { category: category.id, title: 'my-title' },
+      overrideAccess: true,
     })
     const found = await payload.find({
       collection: 'categories',
       where: { 'relatedPosts.title': { equals: 'my-title' } },
+      overrideAccess: true,
     })
 
     expect(found.docs).toHaveLength(1)
@@ -1846,10 +1932,11 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
   })
 
   test('should support where querying by a join field as ID', async ({ payload }) => {
-    const category = await payload.create({ collection: 'categories', data: {} })
+    const category = await payload.create({ collection: 'categories', data: {}, overrideAccess: true })
     const post = await payload.create({
       collection: 'posts',
       data: { category: category.id, title: 'my-title' },
+      overrideAccess: true,
     })
     const found_1 = await payload.find({
       collection: 'categories',
@@ -1873,15 +1960,17 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
   test('should support where querying by a join field with hasMany relationship', async ({
     payload,
   }) => {
-    const category = await payload.create({ collection: 'categories', data: {} })
+    const category = await payload.create({ collection: 'categories', data: {}, overrideAccess: true })
     await payload.create({
       collection: 'posts',
       data: { categories: [category.id], title: 'my-title' },
+      overrideAccess: true,
     })
 
     const found = await payload.find({
       collection: 'categories',
       where: { 'hasManyPosts.title': { equals: 'my-title' } },
+      overrideAccess: true,
     })
     expect(found.docs).toHaveLength(1)
     expect(found.docs[0].id).toBe(category.id)
@@ -1890,14 +1979,16 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
   test('should support where querying by a join field with relationship nested to a group', async ({
     payload,
   }) => {
-    const category = await payload.create({ collection: 'categories', data: {} })
+    const category = await payload.create({ collection: 'categories', data: {}, overrideAccess: true })
     await payload.create({
       collection: 'posts',
       data: { group: { category: category.id }, title: 'my-category-title' },
+      overrideAccess: true,
     })
     const found = await payload.find({
       collection: 'categories',
       where: { 'group.relatedPosts.title': { equals: 'my-category-title' } },
+      overrideAccess: true,
     })
 
     expect(found.docs).toHaveLength(1)
@@ -1907,28 +1998,31 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
   test('should support where querying by a join field with relationship nested to an array', async ({
     payload,
   }) => {
-    const category = await payload.create({ collection: 'categories', data: {} })
+    const category = await payload.create({ collection: 'categories', data: {}, overrideAccess: true })
     const post = await payload.create({
       collection: 'posts',
       data: { array: [{ category: category.id }], title: 'array-join-where-test' },
+      overrideAccess: true,
     })
     const found = await payload.find({
       collection: 'categories',
       where: { 'arrayPosts.title': { equals: 'array-join-where-test' } },
+      overrideAccess: true,
     })
 
     expect(found.docs).toHaveLength(1)
     expect(found.docs[0].id).toBe(category.id)
 
-    await payload.delete({ collection: 'posts', id: post.id })
-    await payload.delete({ collection: 'categories', id: category.id })
+    await payload.delete({ collection: 'posts', id: post.id, overrideAccess: true })
+    await payload.delete({ collection: 'categories', id: category.id, overrideAccess: true })
   })
 
   test('should support where querying by a join field multiple times', async ({ payload }) => {
-    const category = await payload.create({ collection: 'categories', data: {} })
+    const category = await payload.create({ collection: 'categories', data: {}, overrideAccess: true })
     await payload.create({
       collection: 'posts',
       data: { group: { category: category.id }, isFiltered: true, title: 'my-category-title' },
+      overrideAccess: true,
     })
 
     const found = await payload.find({
@@ -1946,6 +2040,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
           },
         ],
       },
+      overrideAccess: true,
     })
 
     expect(found.docs).toHaveLength(1)
@@ -1955,10 +2050,11 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
   test('should support where querying by a join field with hasMany relationship multiple times', async ({
     payload,
   }) => {
-    const category = await payload.create({ collection: 'categories', data: {} })
+    const category = await payload.create({ collection: 'categories', data: {}, overrideAccess: true })
     await payload.create({
       collection: 'posts',
       data: { categories: [category.id], title: 'my-title', isFiltered: true },
+      overrideAccess: true,
     })
 
     const found = await payload.find({
@@ -1976,6 +2072,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
           },
         ],
       },
+      overrideAccess: true,
     })
     expect(found.docs).toHaveLength(1)
     expect(found.docs[0].id).toBe(category.id)
@@ -2156,6 +2253,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
           collection: postsSlug,
           limit: 1,
           where: { title: { $raw: 'true' } } as any,
+          overrideAccess: true,
         }),
       ).rejects.toBeTruthy()
     })
@@ -2235,5 +2333,6 @@ async function createPost(
       title: 'test',
       ...overrides,
     },
+    overrideAccess: true,
   })
 }

--- a/test/joins/queryPath.int.spec.ts
+++ b/test/joins/queryPath.int.spec.ts
@@ -52,6 +52,7 @@ test.suite({ db: (adapter) => adapter === 'mongodb' || adapter === 'mongodb-atla
         collection: 'categories',
         // @ts-expect-error not generated
         data: { title: 'a' },
+        overrideAccess: true,
       })
       createdIDs.push(category.id)
 
@@ -68,7 +69,7 @@ test.suite({ db: (adapter) => adapter === 'mongodb' || adapter === 'mongodb-atla
       const payload = await getPayloadInstance()
 
       for (const id of createdIDs) {
-        await payload.delete({ collection: 'categories', id })
+        await payload.delete({ collection: 'categories', id, overrideAccess: true })
       }
 
       createdIDs.length = 0
@@ -87,6 +88,7 @@ test.suite({ db: (adapter) => adapter === 'mongodb' || adapter === 'mongodb-atla
         // @ts-expect-error not generated
         select: { title: true },
         where: { title: { equals: 'a' } },
+        overrideAccess: true,
       })
 
       expect(aggregateSpy).not.toHaveBeenCalled()
@@ -106,6 +108,7 @@ test.suite({ db: (adapter) => adapter === 'mongodb' || adapter === 'mongodb-atla
         joins: { posts: false },
         limit: 20,
         where: { title: { equals: 'a' } },
+        overrideAccess: true,
       })
 
       expect(aggregateSpy).not.toHaveBeenCalled()
@@ -124,6 +127,7 @@ test.suite({ db: (adapter) => adapter === 'mongodb' || adapter === 'mongodb-atla
         id: category.id,
         // @ts-expect-error not generated
         select: { title: true },
+        overrideAccess: true,
       })
 
       expect(aggregateSpy).not.toHaveBeenCalled()
@@ -141,6 +145,7 @@ test.suite({ db: (adapter) => adapter === 'mongodb' || adapter === 'mongodb-atla
         collection: 'categories',
         limit: 20,
         where: { title: { equals: 'a' } },
+        overrideAccess: true,
       })
 
       expect(aggregateSpy).toHaveBeenCalledTimes(1)

--- a/test/joins/seed.ts
+++ b/test/joins/seed.ts
@@ -26,6 +26,7 @@ export const seed = async (_payload: Payload) => {
       email: devUser.email,
       password: devUser.password,
     },
+    overrideAccess: true,
   })
 
   const category = await _payload.create({
@@ -34,6 +35,7 @@ export const seed = async (_payload: Payload) => {
       name: 'example',
       group: {},
     },
+    overrideAccess: true,
   })
 
   await _payload.create({
@@ -42,6 +44,7 @@ export const seed = async (_payload: Payload) => {
       category: category.id,
       title: 'Test Post 1',
     },
+    overrideAccess: true,
   })
 
   const post1 = await _payload.create({
@@ -54,6 +57,7 @@ export const seed = async (_payload: Payload) => {
       title: 'Test Post 1',
       localizedText: 'Text in en',
     },
+    overrideAccess: true,
   })
 
   const post2 = await _payload.create({
@@ -66,6 +70,7 @@ export const seed = async (_payload: Payload) => {
       title: 'Test Post 2',
       localizedText: 'Text in en',
     },
+    overrideAccess: true,
   })
 
   const post3 = await _payload.create({
@@ -78,6 +83,7 @@ export const seed = async (_payload: Payload) => {
       title: 'Test Post 3',
       localizedText: 'Text in en',
     },
+    overrideAccess: true,
   })
 
   await _payload.update({
@@ -87,6 +93,7 @@ export const seed = async (_payload: Payload) => {
       localizedText: 'Text in es',
     },
     locale: 'es',
+    overrideAccess: true,
   })
 
   await _payload.update({
@@ -96,6 +103,7 @@ export const seed = async (_payload: Payload) => {
       localizedText: 'Text in es',
     },
     locale: 'es',
+    overrideAccess: true,
   })
 
   await _payload.update({
@@ -105,6 +113,7 @@ export const seed = async (_payload: Payload) => {
       localizedText: 'Text in es',
     },
     locale: 'es',
+    overrideAccess: true,
   })
 
   // create an upload with image.png
@@ -114,6 +123,7 @@ export const seed = async (_payload: Payload) => {
     collection: uploadsSlug,
     data: {},
     file: imageFile,
+    overrideAccess: true,
   })
 
   // create a post that uses the upload
@@ -122,6 +132,7 @@ export const seed = async (_payload: Payload) => {
     data: {
       upload: uploadedImage,
     },
+    overrideAccess: true,
   })
 
   const restrictedCategory = await _payload.create({
@@ -129,6 +140,7 @@ export const seed = async (_payload: Payload) => {
     data: {
       name: 'categoryJoinRestricted',
     },
+    overrideAccess: true,
   })
   await _payload.create({
     collection: collectionRestrictedSlug,
@@ -137,6 +149,7 @@ export const seed = async (_payload: Payload) => {
       canRead: false,
       category: restrictedCategory.id,
     },
+    overrideAccess: true,
   })
   await _payload.create({
     collection: collectionRestrictedSlug,
@@ -145,6 +158,7 @@ export const seed = async (_payload: Payload) => {
       canRead: true,
       category: restrictedCategory.id,
     },
+    overrideAccess: true,
   })
 
   const root_folder = await _payload.create({
@@ -153,65 +167,78 @@ export const seed = async (_payload: Payload) => {
       _h_folders: null,
       name: 'Root folder',
     },
+    overrideAccess: true,
   })
 
   const page_1 = await _payload.create({
     collection: 'example-pages',
     data: { title: 'page 1', name: 'Andrew', _h_folders: root_folder },
+    overrideAccess: true,
   })
 
   const post_1 = await _payload.create({
     collection: 'example-posts',
     data: { title: 'page 1', description: 'This is post 1', _h_folders: root_folder },
+    overrideAccess: true,
   })
 
   const page_2 = await _payload.create({
     collection: 'example-pages',
     data: { title: 'page 2', name: 'Sophia', _h_folders: root_folder },
+    overrideAccess: true,
   })
 
   const page_3 = await _payload.create({
     collection: 'example-pages',
     data: { title: 'page 3', name: 'Michael', _h_folders: root_folder },
+    overrideAccess: true,
   })
 
   const post_2 = await _payload.create({
     collection: 'example-posts',
     data: { title: 'post 2', description: 'This is post 2', _h_folders: root_folder },
+    overrideAccess: true,
   })
 
   const post_3 = await _payload.create({
     collection: 'example-posts',
     data: { title: 'post 3', description: 'This is post 3', _h_folders: root_folder },
+    overrideAccess: true,
   })
 
   const sub_folder_1 = await _payload.create({
     collection: 'folders',
     data: { _h_folders: root_folder, name: 'Sub Folder 1' },
+    overrideAccess: true,
   })
 
   const page_4 = await _payload.create({
     collection: 'example-pages',
     data: { title: 'page 4', name: 'Emma', _h_folders: sub_folder_1 },
+    overrideAccess: true,
   })
 
   const post_4 = await _payload.create({
     collection: 'example-posts',
     data: { title: 'post 4', description: 'This is post 4', _h_folders: sub_folder_1 },
+    overrideAccess: true,
   })
 
   const sub_folder_2 = await _payload.create({
     collection: 'folders',
     data: { _h_folders: root_folder, name: 'Sub Folder 2' },
+    overrideAccess: true,
   })
 
   const page_5 = await _payload.create({
     collection: 'example-pages',
     data: { title: 'page 5', name: 'Liam', _h_folders: sub_folder_2 },
+    overrideAccess: true,
   })
 
   const post_5 = await _payload.create({
     collection: 'example-posts',
     data: { title: 'post 5', description: 'This is post 5', _h_folders: sub_folder_2 },
+    overrideAccess: true,
   })
 }

--- a/test/lexical-mdx/config.ts
+++ b/test/lexical-mdx/config.ts
@@ -48,11 +48,13 @@ export default buildConfigWithDefaults({
         email: devUser.email,
         password: devUser.password,
       },
+      overrideAccess: true,
     })
 
     await payload.delete({
       collection: 'posts',
       where: {},
+      overrideAccess: true,
     })
 
     // Recursively collect all paths to .mdx files RELATIVE to basePath
@@ -79,6 +81,7 @@ export default buildConfigWithDefaults({
           docPath: file,
         },
         depth: 0,
+        overrideAccess: true,
       })
     }
   },

--- a/test/lexical/benchmarks/perf.spec.ts
+++ b/test/lexical/benchmarks/perf.spec.ts
@@ -229,6 +229,7 @@ describe('Lexical Performance Benchmarks', () => {
     const docs = await payload.find({
       collection: lexicalBenchmarkSlug,
       limit: 1,
+      overrideAccess: true,
     })
 
     const docId = docs.docs[0]?.id

--- a/test/lexical/collections/Lexical/e2e/blocks/e2e.spec.ts
+++ b/test/lexical/collections/Lexical/e2e/blocks/e2e.spec.ts
@@ -195,6 +195,7 @@ describe('lexicalBlocks', () => {
           text: 'invalid',
         },
         depth: 0,
+        overrideAccess: true,
       })
 
       const { newBlock } = await createBlock({
@@ -391,6 +392,7 @@ describe('lexicalBlocks', () => {
           text: 'invalid',
         },
         depth: 0,
+        overrideAccess: true,
       })
 
       const { newBlock } = await createBlock({

--- a/test/lexical/collections/Lexical/e2e/main/e2e.spec.ts
+++ b/test/lexical/collections/Lexical/e2e/main/e2e.spec.ts
@@ -1891,6 +1891,7 @@ describe('lexicalMain', () => {
         },
         title: 'Test Custom Cell',
       },
+      overrideAccess: true,
     })
 
     const url = new AdminUrlUtil(serverURL, lexicalCustomCellSlug)

--- a/test/lexical/collections/_LexicalFullyFeatured/db/e2e.spec.ts
+++ b/test/lexical/collections/_LexicalFullyFeatured/db/e2e.spec.ts
@@ -82,6 +82,7 @@ describe('Lexical Fully Featured - database', () => {
       const uploadedImage = await payload.find({
         collection: 'uploads',
         where: { filename: { equals: expectedFileName || 'payload-1.jpg' } },
+        overrideAccess: true,
       })
       expect(uploadedImage.totalDocs).toBe(1)
     }
@@ -126,6 +127,7 @@ describe('Lexical Fully Featured - database', () => {
       const lexicalFullyFeatured = await payload.find({
         collection: lexicalFullyFeaturedSlug,
         limit: 1,
+        overrideAccess: true,
       })
       const richText = lexicalFullyFeatured?.docs?.[0]?.richText
 
@@ -231,6 +233,7 @@ describe('Lexical Fully Featured - database', () => {
           ],
         }),
       },
+      overrideAccess: true,
     })
 
     /**

--- a/test/lexical/components/Image.tsx
+++ b/test/lexical/components/Image.tsx
@@ -6,6 +6,7 @@ export const Image: React.FC<AdminViewServerProps> = async ({ payload }) => {
   const images = await payload.find({
     collection: 'uploads',
     limit: 1,
+    overrideAccess: true,
   })
 
   if (!images?.docs?.length) {

--- a/test/lexical/lexical.int.spec.ts
+++ b/test/lexical/lexical.int.spec.ts
@@ -83,6 +83,7 @@ test.suite({ config: './config.ts' })('Lexical', () => {
             equals: 'array doc 1',
           },
         },
+        overrideAccess: true,
       })
     ).docs[0].id
 
@@ -95,6 +96,7 @@ test.suite({ config: './config.ts' })('Lexical', () => {
             equals: 'payload.jpg',
           },
         },
+        overrideAccess: true,
       })
     ).docs[0].id
 
@@ -107,6 +109,7 @@ test.suite({ config: './config.ts' })('Lexical', () => {
             equals: 'Seeded text document',
           },
         },
+        overrideAccess: true,
       })
     ).docs[0].id
 
@@ -119,6 +122,7 @@ test.suite({ config: './config.ts' })('Lexical', () => {
             equals: 'Rich Text',
           },
         },
+        overrideAccess: true,
       })
     ).docs[0].id
   })
@@ -134,6 +138,7 @@ test.suite({ config: './config.ts' })('Lexical', () => {
               equals: richTextDocData.title,
             },
           },
+          overrideAccess: true,
         })
       ).docs[0] as never
 
@@ -172,6 +177,7 @@ test.suite({ config: './config.ts' })('Lexical', () => {
               equals: richTextDocData.title,
             },
           },
+          overrideAccess: true,
         })
       ).docs[0] as never
 
@@ -212,6 +218,7 @@ test.suite({ config: './config.ts' })('Lexical', () => {
               equals: richTextDocData.title,
             },
           },
+          overrideAccess: true,
         })
       ).docs[0] as never
 
@@ -300,6 +307,7 @@ test.suite({ config: './config.ts' })('Lexical', () => {
           },
         },
       },
+      overrideAccess: true,
     })
 
     expect(newLexicalDoc.lexicalWithBlocks_markdown).toEqual(
@@ -334,6 +342,7 @@ test.suite({ config: './config.ts' })('Lexical', () => {
             },
           },
         },
+        overrideAccess: true,
       })
 
       expect(newLexicalDoc.lexicalWithBlocks_markdown).toEqual(`![uploads:${createdJPGDocID}]()`)
@@ -344,6 +353,7 @@ test.suite({ config: './config.ts' })('Lexical', () => {
         collection: lexicalFieldsSlug,
         depth: 0,
         where: { title: { equals: lexicalDocData.title } },
+        overrideAccess: true,
       })
 
       const markdown = lexicalDoc.docs[0]?.lexicalWithBlocks_markdown as string
@@ -363,6 +373,7 @@ test.suite({ config: './config.ts' })('Lexical', () => {
               equals: lexicalDocData.title,
             },
           },
+          overrideAccess: true,
         })
       ).docs[0] as never
 
@@ -387,6 +398,7 @@ test.suite({ config: './config.ts' })('Lexical', () => {
               equals: lexicalDocData.title,
             },
           },
+          overrideAccess: true,
         })
       ).docs[0] as never
 
@@ -413,6 +425,7 @@ test.suite({ config: './config.ts' })('Lexical', () => {
               equals: lexicalDocData.title,
             },
           },
+          overrideAccess: true,
         })
       ).docs[0] as never
 
@@ -446,6 +459,7 @@ test.suite({ config: './config.ts' })('Lexical', () => {
               equals: lexicalDocData.title,
             },
           },
+          overrideAccess: true,
         })
       ).docs[0] as never
 
@@ -484,6 +498,7 @@ test.suite({ config: './config.ts' })('Lexical', () => {
               equals: lexicalDocData.title,
             },
           },
+          overrideAccess: true,
         })
       ).docs[0] as never
 
@@ -518,6 +533,7 @@ test.suite({ config: './config.ts' })('Lexical', () => {
               equals: lexicalDocData.title,
             },
           },
+          overrideAccess: true,
         })
       ).docs[0] as never
 
@@ -567,6 +583,7 @@ test.suite({ config: './config.ts' })('Lexical', () => {
               equals: lexicalDocData.title,
             },
           },
+          overrideAccess: true,
         })
       ).docs[0] as never
 
@@ -613,6 +630,7 @@ test.suite({ config: './config.ts' })('Lexical', () => {
             equals: 'Localized Lexical en',
           },
         },
+        overrideAccess: true,
       })
 
       expect(lexicalDocEN.docs[0].lexicalBlocksLocalized.root.children[0].children[0].text).toEqual(
@@ -623,6 +641,7 @@ test.suite({ config: './config.ts' })('Lexical', () => {
         collection: 'lexical-localized-fields',
         locale: 'es',
         id: lexicalDocEN.docs[0].id,
+        overrideAccess: true,
       })
 
       expect(lexicalDocES.lexicalBlocksLocalized.root.children[0].children[0].text).toEqual(
@@ -641,6 +660,7 @@ test.suite({ config: './config.ts' })('Lexical', () => {
             equals: 'Localized Lexical en',
           },
         },
+        overrideAccess: true,
       })
 
       expect(
@@ -656,6 +676,7 @@ test.suite({ config: './config.ts' })('Lexical', () => {
         collection: 'lexical-localized-fields',
         locale: 'es',
         id: lexicalDocEN.docs[0].id,
+        overrideAccess: true,
       })
 
       expect(lexicalDocES.lexicalBlocksSubLocalized.root.children[0].children[0].text).toEqual(
@@ -681,6 +702,7 @@ test.suite({ config: './config.ts' })('Lexical', () => {
             'English text in block',
           ) as any,
         },
+        overrideAccess: true,
       })
 
       expect(
@@ -693,6 +715,7 @@ test.suite({ config: './config.ts' })('Lexical', () => {
         locale: 'en',
         id: lexicalDocEN.id,
         data: lexicalDocEN,
+        overrideAccess: true,
       })
 
       expect(
@@ -742,6 +765,7 @@ test.suite({ config: './config.ts' })('Lexical', () => {
             },
           ],
         },
+        overrideAccess: true,
       })
 
       // Verify create operation has undefined previousValue (expected)
@@ -784,6 +808,7 @@ test.suite({ config: './config.ts' })('Lexical', () => {
             },
           ],
         },
+        overrideAccess: true,
       })
 
       expect(autosaveHookLog.relationshipField?.operation).toBe('update')

--- a/test/lexical/seed.ts
+++ b/test/lexical/seed.ts
@@ -110,6 +110,7 @@ export const seed = async (_payload: Payload) => {
       password: devUser.password,
     },
     depth: 0,
+    overrideAccess: true,
   })
 
   const jpgPath = path.resolve(lexicalDir, './collections/Upload/payload.jpg')
@@ -122,18 +123,21 @@ export const seed = async (_payload: Payload) => {
     collection: arrayFieldsSlug,
     data: arrayDoc,
     depth: 0,
+    overrideAccess: true,
   })
 
   const createdTextDoc = await _payload.create({
     collection: textFieldsSlug,
     data: textDoc,
     depth: 0,
+    overrideAccess: true,
   })
 
   await _payload.create({
     collection: textFieldsSlug,
     data: anotherTextDoc,
     depth: 0,
+    overrideAccess: true,
   })
 
   const createdPNGDoc = await _payload.create({
@@ -141,6 +145,7 @@ export const seed = async (_payload: Payload) => {
     data: {},
     depth: 0,
     file: pngFile,
+    overrideAccess: true,
   })
 
   const createdPNGDoc2 = await _payload.create({
@@ -148,6 +153,7 @@ export const seed = async (_payload: Payload) => {
     data: {},
     depth: 0,
     file: pngFile,
+    overrideAccess: true,
   })
 
   const createdJPGDoc = await _payload.create({
@@ -158,6 +164,7 @@ export const seed = async (_payload: Payload) => {
     },
     depth: 0,
     file: jpgFile,
+    overrideAccess: true,
   })
 
   const formattedID =
@@ -182,6 +189,7 @@ export const seed = async (_payload: Payload) => {
     collection: richTextFieldsSlug,
     data: richTextDocWithRelationship,
     depth: 0,
+    overrideAccess: true,
   })
 
   const formattedRichTextDocID =
@@ -199,6 +207,7 @@ export const seed = async (_payload: Payload) => {
     collection: lexicalFieldsSlug,
     data: lexicalDocWithRelId,
     depth: 0,
+    overrideAccess: true,
   })
 
   // Editor state without customAdminComponentBlock (for lexical-views)
@@ -407,6 +416,7 @@ export const seed = async (_payload: Payload) => {
       vanillaView: editorStateBasic,
     },
     depth: 0,
+    overrideAccess: true,
   })
 
   await _payload.create({
@@ -415,6 +425,7 @@ export const seed = async (_payload: Payload) => {
       customFrontendViews: editorStateFrontend,
     },
     depth: 0,
+    overrideAccess: true,
   })
 
   const lexicalLocalizedDoc1 = await _payload.create({
@@ -429,6 +440,7 @@ export const seed = async (_payload: Payload) => {
     },
     depth: 0,
     locale: 'en',
+    overrideAccess: true,
   })
 
   await _payload.create({
@@ -437,6 +449,7 @@ export const seed = async (_payload: Payload) => {
       richText: buildEditorState<LexicalRelationshipField['richText']>({ text: 'English text' }),
     },
     depth: 0,
+    overrideAccess: true,
   })
 
   // The 2nd child is the localized block — narrow to a node that carries `fields` to reuse its id.
@@ -460,6 +473,7 @@ export const seed = async (_payload: Payload) => {
     },
     depth: 0,
     locale: 'es',
+    overrideAccess: true,
   })
 
   const lexicalLocalizedDoc2 = await _payload.create({
@@ -494,6 +508,7 @@ export const seed = async (_payload: Payload) => {
     },
     depth: 0,
     locale: 'en',
+    overrideAccess: true,
   })
 
   await _payload.update({
@@ -517,6 +532,7 @@ export const seed = async (_payload: Payload) => {
     },
     depth: 0,
     locale: 'es',
+    overrideAccess: true,
   })
 
   const getInlineBlock = (): Extract<
@@ -597,6 +613,7 @@ export const seed = async (_payload: Payload) => {
       },
     },
     depth: 0,
+    overrideAccess: true,
   })
 
   await _payload.create({
@@ -666,6 +683,7 @@ export const seed = async (_payload: Payload) => {
       title: 'title',
     },
     depth: 0,
+    overrideAccess: true,
   })
 
   const benchmarkBlockNodes = Array.from({ length: 30 }, (_, i) => ({

--- a/test/live-preview/app-tanstack/functions/livePreview.functions.ts
+++ b/test/live-preview/app-tanstack/functions/livePreview.functions.ts
@@ -15,6 +15,7 @@ export const getLivePreviewDoc = createServerFn({ method: 'GET' })
         draft: true,
         trash: true,
         where: { slug: { equals: slug } },
+        overrideAccess: true,
       })
 
       return docs[0] ? toSerializable({ ...docs[0] }, {}) : null

--- a/test/live-preview/app/live-preview/_api/getDoc.ts
+++ b/test/live-preview/app/live-preview/_api/getDoc.ts
@@ -27,6 +27,7 @@ export const getDoc = async <T>(args: {
       where,
       draft,
       trash: true, // Include trashed documents
+      overrideAccess: true,
     })
 
     if (docs[0]) {

--- a/test/live-preview/app/live-preview/_api/getDocs.ts
+++ b/test/live-preview/app/live-preview/_api/getDocs.ts
@@ -9,6 +9,7 @@ export const getDocs = async <T>(collection: CollectionSlug): Promise<T[]> => {
       collection,
       depth: 0,
       limit: 100,
+      overrideAccess: true,
     })
 
     if (docs) {

--- a/test/live-preview/app/live-preview/_api/getFooter.ts
+++ b/test/live-preview/app/live-preview/_api/getFooter.ts
@@ -9,6 +9,7 @@ export async function getFooter(): Promise<Footer> {
   try {
     const footer = await payload.findGlobal({
       slug: 'footer',
+      overrideAccess: true,
     })
 
     return footer

--- a/test/live-preview/app/live-preview/_api/getHeader.ts
+++ b/test/live-preview/app/live-preview/_api/getHeader.ts
@@ -9,6 +9,7 @@ export async function getHeader(): Promise<Header> {
   try {
     const header = await payload.findGlobal({
       slug: 'header',
+      overrideAccess: true,
     })
 
     return header

--- a/test/live-preview/e2e.spec.ts
+++ b/test/live-preview/e2e.spec.ts
@@ -90,6 +90,7 @@ describe('Live Preview', () => {
           email: devUser.email,
           password: devUser.password,
         },
+        overrideAccess: true,
       })
       ?.then((res) => res.user) // TODO: this type is wrong
   })
@@ -477,6 +478,7 @@ describe('Live Preview', () => {
         },
         title: initialTitle,
       },
+      overrideAccess: true,
     })
 
     await page.goto(pagesURLUtil.edit(testDoc.id))
@@ -619,6 +621,7 @@ describe('Live Preview', () => {
         },
         title: initialTitle,
       },
+      overrideAccess: true,
     })
 
     await page.goto(ssrAutosavePagesURLUtil.edit(testDoc.id))

--- a/test/live-preview/int.spec.ts
+++ b/test/live-preview/int.spec.ts
@@ -87,6 +87,7 @@ test.suite({ config: './config.ts' })('Collections - Live Preview', () => {
           ...initialData,
           slug: 'testPage',
         } as Page,
+        overrideAccess: true,
       })
     }
 
@@ -96,6 +97,7 @@ test.suite({ config: './config.ts' })('Collections - Live Preview', () => {
         title: 'Tenant 1',
         clientURL: `http://localhost:${process.env.PORT || 3000}`,
       },
+      overrideAccess: true,
     })
 
     // Create image
@@ -109,6 +111,7 @@ test.suite({ config: './config.ts' })('Collections - Live Preview', () => {
         alt: 'Image 1',
       },
       file,
+      overrideAccess: true,
     })
 
     testPost = await payload.create({
@@ -123,6 +126,7 @@ test.suite({ config: './config.ts' })('Collections - Live Preview', () => {
           media: media.id,
         },
       },
+      overrideAccess: true,
     })
   })
 
@@ -767,6 +771,7 @@ test.suite({ config: './config.ts' })('Collections - Live Preview', () => {
       data: {
         title: 'Test Post (Recently Updated)',
       },
+      overrideAccess: true,
     })
 
     const merge2 = await mergeData({
@@ -808,6 +813,7 @@ test.suite({ config: './config.ts' })('Collections - Live Preview', () => {
         localizedTitle: 'Test Post Spanish',
       },
       locale: 'es',
+      overrideAccess: true,
     })
 
     await payload.update({
@@ -817,6 +823,7 @@ test.suite({ config: './config.ts' })('Collections - Live Preview', () => {
       data: {
         localizedTitle: 'Test Post English',
       },
+      overrideAccess: true,
     })
 
     const page = await payload.create({
@@ -827,6 +834,7 @@ test.suite({ config: './config.ts' })('Collections - Live Preview', () => {
         slug: 'testpage',
       },
       locale: 'en',
+      overrideAccess: true,
     })
 
     const initialData = await createPageWithInitialData({

--- a/test/live-preview/prod/app/live-preview/_api/getDoc.ts
+++ b/test/live-preview/prod/app/live-preview/_api/getDoc.ts
@@ -27,6 +27,7 @@ export const getDoc = async <T>(args: {
       where,
       draft,
       trash: true, // Include trashed documents
+      overrideAccess: true,
     })
 
     if (docs[0]) {

--- a/test/live-preview/prod/app/live-preview/_api/getDocs.ts
+++ b/test/live-preview/prod/app/live-preview/_api/getDocs.ts
@@ -9,6 +9,7 @@ export const getDocs = async <T>(collection: CollectionSlug): Promise<T[]> => {
       collection,
       depth: 0,
       limit: 100,
+      overrideAccess: true,
     })
 
     if (docs) {

--- a/test/live-preview/prod/app/live-preview/_api/getFooter.ts
+++ b/test/live-preview/prod/app/live-preview/_api/getFooter.ts
@@ -9,6 +9,7 @@ export async function getFooter(): Promise<Footer> {
   try {
     const footer = await payload.findGlobal({
       slug: 'footer',
+      overrideAccess: true,
     })
 
     return footer

--- a/test/live-preview/prod/app/live-preview/_api/getHeader.ts
+++ b/test/live-preview/prod/app/live-preview/_api/getHeader.ts
@@ -9,6 +9,7 @@ export async function getHeader(): Promise<Header> {
   try {
     const header = await payload.findGlobal({
       slug: 'header',
+      overrideAccess: true,
     })
 
     return header

--- a/test/live-preview/seed/index.ts
+++ b/test/live-preview/seed/index.ts
@@ -36,6 +36,7 @@ export const seed: Config['onInit'] = async (payload) => {
         equals: devUser.email,
       },
     },
+    overrideAccess: true,
   })
 
   // Seed already ran => this is likely a consecutive, uncached getPayload call
@@ -52,16 +53,19 @@ export const seed: Config['onInit'] = async (payload) => {
       email: devUser.email,
       password: devUser.password,
     },
+    overrideAccess: true,
   })
 
   const tenant1Doc = await payload.create({
     collection: tenantsSlug,
     data: tenant1,
+    overrideAccess: true,
   })
 
   await payload.create({
     collection: tenantsSlug,
     data: tenant2,
+    overrideAccess: true,
   })
 
   const media = await payload.create({
@@ -70,6 +74,7 @@ export const seed: Config['onInit'] = async (payload) => {
     data: {
       alt: 'Image 1',
     },
+    overrideAccess: true,
   })
 
   const mediaID = payload.db.defaultIDType === 'number' ? media.id : `"${media.id}"`
@@ -82,6 +87,7 @@ export const seed: Config['onInit'] = async (payload) => {
         .replace(/"\{\{IMAGE\}\}"/g, mediaID)
         .replace(/"\{\{TENANT_1_ID\}\}"/g, tenantID),
     ),
+    overrideAccess: true,
   })
 
   const post2Doc = await payload.create({
@@ -91,6 +97,7 @@ export const seed: Config['onInit'] = async (payload) => {
         .replace(/"\{\{IMAGE\}\}"/g, mediaID)
         .replace(/"\{\{TENANT_1_ID\}\}"/g, tenantID),
     ),
+    overrideAccess: true,
   })
 
   const post3Doc = await payload.create({
@@ -100,6 +107,7 @@ export const seed: Config['onInit'] = async (payload) => {
         .replace(/"\{\{IMAGE\}\}"/g, mediaID)
         .replace(/"\{\{TENANT_1_ID\}\}"/g, tenantID),
     ),
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -109,11 +117,13 @@ export const seed: Config['onInit'] = async (payload) => {
         .replace(/"\{\{IMAGE\}\}"/g, mediaID)
         .replace(/"\{\{TENANT_1_ID\}\}"/g, tenantID),
     ),
+    overrideAccess: true,
   })
 
   const postsPageDoc = await payload.create({
     collection: pagesSlug,
     data: JSON.parse(JSON.stringify(postsPage).replace(/"\{\{IMAGE\}\}"/g, mediaID)),
+    overrideAccess: true,
   })
 
   let postsPageDocID = postsPageDoc.id
@@ -139,6 +149,7 @@ export const seed: Config['onInit'] = async (payload) => {
         .replace(/"\{\{POST_3_ID\}\}"/g, post3DocID)
         .replace(/"\{\{TENANT_1_ID\}\}"/g, tenantID),
     ),
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -156,6 +167,7 @@ export const seed: Config['onInit'] = async (payload) => {
       title: 'Custom Live Preview',
       slug: 'custom-live-preview',
     },
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -173,6 +185,7 @@ export const seed: Config['onInit'] = async (payload) => {
       title: 'SSR Home',
       slug: 'home',
     },
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -190,6 +203,7 @@ export const seed: Config['onInit'] = async (payload) => {
       title: 'SSR Home',
       slug: 'home',
     },
+    overrideAccess: true,
   })
 
   await payload.updateGlobal({
@@ -201,10 +215,12 @@ export const seed: Config['onInit'] = async (payload) => {
         .replace(/"\{\{POST_2_ID\}\}"/g, post2DocID)
         .replace(/"\{\{POST_3_ID\}\}"/g, post3DocID),
     ),
+    overrideAccess: true,
   })
 
   await payload.updateGlobal({
     slug: 'footer',
     data: JSON.parse(JSON.stringify(footer)),
+    overrideAccess: true,
   })
 }

--- a/test/live-preview/utilities/formatLivePreviewURL.ts
+++ b/test/live-preview/utilities/formatLivePreviewURL.ts
@@ -21,6 +21,7 @@ export const formatLivePreviewURL: LivePreviewConfig['url'] = async ({
           },
           limit: 1,
           depth: 0,
+          overrideAccess: true,
         })
         .then((res) => res?.docs?.[0])
 

--- a/test/localization-rtl/config.ts
+++ b/test/localization-rtl/config.ts
@@ -63,6 +63,7 @@ export default buildConfigWithDefaults({
         email: devUser.email,
         password: devUser.password,
       },
+      overrideAccess: true,
     })
   },
 })

--- a/test/localization/config.ts
+++ b/test/localization/config.ts
@@ -567,6 +567,7 @@ export default buildConfigWithDefaults({
       data: {
         title: englishTitle,
       },
+      overrideAccess: true,
     })
 
     const localizedPost = await payload.create({
@@ -574,6 +575,7 @@ export default buildConfigWithDefaults({
       data: {
         title: englishTitle,
       },
+      overrideAccess: true,
     })
 
     await payload.create({
@@ -582,6 +584,7 @@ export default buildConfigWithDefaults({
         date: new Date().toISOString(),
         localizedDate: new Date().toISOString(),
       },
+      overrideAccess: true,
     })
 
     await payload.create({
@@ -591,6 +594,7 @@ export default buildConfigWithDefaults({
         password: devUser.password,
         relation: localizedPost.id,
       },
+      overrideAccess: true,
     })
 
     await payload.update({
@@ -600,6 +604,7 @@ export default buildConfigWithDefaults({
         title: spanishTitle,
       },
       locale: spanishLocale,
+      overrideAccess: true,
     })
 
     const localizedRelation = await payload.create({
@@ -607,6 +612,7 @@ export default buildConfigWithDefaults({
       data: {
         title: relationEnglishTitle,
       },
+      overrideAccess: true,
     })
 
     await payload.update({
@@ -616,6 +622,7 @@ export default buildConfigWithDefaults({
         title: relationSpanishTitle,
       },
       locale: spanishLocale,
+      overrideAccess: true,
     })
 
     const localizedRelation2 = await payload.create({
@@ -623,6 +630,7 @@ export default buildConfigWithDefaults({
       data: {
         title: relationEnglishTitle2,
       },
+      overrideAccess: true,
     })
     await payload.update({
       id: localizedPost.id,
@@ -631,6 +639,7 @@ export default buildConfigWithDefaults({
         title: relationSpanishTitle2,
       },
       locale: spanishLocale,
+      overrideAccess: true,
     })
 
     await payload.create({
@@ -644,6 +653,7 @@ export default buildConfigWithDefaults({
         ],
         relationship: localizedRelation.id,
       },
+      overrideAccess: true,
     })
     const relationshipLocalized = await payload.create({
       collection: relationshipLocalizedSlug,
@@ -662,6 +672,7 @@ export default buildConfigWithDefaults({
         relationshipHasMany: [localizedRelation.id, localizedRelation2.id],
       },
       locale: 'en',
+      overrideAccess: true,
     })
 
     await payload.update({
@@ -671,6 +682,7 @@ export default buildConfigWithDefaults({
         relationMultiRelationTo: { relationTo: collection, value: localizedPost.id },
       },
       locale: 'es',
+      overrideAccess: true,
     })
 
     const globalArray = await payload.updateGlobal({
@@ -685,6 +697,7 @@ export default buildConfigWithDefaults({
           },
         ],
       },
+      overrideAccess: true,
     })
 
     await payload.updateGlobal({
@@ -696,6 +709,7 @@ export default buildConfigWithDefaults({
         })),
       },
       locale: 'es',
+      overrideAccess: true,
     })
   },
 })

--- a/test/localization/e2e.spec.ts
+++ b/test/localization/e2e.spec.ts
@@ -274,6 +274,7 @@ describe('Localization', () => {
           title: englishTitle,
         },
         locale: defaultLocale,
+        overrideAccess: true,
       })
 
       const id = localizedPost.id.toString()
@@ -286,6 +287,7 @@ describe('Localization', () => {
           title: spanishTitle,
         },
         locale: spanishLocale,
+        overrideAccess: true,
       })
 
       await page.goto(url.edit(id))
@@ -773,6 +775,7 @@ describe('Localization', () => {
         collection: 'blocks-fields',
         locale: 'all',
         where: { id: { equals: docID } },
+        overrideAccess: true,
       })
 
       expect(doc.docs).toHaveLength(1)
@@ -1025,6 +1028,7 @@ describe('Localization', () => {
           title: 'Existing doc title',
         },
         locale: defaultLocale,
+        overrideAccess: true,
       })
 
       // seoTitle is in the SEO tab (active by default) — fill it first

--- a/test/localization/int.spec.ts
+++ b/test/localization/int.spec.ts
@@ -62,6 +62,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
         data: {
           title: englishTitle,
         },
+        overrideAccess: true,
       })
 
       postWithLocalizedData = await payload.create({
@@ -69,6 +70,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
         data: {
           title: englishTitle,
         },
+        overrideAccess: true,
       })
 
       await payload.update({
@@ -78,6 +80,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
           title: spanishTitle,
         },
         locale: spanishLocale,
+        overrideAccess: true,
       })
 
       await payload.updateGlobal({
@@ -86,6 +89,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
           text: spanishTitle,
         },
         locale: spanishLocale,
+        overrideAccess: true,
       })
 
       await payload.updateGlobal({
@@ -94,6 +98,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
           text: englishTitle,
         },
         locale: englishLocale,
+        overrideAccess: true,
       })
     })
 
@@ -104,6 +109,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
           where: {
             title: { equals: post1.title },
           },
+          overrideAccess: true,
         })
         expect(allDocs.docs).toContainEqual(expect.objectContaining(post1))
       })
@@ -116,6 +122,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
             title: spanishTitle,
           },
           locale: spanishLocale,
+          overrideAccess: true,
         })
 
         expect(updated.title).toEqual(spanishTitle)
@@ -124,6 +131,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
           id: post1.id,
           collection,
           locale: 'all',
+          overrideAccess: true,
         })
 
         expect(localized.title.en).toEqual(englishTitle)
@@ -138,12 +146,14 @@ test.suite({ config: './config.ts' })('Localization', () => {
             title: '',
           },
           locale: spanishLocale,
+          overrideAccess: true,
         })
 
         const retrievedInSpanish = await payload.findByID({
           id: post1.id,
           collection,
           locale: spanishLocale,
+          overrideAccess: true,
         })
 
         expect(retrievedInSpanish.title).toEqual(englishTitle)
@@ -152,6 +162,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
           id: post1.id,
           collection,
           locale: 'all',
+          overrideAccess: true,
         })
 
         expect(localizedFallback.title.en).toEqual(englishTitle)
@@ -168,12 +179,14 @@ test.suite({ config: './config.ts' })('Localization', () => {
               },
             ],
           },
+          overrideAccess: true,
         })
 
         const resultAllLocales: any = await payload.findByID({
           id: localizedArrayPost.id,
           collection: arrayCollectionSlug,
           locale: 'all',
+          overrideAccess: true,
         })
 
         expect(resultAllLocales.items.en[0].text).toEqual('localized array item')
@@ -183,6 +196,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
           id: localizedArrayPost.id,
           collection: arrayCollectionSlug,
           locale: spanishLocale,
+          overrideAccess: true,
         })
 
         expect(resultSpanishLocale.items[0].text).toEqual('localized array item')
@@ -195,6 +209,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
           id: postWithLocalizedData.id,
           collection,
           locale: portugueseLocale,
+          overrideAccess: true,
         })
 
         expect(localizedFallback.title).toEqual(spanishTitle)
@@ -206,6 +221,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
           collection,
           locale: portugueseLocale,
           fallbackLocale: 'none',
+          overrideAccess: true,
         })
 
         expect(localizedFallback.title).not.toBeDefined()
@@ -229,6 +245,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
             collection: localizedPostsSlug,
             data: englishData,
             locale: englishLocale,
+            overrideAccess: true,
           })
 
           await payload.update({
@@ -236,12 +253,14 @@ test.suite({ config: './config.ts' })('Localization', () => {
             collection: localizedPostsSlug,
             data: spanishData,
             locale: spanishLocale,
+            overrideAccess: true,
           })
           await payload.update({
             id: localizedDoc.id,
             collection: localizedPostsSlug,
             data: { localizedCheckbox: true },
             locale: portugueseLocale,
+            overrideAccess: true,
           })
         })
 
@@ -252,6 +271,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
             id: localizedDoc.id,
             collection: localizedPostsSlug,
             locale: portugueseLocale,
+            overrideAccess: true,
           })
 
           expect(portugueseDoc.title).toStrictEqual(spanishData.title)
@@ -267,6 +287,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
             data: {
               title: englishTitle,
             },
+            overrideAccess: true,
           })
 
           localizedPost = await payload.update({
@@ -276,6 +297,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
               title: spanishTitle,
             },
             locale: spanishLocale,
+            overrideAccess: true,
           })
         })
 
@@ -283,6 +305,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
           const localized = await payload.findByID({
             id: localizedPost.id,
             collection,
+            overrideAccess: true,
           })
 
           expect(localized.title).toEqual(englishTitle)
@@ -293,6 +316,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
             id: localizedPost.id,
             collection,
             locale: defaultLocale,
+            overrideAccess: true,
           })
 
           expect(localized.title).toEqual(englishTitle)
@@ -303,6 +327,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
             id: localizedPost.id,
             collection,
             locale: spanishLocale,
+            overrideAccess: true,
           })
 
           expect(localized.title).toEqual(spanishTitle)
@@ -313,6 +338,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
             id: localizedPost.id,
             collection,
             locale: 'all',
+            overrideAccess: true,
           })
 
           expect(localized.title.en).toEqual(englishTitle)
@@ -355,6 +381,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
                 equals: englishTitle,
               },
             },
+            overrideAccess: true,
           })
 
           expect(result.docs.map(({ id }) => id)).toContain(localizedPost.id)
@@ -369,6 +396,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
                 equals: spanishTitle,
               },
             },
+            overrideAccess: true,
           })
 
           expect(result.docs.map(({ id }) => id)).toContain(localizedPost.id)
@@ -383,17 +411,18 @@ test.suite({ config: './config.ts' })('Localization', () => {
                 equals: spanishTitle,
               },
             },
+            overrideAccess: true,
           })
 
           expect(result.docs.map(({ id }) => id)).toContain(localizedPost.id)
         })
 
         test('by localized field value with sorting', async ({ payload }) => {
-          const doc_1 = await payload.create({ collection, data: { title: 'word_b' } })
-          const doc_2 = await payload.create({ collection, data: { title: 'word_a' } })
-          const doc_3 = await payload.create({ collection, data: { title: 'word_c' } })
+          const doc_1 = await payload.create({ collection, data: { title: 'word_b' }, overrideAccess: true })
+          const doc_2 = await payload.create({ collection, data: { title: 'word_a' }, overrideAccess: true })
+          const doc_3 = await payload.create({ collection, data: { title: 'word_c' }, overrideAccess: true })
 
-          await payload.create({ collection, data: { title: 'others_c' } })
+          await payload.create({ collection, data: { title: 'others_c' }, overrideAccess: true })
 
           const { docs } = await payload.find({
             collection,
@@ -403,6 +432,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
                 like: 'word',
               },
             },
+            overrideAccess: true,
           })
 
           expect(docs).toHaveLength(3)
@@ -423,6 +453,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
                   localizedDescription: 'something',
                 },
                 locale: englishLocale,
+                overrideAccess: true,
               })
 
               localizedAccentPostTwo = await payload.create({
@@ -432,6 +463,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
                   localizedDescription: 'veterinarian',
                 },
                 locale: englishLocale,
+                overrideAccess: true,
               })
 
               await payload.update({
@@ -442,6 +474,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
                   localizedDescription: 'valami',
                 },
                 locale: hungarianLocale,
+                overrideAccess: true,
               })
 
               await payload.update({
@@ -452,6 +485,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
                   localizedDescription: 'állatorvos',
                 },
                 locale: hungarianLocale,
+                overrideAccess: true,
               })
             })
 
@@ -465,6 +499,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
                   },
                 },
                 locale: hungarianLocale,
+                overrideAccess: true,
               })
 
               expect(sortByDescriptionQuery.docs[0].id).toEqual(localizedAccentPostTwo.id)
@@ -482,6 +517,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
             localizedDate: new Date().toISOString(),
             date: new Date().toISOString(),
           },
+          overrideAccess: true,
         })
         expect(document.localizedDate).toBeTruthy()
       })
@@ -493,6 +529,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
             localizedDate: new Date().toISOString(),
             date: new Date().toISOString(),
           },
+          overrideAccess: true,
         })
 
         expect(typeof document.localizedDate).toBe('string')
@@ -514,6 +551,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
               title: `EN ${i}`,
             },
             locale: englishLocale,
+            overrideAccess: true,
           })
 
           posts.push(post)
@@ -526,6 +564,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
               title: `ES ${i}`,
             },
             locale: spanishLocale,
+            overrideAccess: true,
           })
         }
       })
@@ -533,10 +572,12 @@ test.suite({ config: './config.ts' })('Localization', () => {
       test('should have correct totalDocs when unsorted', async ({ payload }) => {
         const simpleQuery = await payload.find({
           collection: localizedSortSlug,
+          overrideAccess: true,
         })
         const sortByIdQuery = await payload.find({
           collection: localizedSortSlug,
           sort: 'id',
+          overrideAccess: true,
         })
 
         expect(simpleQuery.totalDocs).toEqual(expectedTotalDocs)
@@ -548,10 +589,12 @@ test.suite({ config: './config.ts' })('Localization', () => {
         const sortByTitleQuery = await payload.find({
           collection: localizedSortSlug,
           sort: 'title',
+          overrideAccess: true,
         })
         const sortByDateQuery = await payload.find({
           collection: localizedSortSlug,
           sort: 'date',
+          overrideAccess: true,
         })
 
         expect(sortByTitleQuery.totalDocs).toEqual(expectedTotalDocs)
@@ -562,6 +605,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
         const { docs: docsAsc } = await payload.find({
           collection: localizedSortSlug,
           sort: 'title',
+          overrideAccess: true,
         })
         docsAsc.forEach((doc, i) => {
           expect(posts[i].id).toBe(doc.id)
@@ -570,6 +614,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
         const { docs: docsDesc } = await payload.find({
           collection: localizedSortSlug,
           sort: '-title',
+          overrideAccess: true,
         })
         docsDesc.forEach((doc, i) => {
           expect(posts.at(posts.length - i - 1).id).toBe(doc.id)
@@ -608,13 +653,14 @@ test.suite({ config: './config.ts' })('Localization', () => {
 
         for (let i = 0; i < randomWords.length; i++) {
           const en = randomWords[i]
-          const post = await payload.create({ collection: 'localized-sort', data: { title: en } })
+          const post = await payload.create({ collection: 'localized-sort', data: { title: en }, overrideAccess: true })
           const es = randomWordsSpanish[i]
           await payload.update({
             collection: 'localized-sort',
             data: { title: es },
             id: post.id,
             locale: 'es',
+            overrideAccess: true,
           })
 
           randomWordsPosts.push(post.id)
@@ -629,6 +675,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
           collection: localizedSortSlug,
           sort: 'title',
           where: q,
+          overrideAccess: true,
         })
         randomWordsEnAsc.forEach((doc, i) => {
           expect(ascSortedWordsEn[i]).toBe(doc.title)
@@ -638,6 +685,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
           collection: localizedSortSlug,
           sort: '-title',
           where: q,
+          overrideAccess: true,
         })
 
         randomWordsEnDesc.forEach((doc, i) => {
@@ -654,6 +702,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
           sort: 'title',
           where: q,
           locale: 'es',
+          overrideAccess: true,
         })
 
         randomWordsEsAsc.forEach((doc, i) => {
@@ -666,6 +715,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
           sort: '-title',
           where: q,
           locale: 'es',
+          overrideAccess: true,
         })
 
         randomWordsEsDesc.forEach((doc, i) => {
@@ -713,6 +763,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
             ],
             localizedRelationship: localizedRelation.id,
           },
+          overrideAccess: true,
         })
       })
 
@@ -725,6 +776,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
                 equals: localizedRelation.title,
               },
             },
+            overrideAccess: true,
           })
 
           expect(result.docs[0].id).toEqual(withRelationship.id)
@@ -739,6 +791,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
                 equals: relationSpanishTitle,
               },
             },
+            overrideAccess: true,
           })
 
           expect(result.docs[0].id).toEqual(withRelationship.id)
@@ -753,6 +806,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
                 equals: relationSpanishTitle,
               },
             },
+            overrideAccess: true,
           })
 
           expect(result.docs[0].id).toEqual(withRelationship.id)
@@ -764,6 +818,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
             collection: relationshipLocalizedSlug,
             depth: 1,
             locale: 'all',
+            overrideAccess: true,
           })
 
           expect(result.docs[0].relationship.en.id).toBeDefined()
@@ -783,6 +838,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
                 equals: localizedRelation.title,
               },
             },
+            overrideAccess: true,
           })
 
           expect(result.docs.map(({ id }) => id)).toContain(withRelationship.id)
@@ -795,6 +851,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
                 equals: localizedRelation2.title,
               },
             },
+            overrideAccess: true,
           })
 
           expect(result2.docs.map(({ id }) => id)).toContain(withRelationship.id)
@@ -809,6 +866,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
                 equals: relationSpanishTitle,
               },
             },
+            overrideAccess: true,
           })
 
           expect(result.docs[0].id).toEqual(withRelationship.id)
@@ -822,6 +880,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
                 equals: relationSpanishTitle2,
               },
             },
+            overrideAccess: true,
           })
 
           expect(result2.docs[0].id).toEqual(withRelationship.id)
@@ -833,6 +892,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
             collection: withLocalizedRelSlug,
             depth: 1,
             locale: spanishLocale,
+            overrideAccess: true,
           })
           expect((result.localizedRelationship as LocalizedPost).title).toEqual(
             relationSpanishTitle,
@@ -845,6 +905,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
               collection: withLocalizedRelSlug,
               locale: 'all',
               where,
+              overrideAccess: true,
             })
           }
 
@@ -894,6 +955,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
                 equals: localizedRelation.id,
               },
             },
+            overrideAccess: true,
           })
 
           expect(result.docs[0].id).toEqual(withRelationship.id)
@@ -907,6 +969,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
                 equals: localizedRelation.id,
               },
             },
+            overrideAccess: true,
           })
 
           expect(result2.docs[0].id).toEqual(withRelationship.id)
@@ -922,6 +985,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
                 equals: localizedRelation.id,
               },
             },
+            overrideAccess: true,
           })
 
           expect(result.docs[0].id).toEqual(withRelationship.id)
@@ -935,6 +999,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
                 equals: localizedRelation.id,
               },
             },
+            overrideAccess: true,
           })
 
           expect(result2.docs[0].id).toEqual(withRelationship.id)
@@ -947,6 +1012,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
                 equals: localizedRelation2.id,
               },
             },
+            overrideAccess: true,
           })
 
           expect(result3.docs[0].id).toEqual(withRelationship.id)
@@ -959,6 +1025,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
                 equals: localizedRelation2.id,
               },
             },
+            overrideAccess: true,
           })
 
           expect(result4.docs[0].id).toEqual(withRelationship.id)
@@ -970,6 +1037,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
       test('should allow moving rows and retain existing row locale data', async ({ payload }) => {
         const globalArray: any = await payload.findGlobal({
           slug: 'global-array',
+          overrideAccess: true,
         })
 
         const reversedArrayRows = [...globalArray.array].reverse()
@@ -980,6 +1048,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
             array: reversedArrayRows,
           },
           locale: 'all',
+          overrideAccess: true,
         })
 
         expect(updatedGlobal.array[0].text.en).toStrictEqual('test en 2')
@@ -1002,6 +1071,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
             },
             title: 'hello',
           },
+          overrideAccess: true,
         })
 
         await payload.update({
@@ -1019,6 +1089,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
             title: 'en espanol, big bird',
           },
           locale: spanishLocale,
+          overrideAccess: true,
         })
 
         const updatedDoc = await payload.update({
@@ -1027,6 +1098,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
           data: {
             title: 'hello x2',
           },
+          overrideAccess: true,
         })
 
         expect(updatedDoc.nav.layout[0].blockType).toStrictEqual('text')
@@ -1035,6 +1107,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
           id: newDoc.id,
           collection: withRequiredLocalizedFields,
           locale: spanishLocale,
+          overrideAccess: true,
         })
 
         expect(spanishDoc.nav.layout[0].blockType).toStrictEqual('number')
@@ -1171,6 +1244,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
           id: createResult.id,
           collection: localizedPostsSlug,
           locale: 'all',
+          overrideAccess: true,
         })
 
         expect(createResult.title).toStrictEqual(englishTitle)
@@ -1186,6 +1260,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
             title: englishTitle,
           },
           locale: defaultLocale,
+          overrideAccess: true,
         })
         const spanishDoc = await payload.create({
           collection: localizedPostsSlug,
@@ -1193,6 +1268,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
             title: spanishTitle,
           },
           locale: spanishLocale,
+          overrideAccess: true,
         })
         const query = `
       {
@@ -1235,6 +1311,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
               },
             ],
           },
+          overrideAccess: true,
         })
 
         docID = englishDoc.id
@@ -1245,6 +1322,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
           id: docID,
           collection: arrayCollectionSlug,
           locale: spanishLocale,
+          overrideAccess: true,
         })
 
         expect(spanishDoc.items[0].text).toStrictEqual(englishTitle)
@@ -1259,6 +1337,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
           },
           fallbackLocale: false,
           locale: spanishLocale,
+          overrideAccess: true,
         })
 
         expect(updatedSpanishDoc.items).toStrictEqual(null)
@@ -1275,6 +1354,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
             ],
           },
           locale: defaultLocale,
+          overrideAccess: true,
         })
 
         await payload.update({
@@ -1284,12 +1364,14 @@ test.suite({ config: './config.ts' })('Localization', () => {
             items: [],
           },
           locale: spanishLocale,
+          overrideAccess: true,
         })
 
         const docWithoutFallback = await payload.findByID({
           id: englishDoc.id,
           collection: arrayCollectionSlug,
           locale: spanishLocale,
+          overrideAccess: true,
         })
 
         if (isMongoose(payload)) {
@@ -1313,6 +1395,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
             items: [],
           },
           locale: spanishLocale,
+          overrideAccess: true,
         })
 
         const updatedSpanishDoc = await payload.update({
@@ -1322,6 +1405,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
             items: null,
           },
           locale: spanishLocale,
+          overrideAccess: true,
         })
 
         // should return the value of the fallback locale
@@ -1343,6 +1427,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
               children: 'something',
             },
           },
+          overrideAccess: true,
         })
 
         const { docs: relationshipDocs } = await restClient
@@ -1393,6 +1478,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
             ],
           },
           locale: defaultLocale,
+          overrideAccess: true,
         })
 
         await payload.update({
@@ -1405,18 +1491,21 @@ test.suite({ config: './config.ts' })('Localization', () => {
             })),
           },
           locale: spanishLocale,
+          overrideAccess: true,
         })
 
         const docDefaultLocale = await payload.findByID({
           id,
           collection: nestedToArrayAndBlockCollectionSlug,
           locale: defaultLocale,
+          overrideAccess: true,
         })
 
         const docSpanishLocale = await payload.findByID({
           id,
           collection: nestedToArrayAndBlockCollectionSlug,
           locale: spanishLocale,
+          overrideAccess: true,
         })
 
         const rowDefault = docDefaultLocale.blocks[0].array[0]
@@ -1438,6 +1527,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
             title: englishTitle,
           },
           locale: defaultLocale,
+          overrideAccess: true,
         })
 
         const id = localizedPost.id.toString()
@@ -1450,18 +1540,21 @@ test.suite({ config: './config.ts' })('Localization', () => {
             title: spanishTitle,
           },
           locale: spanishLocale,
+          overrideAccess: true,
         })
 
         const result = await payload.duplicate({
           id,
           collection: localizedPostsSlug,
           locale: defaultLocale,
+          overrideAccess: true,
         })
 
         const allLocales = await payload.findByID({
           id: result.id,
           collection: localizedPostsSlug,
           locale: 'all',
+          overrideAccess: true,
         })
 
         // check fields
@@ -1547,6 +1640,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
             title: 'hello',
           },
           locale: defaultLocale,
+          overrideAccess: true,
         })
 
         await payload.update({
@@ -1612,18 +1706,21 @@ test.suite({ config: './config.ts' })('Localization', () => {
             },
           },
           locale: spanishLocale,
+          overrideAccess: true,
         })
 
         const result = await payload.duplicate({
           id: doc.id,
           collection: withRequiredLocalizedFields,
           locale: defaultLocale,
+          overrideAccess: true,
         })
 
         const allLocales = await payload.findByID({
           id: result.id,
           collection: withRequiredLocalizedFields,
           locale: 'all',
+          overrideAccess: true,
         })
 
         // check fields
@@ -1650,6 +1747,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
             title: englishTitle,
             description: 'keep me',
           },
+          overrideAccess: true,
         })
 
         await payload.update({
@@ -1659,18 +1757,21 @@ test.suite({ config: './config.ts' })('Localization', () => {
             title: spanishTitle,
           },
           locale: spanishLocale,
+          overrideAccess: true,
         })
 
         const duplicated = await payload.duplicate({
           id: post.id,
           collection,
           selectedLocales: [spanishLocale],
+          overrideAccess: true,
         })
 
         const allLocales = await payload.findByID({
           id: duplicated.id,
           collection,
           locale: 'all',
+          overrideAccess: true,
         })
 
         expect(allLocales?.title?.en).toBe(undefined)
@@ -1689,6 +1790,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
             },
           },
           locale: englishLocale,
+          overrideAccess: true,
         })
 
         expect(result.groupLocalized?.title).toBe('hello en')
@@ -1702,17 +1804,20 @@ test.suite({ config: './config.ts' })('Localization', () => {
               title: 'hello es',
             },
           },
+          overrideAccess: true,
         })
 
         const docEn = await payload.findByID({
           collection: groupSlug,
           locale: englishLocale,
           id: result.id,
+          overrideAccess: true,
         })
         const docEs = await payload.findByID({
           collection: groupSlug,
           locale: spanishLocale,
           id: result.id,
+          overrideAccess: true,
         })
 
         expect(docEn.groupLocalized.title).toBe('hello en')
@@ -1730,6 +1835,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
               title: 'hello en',
             },
           },
+          overrideAccess: true,
         })
 
         expect(result.group.title).toBe('hello en')
@@ -1743,17 +1849,20 @@ test.suite({ config: './config.ts' })('Localization', () => {
               title: 'hello es',
             },
           },
+          overrideAccess: true,
         })
 
         const docEn = await payload.findByID({
           collection: groupSlug,
           locale: englishLocale,
           id: result.id,
+          overrideAccess: true,
         })
         const docEs = await payload.findByID({
           collection: groupSlug,
           locale: spanishLocale,
           id: result.id,
+          overrideAccess: true,
         })
 
         expect(docEn.group.title).toBe('hello en')
@@ -1777,6 +1886,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
               array: [{ title: 'hello en' }],
             },
           },
+          overrideAccess: true,
         })
 
         expect(result.deep.array[0].title).toBe('hello en')
@@ -1802,17 +1912,20 @@ test.suite({ config: './config.ts' })('Localization', () => {
               ],
             },
           },
+          overrideAccess: true,
         })
 
         const docEn = await payload.findByID({
           collection: groupSlug,
           locale: englishLocale,
           id: result.id,
+          overrideAccess: true,
         })
         const docEs = await payload.findByID({
           collection: groupSlug,
           locale: spanishLocale,
           id: result.id,
+          overrideAccess: true,
         })
 
         expect(docEn.deep.array[0].title).toBe('hello en')
@@ -1830,6 +1943,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
             },
           },
           locale: 'en',
+          overrideAccess: true,
         })
 
         expect(doc.groupLocalizedRow.text).toBe('hello world')
@@ -1843,15 +1957,16 @@ test.suite({ config: './config.ts' })('Localization', () => {
           },
           locale: 'es',
           id: doc.id,
+          overrideAccess: true,
         })
 
         expect(docES.groupLocalizedRow.text).toBe('hola world or something')
 
         // check if docES didnt break EN
-        const docEN = await payload.findByID({ collection: 'groups', id: doc.id, locale: 'en' })
+        const docEN = await payload.findByID({ collection: 'groups', id: doc.id, locale: 'en', overrideAccess: true })
         expect(docEN.groupLocalizedRow.text).toBe('hello world')
 
-        const all = await payload.findByID({ collection: 'groups', id: doc.id, locale: 'all' })
+        const all = await payload.findByID({ collection: 'groups', id: doc.id, locale: 'all', overrideAccess: true })
 
         expect(all.groupLocalizedRow.en.text).toBe('hello world')
         expect(all.groupLocalizedRow.es.text).toBe('hola world or something')
@@ -1864,6 +1979,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
           data: {
             tabLocalized: {},
           },
+          overrideAccess: true,
         })
 
         expect(result).toBeTruthy()
@@ -1880,6 +1996,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
               title: 'hello en',
             },
           },
+          overrideAccess: true,
         })
 
         expect(result.tabLocalized?.title).toBe('hello en')
@@ -1893,18 +2010,21 @@ test.suite({ config: './config.ts' })('Localization', () => {
               title: 'hello es',
             },
           },
+          overrideAccess: true,
         })
 
         const docEn = await payload.findByID({
           collection: tabSlug,
           locale: englishLocale,
           id: result.id,
+          overrideAccess: true,
         })
 
         const docEs = await payload.findByID({
           collection: tabSlug,
           locale: spanishLocale,
           id: result.id,
+          overrideAccess: true,
         })
 
         expect(docEn.tabLocalized.title).toBe('hello en')
@@ -1924,6 +2044,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
               ],
             },
           },
+          overrideAccess: true,
         })
 
         expect(result.tabLocalized.array[0].title).toBe('hello en')
@@ -1937,18 +2058,21 @@ test.suite({ config: './config.ts' })('Localization', () => {
               array: [{ title: 'hello es' }],
             },
           },
+          overrideAccess: true,
         })
 
         const docEn = await payload.findByID({
           collection: tabSlug,
           locale: englishLocale,
           id: result.id,
+          overrideAccess: true,
         })
 
         const docEs = await payload.findByID({
           collection: tabSlug,
           locale: spanishLocale,
           id: result.id,
+          overrideAccess: true,
         })
 
         expect(docEn.tabLocalized.array[0].title).toBe('hello en')
@@ -1966,6 +2090,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
               title: 'hello en',
             },
           },
+          overrideAccess: true,
         })
 
         expect(result.tab.title).toBe('hello en')
@@ -1979,17 +2104,20 @@ test.suite({ config: './config.ts' })('Localization', () => {
               title: 'hello es',
             },
           },
+          overrideAccess: true,
         })
 
         const docEn = await payload.findByID({
           collection: tabSlug,
           locale: englishLocale,
           id: result.id,
+          overrideAccess: true,
         })
         const docEs = await payload.findByID({
           collection: tabSlug,
           locale: spanishLocale,
           id: result.id,
+          overrideAccess: true,
         })
 
         expect(docEn.tab.title).toBe('hello en')
@@ -2013,6 +2141,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
               array: [{ title: 'hello en' }],
             },
           },
+          overrideAccess: true,
         })
 
         expect(result.deep.array[0].title).toBe('hello en')
@@ -2038,17 +2167,20 @@ test.suite({ config: './config.ts' })('Localization', () => {
               ],
             },
           },
+          overrideAccess: true,
         })
 
         const docEn = await payload.findByID({
           collection: tabSlug,
           locale: englishLocale,
           id: result.id,
+          overrideAccess: true,
         })
         const docEs = await payload.findByID({
           collection: tabSlug,
           locale: spanishLocale,
           id: result.id,
+          overrideAccess: true,
         })
 
         expect(docEn.deep.array[0].title).toBe('hello en')
@@ -2070,6 +2202,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
               },
             },
           },
+          overrideAccess: true,
         })
 
         await payload.update({
@@ -2083,18 +2216,21 @@ test.suite({ config: './config.ts' })('Localization', () => {
               },
             },
           },
+          overrideAccess: true,
         })
 
         const readEn = await payload.findByID({
           collection: tabSlug,
           locale: englishLocale,
           id: docEs.id,
+          overrideAccess: true,
         })
 
         const readEs = await payload.findByID({
           collection: tabSlug,
           locale: spanishLocale,
           id: docEs.id,
+          overrideAccess: true,
         })
 
         expect(readEn.tabLocalized.group.heading).toBe('English heading')
@@ -2145,6 +2281,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
               },
             ],
           },
+          overrideAccess: true,
         })
 
         id = doc.id
@@ -2152,6 +2289,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
         const retrievedInEN = await payload.findByID({
           collection: 'blocks-fields',
           id,
+          overrideAccess: true,
         })
 
         await payload.update({
@@ -2183,12 +2321,14 @@ test.suite({ config: './config.ts' })('Localization', () => {
               },
             ],
           },
+          overrideAccess: true,
         })
 
         const retrieved = await payload.findByID({
           collection: 'blocks-fields',
           id,
           locale: 'all',
+          overrideAccess: true,
         })
 
         expect(retrieved.content.en[0].content).toHaveLength(1)
@@ -2210,6 +2350,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
           await payload.find({
             collection: 'localized-posts',
             depth: 0,
+            overrideAccess: true,
           })
         ).docs[0]
 
@@ -2217,6 +2358,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
           await payload.find({
             collection: 'localized-posts',
             depth: 0,
+            overrideAccess: true,
           })
         ).docs[1]
 
@@ -2285,6 +2427,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
               },
             ],
           },
+          overrideAccess: true,
         })
 
         const updatedEsDoc = await payload.update({
@@ -2299,6 +2442,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
               },
             ],
           },
+          overrideAccess: true,
         })
 
         const esArrayBlocks = updatedEsDoc.arrayWithBlocks[0].blocksWithinArray
@@ -2321,6 +2465,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
           collection: 'nested-arrays',
           locale: 'en',
           depth: 0,
+          overrideAccess: true,
         })
         removeId(enDoc2.arrayWithBlocks[0].blocksWithinArray)
         expect(enDoc2.arrayWithBlocks[0].blocksWithinArray).toEqual(blocksWithinArrayEN)
@@ -2331,12 +2476,14 @@ test.suite({ config: './config.ts' })('Localization', () => {
           await payload.find({
             collection: 'localized-posts',
             depth: 0,
+            overrideAccess: true,
           })
         ).docs[0]
         const randomTextDoc2 = (
           await payload.find({
             collection: 'localized-posts',
             depth: 0,
+            overrideAccess: true,
           })
         ).docs[1]
 
@@ -2351,6 +2498,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
               },
             ],
           },
+          overrideAccess: true,
         })
 
         const updatedEsDoc = await payload.update({
@@ -2366,6 +2514,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
               },
             ],
           },
+          overrideAccess: true,
         })
 
         expect(updatedEsDoc.arrayWithLocalizedRelation).toHaveLength(1)
@@ -2380,6 +2529,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
           collection: 'nested-arrays',
           locale: 'en',
           depth: 0,
+          overrideAccess: true,
         })
         expect(enDoc2.arrayWithLocalizedRelation).toHaveLength(1)
         expect(enDoc2.arrayWithLocalizedRelation[0].localizedRelation).toBe(randomTextDoc.id)
@@ -2404,6 +2554,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
               },
             ],
           },
+          overrideAccess: true,
         })
 
         const updated = await payload.update({
@@ -2433,6 +2584,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
             ],
           },
           locale: 'es',
+          overrideAccess: true,
         })
 
         console.dir(updated, { depth: null })
@@ -2460,6 +2612,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
               },
             ],
           },
+          overrideAccess: true,
         })
 
         expect(doc.blocks?.[0]?.someText).toBe('some-block-text-en')
@@ -2471,6 +2624,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
           id: doc.id,
           collection: 'nested',
           locale: 'all',
+          overrideAccess: true,
         })
 
         expect(findAllLocales.blocks?.[0]?.someText).toStrictEqual({
@@ -2500,6 +2654,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
               },
             ],
           },
+          overrideAccess: true,
         })
 
         expect(updatedDoc.blocks?.[0]?.someText).toBe('some-block-text-es')
@@ -2510,6 +2665,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
           id: doc.id,
           collection: 'nested',
           locale: 'all',
+          overrideAccess: true,
         })
 
         expect(refreshedDoc.blocks?.[0]?.someText).toStrictEqual({
@@ -2533,6 +2689,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
             description: 'some-not-localized-description',
             localizedDescription: 'some-localized-description',
           },
+          overrideAccess: true,
         })
 
         expect(doc.title).toBe('some-localized-title')
@@ -2542,6 +2699,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
           id: doc.id,
           collection: 'localized-posts',
           locale: 'all',
+          overrideAccess: true,
         })
 
         expect(findAllLocales.title).toStrictEqual({
@@ -2560,6 +2718,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
             description: 'some-not-localized-description-es',
             localizedDescription: 'some-localized-description-es',
           },
+          overrideAccess: true,
         })
 
         expect(updatedDoc.title).toBe('some-localized-title-es')
@@ -2569,6 +2728,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
           id: doc.id,
           collection: 'localized-posts',
           locale: 'all',
+          overrideAccess: true,
         })
 
         expect(refreshedDoc.title).toStrictEqual({
@@ -2587,12 +2747,14 @@ test.suite({ config: './config.ts' })('Localization', () => {
           await payload.find({
             collection: 'localized-posts',
             depth: 0,
+            overrideAccess: true,
           })
         ).docs[0]
         const randomDoc2 = (
           await payload.find({
             collection: 'localized-posts',
             depth: 0,
+            overrideAccess: true,
           })
         ).docs[1]
 
@@ -2622,6 +2784,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
               },
             ],
           },
+          overrideAccess: true,
         })
 
         await payload.update({
@@ -2652,6 +2815,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
               },
             ],
           },
+          overrideAccess: true,
         })
 
         const retrieved = await payload.findByID({
@@ -2659,6 +2823,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
           id: newDoc.id,
           depth: 0,
           locale: 'all',
+          overrideAccess: true,
         })
 
         expect(retrieved.array.en[0].relation.value).toStrictEqual(randomDoc.id)
@@ -2693,12 +2858,14 @@ test.suite({ config: './config.ts' })('Localization', () => {
           await payload.find({
             collection: 'localized-posts',
             depth: 0,
+            overrideAccess: true,
           })
         ).docs[0]
         const randomDoc2 = (
           await payload.find({
             collection: 'localized-posts',
             depth: 0,
+            overrideAccess: true,
           })
         ).docs[1]
 
@@ -2745,6 +2912,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
               },
             ],
           },
+          overrideAccess: true,
         })
 
         expect(docEn.blocks[0].nestedBlocks[0].relation.value).toBe(randomDoc.id)
@@ -2796,6 +2964,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
               },
             ],
           },
+          overrideAccess: true,
         })
 
         expect(docEs.blocks[0].nestedBlocks[0].relation.value).toBe(randomDoc2.id)
@@ -2807,6 +2976,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
           id: docEn.id,
           locale: 'all',
           depth: 0,
+          overrideAccess: true,
         })
 
         expect(docAll.blocks.en[0].nestedBlocks[0].relation.value).toBe(randomDoc.id)
@@ -2825,12 +2995,14 @@ test.suite({ config: './config.ts' })('Localization', () => {
           await payload.find({
             collection: 'localized-posts',
             depth: 0,
+            overrideAccess: true,
           })
         ).docs[0]
         const randomDoc2 = (
           await payload.find({
             collection: 'localized-posts',
             depth: 0,
+            overrideAccess: true,
           })
         ).docs[1]
 
@@ -2874,6 +3046,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
               },
             ],
           },
+          overrideAccess: true,
         })
 
         expect(docEn.blocks[0].array[0].relation.value).toBe(randomDoc.id)
@@ -2922,6 +3095,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
               },
             ],
           },
+          overrideAccess: true,
         })
 
         expect(docEs.blocks[0].array[0].relation.value).toBe(randomDoc2.id)
@@ -2933,6 +3107,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
           id: docEn.id,
           locale: 'all',
           depth: 0,
+          overrideAccess: true,
         })
 
         expect(docAll.blocks.en[0].array[0].relation.value).toBe(randomDoc.id)
@@ -2953,6 +3128,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
           data: {
             unique: 'text',
           },
+          overrideAccess: true,
         })
 
         await payload.create({
@@ -2961,6 +3137,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
           data: {
             unique: 'text',
           },
+          overrideAccess: true,
         })
 
         await payload.create({
@@ -2969,6 +3146,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
           data: {
             unique: 'text',
           },
+          overrideAccess: true,
         })
 
         await expect(
@@ -2978,6 +3156,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
             data: {
               unique: 'text',
             },
+            overrideAccess: true,
           }),
         ).rejects.toBeTruthy()
       })
@@ -2993,6 +3172,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
           data: {
             unique: uniqueValue,
           },
+          overrideAccess: true,
         })
 
         try {
@@ -3002,6 +3182,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
             data: {
               unique: uniqueValue,
             },
+            overrideAccess: true,
           })
           expect.unreachable('Should have thrown a ValidationError')
         } catch (error: any) {
@@ -3032,6 +3213,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
               layout: blockData,
             },
           },
+          overrideAccess: true,
         })
 
         try {
@@ -3045,6 +3227,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
                 layout: blockData,
               },
             },
+            overrideAccess: true,
           })
           expect.unreachable('Should have thrown a ValidationError')
         } catch (error: any) {
@@ -3071,6 +3254,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
                 equals: devUser.email,
               },
             },
+            overrideAccess: true,
           })
         ).docs[0] as unknown as User
 
@@ -3088,6 +3272,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
             unique: 'unique-field',
             localizedCheckbox: true,
           },
+          overrideAccess: true,
         })
 
         const req = await createLocalReq({ user }, payload)
@@ -3126,6 +3311,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
               },
             ],
           },
+          overrideAccess: true,
         })
 
         const req = await createLocalReq({ user }, payload)
@@ -3156,6 +3342,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
               },
             ],
           },
+          overrideAccess: true,
         })
 
         const req = await createLocalReq({ user }, payload)
@@ -3182,6 +3369,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
               },
             ],
           },
+          overrideAccess: true,
         })
 
         const req = await createLocalReq({ user }, payload)
@@ -3200,6 +3388,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
         const refreshedDoc = await payload.findByID({
           id: doc.id,
           collection: 'nested',
+          overrideAccess: true,
         })
 
         // The source data should remain unchanged
@@ -3219,6 +3408,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
               },
             ],
           },
+          overrideAccess: true,
         })
 
         const req = await createLocalReq({ user }, payload)
@@ -3236,6 +3426,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
         const refreshedDoc = await payload.findByID({
           id: doc.id,
           collection: 'nested',
+          overrideAccess: true,
         })
 
         // The source data should remain unchanged
@@ -3259,6 +3450,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
             ],
           },
           locale: 'en',
+          overrideAccess: true,
         })
 
         try {
@@ -3277,6 +3469,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
           await payload.delete({
             id: doc.id,
             collection: arrayCollectionSlug,
+            overrideAccess: true,
           })
         }
       })
@@ -3307,6 +3500,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
               },
             ],
           },
+          overrideAccess: true,
         })
 
         // Add content to Spanish locale separately
@@ -3323,6 +3517,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
               },
             ],
           },
+          overrideAccess: true,
         })
 
         // Verify initial state - English data should exist
@@ -3330,6 +3525,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
           id: doc.id,
           collection: 'blocks-fields',
           locale: 'en',
+          overrideAccess: true,
         })
 
         expect(enDocBefore.title).toBe('English Title')
@@ -3352,6 +3548,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
           id: doc.id,
           collection: 'blocks-fields',
           locale: 'en',
+          overrideAccess: true,
         })
 
         expect(enDocAfter.title).toBe('English Title')
@@ -3364,6 +3561,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
           collection: 'blocks-fields',
           locale: 'es',
           draft: true,
+          overrideAccess: true,
         })
 
         expect(esDocAfter.title).toBe('English Title')
@@ -3387,6 +3585,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
               },
             ],
           },
+          overrideAccess: true,
         })
 
         // Verify draft exists
@@ -3395,6 +3594,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
           collection: 'blocks-fields',
           locale: 'en',
           draft: true,
+          overrideAccess: true,
         })
 
         expect(draftBefore.title).toBe('Draft English Title')
@@ -3416,6 +3616,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
           collection: 'blocks-fields',
           locale: 'en',
           draft: true,
+          overrideAccess: true,
         })
 
         expect(draftAfter.title).toBe('Draft English Title')
@@ -3432,6 +3633,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
           data: {
             title: 'Published EN',
           },
+          overrideAccess: true,
         })
 
         // Create draft with different content
@@ -3443,6 +3645,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
           data: {
             title: 'Draft EN',
           },
+          overrideAccess: true,
         })
 
         // Verify both published and draft exist with different content
@@ -3451,12 +3654,14 @@ test.suite({ config: './config.ts' })('Localization', () => {
           collection: 'blocks-fields',
           locale: 'en',
           draft: false,
+          overrideAccess: true,
         })
         const enDraftBefore = await payload.findByID({
           id: doc.id,
           collection: 'blocks-fields',
           locale: 'en',
           draft: true,
+          overrideAccess: true,
         })
 
         expect(enPublishedBefore.title).toBe('Published EN')
@@ -3480,6 +3685,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
           collection: 'blocks-fields',
           locale: 'en',
           draft: false,
+          overrideAccess: true,
         })
 
         expect(enPublishedAfter.title).toBe('Published EN')
@@ -3495,6 +3701,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
               collection,
               locale: portugueseLocale,
               fallbackLocale: [spanishLocale, englishLocale],
+              overrideAccess: true,
             })
 
             expect(result).toBeDefined()
@@ -3509,6 +3716,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
               collection,
               locale: portugueseLocale,
               fallbackLocale: ['hu', 'ar', spanishLocale],
+              overrideAccess: true,
             })
 
             expect(result).toBeDefined()
@@ -3521,6 +3729,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
               collection,
               locale: portugueseLocale,
               fallbackLocale: ['hu', 'ar'],
+              overrideAccess: true,
             })
 
             expect(result).toBeDefined()
@@ -3534,6 +3743,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
               slug: global,
               locale: portugueseLocale,
               fallbackLocale: [spanishLocale, englishLocale],
+              overrideAccess: true,
             })
 
             expect(result).toBeDefined()
@@ -3547,6 +3757,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
               slug: global,
               locale: portugueseLocale,
               fallbackLocale: ['hu', spanishLocale],
+              overrideAccess: true,
             })
             expect(result).toBeDefined()
             expect(result.text).toBe(spanishTitle)
@@ -3557,6 +3768,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
               slug: global,
               locale: portugueseLocale,
               fallbackLocale: ['hu', 'ar'],
+              overrideAccess: true,
             })
 
             expect(result).toBeDefined()
@@ -3779,6 +3991,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
         data: {
           title: englishTitle,
         },
+        overrideAccess: true,
       })
 
       postWithLocalizedData = await payload.create({
@@ -3786,6 +3999,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
         data: {
           title: englishTitle,
         },
+        overrideAccess: true,
       })
 
       await payload.update({
@@ -3795,6 +4009,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
           title: spanishTitle,
         },
         locale: spanishLocale,
+        overrideAccess: true,
       })
     })
 
@@ -3805,6 +4020,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
           where: {
             title: { equals: post1.title },
           },
+          overrideAccess: true,
         })
         expect(allDocs.docs).toContainEqual(expect.objectContaining(post1))
       })
@@ -3817,6 +4033,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
             title: spanishTitle,
           },
           locale: spanishLocale,
+          overrideAccess: true,
         })
 
         expect(updated.title).toEqual(spanishTitle)
@@ -3825,6 +4042,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
           id: post1.id,
           collection,
           locale: 'all',
+          overrideAccess: true,
         })
 
         expect(localized.title.en).toEqual(englishTitle)
@@ -3836,6 +4054,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
           id: post1.id,
           collection,
           locale: portugueseLocale,
+          overrideAccess: true,
         })
 
         expect(retrievedDoc.title).not.toBeDefined()
@@ -3847,6 +4066,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
           collection,
           locale: portugueseLocale,
           fallbackLocale: englishLocale,
+          overrideAccess: true,
         })
 
         expect(fallbackDoc.title).toBe(englishTitle)
@@ -3859,6 +4079,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
           id: postWithLocalizedData.id,
           collection,
           locale: portugueseLocale,
+          overrideAccess: true,
         })
 
         expect(localizedFallback.title).not.toBeDefined()
@@ -3870,6 +4091,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
           collection,
           locale: portugueseLocale,
           fallbackLocale: false,
+          overrideAccess: true,
         })
 
         expect(localizedFallback.title).not.toBeDefined()
@@ -3882,6 +4104,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
             text: 'Post EN',
           },
           locale: 'en',
+          overrideAccess: true,
         })
 
         await payload.update({
@@ -3891,6 +4114,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
             selfRelation: originalPost.id,
           },
           locale: 'en',
+          overrideAccess: true,
         })
 
         const spanishPostWithEnglishFallback = await payload.findByID({
@@ -3898,6 +4122,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
           id: originalPost.id,
           locale: 'es',
           fallbackLocale: 'en',
+          overrideAccess: true,
         })
 
         expect(spanishPostWithEnglishFallback.text).toBe('Post EN')
@@ -3907,6 +4132,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
           id: originalPost.id,
           locale: 'es',
           fallbackLocale: false,
+          overrideAccess: true,
         })
 
         expect(spanishPostWithNoFallback?.selfRelation?.text).toBeUndefined()
@@ -3929,6 +4155,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
             exists: true,
           },
         },
+        overrideAccess: true,
       })
     })
     test('should only nest the top level localized field values under locale keys', async ({
@@ -3970,12 +4197,14 @@ test.suite({ config: './config.ts' })('Localization', () => {
           _status: 'draft',
         },
         locale: 'en',
+        overrideAccess: true,
       })
 
       const allLocalesDoc = await payload.findByID({
         collection: allFieldsLocalizedSlug,
         id: doc.id,
         locale: 'all',
+        overrideAccess: true,
       })
 
       // Verify simple localized fields have locale keys at top level
@@ -4046,6 +4275,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
             },
           },
         },
+        overrideAccess: true,
       })
 
       const queriedDoc = await payload.find({
@@ -4053,6 +4283,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
         where: {
           'group.en.text': { equals: 'some text' },
         },
+        overrideAccess: true,
       })
 
       expect(queriedDoc.docs).toHaveLength(1)
@@ -4077,12 +4308,14 @@ test.suite({ config: './config.ts' })('Localization', () => {
               _status: 'published',
             },
             locale: defaultLocale,
+            overrideAccess: true,
           })
 
           const esDoc = await payload.findByID({
             locale: spanishLocale,
             id: doc.id,
             collection: allFieldsLocalizedSlug,
+            overrideAccess: true,
           })
 
           expect(esDoc._status).toContain('draft')
@@ -4097,12 +4330,14 @@ test.suite({ config: './config.ts' })('Localization', () => {
             },
             locale: defaultLocale,
             publishAllLocales: true,
+            overrideAccess: true,
           })
 
           const esDoc = await payload.findByID({
             locale: spanishLocale,
             id: doc.id,
             collection: allFieldsLocalizedSlug,
+            overrideAccess: true,
           })
 
           expect(esDoc._status).toContain('published')
@@ -4123,6 +4358,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
             },
             draft: true,
             locale: defaultLocale,
+            overrideAccess: true,
           })
           // update english published 1
           await payload.update({
@@ -4133,6 +4369,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
               _status: 'published',
             },
             locale: defaultLocale,
+            overrideAccess: true,
           })
 
           // create spanish draft 1
@@ -4145,6 +4382,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
             },
             draft: true,
             locale: spanishLocale,
+            overrideAccess: true,
           })
           // update spanish published 1
           await payload.update({
@@ -4155,6 +4393,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
               _status: 'published',
             },
             locale: spanishLocale,
+            overrideAccess: true,
           })
           // update spanish draft 2
           await payload.update({
@@ -4166,6 +4405,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
             },
             draft: true,
             locale: spanishLocale,
+            overrideAccess: true,
           })
 
           const publishedDoc = await payload.findByID({
@@ -4173,6 +4413,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
             id: doc.id,
             locale: 'all',
             draft: false,
+            overrideAccess: true,
           })
 
           expect(publishedDoc._status!.en).toBe('published')
@@ -4185,6 +4426,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
             id: doc.id,
             draft: true,
             locale: 'all',
+            overrideAccess: true,
           })
 
           expect(latestVersionDoc._status!.en).toBe('published')
@@ -4201,6 +4443,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
               _status: 'published',
             },
             locale: defaultLocale,
+            overrideAccess: true,
           })
           await payload.update({
             collection: allFieldsLocalizedSlug,
@@ -4211,6 +4454,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
             },
             draft: true,
             locale: spanishLocale,
+            overrideAccess: true,
           })
 
           const esPublished = await payload.find({
@@ -4230,6 +4474,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
                 },
               ],
             },
+            overrideAccess: true,
           })
           expect(esPublished.totalDocs).toBe(0)
 
@@ -4251,6 +4496,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
                 },
               ],
             },
+            overrideAccess: true,
           })
 
           expect(esDraft.totalDocs).toBe(1)
@@ -4274,6 +4520,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
                 },
               ],
             },
+            overrideAccess: true,
           })
           expect(enPublished.totalDocs).toBe(1)
           expect(enPublished.docs[0]!.text).toBe('Localized Metadata EN')
@@ -4289,6 +4536,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
               _status: 'published',
             },
             locale: defaultLocale,
+            overrideAccess: true,
           })
 
           await payload.update({
@@ -4300,6 +4548,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
             },
             draft: true,
             locale: defaultLocale,
+            overrideAccess: true,
           })
 
           await payload.update({
@@ -4310,6 +4559,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
               _status: 'published',
             },
             locale: spanishLocale,
+            overrideAccess: true,
           })
 
           const mainDocument = await payload.findByID({
@@ -4317,6 +4567,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
             id: doc.id,
             collection: allFieldsLocalizedSlug,
             draft: false,
+            overrideAccess: true,
           })
 
           expect(mainDocument._status!.es).toBe('published')
@@ -4329,6 +4580,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
             id: doc.id,
             collection: allFieldsLocalizedSlug,
             draft: true,
+            overrideAccess: true,
           })
 
           expect(latestVersion._status!.es).toBe('published')
@@ -4345,6 +4597,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
               _status: 'draft',
             },
             locale: defaultLocale,
+            overrideAccess: true,
           })
 
           await payload.update({
@@ -4355,6 +4608,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
               _status: 'draft',
             },
             locale: spanishLocale,
+            overrideAccess: true,
           })
 
           await payload.update({
@@ -4366,6 +4620,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
             },
             locale: 'en',
             publishAllLocales: true,
+            overrideAccess: true,
           })
 
           const mainDocument = await payload.findByID({
@@ -4373,6 +4628,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
             id: doc.id,
             collection: allFieldsLocalizedSlug,
             draft: false,
+            overrideAccess: true,
           })
 
           expect(mainDocument._status!.en).toBe('published')
@@ -4385,6 +4641,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
             id: doc.id,
             unpublishAllLocales: true,
             data: {},
+            overrideAccess: true,
           })
 
           const unpublishedDocument = await payload.findByID({
@@ -4392,6 +4649,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
             id: doc.id,
             collection: allFieldsLocalizedSlug,
             draft: false,
+            overrideAccess: true,
           })
 
           expect(unpublishedDocument._status!.en).toBe('draft')
@@ -4415,6 +4673,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
             },
             draft: true,
             locale: defaultLocale,
+            overrideAccess: true,
           })
           // update english published 1
           await payload.updateGlobal({
@@ -4424,6 +4683,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
               _status: 'published',
             },
             locale: defaultLocale,
+            overrideAccess: true,
           })
 
           // create spanish draft 1
@@ -4435,6 +4695,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
             },
             draft: true,
             locale: spanishLocale,
+            overrideAccess: true,
           })
           // update spanish published 1
           await payload.updateGlobal({
@@ -4444,6 +4705,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
               _status: 'published',
             },
             locale: spanishLocale,
+            overrideAccess: true,
           })
           // update spanish draft 2
           await payload.updateGlobal({
@@ -4454,12 +4716,14 @@ test.suite({ config: './config.ts' })('Localization', () => {
             },
             draft: true,
             locale: spanishLocale,
+            overrideAccess: true,
           })
 
           const publishedDoc = await payload.findGlobal({
             slug: globalWithDraftsSlug,
             locale: 'all',
             draft: false,
+            overrideAccess: true,
           })
 
           expect(publishedDoc._status!.en).toBe('published')
@@ -4471,6 +4735,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
             slug: globalWithDraftsSlug,
             draft: true,
             locale: 'all',
+            overrideAccess: true,
           })
 
           expect(latestVersionDoc._status!.en).toBe('published')
@@ -4489,6 +4754,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
               _status: 'published',
             },
             locale: defaultLocale,
+            overrideAccess: true,
           })
 
           await payload.updateGlobal({
@@ -4499,6 +4765,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
             },
             draft: true,
             locale: defaultLocale,
+            overrideAccess: true,
           })
 
           await payload.updateGlobal({
@@ -4508,12 +4775,14 @@ test.suite({ config: './config.ts' })('Localization', () => {
               _status: 'published',
             },
             locale: spanishLocale,
+            overrideAccess: true,
           })
 
           const mainDocument = await payload.findGlobal({
             slug: globalWithDraftsSlug,
             locale: 'all',
             draft: false,
+            overrideAccess: true,
           })
 
           expect(mainDocument._status!.es).toBe('published')
@@ -4525,6 +4794,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
             slug: globalWithDraftsSlug,
             locale: 'all',
             draft: true,
+            overrideAccess: true,
           })
 
           expect(latestVersion._status!.es).toBe('published')
@@ -4541,6 +4811,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
               _status: 'draft',
             },
             locale: defaultLocale,
+            overrideAccess: true,
           })
 
           await payload.updateGlobal({
@@ -4550,6 +4821,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
               _status: 'draft',
             },
             locale: spanishLocale,
+            overrideAccess: true,
           })
 
           await payload.updateGlobal({
@@ -4560,12 +4832,14 @@ test.suite({ config: './config.ts' })('Localization', () => {
             },
             locale: defaultLocale,
             publishAllLocales: true,
+            overrideAccess: true,
           })
 
           const mainDocument = await payload.findGlobal({
             slug: globalWithDraftsSlug,
             locale: 'all',
             draft: false,
+            overrideAccess: true,
           })
 
           expect(mainDocument._status!.en).toBe('published')
@@ -4577,12 +4851,14 @@ test.suite({ config: './config.ts' })('Localization', () => {
             slug: globalWithDraftsSlug,
             unpublishAllLocales: true,
             data: {},
+            overrideAccess: true,
           })
 
           const unpublishedDocument = await payload.findGlobal({
             slug: globalWithDraftsSlug,
             locale: 'all',
             draft: false,
+            overrideAccess: true,
           })
 
           expect(unpublishedDocument._status!.en).toBe('draft')
@@ -4601,6 +4877,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
             text: englishTitle,
           },
           locale: englishLocale,
+          overrideAccess: true,
         })
 
         await payload.update({
@@ -4610,6 +4887,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
             text: spanishTitle,
           },
           locale: spanishLocale,
+          overrideAccess: true,
         })
       })
 
@@ -4621,12 +4899,14 @@ test.suite({ config: './config.ts' })('Localization', () => {
             text: '',
           },
           locale: spanishLocale,
+          overrideAccess: true,
         })
 
         const localizedFallback: any = await payload.findByID({
           id: allFieldsPostWithLocalizedData.id,
           collection: allFieldsLocalizedSlug,
           locale: 'all',
+          overrideAccess: true,
         })
 
         expect(localizedFallback.text.en).toEqual(englishTitle)
@@ -4636,6 +4916,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
           id: allFieldsPostWithLocalizedData.id,
           collection: allFieldsLocalizedSlug,
           locale: spanishLocale,
+          overrideAccess: true,
         })
 
         expect(retrievedInSpanish.text).toEqual(englishTitle)
@@ -4647,6 +4928,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
           collection: allFieldsLocalizedSlug,
           locale: portugueseLocale,
           fallbackLocale: 'none',
+          overrideAccess: true,
         })
 
         expect(localizedFallback.text).not.toBeDefined()
@@ -4662,6 +4944,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
           title: 'Localized Drafts EN',
         },
         locale: defaultLocale,
+        overrideAccess: true,
       })
 
       const result2 = await payload.countVersions({
@@ -4671,6 +4954,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
             equals: 'Localized Drafts EN',
           },
         },
+        overrideAccess: true,
       })
       expect(result2.totalDocs).toBe(1)
     })
@@ -4682,12 +4966,14 @@ test.suite({ config: './config.ts' })('Localization', () => {
         slug: globalWithDraftsSlug,
         data: { text: 'global count en', _status: 'published' },
         locale: defaultLocale,
+        overrideAccess: true,
       })
 
       await payload.updateGlobal({
         slug: globalWithDraftsSlug,
         data: { text: 'global count es', _status: 'published' },
         locale: spanishLocale,
+        overrideAccess: true,
       })
 
       const englishWhere = { 'version.text': { equals: 'global count en' } }
@@ -4696,12 +4982,14 @@ test.suite({ config: './config.ts' })('Localization', () => {
         global: globalWithDraftsSlug,
         locale: defaultLocale,
         where: englishWhere,
+        overrideAccess: true,
       })
 
       const inSpanish = await payload.countGlobalVersions({
         global: globalWithDraftsSlug,
         locale: spanishLocale,
         where: englishWhere,
+        overrideAccess: true,
       })
 
       expect(inEnglish.totalDocs).toBeGreaterThan(0)
@@ -4724,6 +5012,7 @@ async function createLocalizedPost(
     data: {
       title: data.title.en,
     },
+    overrideAccess: true,
   })
 
   await payload.update({
@@ -4733,6 +5022,7 @@ async function createLocalizedPost(
       title: data.title.es,
     },
     locale: spanishLocale,
+    overrideAccess: true,
   })
 
   return localizedRelation

--- a/test/localization/localizeStatus.int.spec.ts
+++ b/test/localization/localizeStatus.int.spec.ts
@@ -82,6 +82,7 @@ test.suite({ config: './localizeStatus.config.ts' })('localizeStatus migration',
         const post1 = await payload.create({
           collection: 'testMigrationPosts',
           data: { title: 'Post 1' },
+          overrideAccess: true,
         })
 
         // Publish the post
@@ -89,6 +90,7 @@ test.suite({ config: './localizeStatus.config.ts' })('localizeStatus migration',
           id: post1.id,
           collection: 'testMigrationPosts',
           data: { _status: 'published', title: 'Post 1 Updated' },
+          overrideAccess: true,
         })
 
         // Step 2: Verify "before" state
@@ -277,6 +279,7 @@ test.suite({ config: './localizeStatus.config.ts' })('localizeStatus migration',
         const post = await payload.create({
           collection: 'testMigrationPosts',
           data: { title: 'Initial Draft' },
+          overrideAccess: true,
         })
 
         // Publish it
@@ -284,6 +287,7 @@ test.suite({ config: './localizeStatus.config.ts' })('localizeStatus migration',
           id: post.id,
           collection: 'testMigrationPosts',
           data: { _status: 'published', title: 'Published Version' },
+          overrideAccess: true,
         })
 
         // Make a draft change
@@ -291,6 +295,7 @@ test.suite({ config: './localizeStatus.config.ts' })('localizeStatus migration',
           id: post.id,
           collection: 'testMigrationPosts',
           data: { _status: 'draft', title: 'Draft Changes' },
+          overrideAccess: true,
         })
 
         // Publish again
@@ -298,6 +303,7 @@ test.suite({ config: './localizeStatus.config.ts' })('localizeStatus migration',
           id: post.id,
           collection: 'testMigrationPosts',
           data: { _status: 'published', title: 'Re-published' },
+          overrideAccess: true,
         })
 
         // Query BEFORE migration
@@ -537,6 +543,7 @@ test.suite({ config: './localizeStatus.config.ts' })('localizeStatus migration',
         const doc = await payload.create({
           collection: 'testNoVersions',
           data: { title: 'Test document' },
+          overrideAccess: true,
         })
 
         expect(doc.id).toBeDefined()
@@ -680,12 +687,14 @@ test.suite({ config: './localizeStatus.config.ts' })('localizeStatus migration',
         const post1 = await payload.create({
           collection: 'testMigrationPosts',
           data: { title: 'Post 1' },
+          overrideAccess: true,
         })
 
         await payload.update({
           id: post1.id,
           collection: 'testMigrationPosts',
           data: { _status: 'published', title: 'Post 1 Updated' },
+          overrideAccess: true,
         })
 
         const beforeVersions = (await drizzle.all(
@@ -897,6 +906,7 @@ test.suite({ config: './localizeStatus.config.ts' })('localizeStatus migration',
         const doc = await payload.create({
           collection: 'testNoVersions',
           data: { title: 'Test document' },
+          overrideAccess: true,
         })
 
         expect(doc.id).toBeDefined()
@@ -950,6 +960,7 @@ test.suite({ config: './localizeStatus.config.ts' })('localizeStatus migration',
         const post = await payload.create({
           collection: 'testMigrationPosts',
           data: { title: 'MongoDB Test Post' },
+          overrideAccess: true,
         })
 
         // Publish the post
@@ -957,6 +968,7 @@ test.suite({ config: './localizeStatus.config.ts' })('localizeStatus migration',
           id: post.id,
           collection: 'testMigrationPosts',
           data: { _status: 'published', title: 'MongoDB Test Post Published' },
+          overrideAccess: true,
         })
 
         // Step 2: Get MongoDB connection and verify "before" state

--- a/test/localization/testMigration.ts
+++ b/test/localization/testMigration.ts
@@ -44,6 +44,7 @@ async function main() {
   const post = await payload.create({
     collection: 'testMigrationPosts',
     data: { title: 'Test Post' },
+    overrideAccess: true,
   })
   console.log(`   Created post: ${post.id}`)
 
@@ -51,6 +52,7 @@ async function main() {
     id: post.id,
     collection: 'testMigrationPosts',
     data: { _status: 'published', title: 'Published Post' },
+    overrideAccess: true,
   })
   console.log(`   Published post: ${post.id}\n`)
 

--- a/test/locked-documents/bulk-delete.int.spec.ts
+++ b/test/locked-documents/bulk-delete.int.spec.ts
@@ -16,6 +16,7 @@ test.suite({ config: './config.ts' })('Locked documents - bulk delete', () => {
         email: 'bulk-delete-owner@payloadcms.com',
         password: 'test',
       },
+      overrideAccess: true,
     })
 
     const otherUser = await payload.create({
@@ -24,6 +25,7 @@ test.suite({ config: './config.ts' })('Locked documents - bulk delete', () => {
         email: 'bulk-delete-other@payloadcms.com',
         password: 'test',
       },
+      overrideAccess: true,
     })
 
     const lockedPost = await payload.create({
@@ -31,6 +33,7 @@ test.suite({ config: './config.ts' })('Locked documents - bulk delete', () => {
       data: {
         text: 'bulk delete locked post',
       },
+      overrideAccess: true,
     })
 
     const unlockedPost = await payload.create({
@@ -38,6 +41,7 @@ test.suite({ config: './config.ts' })('Locked documents - bulk delete', () => {
       data: {
         text: 'bulk delete unlocked post',
       },
+      overrideAccess: true,
     })
 
     // Give locking ownership of one of the two documents to another user
@@ -54,6 +58,7 @@ test.suite({ config: './config.ts' })('Locked documents - bulk delete', () => {
           value: otherUser.id,
         },
       },
+      overrideAccess: true,
     })
 
     // The other document is locked by the user performing the delete, so it is not blocked. It
@@ -71,6 +76,7 @@ test.suite({ config: './config.ts' })('Locked documents - bulk delete', () => {
           value: deletingUser.id,
         },
       },
+      overrideAccess: true,
     })
 
     const { docs, errors } = await payload.delete({
@@ -80,6 +86,7 @@ test.suite({ config: './config.ts' })('Locked documents - bulk delete', () => {
       where: {
         id: { in: [lockedPost.id, unlockedPost.id] },
       },
+      overrideAccess: true,
     })
 
     expect(docs).toHaveLength(1)
@@ -95,6 +102,7 @@ test.suite({ config: './config.ts' })('Locked documents - bulk delete', () => {
       where: {
         id: { in: [lockedPost.id, unlockedPost.id] },
       },
+      overrideAccess: true,
     })
 
     expect(remainingPosts.docs).toHaveLength(1)
@@ -105,6 +113,7 @@ test.suite({ config: './config.ts' })('Locked documents - bulk delete', () => {
       payload.findByID({
         id: ownLock.id,
         collection: lockedDocumentCollection,
+        overrideAccess: true,
       }),
     ).rejects.toBeInstanceOf(NotFound)
   })

--- a/test/locked-documents/e2e.spec.ts
+++ b/test/locked-documents/e2e.spec.ts
@@ -90,6 +90,7 @@ describe('Locked Documents', () => {
         where: {
           'document.value': { equals: id },
         },
+        overrideAccess: true,
       })
 
       expect(lockedDocs.docs.length).toBe(0)
@@ -124,6 +125,7 @@ describe('Locked Documents', () => {
           password: '1234',
           roles: ['is_user'],
         },
+        overrideAccess: true,
       })
 
       lockedDoc = await payload.create({
@@ -139,6 +141,7 @@ describe('Locked Documents', () => {
             value: user2.id,
           },
         },
+        overrideAccess: true,
       })
 
       testLockedDoc = await payload.create({
@@ -154,6 +157,7 @@ describe('Locked Documents', () => {
             value: user2.id,
           },
         },
+        overrideAccess: true,
       })
     })
 
@@ -347,6 +351,7 @@ describe('Locked Documents', () => {
           password: '1234',
           roles: ['is_user'],
         },
+        overrideAccess: true,
       })
 
       expiredDocOne = await createTestDoc({
@@ -366,6 +371,7 @@ describe('Locked Documents', () => {
             value: user2.id,
           },
         },
+        overrideAccess: true,
       })
 
       expiredDocTwo = await createTestDoc({
@@ -385,6 +391,7 @@ describe('Locked Documents', () => {
             value: user2.id,
           },
         },
+        overrideAccess: true,
       })
 
       testDoc = await createTestDoc({ text: 'hello' })
@@ -406,6 +413,7 @@ describe('Locked Documents', () => {
       const lockedTestDocs = await payload.find({
         collection: lockedDocumentCollection,
         pagination: false,
+        overrideAccess: true,
       })
 
       expect(lockedTestDocs.docs.length).toBe(2)
@@ -420,6 +428,7 @@ describe('Locked Documents', () => {
       const lockedDocs = await payload.find({
         collection: lockedDocumentCollection,
         pagination: false,
+        overrideAccess: true,
       })
 
       expect(lockedDocs.docs.length).toBe(1)
@@ -440,6 +449,7 @@ describe('Locked Documents', () => {
         where: {
           'document.value': { equals: postDoc.id },
         },
+        overrideAccess: true,
       })
 
       expect(lockedDocs.docs.length).toBe(1)
@@ -460,6 +470,7 @@ describe('Locked Documents', () => {
         where: {
           'document.value': { equals: postDoc.id },
         },
+        overrideAccess: true,
       })
 
       expect(lockedDocs.docs.length).toBe(1)
@@ -475,6 +486,7 @@ describe('Locked Documents', () => {
         where: {
           'document.value': { equals: postDoc.id },
         },
+        overrideAccess: true,
       })
 
       expect(unlockedDocs.docs.length).toBe(0)
@@ -495,6 +507,7 @@ describe('Locked Documents', () => {
         where: {
           'document.value': { equals: postDoc.id },
         },
+        overrideAccess: true,
       })
 
       expect(lockedDocs.docs.length).toBe(1)
@@ -517,6 +530,7 @@ describe('Locked Documents', () => {
         where: {
           'document.value': { equals: postDoc.id },
         },
+        overrideAccess: true,
       })
 
       expect(unlockedDocs.docs.length).toBe(1)
@@ -526,6 +540,7 @@ describe('Locked Documents', () => {
         where: {
           'document.value': { equals: postDoc.id },
         },
+        overrideAccess: true,
       })
     })
 
@@ -544,6 +559,7 @@ describe('Locked Documents', () => {
         where: {
           'document.value': { equals: postDocTwo.id },
         },
+        overrideAccess: true,
       })
 
       expect(lockedDocs.docs.length).toBe(1)
@@ -568,6 +584,7 @@ describe('Locked Documents', () => {
         where: {
           'document.value': { equals: postDoc.id },
         },
+        overrideAccess: true,
       })
 
       expect(unlockedDocs.docs.length).toBe(0)
@@ -594,6 +611,7 @@ describe('Locked Documents', () => {
       serverComponentDoc = await payload.create({
         collection: 'server-components',
         data: {},
+        overrideAccess: true,
       })
 
       expiredTestDoc = await createTestDoc({
@@ -607,6 +625,7 @@ describe('Locked Documents', () => {
           password: '1234',
           roles: ['is_user'],
         },
+        overrideAccess: true,
       })
 
       lockedDoc = await payload.create({
@@ -622,6 +641,7 @@ describe('Locked Documents', () => {
             value: user2.id,
           },
         },
+        overrideAccess: true,
       })
 
       expiredTestLockedDoc = await payload.create({
@@ -637,6 +657,7 @@ describe('Locked Documents', () => {
             value: user2.id,
           },
         },
+        overrideAccess: true,
       })
 
       expiredPostDoc = await createPostDoc({
@@ -658,6 +679,7 @@ describe('Locked Documents', () => {
             value: user2.id,
           },
         },
+        overrideAccess: true,
       })
 
       lockedServerComponentDoc = await payload.create({
@@ -673,6 +695,7 @@ describe('Locked Documents', () => {
             value: user2.id,
           },
         },
+        overrideAccess: true,
       })
     })
 
@@ -815,6 +838,7 @@ describe('Locked Documents', () => {
       serverComponentDoc = await payload.create({
         collection: 'server-components',
         data: {},
+        overrideAccess: true,
       })
 
       user2 = await payload.create({
@@ -824,6 +848,7 @@ describe('Locked Documents', () => {
           password: '1234',
           roles: ['is_user'],
         },
+        overrideAccess: true,
       })
 
       lockedDoc = await payload.create({
@@ -839,6 +864,7 @@ describe('Locked Documents', () => {
             value: user2.id,
           },
         },
+        overrideAccess: true,
       })
 
       lockedServerComponentsDoc = await payload.create({
@@ -854,6 +880,7 @@ describe('Locked Documents', () => {
             value: user2.id,
           },
         },
+        overrideAccess: true,
       })
     })
 
@@ -875,6 +902,7 @@ describe('Locked Documents', () => {
         where: {
           'document.value': { equals: postDoc.id },
         },
+        overrideAccess: true,
       })
 
       await wait(500)
@@ -923,6 +951,7 @@ describe('Locked Documents', () => {
       serverComponentsDoc = await payload.create({
         collection: 'server-components',
         data: {},
+        overrideAccess: true,
       })
 
       user2 = await payload.create({
@@ -932,6 +961,7 @@ describe('Locked Documents', () => {
           password: '1234',
           roles: ['is_user'],
         },
+        overrideAccess: true,
       })
 
       lockedDoc = await payload.create({
@@ -947,6 +977,7 @@ describe('Locked Documents', () => {
             value: user2.id,
           },
         },
+        overrideAccess: true,
       })
 
       lockedServerComponentsDoc = await payload.create({
@@ -962,6 +993,7 @@ describe('Locked Documents', () => {
             value: user2.id,
           },
         },
+        overrideAccess: true,
       })
     })
 
@@ -985,6 +1017,7 @@ describe('Locked Documents', () => {
         where: {
           'document.value': { equals: postDoc.id },
         },
+        overrideAccess: true,
       })
 
       await wait(500)
@@ -1036,6 +1069,7 @@ describe('Locked Documents', () => {
       serverComponentsDoc = await payload.create({
         collection: 'server-components',
         data: {},
+        overrideAccess: true,
       })
 
       user2 = await payload.create({
@@ -1045,6 +1079,7 @@ describe('Locked Documents', () => {
           password: '1234',
           roles: ['is_user'],
         },
+        overrideAccess: true,
       })
     })
 
@@ -1064,6 +1099,7 @@ describe('Locked Documents', () => {
         where: {
           'document.value': { equals: postDoc.id },
         },
+        overrideAccess: true,
       })
 
       await wait(500)
@@ -1078,6 +1114,7 @@ describe('Locked Documents', () => {
             value: user2.id,
           },
         },
+        overrideAccess: true,
       })
 
       await wait(1000)
@@ -1092,6 +1129,7 @@ describe('Locked Documents', () => {
       await payload.delete({
         id: lockedDoc.docs[0]?.id,
         collection: lockedDocumentCollection,
+        overrideAccess: true,
       })
     })
 
@@ -1111,6 +1149,7 @@ describe('Locked Documents', () => {
         where: {
           'document.value': { equals: postDoc.id },
         },
+        overrideAccess: true,
       })
 
       await wait(500)
@@ -1125,6 +1164,7 @@ describe('Locked Documents', () => {
             value: user2.id,
           },
         },
+        overrideAccess: true,
       })
 
       await wait(1000)
@@ -1144,6 +1184,7 @@ describe('Locked Documents', () => {
       await payload.delete({
         id: lockedDoc.docs[0]?.id,
         collection: lockedDocumentCollection,
+        overrideAccess: true,
       })
     })
 
@@ -1163,6 +1204,7 @@ describe('Locked Documents', () => {
         where: {
           'document.value': { equals: postDoc.id },
         },
+        overrideAccess: true,
       })
 
       await wait(500)
@@ -1177,6 +1219,7 @@ describe('Locked Documents', () => {
             value: user2.id,
           },
         },
+        overrideAccess: true,
       })
 
       await wait(500)
@@ -1215,6 +1258,7 @@ describe('Locked Documents', () => {
         where: {
           'document.value': { equals: serverComponentsDoc.id },
         },
+        overrideAccess: true,
       })
 
       await wait(500)
@@ -1229,6 +1273,7 @@ describe('Locked Documents', () => {
             value: user2.id,
           },
         },
+        overrideAccess: true,
       })
 
       await wait(500)
@@ -1261,6 +1306,7 @@ describe('Locked Documents', () => {
           password: '1234',
           roles: ['is_user'],
         },
+        overrideAccess: true,
       })
 
       lockedAdminGlobal = await payload.create({
@@ -1273,6 +1319,7 @@ describe('Locked Documents', () => {
             value: user2.id,
           },
         },
+        overrideAccess: true,
       })
 
       lockedMenuGlobal = await payload.create({
@@ -1285,6 +1332,7 @@ describe('Locked Documents', () => {
             value: user2.id,
           },
         },
+        overrideAccess: true,
       })
     })
 
@@ -1300,6 +1348,7 @@ describe('Locked Documents', () => {
       await payload.delete({
         id: lockedMenuGlobal.id,
         collection: lockedDocumentCollection,
+        overrideAccess: true,
       })
 
       await wait(500)
@@ -1313,6 +1362,7 @@ describe('Locked Documents', () => {
       await payload.delete({
         id: lockedMenuGlobal.id,
         collection: lockedDocumentCollection,
+        overrideAccess: true,
       })
 
       await page.goto(globalUrl.global('menu'))
@@ -1345,6 +1395,7 @@ describe('Locked Documents', () => {
       await payload.delete({
         id: lockedAdminGlobal.id,
         collection: lockedDocumentCollection,
+        overrideAccess: true,
       })
     })
 
@@ -1359,6 +1410,7 @@ describe('Locked Documents', () => {
             value: user2.id,
           },
         },
+        overrideAccess: true,
       })
 
       await page.goto(postsUrl.admin)
@@ -1397,6 +1449,7 @@ describe('Locked Documents', () => {
           fieldA: 'Original A',
           fieldB: 'Original B',
         },
+        overrideAccess: true,
       })) as unknown as Simple
 
       simpleWithVersionsDoc = (await payload.create({
@@ -1405,6 +1458,7 @@ describe('Locked Documents', () => {
           fieldA: 'Original A',
           fieldB: 'Original B',
         },
+        overrideAccess: true,
       })) as unknown as SimpleWithVersion
 
       // Create a second browser context for user 2 (user 1 uses the parent test's page)
@@ -1694,6 +1748,7 @@ describe('Locked Documents', () => {
             fieldA: 'Initial Value',
             fieldB: 'Initial Value B',
           },
+          overrideAccess: true,
         })) as unknown as Autosave
 
         createdAutosaveIDs.push(autosaveDoc.id)
@@ -1732,7 +1787,7 @@ describe('Locked Documents', () => {
 
           // Clean up created autosave document
           for (const id of createdAutosaveIDs) {
-            await payload.delete({ id, collection: 'autosave' }).catch(() => {
+            await payload.delete({ id, collection: 'autosave', overrideAccess: true }).catch(() => {
               // Ignore deletion errors (document might already be deleted)
             })
           }
@@ -2142,6 +2197,7 @@ async function createPageDoc(data: Partial<PageType>): Promise<PageType> {
   return payload.create({
     collection: 'pages',
     data,
+    overrideAccess: true,
   }) as unknown as Promise<PageType>
 }
 
@@ -2149,6 +2205,7 @@ async function createPostDoc(data: Partial<Post>): Promise<Post> {
   return payload.create({
     collection: 'posts',
     data,
+    overrideAccess: true,
   }) as unknown as Promise<Post>
 }
 
@@ -2156,5 +2213,6 @@ async function createTestDoc(data: Partial<Test>): Promise<Test> {
   return payload.create({
     collection: 'tests',
     data,
+    overrideAccess: true,
   }) as unknown as Promise<Test>
 }

--- a/test/locked-documents/int.spec.ts
+++ b/test/locked-documents/int.spec.ts
@@ -31,6 +31,7 @@ test.suite({ config: './config.ts' })('Locked documents', () => {
         email: devUser.email,
         password: devUser.password,
       },
+      overrideAccess: true,
     })
 
     user = loginResult.user
@@ -41,6 +42,7 @@ test.suite({ config: './config.ts' })('Locked documents', () => {
         email: 'test@payloadcms.com',
         password: 'test',
       },
+      overrideAccess: true,
     })
 
     post = await payload.create({
@@ -48,6 +50,7 @@ test.suite({ config: './config.ts' })('Locked documents', () => {
       data: {
         text: 'some post',
       },
+      overrideAccess: true,
     })
 
     await payload.create({
@@ -55,6 +58,7 @@ test.suite({ config: './config.ts' })('Locked documents', () => {
       data: {
         text: 'some page',
       },
+      overrideAccess: true,
     })
 
     await payload.updateGlobal({
@@ -62,6 +66,7 @@ test.suite({ config: './config.ts' })('Locked documents', () => {
       data: {
         globalText: 'global text',
       },
+      overrideAccess: true,
     })
   })
 
@@ -76,6 +81,7 @@ test.suite({ config: './config.ts' })('Locked documents', () => {
         text: 'updated post',
       },
       id: post.id,
+      overrideAccess: true,
     })
 
     expect(updatedPost.text).toEqual('updated post')
@@ -87,6 +93,7 @@ test.suite({ config: './config.ts' })('Locked documents', () => {
       data: {
         globalText: 'updated global text',
       },
+      overrideAccess: true,
     })
 
     expect(updatedGlobalMenu.globalText).toEqual('updated global text')
@@ -96,6 +103,7 @@ test.suite({ config: './config.ts' })('Locked documents', () => {
     const { docs } = await payload.find({
       collection: postsSlug,
       depth: 0,
+      overrideAccess: true,
     })
 
     expect(docs).toHaveLength(2)
@@ -103,11 +111,13 @@ test.suite({ config: './config.ts' })('Locked documents', () => {
     await payload.delete({
       collection: postsSlug,
       id: post.id,
+      overrideAccess: true,
     })
 
     const { docs: deletedResults } = await payload.find({
       collection: postsSlug,
       depth: 0,
+      overrideAccess: true,
     })
 
     expect(deletedResults).toHaveLength(1)
@@ -119,6 +129,7 @@ test.suite({ config: './config.ts' })('Locked documents', () => {
       data: {
         text: 'new post 2',
       },
+      overrideAccess: true,
     })
 
     // Set lock duration to 1 second for testing purposes
@@ -138,6 +149,7 @@ test.suite({ config: './config.ts' })('Locked documents', () => {
         },
         globalSlug: undefined,
       },
+      overrideAccess: true,
     })
 
     await wait(1100)
@@ -149,6 +161,7 @@ test.suite({ config: './config.ts' })('Locked documents', () => {
       },
       overrideLock: false,
       id: newPost2.id,
+      overrideAccess: true,
     })
     postConfig.lockDocuments = { duration: 300 }
 
@@ -161,6 +174,7 @@ test.suite({ config: './config.ts' })('Locked documents', () => {
       await payload.findByID({
         collection: lockedDocumentCollection,
         id: lockedDocInstance.id,
+        overrideAccess: true,
       })
     } catch (error) {
       expect(error).toBeInstanceOf(NotFound)
@@ -171,6 +185,7 @@ test.suite({ config: './config.ts' })('Locked documents', () => {
       where: {
         id: { equals: lockedDocInstance.id },
       },
+      overrideAccess: true,
     })
 
     // Updating a document with the local API should not keep a stored doc
@@ -195,6 +210,7 @@ test.suite({ config: './config.ts' })('Locked documents', () => {
         document: undefined,
         globalSlug: menuSlug,
       },
+      overrideAccess: true,
     })
 
     await wait(1100)
@@ -205,6 +221,7 @@ test.suite({ config: './config.ts' })('Locked documents', () => {
       },
       overrideLock: false,
       slug: menuSlug,
+      overrideAccess: true,
     })
     globalConfig.lockDocuments = { duration: 300 }
 
@@ -217,6 +234,7 @@ test.suite({ config: './config.ts' })('Locked documents', () => {
       await payload.findByID({
         collection: lockedDocumentCollection,
         id: lockedGlobalInstance.id,
+        overrideAccess: true,
       })
     } catch (error) {
       expect(error).toBeInstanceOf(NotFound)
@@ -227,6 +245,7 @@ test.suite({ config: './config.ts' })('Locked documents', () => {
       where: {
         id: { equals: lockedGlobalInstance.id },
       },
+      overrideAccess: true,
     })
 
     // Updating a document with the local API should not keep a stored doc
@@ -240,6 +259,7 @@ test.suite({ config: './config.ts' })('Locked documents', () => {
       data: {
         text: 'some post',
       },
+      overrideAccess: true,
     })
 
     // Give locking ownership to another user
@@ -256,6 +276,7 @@ test.suite({ config: './config.ts' })('Locked documents', () => {
           value: user2.id,
         },
       },
+      overrideAccess: true,
     })
 
     try {
@@ -266,6 +287,7 @@ test.suite({ config: './config.ts' })('Locked documents', () => {
         },
         overrideLock: false, // necessary to trigger the lock check
         id: newPost.id,
+        overrideAccess: true,
       })
     } catch (error: any) {
       expect(error).toBeInstanceOf(Locked)
@@ -275,6 +297,7 @@ test.suite({ config: './config.ts' })('Locked documents', () => {
     const updatedPost = await payload.findByID({
       collection: postsSlug,
       id: newPost.id,
+      overrideAccess: true,
     })
 
     // Should not allow update - expect data not to change
@@ -293,6 +316,7 @@ test.suite({ config: './config.ts' })('Locked documents', () => {
           value: user2.id,
         },
       },
+      overrideAccess: true,
     })
 
     try {
@@ -302,6 +326,7 @@ test.suite({ config: './config.ts' })('Locked documents', () => {
         },
         overrideLock: false, // necessary to trigger the lock check
         slug: menuSlug,
+        overrideAccess: true,
       })
     } catch (error: any) {
       expect(error).toBeInstanceOf(Locked)
@@ -310,6 +335,7 @@ test.suite({ config: './config.ts' })('Locked documents', () => {
 
     const updatedGlobalMenu = await payload.findGlobal({
       slug: menuSlug,
+      overrideAccess: true,
     })
 
     // Should not allow update - expect data not to change
@@ -323,6 +349,7 @@ test.suite({ config: './config.ts' })('Locked documents', () => {
       data: {
         text: 'new post 3',
       },
+      overrideAccess: true,
     })
 
     // Give locking ownership to another user
@@ -339,13 +366,15 @@ test.suite({ config: './config.ts' })('Locked documents', () => {
           value: user2.id,
         },
       },
+      overrideAccess: true,
     })
 
     try {
       await payload.delete({
         collection: postsSlug,
         id: newPost3.id,
-        overrideLock: false, // necessary to trigger the lock check
+        overrideLock: false,
+        overrideAccess: true, // necessary to trigger the lock check
       })
     } catch (error: any) {
       expect(error).toBeInstanceOf(Locked)
@@ -357,6 +386,7 @@ test.suite({ config: './config.ts' })('Locked documents', () => {
       where: {
         id: { equals: newPost3.id },
       },
+      overrideAccess: true,
     })
 
     expect(findPostDocs.docs).toHaveLength(1)
@@ -368,6 +398,7 @@ test.suite({ config: './config.ts' })('Locked documents', () => {
       data: {
         text: 'new post 4',
       },
+      overrideAccess: true,
     })
 
     // Set lock duration to 1 second for testing purposes
@@ -387,6 +418,7 @@ test.suite({ config: './config.ts' })('Locked documents', () => {
         },
         globalSlug: undefined,
       },
+      overrideAccess: true,
     })
 
     await wait(1100)
@@ -395,6 +427,7 @@ test.suite({ config: './config.ts' })('Locked documents', () => {
       collection: postsSlug,
       id: newPost4.id,
       overrideLock: false,
+      overrideAccess: true,
     })
 
     const findPostDocs = await payload.find({
@@ -402,6 +435,7 @@ test.suite({ config: './config.ts' })('Locked documents', () => {
       where: {
         id: { equals: newPost4.id },
       },
+      overrideAccess: true,
     })
 
     expect(findPostDocs.docs).toHaveLength(0)
@@ -411,6 +445,7 @@ test.suite({ config: './config.ts' })('Locked documents', () => {
       await payload.findByID({
         collection: lockedDocumentCollection,
         id: lockedDocInstance.id,
+        overrideAccess: true,
       })
     } catch (error) {
       expect(error).toBeInstanceOf(NotFound)
@@ -421,6 +456,7 @@ test.suite({ config: './config.ts' })('Locked documents', () => {
       where: {
         id: { equals: lockedDocInstance.id },
       },
+      overrideAccess: true,
     })
 
     expect(docsFromLocksCollection.docs).toHaveLength(0)
@@ -434,6 +470,7 @@ test.suite({ config: './config.ts' })('Locked documents', () => {
       data: {
         text: 'new post 5',
       },
+      overrideAccess: true,
     })
 
     // Give locking ownership to another user
@@ -450,6 +487,7 @@ test.suite({ config: './config.ts' })('Locked documents', () => {
         },
         globalSlug: undefined,
       },
+      overrideAccess: true,
     })
 
     const updateLockedDoc = await payload.update({
@@ -459,6 +497,7 @@ test.suite({ config: './config.ts' })('Locked documents', () => {
       },
       id: newPost5.id,
       overrideLock: true,
+      overrideAccess: true,
     })
 
     // Should allow update since using overrideLock flag
@@ -469,6 +508,7 @@ test.suite({ config: './config.ts' })('Locked documents', () => {
       await payload.findByID({
         collection: lockedDocumentCollection,
         id: lockedDocInstance.id,
+        overrideAccess: true,
       })
     } catch (error) {
       expect(error).toBeInstanceOf(NotFound)
@@ -479,6 +519,7 @@ test.suite({ config: './config.ts' })('Locked documents', () => {
       where: {
         id: { equals: lockedDocInstance.id },
       },
+      overrideAccess: true,
     })
 
     // Updating a document with the local API should not keep a stored doc
@@ -500,6 +541,7 @@ test.suite({ config: './config.ts' })('Locked documents', () => {
         },
         document: undefined,
       },
+      overrideAccess: true,
     })
 
     const updateGlobalLockedDoc = await payload.updateGlobal({
@@ -508,6 +550,7 @@ test.suite({ config: './config.ts' })('Locked documents', () => {
       },
       slug: menuSlug,
       overrideLock: true,
+      overrideAccess: true,
     })
 
     // Should allow update since using overrideLock flag
@@ -518,6 +561,7 @@ test.suite({ config: './config.ts' })('Locked documents', () => {
       await payload.findByID({
         collection: lockedDocumentCollection,
         id: lockedGlobalInstance.id,
+        overrideAccess: true,
       })
     } catch (error) {
       expect(error).toBeInstanceOf(NotFound)
@@ -528,6 +572,7 @@ test.suite({ config: './config.ts' })('Locked documents', () => {
       where: {
         id: { equals: lockedGlobalInstance.id },
       },
+      overrideAccess: true,
     })
 
     // Updating a document with the local API should not keep a stored doc
@@ -543,6 +588,7 @@ test.suite({ config: './config.ts' })('Locked documents', () => {
       data: {
         text: 'new post 6',
       },
+      overrideAccess: true,
     })
 
     // Give locking ownership to another user
@@ -559,12 +605,14 @@ test.suite({ config: './config.ts' })('Locked documents', () => {
         },
         globalSlug: undefined,
       },
+      overrideAccess: true,
     })
 
     await payload.delete({
       collection: postsSlug,
       id: newPost6.id,
       overrideLock: true,
+      overrideAccess: true,
     })
 
     const findPostDocs = await payload.find({
@@ -572,6 +620,7 @@ test.suite({ config: './config.ts' })('Locked documents', () => {
       where: {
         id: { equals: newPost6.id },
       },
+      overrideAccess: true,
     })
 
     expect(findPostDocs.docs).toHaveLength(0)
@@ -581,6 +630,7 @@ test.suite({ config: './config.ts' })('Locked documents', () => {
       await payload.findByID({
         collection: lockedDocumentCollection,
         id: lockedDocInstance.id,
+        overrideAccess: true,
       })
     } catch (error) {
       expect(error).toBeInstanceOf(NotFound)
@@ -591,6 +641,7 @@ test.suite({ config: './config.ts' })('Locked documents', () => {
       where: {
         id: { equals: lockedDocInstance.id },
       },
+      overrideAccess: true,
     })
 
     expect(docsFromLocksCollection.docs).toHaveLength(0)
@@ -604,6 +655,7 @@ test.suite({ config: './config.ts' })('Locked documents', () => {
       data: {
         text: 'new post 7',
       },
+      overrideAccess: true,
     })
 
     const lockedDocInstance = await payload.create({
@@ -619,6 +671,7 @@ test.suite({ config: './config.ts' })('Locked documents', () => {
         },
         globalSlug: undefined,
       },
+      overrideAccess: true,
     })
 
     // This is the take over action - changing the user to the current user
@@ -628,6 +681,7 @@ test.suite({ config: './config.ts' })('Locked documents', () => {
         user: { relationTo: 'users', value: user?.id },
       },
       id: lockedDocInstance.id,
+      overrideAccess: true,
     })
 
     const docsFromLocksCollection = await payload.find({
@@ -635,6 +689,7 @@ test.suite({ config: './config.ts' })('Locked documents', () => {
       where: {
         'user.value': { equals: user.id },
       },
+      overrideAccess: true,
     })
 
     expect(docsFromLocksCollection.docs).toHaveLength(1)

--- a/test/login-with-username/int.spec.ts
+++ b/test/login-with-username/int.spec.ts
@@ -14,6 +14,7 @@ test.suite({ config: './config.ts' })('Login With Username Feature', () => {
           email: null,
           username: null,
         },
+        overrideAccess: true,
       })
     } catch (error) {
       errors = error.data.errors
@@ -32,6 +33,7 @@ test.suite({ config: './config.ts' })('Login With Username Feature', () => {
         username: usernameToUse,
         password: 'test',
       },
+      overrideAccess: true,
     })
 
     let errors = []
@@ -43,6 +45,7 @@ test.suite({ config: './config.ts' })('Login With Username Feature', () => {
           email: null,
           username: null,
         },
+        overrideAccess: true,
       })
     } catch (error) {
       errors = error.data.errors
@@ -56,6 +59,7 @@ test.suite({ config: './config.ts' })('Login With Username Feature', () => {
       data: {
         username: null,
       },
+      overrideAccess: true,
     })
     expect(errors).toHaveLength(0)
 
@@ -66,6 +70,7 @@ test.suite({ config: './config.ts' })('Login With Username Feature', () => {
         data: {
           email: null,
         },
+        overrideAccess: true,
       })
     } catch (error) {
       errors = error.data.errors
@@ -81,6 +86,7 @@ test.suite({ config: './config.ts' })('Login With Username Feature', () => {
         username: 'dev',
         password: devUser.password,
       },
+      overrideAccess: true,
     })
 
     const loginWithEmail = await payload.login({
@@ -89,6 +95,7 @@ test.suite({ config: './config.ts' })('Login With Username Feature', () => {
         email: devUser.email,
         password: devUser.password,
       },
+      overrideAccess: true,
     })
     expect(loginWithEmail).toHaveProperty('token')
 
@@ -98,6 +105,7 @@ test.suite({ config: './config.ts' })('Login With Username Feature', () => {
         username: 'dev',
         password: devUser.password,
       },
+      overrideAccess: true,
     })
     expect(loginWithUsername).toHaveProperty('token')
   })
@@ -110,6 +118,7 @@ test.suite({ config: './config.ts' })('Login With Username Feature', () => {
         email: 'email1@mail.com',
         password: 'test',
       },
+      overrideAccess: true,
     })
 
     // create second user with just email
@@ -119,6 +128,7 @@ test.suite({ config: './config.ts' })('Login With Username Feature', () => {
         email: 'email2@mail.com',
         password: 'test',
       },
+      overrideAccess: true,
     })
     expect(emailUser2).toHaveProperty('id')
 
@@ -129,6 +139,7 @@ test.suite({ config: './config.ts' })('Login With Username Feature', () => {
         username: 'username1',
         password: 'test',
       },
+      overrideAccess: true,
     })
 
     // create second user with just username
@@ -138,6 +149,7 @@ test.suite({ config: './config.ts' })('Login With Username Feature', () => {
         username: 'username2',
         password: 'test',
       },
+      overrideAccess: true,
     })
     expect(usernameUser2).toHaveProperty('id')
   })

--- a/test/nested-fields/config.ts
+++ b/test/nested-fields/config.ts
@@ -200,6 +200,7 @@ export default buildConfigWithDefaults({
         email: devUser.email,
         password: devUser.password,
       },
+      overrideAccess: true,
     })
   },
 })

--- a/test/payload-cloud/config.ts
+++ b/test/payload-cloud/config.ts
@@ -41,6 +41,7 @@ export default buildConfigWithDefaults({
         email: devUser.email,
         password: devUser.password,
       },
+      overrideAccess: true,
     })
   },
 })

--- a/test/payload-cloud/int.spec.ts
+++ b/test/payload-cloud/int.spec.ts
@@ -71,6 +71,7 @@ test.suite({ config: './config.ts' })('@payloadcms/payload--cloud', () => {
         await payload.delete({
           collection: 'documents',
           id: doc.id,
+          overrideAccess: true,
         })
       },
     )

--- a/test/plugin-cloud-storage/buildPluginCloudStorageIntConfig.ts
+++ b/test/plugin-cloud-storage/buildPluginCloudStorageIntConfig.ts
@@ -218,6 +218,7 @@ export function buildPluginCloudStorageIntConfig({
           email: devUser.email,
           password: devUser.password,
         },
+        overrideAccess: true,
       })
 
       payload.logger.info(

--- a/test/plugin-cloud-storage/int.compositePrefixes.int.spec.ts
+++ b/test/plugin-cloud-storage/int.compositePrefixes.int.spec.ts
@@ -71,6 +71,7 @@ test.suite({ config: configPath })('@payloadcms/plugin-cloud-storage (composite 
             prefix: docPrefix,
           },
           filePath: path.resolve(dirname, '../uploads/image.png'),
+          overrideAccess: true,
         })
 
         expect(upload.id).toBeTruthy()
@@ -93,6 +94,7 @@ test.suite({ config: configPath })('@payloadcms/plugin-cloud-storage (composite 
           collection: mediaWithCompositePrefixesSlug,
           data: {},
           filePath: path.resolve(dirname, '../uploads/image.png'),
+          overrideAccess: true,
         })
 
         expect(upload.id).toBeTruthy()

--- a/test/plugin-cloud-storage/int.spec.ts
+++ b/test/plugin-cloud-storage/int.spec.ts
@@ -48,6 +48,7 @@ async function verifyUploads({
   const uploadData = (await payload.findByID({
     id: uploadId,
     collection: collectionSlug,
+    overrideAccess: true,
   })) as unknown as { filename: string; sizes: Record<string, { filename: string }> }
 
   const sizes = uploadData.sizes ?? {}
@@ -298,6 +299,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-cloud-storage', () => 
             collection: mediaSlug,
             data: {},
             filePath: path.resolve(dirname, '../uploads/image.png'),
+            overrideAccess: true,
           })
 
           expect(upload.id).toBeTruthy()
@@ -318,6 +320,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-cloud-storage', () => 
             collection: mediaWithPrefixSlug,
             data: {},
             filePath: path.resolve(dirname, '../uploads/image.png'),
+            overrideAccess: true,
           })
 
           expect(upload.id).toBeTruthy()
@@ -348,6 +351,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-cloud-storage', () => 
               collection: restrictedMediaSlug,
               data: {},
               filePath: path.resolve(dirname, './test.json'),
+              overrideAccess: true,
             }),
           ).rejects.toThrow()
 
@@ -364,6 +368,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-cloud-storage', () => 
             collection: restrictedMediaSlug,
             data: {},
             filePath: path.resolve(dirname, './image.png'),
+            overrideAccess: true,
           })
 
           expect(upload.id).toBeTruthy()
@@ -389,11 +394,13 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-cloud-storage', () => 
             collection: mediaSlug,
             data: {},
             filePath: path.resolve(dirname, '../uploads/image.png'),
+            overrideAccess: true,
           })
 
           const apiResponse = await payload.findByID({
             id: upload.id,
             collection: mediaSlug,
+            overrideAccess: true,
           })
           expect(apiResponse.sizes).toBeTruthy()
 
@@ -435,6 +442,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-cloud-storage', () => 
             collection: mediaWithPrefixSlug,
             data: {},
             filePath: path.resolve(dirname, '../uploads/image.png'),
+            overrideAccess: true,
           })
 
           expect(upload.filename).toBeTruthy()
@@ -469,6 +477,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-cloud-storage', () => 
             collection: mediaWithCustomURLSlug,
             data: {},
             filePath: path.resolve(dirname, '../uploads/image.png'),
+            overrideAccess: true,
           })
 
           expect(upload.id).toBeTruthy()
@@ -496,6 +505,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-cloud-storage', () => 
           const apiResponse = await payload.findByID({
             id: upload.id,
             collection: mediaWithCustomURLSlug,
+            overrideAccess: true,
           })
 
           expect(apiResponse.url).toContain('test-cdn.example.com')
@@ -509,6 +519,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-cloud-storage', () => 
             collection: mediaWithGenerateFileURLSlug,
             data: {},
             filePath: path.resolve(dirname, '../uploads/image.png'),
+            overrideAccess: true,
           })
 
           expect(upload.id).toBeTruthy()
@@ -534,6 +545,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-cloud-storage', () => 
           const apiResponse = await payload.findByID({
             id: upload.id,
             collection: mediaWithGenerateFileURLSlug,
+            overrideAccess: true,
           })
 
           expect(apiResponse.url).toContain('cdn-proxied.example.com')
@@ -548,7 +560,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-cloud-storage', () => 
       test.afterEach(async ({ payload }) => {
         for (const id of createdIDs) {
           try {
-            await payload.delete({ id, collection: testMetadataSlug })
+            await payload.delete({ id, collection: testMetadataSlug, overrideAccess: true })
           } catch (e) {
             // Ignore
           }
@@ -565,6 +577,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-cloud-storage', () => 
             testNote: 'Testing automatic metadata persistence',
           },
           filePath: path.resolve(dirname, '../uploads/image.png'),
+          overrideAccess: true,
         })
 
         createdIDs.push(upload.id)
@@ -656,6 +669,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-cloud-storage', () => 
             testNote: 'Testing update metadata persistence',
           },
           filePath: path.resolve(dirname, '../uploads/image.png'),
+          overrideAccess: true,
         })
 
         createdIDs.push(upload.id)
@@ -670,6 +684,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-cloud-storage', () => 
             testNote: 'Updated test note',
           },
           filePath: path.resolve(dirname, './image.png'),
+          overrideAccess: true,
         })
 
         expect(updatedUpload.testNote).toBe('Updated test note')
@@ -706,7 +721,11 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-cloud-storage', () => 
       test.afterEach(async ({ payload }) => {
         for (const id of createdIDs) {
           try {
-            await payload.delete({ id, collection: mediaWithThrowingHookSlug })
+            await payload.delete({
+              id,
+              collection: mediaWithThrowingHookSlug,
+              overrideAccess: true,
+            })
           } catch (_) {
             // Ignore
           }
@@ -722,6 +741,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-cloud-storage', () => 
             collection: mediaWithThrowingHookSlug,
             data: { shouldThrow: true },
             filePath: path.resolve(dirname, '../uploads/image.png'),
+            overrideAccess: true,
           }),
         ).rejects.toThrow('User afterChange hook throws error')
       })
@@ -741,6 +761,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-cloud-storage', () => 
           collection: mediaWithThrowingHookSlug,
           data: { shouldThrow: false },
           file: buildFile('initial.png'),
+          overrideAccess: true,
         })
 
         createdIDs.push(initial.id)
@@ -757,6 +778,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-cloud-storage', () => 
             collection: mediaWithThrowingHookSlug,
             data: { shouldThrow: true },
             file: buildFile('replacement.png'),
+            overrideAccess: true,
           }),
         ).rejects.toThrow('User afterChange hook throws error')
 
@@ -773,7 +795,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-cloud-storage', () => 
       test.afterEach(async ({ payload }) => {
         for (const id of createdIDs) {
           try {
-            await payload.delete({ id, collection: mediaWithOverwriteSlug })
+            await payload.delete({ id, collection: mediaWithOverwriteSlug, overrideAccess: true })
           } catch (_) {
             // Ignore
           }
@@ -797,6 +819,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-cloud-storage', () => 
           data: {},
           file: buildFile('overwrite.png'),
           overwriteExistingFiles: true,
+          overrideAccess: true,
         })) as unknown as {
           filename: string
           id: number | string
@@ -824,6 +847,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-cloud-storage', () => 
           data: {},
           file: buildFile('overwrite.png'),
           overwriteExistingFiles: true,
+          overrideAccess: true,
         })) as unknown as {
           filename: string
           sizes: Record<string, { filename: string }>

--- a/test/plugin-ecommerce/app/(shop)/shop/order/[id]/page.tsx
+++ b/test/plugin-ecommerce/app/(shop)/shop/order/[id]/page.tsx
@@ -14,6 +14,7 @@ export const Page = async ({ params: paramsPromise }: { params: Promise<{ id: st
     collection: 'orders',
     id: orderID,
     depth: 2,
+    overrideAccess: true,
   })
 
   return (

--- a/test/plugin-ecommerce/app/(shop)/shop/page.tsx
+++ b/test/plugin-ecommerce/app/(shop)/shop/page.tsx
@@ -15,6 +15,7 @@ export const Page = async () => {
     collection: 'products',
     depth: 2,
     limit: 10,
+    overrideAccess: true,
   })
 
   return (

--- a/test/plugin-ecommerce/config.ts
+++ b/test/plugin-ecommerce/config.ts
@@ -125,6 +125,7 @@ export default buildConfigWithDefaults({
         email: devUser.email,
         password: devUser.password,
       },
+      overrideAccess: true,
     })
 
     await seed(payload)

--- a/test/plugin-ecommerce/e2e.spec.ts
+++ b/test/plugin-ecommerce/e2e.spec.ts
@@ -54,6 +54,7 @@ test.describe('Ecommerce Plugin', () => {
         priceInUSD: 1999,
         priceInUSDEnabled: true,
       },
+      overrideAccess: true,
     })
     productWithPriceId = productWithPrice.id
     createdProductIDs.push(productWithPriceId)
@@ -65,6 +66,7 @@ test.describe('Ecommerce Plugin', () => {
         priceInUSD: 0,
         priceInUSDEnabled: true,
       },
+      overrideAccess: true,
     })
     zeroPriceProductId = zeroPriceProduct.id
     createdProductIDs.push(zeroPriceProductId)
@@ -73,6 +75,7 @@ test.describe('Ecommerce Plugin', () => {
     const noPriceProduct = await payload.create({
       collection: 'products',
       data: {},
+      overrideAccess: true,
     })
     noPriceProductId = noPriceProduct.id
     createdProductIDs.push(noPriceProductId)
@@ -82,6 +85,7 @@ test.describe('Ecommerce Plugin', () => {
       collection: 'variants',
       limit: 1,
       where: { priceInUSD: { equals: 1999 } },
+      overrideAccess: true,
     })
 
     if (seededVariants.docs.length > 0) {
@@ -91,7 +95,7 @@ test.describe('Ecommerce Plugin', () => {
 
   test.afterAll(async () => {
     for (const id of createdProductIDs) {
-      await payload.delete({ id, collection: 'products' }).catch(() => {})
+      await payload.delete({ id, collection: 'products', overrideAccess: true }).catch(() => {})
     }
   })
 
@@ -170,6 +174,7 @@ test.describe('Ecommerce Plugin', () => {
           priceInUSD: 999,
           priceInUSDEnabled: true,
         },
+        overrideAccess: true,
       })
       createdProductIDs.push(editableProduct.id)
 
@@ -197,6 +202,7 @@ test.describe('Ecommerce Plugin', () => {
       const updatedProductResult = await payload.find({
         collection: 'products',
         where: { id: { equals: editableProduct.id } },
+        overrideAccess: true,
       })
       expect(updatedProductResult.docs[0]?.priceInUSD).toBe(2499)
     })

--- a/test/plugin-ecommerce/int.spec.ts
+++ b/test/plugin-ecommerce/int.spec.ts
@@ -48,6 +48,7 @@ test.suite({ config: './config.ts' })('ecommerce', () => {
       collection: 'variants',
       depth: 0,
       limit: 1,
+      overrideAccess: true,
     })
 
     expect(variants).toBeTruthy()
@@ -287,12 +288,14 @@ test.suite({ config: './config.ts' })('ecommerce', () => {
       const products = await payload.find({
         collection: 'products',
         limit: 1,
+        overrideAccess: true,
       })
       productId = products.docs[0]?.id as string
 
       const variants = await payload.find({
         collection: 'variants',
         limit: 1,
+        overrideAccess: true,
       })
       variantId = variants.docs[0]?.id as string
     })
@@ -748,12 +751,14 @@ test.suite({ config: './config.ts' })('ecommerce', () => {
       const products = await payload.find({
         collection: 'products',
         limit: 1,
+        overrideAccess: true,
       })
       productId = products.docs[0]?.id as string
 
       const variants = await payload.find({
         collection: 'variants',
         limit: 1,
+        overrideAccess: true,
       })
       variantId = variants.docs[0]?.id as string
     })
@@ -772,6 +777,7 @@ test.suite({ config: './config.ts' })('ecommerce', () => {
           email: `merge-test-${Date.now()}@test.com`,
           password: 'test123',
         },
+        overrideAccess: true,
       })
 
       await restClient.login({
@@ -857,6 +863,7 @@ test.suite({ config: './config.ts' })('ecommerce', () => {
           email: `merge-combine-${Date.now()}@test.com`,
           password: 'test123',
         },
+        overrideAccess: true,
       })
 
       await restClient.login({
@@ -921,6 +928,7 @@ test.suite({ config: './config.ts' })('ecommerce', () => {
           email: `merge-delete-${Date.now()}@test.com`,
           password: 'test123',
         },
+        overrideAccess: true,
       })
 
       await restClient.login({
@@ -1001,6 +1009,7 @@ test.suite({ config: './config.ts' })('ecommerce', () => {
           email: `merge-invalid-${Date.now()}@test.com`,
           password: 'test123',
         },
+        overrideAccess: true,
       })
 
       await restClient.login({
@@ -1041,6 +1050,7 @@ test.suite({ config: './config.ts' })('ecommerce', () => {
       const products = await payload.find({
         collection: 'products',
         limit: 1,
+        overrideAccess: true,
       })
       productId = products.docs[0]?.id as string
     })
@@ -1055,6 +1065,7 @@ test.suite({ config: './config.ts' })('ecommerce', () => {
           email: `auth-cart-${Date.now()}@test.com`,
           password: 'test123',
         },
+        overrideAccess: true,
       })
 
       await restClient.login({
@@ -1094,6 +1105,7 @@ test.suite({ config: './config.ts' })('ecommerce', () => {
           email: `auth-add-${Date.now()}@test.com`,
           password: 'test123',
         },
+        overrideAccess: true,
       })
 
       await restClient.login({
@@ -1139,6 +1151,7 @@ test.suite({ config: './config.ts' })('ecommerce', () => {
           email: `auth-nosecret-${Date.now()}@test.com`,
           password: 'test123',
         },
+        overrideAccess: true,
       })
 
       await restClient.login({
@@ -1171,6 +1184,7 @@ test.suite({ config: './config.ts' })('ecommerce', () => {
       const products = await payload.find({
         collection: 'products',
         limit: 1,
+        overrideAccess: true,
       })
       productId = products.docs[0]?.id as string
     })
@@ -1192,6 +1206,7 @@ test.suite({ config: './config.ts' })('ecommerce', () => {
           email: `transfer-${Date.now()}@test.com`,
           password: 'test123',
         },
+        overrideAccess: true,
       })
 
       // Login as the user

--- a/test/plugin-ecommerce/seed/index.ts
+++ b/test/plugin-ecommerce/seed/index.ts
@@ -24,6 +24,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
         password: 'customer',
       },
       req,
+      overrideAccess: true,
     })
 
     const sizeVariantType = await payload.create({
@@ -32,6 +33,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
         name: 'size',
         label: 'Size',
       },
+      overrideAccess: true,
     })
 
     const [small, medium, large, xlarge] = await Promise.all(
@@ -42,6 +44,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
             ...option,
             variantType: sizeVariantType.id,
           },
+          overrideAccess: true,
         })
       }),
     )
@@ -52,6 +55,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
         name: 'color',
         label: 'Color',
       },
+      overrideAccess: true,
     })
 
     const [black, white] = await Promise.all(
@@ -62,6 +66,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
             ...option,
             variantType: colorVariantType.id,
           },
+          overrideAccess: true,
         })
       }),
     )
@@ -73,6 +78,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
         variantTypes: [sizeVariantType.id, colorVariantType.id],
         enableVariants: true,
       },
+      overrideAccess: true,
     })
 
     const hoodieSmallWhite = await payload.create({
@@ -84,6 +90,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
         priceInUSDEnabled: true,
         priceInUSD: 1999,
       },
+      overrideAccess: true,
     })
 
     const hoodieMediumWhite = await payload.create({
@@ -95,6 +102,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
         priceInUSDEnabled: true,
         priceInUSD: 1999,
       },
+      overrideAccess: true,
     })
 
     const hatProduct = await payload.create({
@@ -106,6 +114,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
         priceInEUREnabled: true,
         priceInEUR: 2599,
       },
+      overrideAccess: true,
     })
 
     const pendingPaymentRecord = await payload.create({
@@ -120,6 +129,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
         },
         status: 'pending',
       },
+      overrideAccess: true,
     })
 
     const succeededPaymentRecord = await payload.create({
@@ -134,6 +144,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
         },
         status: 'succeeded',
       },
+      overrideAccess: true,
     })
 
     return true

--- a/test/plugin-form-builder/components/views/UploadFormTest/index.tsx
+++ b/test/plugin-form-builder/components/views/UploadFormTest/index.tsx
@@ -37,6 +37,7 @@ async function UploadFormTestViewAsync({
     collection: 'forms',
     depth: 0,
     limit: 100,
+    overrideAccess: true,
     pagination: false,
   })
 

--- a/test/plugin-form-builder/config.ts
+++ b/test/plugin-form-builder/config.ts
@@ -173,6 +173,7 @@ export default buildConfigWithDefaults({
         password: devUser.password,
         roles: ['admin'],
       },
+      overrideAccess: true,
     })
 
     await seed(payload)

--- a/test/plugin-form-builder/e2e.spec.ts
+++ b/test/plugin-form-builder/e2e.spec.ts
@@ -96,12 +96,14 @@ test.describe('Form Builder Plugin', () => {
         collection: formsSlug,
         limit: 1,
         where: { title: { equals: 'Contact Form' } },
+        overrideAccess: true,
       })
       const { docs: submissions } = await payload.find({
         collection: formSubmissionsSlug,
         limit: 1,
         sort: 'createdAt',
         where: { form: { equals: contactForms[0]!.id } },
+        overrideAccess: true,
       })
       const seededSubmission = submissions[0]!
 
@@ -124,6 +126,7 @@ test.describe('Form Builder Plugin', () => {
             contains: 'Contact',
           },
         },
+        overrideAccess: true,
       })
 
       const createdSubmission = await payload.create({
@@ -141,6 +144,7 @@ test.describe('Form Builder Plugin', () => {
             },
           ],
         },
+        overrideAccess: true,
       })
 
       await page.goto(submissionsUrl.edit(createdSubmission.id))
@@ -181,6 +185,7 @@ test.describe('Form Builder Plugin', () => {
             contains: 'Booking',
           },
         },
+        overrideAccess: true,
       })
 
       const createdSubmission = await payload.create({
@@ -202,6 +207,7 @@ test.describe('Form Builder Plugin', () => {
             },
           ],
         },
+        overrideAccess: true,
       })
 
       await page.goto(submissionsUrl.edit(createdSubmission.id))
@@ -224,6 +230,7 @@ test.describe('Form Builder Plugin', () => {
             equals: 'Upload Form',
           },
         },
+        overrideAccess: true,
       })
 
       const uploadForm = docs[0]
@@ -256,6 +263,7 @@ test.describe('Form Builder Plugin', () => {
         depth: 0,
         limit: 1,
         where: { id: { equals: result.doc.id } },
+        overrideAccess: true,
       })
       const avatarUpload = submissionDocs[0]?.submissionUploads?.[0]
       // value is now hasMany array; at depth=0 each item is { relationTo, value: rawId }
@@ -270,13 +278,18 @@ test.describe('Form Builder Plugin', () => {
       const { docs: mediaDocs } = await payload.find({
         collection: mediaSlug,
         where: { id: { equals: mediaId } },
+        overrideAccess: true,
       })
       expect(mediaDocs[0]).toBeDefined()
       expect(mediaDocs[0]?.filename).toContain('test-avatar')
 
       // Cleanup
-      await payload.delete({ id: String(result.doc.id), collection: formSubmissionsSlug })
-      await payload.delete({ id: mediaId, collection: mediaSlug })
+      await payload.delete({
+        id: String(result.doc.id),
+        collection: formSubmissionsSlug,
+        overrideAccess: true,
+      })
+      await payload.delete({ id: mediaId, collection: mediaSlug, overrideAccess: true })
     })
 
     test('validates required upload field via REST API', async ({ request }) => {
@@ -287,6 +300,7 @@ test.describe('Form Builder Plugin', () => {
             equals: 'Upload Form',
           },
         },
+        overrideAccess: true,
       })
 
       const uploadForm = docs[0]
@@ -317,6 +331,7 @@ test.describe('Form Builder Plugin', () => {
             equals: 'Image Upload Form',
           },
         },
+        overrideAccess: true,
       })
 
       const imageForm = docs[0]
@@ -363,6 +378,7 @@ test.describe('Form Builder Plugin', () => {
             equals: 'Image Upload Form',
           },
         },
+        overrideAccess: true,
       })
 
       const imageForm = docs[0]
@@ -393,6 +409,7 @@ test.describe('Form Builder Plugin', () => {
         depth: 0,
         limit: 1,
         where: { id: { equals: result.doc.id } },
+        overrideAccess: true,
       })
       const imageUpload = submissionDocs[0]?.submissionUploads?.[0]
       // value is now hasMany array; at depth=0 each item is { relationTo, value: rawId }
@@ -404,8 +421,12 @@ test.describe('Form Builder Plugin', () => {
       expect(imageRelation?.relationTo).toBe(mediaSlug)
 
       // Cleanup
-      await payload.delete({ id: String(result.doc.id), collection: formSubmissionsSlug })
-      await payload.delete({ id: imageMediaId, collection: mediaSlug })
+      await payload.delete({
+        id: String(result.doc.id),
+        collection: formSubmissionsSlug,
+        overrideAccess: true,
+      })
+      await payload.delete({ id: imageMediaId, collection: mediaSlug, overrideAccess: true })
     })
 
     test('supports pre-uploaded file IDs for backwards compatibility via REST API', async ({
@@ -418,6 +439,7 @@ test.describe('Form Builder Plugin', () => {
             equals: 'Upload Form',
           },
         },
+        overrideAccess: true,
       })
 
       const uploadForm = docs[0]
@@ -459,6 +481,7 @@ test.describe('Form Builder Plugin', () => {
         depth: 0,
         limit: 1,
         where: { id: { equals: result.doc.id } },
+        overrideAccess: true,
       })
       const avatarUpload = submissionDocs[0]?.submissionUploads?.[0]
       // value is now hasMany array; at depth=0 each item is { relationTo, value: rawId }
@@ -469,8 +492,16 @@ test.describe('Form Builder Plugin', () => {
       expect(String(avatarRelation?.value)).toBe(String(preUploadedFileId))
 
       // Cleanup
-      await payload.delete({ id: String(result.doc.id), collection: formSubmissionsSlug })
-      await payload.delete({ id: String(preUploadedFileId), collection: mediaSlug })
+      await payload.delete({
+        id: String(result.doc.id),
+        collection: formSubmissionsSlug,
+        overrideAccess: true,
+      })
+      await payload.delete({
+        id: String(preUploadedFileId),
+        collection: mediaSlug,
+        overrideAccess: true,
+      })
     })
 
     test('can submit form with mixed fields (text + upload) via REST API', async ({ request }) => {
@@ -481,6 +512,7 @@ test.describe('Form Builder Plugin', () => {
             equals: 'Upload Form',
           },
         },
+        overrideAccess: true,
       })
 
       const uploadForm = docs[0]
@@ -517,6 +549,7 @@ test.describe('Form Builder Plugin', () => {
         depth: 0,
         limit: 1,
         where: { id: { equals: result.doc.id } },
+        overrideAccess: true,
       })
       const avatarUpload = submissionDocs[0]?.submissionUploads?.[0]
       // value is now hasMany array; at depth=0 each item is { relationTo, value: rawId }
@@ -528,8 +561,12 @@ test.describe('Form Builder Plugin', () => {
       expect(avatarRelation?.relationTo).toBe(mediaSlug)
 
       // Cleanup
-      await payload.delete({ id: String(result.doc.id), collection: formSubmissionsSlug })
-      await payload.delete({ id: avatarMediaId, collection: mediaSlug })
+      await payload.delete({
+        id: String(result.doc.id),
+        collection: formSubmissionsSlug,
+        overrideAccess: true,
+      })
+      await payload.delete({ id: avatarMediaId, collection: mediaSlug, overrideAccess: true })
     })
 
     test('can submit multi-file upload form via REST API and stores one entry per field', async ({
@@ -538,6 +575,7 @@ test.describe('Form Builder Plugin', () => {
       const { docs } = await payload.find({
         collection: 'forms',
         where: { title: { equals: 'Multi-File Upload Form' } },
+        overrideAccess: true,
       })
 
       const multiFileForm = docs[0]!
@@ -568,6 +606,7 @@ test.describe('Form Builder Plugin', () => {
         depth: 0,
         limit: 1,
         where: { id: { equals: result.doc.id } },
+        overrideAccess: true,
       })
 
       const submissionUploads = submissionDocs[0]?.submissionUploads
@@ -590,9 +629,21 @@ test.describe('Form Builder Plugin', () => {
       expect(docItems[0]?.relationTo).toBe(documentsSlug)
 
       // Cleanup
-      await payload.delete({ id: String(result.doc.id), collection: formSubmissionsSlug })
-      await payload.delete({ id: photosItems[0]!.value, collection: mediaSlug })
-      await payload.delete({ id: docItems[0]!.value, collection: documentsSlug })
+      await payload.delete({
+        id: String(result.doc.id),
+        collection: formSubmissionsSlug,
+        overrideAccess: true,
+      })
+      await payload.delete({
+        id: photosItems[0]!.value,
+        collection: mediaSlug,
+        overrideAccess: true,
+      })
+      await payload.delete({
+        id: docItems[0]!.value,
+        collection: documentsSlug,
+        overrideAccess: true,
+      })
     })
   })
 
@@ -606,14 +657,17 @@ test.describe('Form Builder Plugin', () => {
       const { docs: uploadForms } = await payload.find({
         collection: formsSlug,
         where: { title: { equals: 'Upload Form' } },
+        overrideAccess: true,
       })
       const { docs: imageForms } = await payload.find({
         collection: formsSlug,
         where: { title: { equals: 'Image Upload Form' } },
+        overrideAccess: true,
       })
       const { docs: multiFileForms } = await payload.find({
         collection: formsSlug,
         where: { title: { equals: 'Multi-File Upload Form' } },
+        overrideAccess: true,
       })
       uploadFormId = uploadForms[0]!.id
       imageFormId = imageForms[0]!.id
@@ -652,8 +706,12 @@ test.describe('Form Builder Plugin', () => {
 
       expect(submissionId).toBeTruthy()
       expect(mediaId).toBeTruthy()
-      await payload.delete({ id: submissionId!, collection: formSubmissionsSlug })
-      await payload.delete({ id: mediaId!, collection: mediaSlug })
+      await payload.delete({
+        id: submissionId!,
+        collection: formSubmissionsSlug,
+        overrideAccess: true,
+      })
+      await payload.delete({ id: mediaId!, collection: mediaSlug, overrideAccess: true })
     })
 
     test('Upload Form: submission is visible in admin with submissionUploads image', async () => {
@@ -687,8 +745,12 @@ test.describe('Form Builder Plugin', () => {
       })
 
       // Cleanup
-      await payload.delete({ id: submissionId!, collection: formSubmissionsSlug })
-      await payload.delete({ id: mediaId!, collection: mediaSlug })
+      await payload.delete({
+        id: submissionId!,
+        collection: formSubmissionsSlug,
+        overrideAccess: true,
+      })
+      await payload.delete({ id: mediaId!, collection: mediaSlug, overrideAccess: true })
     })
 
     test('Image Upload Form: shows MIME type error when uploading PDF', async () => {
@@ -729,8 +791,12 @@ test.describe('Form Builder Plugin', () => {
 
       expect(submissionId).toBeTruthy()
       expect(mediaId).toBeTruthy()
-      await payload.delete({ id: submissionId!, collection: formSubmissionsSlug })
-      await payload.delete({ id: mediaId!, collection: mediaSlug })
+      await payload.delete({
+        id: submissionId!,
+        collection: formSubmissionsSlug,
+        overrideAccess: true,
+      })
+      await payload.delete({ id: mediaId!, collection: mediaSlug, overrideAccess: true })
     })
 
     test('Multi-File Upload Form: submits two images + one document and shows both collections in result', async () => {
@@ -766,6 +832,7 @@ test.describe('Form Builder Plugin', () => {
         depth: 0,
         limit: 1,
         where: { id: { equals: submissionId! } },
+        overrideAccess: true,
       })
 
       const uploadedIdsByCollection = new Map<string, string[]>()
@@ -778,11 +845,19 @@ test.describe('Form Builder Plugin', () => {
         }
       }
 
-      await payload.delete({ id: submissionId!, collection: formSubmissionsSlug })
+      await payload.delete({
+        id: submissionId!,
+        collection: formSubmissionsSlug,
+        overrideAccess: true,
+      })
 
       for (const [collection, ids] of uploadedIdsByCollection.entries()) {
         for (const id of ids) {
-          await payload.delete({ id, collection: collection as 'documents' | 'media' })
+          await payload.delete({
+            id,
+            collection: collection as 'documents' | 'media',
+            overrideAccess: true,
+          })
         }
       }
     })

--- a/test/plugin-form-builder/int.spec.ts
+++ b/test/plugin-form-builder/int.spec.ts
@@ -68,17 +68,18 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
     form = (await payload.create({
       collection: formsSlug,
       data: formConfig,
+      overrideAccess: true,
     })) as unknown as Form
   })
 
   test.describe('plugin collections', () => {
     test('adds forms collection', async ({ payload }) => {
-      const { docs: forms } = await payload.find({ collection: formsSlug })
+      const { docs: forms } = await payload.find({ collection: formsSlug, overrideAccess: true })
       expect(forms.length).toBeGreaterThan(0)
     })
 
     test('adds form submissions collection', async ({ payload }) => {
-      const { docs: formSubmissions } = await payload.find({ collection: formSubmissionsSlug })
+      const { docs: formSubmissions } = await payload.find({ collection: formSubmissionsSlug, overrideAccess: true })
       expect(formSubmissions).toHaveLength(1)
     })
   })
@@ -130,6 +131,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
       const testForm = await payload.create({
         collection: formsSlug,
         data: formConfig,
+        overrideAccess: true,
       })
 
       expect(testForm).toHaveProperty('fields')
@@ -178,6 +180,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
       const testForm = await payload.create({
         collection: formsSlug,
         data: formConfig,
+        overrideAccess: true,
       })
 
       expect(testForm).toHaveProperty('custom', 'custom')
@@ -198,6 +201,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
           ],
         },
         depth: 0,
+        overrideAccess: true,
       })
 
       expect(formSubmission).toHaveProperty('form', form.id)
@@ -221,6 +225,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
             ],
           },
           depth: 0,
+          overrideAccess: true,
         })
 
       await expect(req).rejects.toThrow(ValidationError)
@@ -672,7 +677,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
     test.afterEach(async ({ payload }) => {
       for (const id of createdSubmissionIds) {
         try {
-          await payload.delete({ collection: formSubmissionsSlug, id })
+          await payload.delete({ collection: formSubmissionsSlug, id, overrideAccess: true })
         } catch {
           // ignore if already deleted
         }
@@ -681,7 +686,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
 
       for (const id of createdFormIds) {
         try {
-          await payload.delete({ collection: formsSlug, id })
+          await payload.delete({ collection: formsSlug, id, overrideAccess: true })
         } catch {
           // ignore if already deleted
         }
@@ -690,7 +695,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
 
       for (const id of createdMediaIds) {
         try {
-          await payload.delete({ collection: mediaSlug, id })
+          await payload.delete({ collection: mediaSlug, id, overrideAccess: true })
         } catch {
           // ignore if already deleted
         }
@@ -699,7 +704,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
 
       for (const id of createdDocumentIds) {
         try {
-          await payload.delete({ collection: documentsSlug, id })
+          await payload.delete({ collection: documentsSlug, id, overrideAccess: true })
         } catch {
           // ignore if already deleted
         }
@@ -757,6 +762,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
               },
             ],
           },
+          overrideAccess: true,
         })
 
         createdFormIds.push(testForm.id)
@@ -787,6 +793,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
               },
             ],
           },
+          overrideAccess: true,
         })
 
         createdFormIds.push(testForm.id)
@@ -807,6 +814,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
               { blockType: 'upload', name: 'avatar', uploadCollection: mediaSlug },
             ],
           },
+          overrideAccess: true,
         })
 
         createdFormIds.push(testForm.id)
@@ -836,6 +844,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
               },
             ],
           },
+          overrideAccess: true,
         })
 
         createdFormIds.push(testForm.id)
@@ -847,6 +856,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
               form: testForm.id,
               submissionData: [],
             },
+            overrideAccess: true,
           }),
         ).rejects.toThrow(ValidationError)
       })
@@ -870,6 +880,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
               },
             ],
           },
+          overrideAccess: true,
         })
 
         createdFormIds.push(testForm.id)
@@ -881,6 +892,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
               form: testForm.id,
               submissionData: [{ field: 'requiredFile', value: '' }],
             },
+            overrideAccess: true,
           }),
         ).rejects.toThrow(ValidationError)
       })
@@ -893,6 +905,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
           collection: mediaSlug,
           data: { alt: 'test' },
           filePath: testImagePath,
+          overrideAccess: true,
         })
 
         createdMediaIds.push(mediaDoc.id)
@@ -912,6 +925,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
               },
             ],
           },
+          overrideAccess: true,
         })
 
         createdFormIds.push(testForm.id)
@@ -922,6 +936,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
             form: testForm.id,
             submissionData: [{ field: 'requiredFile', value: mediaDoc.id }],
           },
+          overrideAccess: true,
         })
 
         createdSubmissionIds.push(submission.id)
@@ -954,6 +969,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
               },
             ],
           },
+          overrideAccess: true,
         })
 
         createdFormIds.push(testForm.id)
@@ -964,6 +980,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
             form: testForm.id,
             submissionData: [{ field: 'name', value: 'John Doe' }],
           },
+          overrideAccess: true,
         })
 
         createdSubmissionIds.push(submission.id)
@@ -976,6 +993,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
           collection: mediaSlug,
           data: { alt: 'test' },
           filePath: testImagePath,
+          overrideAccess: true,
         })
 
         createdMediaIds.push(mediaDoc.id)
@@ -1007,6 +1025,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
               },
             ],
           },
+          overrideAccess: true,
         })
 
         createdFormIds.push(testForm.id)
@@ -1017,6 +1036,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
             form: testForm.id,
             submissionData: [{ field: 'required', value: mediaDoc.id }],
           },
+          overrideAccess: true,
         })
 
         createdSubmissionIds.push(submission.id)
@@ -1032,6 +1052,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
           collection: documentsSlug,
           data: {},
           filePath: testPdfPath,
+          overrideAccess: true,
         })
 
         createdDocumentIds.push(pdfDoc.id)
@@ -1052,6 +1073,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
               },
             ],
           },
+          overrideAccess: true,
         })
 
         createdFormIds.push(testForm.id)
@@ -1065,6 +1087,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
               form: testForm.id,
               submissionData: [{ field: 'image', value: pdfDoc.id }],
             },
+            overrideAccess: true,
           }),
         ).rejects.toThrow(ValidationError)
       })
@@ -1074,6 +1097,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
           collection: mediaSlug,
           data: { alt: 'test' },
           filePath: testImagePath,
+          overrideAccess: true,
         })
 
         createdMediaIds.push(mediaDoc.id)
@@ -1094,6 +1118,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
               },
             ],
           },
+          overrideAccess: true,
         })
 
         createdFormIds.push(testForm.id)
@@ -1104,6 +1129,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
             form: testForm.id,
             submissionData: [{ field: 'image', value: mediaDoc.id }],
           },
+          overrideAccess: true,
         })
 
         createdSubmissionIds.push(submission.id)
@@ -1129,6 +1155,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
               },
             ],
           },
+          overrideAccess: true,
         })
 
         createdFormIds.push(testForm.id)
@@ -1140,6 +1167,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
               form: testForm.id,
               submissionData: [{ field: 'file', value: '507f1f77bcf86cd799439011' }],
             },
+            overrideAccess: true,
           }),
         ).rejects.toThrow(ValidationError)
       })
@@ -1151,6 +1179,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
           collection: mediaSlug,
           data: { alt: 'test' },
           filePath: testImagePath,
+          overrideAccess: true,
         })
 
         createdMediaIds.push(mediaDoc.id)
@@ -1167,6 +1196,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
               { blockType: 'upload', name: 'avatar', uploadCollection: mediaSlug },
             ],
           },
+          overrideAccess: true,
         })
 
         createdFormIds.push(testForm.id)
@@ -1181,6 +1211,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
               { field: 'avatar', value: mediaDoc.id },
             ],
           },
+          overrideAccess: true,
         })
 
         createdSubmissionIds.push(submission.id)
@@ -1208,6 +1239,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
             title: 'No Upload Form',
             fields: [{ blockType: 'text', name: 'message' }],
           },
+          overrideAccess: true,
         })
 
         createdFormIds.push(testForm.id)
@@ -1218,6 +1250,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
             form: testForm.id,
             submissionData: [{ field: 'message', value: 'Hello World' }],
           },
+          overrideAccess: true,
         })
 
         createdSubmissionIds.push(submission.id)
@@ -1240,6 +1273,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
               { blockType: 'upload', name: 'avatar', uploadCollection: mediaSlug, required: true },
             ],
           },
+          overrideAccess: true,
         })
 
         createdFormIds.push(testForm.id)
@@ -1287,6 +1321,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
         const mediaDoc = await payload.findByID({
           collection: mediaSlug,
           id: avatarMediaId,
+          overrideAccess: true,
         })
 
         expect(mediaDoc).toBeDefined()
@@ -1314,6 +1349,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
               },
             ],
           },
+          overrideAccess: true,
         })
 
         createdFormIds.push(testForm.id)
@@ -1357,6 +1393,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
               { blockType: 'upload', name: 'photo', uploadCollection: mediaSlug },
             ],
           },
+          overrideAccess: true,
         })
 
         createdFormIds.push(testForm.id)
@@ -1423,6 +1460,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
           collection: mediaSlug,
           data: { alt: 'test' },
           filePath: testImagePath,
+          overrideAccess: true,
         })
 
         createdMediaIds.push(mediaDoc.id)
@@ -1442,6 +1480,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
               },
             ],
           },
+          overrideAccess: true,
         })
 
         createdFormIds.push(testForm.id)
@@ -1495,6 +1534,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
               },
             ],
           },
+          overrideAccess: true,
         })
         createdFormIds.push(testForm.id)
 
@@ -1547,6 +1587,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
           collection: mediaSlug,
           data: { alt: 'pre-upload' },
           filePath: testImagePath,
+          overrideAccess: true,
         })
         createdMediaIds.push(mediaDoc.id)
 
@@ -1565,6 +1606,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
               },
             ],
           },
+          overrideAccess: true,
         })
         createdFormIds.push(testForm.id)
 
@@ -1603,6 +1645,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
             title: 'submissionUploads empty test',
             fields: [{ blockType: 'text', name: 'fullName', required: true }],
           },
+          overrideAccess: true,
         })
         createdFormIds.push(testForm.id)
 
@@ -1652,6 +1695,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
               },
             ],
           },
+          overrideAccess: true,
         })
         createdFormIds.push(testForm.id)
 
@@ -1706,6 +1750,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
           collection: mediaSlug,
           data: { alt: 'photo-1' },
           filePath: testImagePath,
+          overrideAccess: true,
         })
         createdMediaIds.push(media1.id)
 
@@ -1713,6 +1758,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
           collection: mediaSlug,
           data: { alt: 'photo-2' },
           filePath: testImagePath,
+          overrideAccess: true,
         })
         createdMediaIds.push(media2.id)
 
@@ -1720,6 +1766,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
           collection: documentsSlug,
           data: {},
           filePath: testPdfPath,
+          overrideAccess: true,
         })
         createdDocumentIds.push(docFile.id)
 
@@ -1745,6 +1792,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
               },
             ],
           },
+          overrideAccess: true,
         })
         createdFormIds.push(testForm.id)
 
@@ -1821,6 +1869,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
               },
             ],
           },
+          overrideAccess: true,
         })
 
         createdFormIds.push(testForm.id)
@@ -1867,11 +1916,13 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
           collection: mediaSlug,
           data: { alt: 'first' },
           filePath: testImagePath,
+          overrideAccess: true,
         })
         const mediaDoc2 = await payload.create({
           collection: mediaSlug,
           data: { alt: 'second' },
           filePath: testImagePath,
+          overrideAccess: true,
         })
 
         createdMediaIds.push(mediaDoc1.id, mediaDoc2.id)
@@ -1891,6 +1942,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
               },
             ],
           },
+          overrideAccess: true,
         })
 
         createdFormIds.push(testForm.id)
@@ -1902,6 +1954,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
               form: testForm.id,
               submissionData: [{ field: 'photo', value: `${mediaDoc1.id},${mediaDoc2.id}` }],
             },
+            overrideAccess: true,
           }),
         ).rejects.toThrow(ValidationError)
       })
@@ -1928,6 +1981,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
               },
             ],
           },
+          overrideAccess: true,
         })
 
         createdFormIds.push(testForm.id)
@@ -1983,12 +2037,13 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
               },
             ],
           },
+          overrideAccess: true,
         })
 
         createdFormIds.push(testForm.id)
 
         // Capture media count before the submission attempt
-        const mediaBefore = await payload.find({ collection: mediaSlug, limit: 0 })
+        const mediaBefore = await payload.find({ collection: mediaSlug, limit: 0, overrideAccess: true })
         const countBefore = mediaBefore.totalDocs
 
         const formData = new FormData()
@@ -2019,7 +2074,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
         expect(response.status).toBe(400)
 
         // The image doc created before the PDF validation failure should have been cleaned up
-        const mediaAfter = await payload.find({ collection: mediaSlug, limit: 0 })
+        const mediaAfter = await payload.find({ collection: mediaSlug, limit: 0, overrideAccess: true })
 
         expect(mediaAfter.totalDocs).toBe(countBefore)
       })

--- a/test/plugin-form-builder/seed/index.ts
+++ b/test/plugin-form-builder/seed/index.ts
@@ -14,6 +14,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
         password: 'demo',
       },
       req,
+      overrideAccess: true,
     })
 
     await payload.create({
@@ -23,6 +24,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
         title: 'Home page',
       },
       req,
+      overrideAccess: true,
     })
 
     const { id: formID } = await payload.create({
@@ -76,6 +78,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
         ],
         title: 'Contact Form',
       },
+      overrideAccess: true,
     })
 
     const { id: dateFormID } = await payload.create({
@@ -135,6 +138,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
         ],
         title: 'Booking Form',
       },
+      overrideAccess: true,
     })
 
     await payload.create({
@@ -152,6 +156,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
           },
         ],
       },
+      overrideAccess: true,
     })
 
     await payload.create({
@@ -161,6 +166,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
         form: formID,
         title: 'Contact',
       },
+      overrideAccess: true,
     })
 
     // Create a form with upload field for e2e testing
@@ -216,6 +222,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
         ],
         title: 'Upload Form',
       },
+      overrideAccess: true,
     })
 
     // Create a form with optional upload and MIME type restrictions
@@ -271,6 +278,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
         ],
         title: 'Image Upload Form',
       },
+      overrideAccess: true,
     })
 
     // Create a form with multiple-file upload field (media) + single upload field (documents)
@@ -329,6 +337,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
         ],
         title: 'Multi-File Upload Form',
       },
+      overrideAccess: true,
     })
 
     return true

--- a/test/plugin-import-export/e2e.spec.ts
+++ b/test/plugin-import-export/e2e.spec.ts
@@ -307,12 +307,14 @@ test.describe('Import Export Plugin', () => {
           where: {
             'input.collectionSlug': { equals: 'custom-id-pages' },
           },
+          overrideAccess: true,
         })
         await payload.delete({
           collection: 'exports' as any,
           where: {
             collectionSlug: { equals: 'custom-id-pages' },
           },
+          overrideAccess: true,
         })
 
         await payload.create({
@@ -321,6 +323,7 @@ test.describe('Import Export Plugin', () => {
             id: `e2e-export-${uniqueId}-1`,
             title: 'E2E Export Custom Page 1',
           },
+          overrideAccess: true,
         })
 
         await payload.create({
@@ -329,6 +332,7 @@ test.describe('Import Export Plugin', () => {
             id: `e2e-export-${uniqueId}-2`,
             title: 'E2E Export Custom Page 2',
           },
+          overrideAccess: true,
         })
 
         await page.goto(customIdPagesURL.list)
@@ -385,6 +389,7 @@ test.describe('Import Export Plugin', () => {
               equals: exportId,
             },
           },
+          overrideAccess: true,
         })
         expect(docs.length).toBe(1)
         expect(docs[0].collectionSlug).toBe('custom-id-pages')
@@ -434,6 +439,7 @@ test.describe('Import Export Plugin', () => {
             id: `preview-export-${uniqueId}-1`,
             title: 'Preview Export Test 1',
           },
+          overrideAccess: true,
         })
         createdPages.push(`preview-export-${uniqueId}-1`)
 
@@ -443,6 +449,7 @@ test.describe('Import Export Plugin', () => {
             id: `preview-export-${uniqueId}-2`,
             title: 'Preview Export Test 2',
           },
+          overrideAccess: true,
         })
         createdPages.push(`preview-export-${uniqueId}-2`)
 
@@ -498,6 +505,7 @@ test.describe('Import Export Plugin', () => {
           await payload.delete({
             id,
             collection: 'custom-id-pages' as any,
+            overrideAccess: true,
           })
         }
       })
@@ -636,6 +644,7 @@ test.describe('Import Export Plugin', () => {
           where: {
             title: { contains: pattern },
           },
+          overrideAccess: true,
         })
       }
       createdPageTitlePatterns.length = 0
@@ -644,6 +653,7 @@ test.describe('Import Export Plugin', () => {
         await payload.delete({
           id,
           collection: 'pages',
+          overrideAccess: true,
         })
       }
       createdPageIDs.length = 0
@@ -691,6 +701,7 @@ test.describe('Import Export Plugin', () => {
         where: {
           title: { contains: 'E2E Import Test' },
         },
+        overrideAccess: true,
       })
 
       expect(importedDocs.docs.length).toBeGreaterThanOrEqual(2)
@@ -730,6 +741,7 @@ test.describe('Import Export Plugin', () => {
         where: {
           title: { contains: 'E2E JSON Import' },
         },
+        overrideAccess: true,
       })
 
       expect(importedDocs.docs.length).toBeGreaterThanOrEqual(2)
@@ -799,6 +811,7 @@ test.describe('Import Export Plugin', () => {
           excerpt: 'Original excerpt',
           title: 'E2E Update Test Original',
         },
+        overrideAccess: true,
       })
 
       createdPageIDs.push(existingDoc.id)
@@ -846,6 +859,7 @@ test.describe('Import Export Plugin', () => {
             equals: existingDoc.id,
           },
         },
+        overrideAccess: true,
       })
 
       expect(updatedDoc?.title).toBe('E2E Update Test Modified')
@@ -887,6 +901,7 @@ test.describe('Import Export Plugin', () => {
         where: {
           title: { contains: 'E2E Published Status Test' },
         },
+        overrideAccess: true,
       })
 
       expect(importedDocs.docs.length).toBe(2)
@@ -931,6 +946,7 @@ test.describe('Import Export Plugin', () => {
         where: {
           title: { equals: 'E2E Explicit Draft Test' },
         },
+        overrideAccess: true,
       })
 
       expect(draftDocs.docs.length).toBe(1)
@@ -942,6 +958,7 @@ test.describe('Import Export Plugin', () => {
         where: {
           title: { equals: 'E2E Explicit Published Test' },
         },
+        overrideAccess: true,
       })
 
       expect(publishedDocs.docs.length).toBe(1)
@@ -1014,6 +1031,7 @@ test.describe('Import Export Plugin', () => {
           where: {
             id: { contains: `e2e-custom-${uniqueId}` },
           },
+          overrideAccess: true,
         })
 
         expect(importedPages.totalDocs).toBe(2)
@@ -1098,6 +1116,7 @@ test.describe('Import Export Plugin', () => {
           limit: 1,
           sort: '-createdAt',
           where: {},
+          overrideAccess: true,
         })
         expect(docs[0]?.status).toBe('completed')
       }).toPass({ timeout: POLL_TOPASS_TIMEOUT })
@@ -1107,6 +1126,7 @@ test.describe('Import Export Plugin', () => {
         where: {
           title: { contains: 'S3 E2E Import' },
         },
+        overrideAccess: true,
       })
 
       expect(posts.totalDocs).toBeGreaterThanOrEqual(3)
@@ -1116,10 +1136,12 @@ test.describe('Import Export Plugin', () => {
       await payload.create({
         collection: postsWithS3Slug,
         data: { title: 'S3 E2E Export 1' },
+        overrideAccess: true,
       })
       await payload.create({
         collection: postsWithS3Slug,
         data: { title: 'S3 E2E Export 2' },
+        overrideAccess: true,
       })
 
       await page.goto(s3ExportsURL.create)
@@ -1234,7 +1256,7 @@ test.describe('Import Export Plugin', () => {
     test.beforeAll(async () => {
       pagesURL = new AdminUrlUtil(serverURL, 'pages')
 
-      const users = await payload.find({ collection: 'users', limit: 1 })
+      const users = await payload.find({ collection: 'users', limit: 1, overrideAccess: true })
       const userId = users.docs[0]!.id
 
       await payload.create({
@@ -1246,6 +1268,7 @@ test.describe('Import Export Plugin', () => {
           customRelNameEmail: userId,
           title: 'E2E beforeExport Preview Test',
         },
+        overrideAccess: true,
       })
     })
 
@@ -1253,6 +1276,7 @@ test.describe('Import Export Plugin', () => {
       await payload.delete({
         collection: 'pages',
         where: { title: { equals: 'E2E beforeExport Preview Test' } },
+        overrideAccess: true,
       })
     })
 
@@ -1309,6 +1333,7 @@ test.describe('Import Export Plugin', () => {
         await payload.create({
           collection: 'posts-with-limits',
           data: { title: `E2E Limit Test Post ${i}` },
+          overrideAccess: true,
         })
       }
     })
@@ -1320,6 +1345,7 @@ test.describe('Import Export Plugin', () => {
         where: {
           title: { contains: 'E2E Limit Test Post' },
         },
+        overrideAccess: true,
       })
     })
 
@@ -1468,12 +1494,14 @@ test.describe('Import Export Plugin', () => {
       const devUsers = await payload.find({
         collection: 'users',
         where: { email: { equals: 'dev@payloadcms.com' } },
+        overrideAccess: true,
       })
 
       await payload.update({
         id: devUsers.docs[0]!.id,
         collection: 'users',
         data: { limit: 7 },
+        overrideAccess: true,
       })
 
       // Create 10 test documents (more than both limits)
@@ -1481,6 +1509,7 @@ test.describe('Import Export Plugin', () => {
         await payload.create({
           collection: 'posts-with-limits',
           data: { title: `E2E Dynamic Limit Post ${i}` },
+          overrideAccess: true,
         })
       }
     })
@@ -1490,12 +1519,14 @@ test.describe('Import Export Plugin', () => {
       const devUsers = await payload.find({
         collection: 'users',
         where: { email: { equals: 'dev@payloadcms.com' } },
+        overrideAccess: true,
       })
 
       await payload.update({
         id: devUsers.docs[0]!.id,
         collection: 'users',
         data: { limit: null as unknown as number },
+        overrideAccess: true,
       })
 
       // Clean up test documents
@@ -1504,6 +1535,7 @@ test.describe('Import Export Plugin', () => {
         where: {
           title: { contains: 'E2E Dynamic Limit Post' },
         },
+        overrideAccess: true,
       })
     })
 
@@ -1658,6 +1690,7 @@ test.describe('Import Export Plugin', () => {
         await payload.delete({
           collection: postsWithColumnMapSlug,
           where: { title: { equals: title } },
+          overrideAccess: true,
         })
       }
       createdTitles.length = 0
@@ -1692,6 +1725,7 @@ test.describe('Import Export Plugin', () => {
         const { docs } = await payload.find({
           collection: postsWithColumnMapSlug,
           where: { title: { in: ['E2E Foreign A', 'E2E Foreign B'] } },
+          overrideAccess: true,
         })
         expect(docs).toHaveLength(2)
       }).toPass({ timeout: POLL_TOPASS_TIMEOUT })
@@ -1700,6 +1734,7 @@ test.describe('Import Export Plugin', () => {
         collection: postsWithColumnMapSlug,
         sort: 'title',
         where: { title: { in: ['E2E Foreign A', 'E2E Foreign B'] } },
+        overrideAccess: true,
       })
 
       expect(imported.docs[0]!.title).toBe('E2E Foreign A')
@@ -1713,6 +1748,7 @@ test.describe('Import Export Plugin', () => {
       await payload.create({
         collection: postsWithColumnMapSlug,
         data: { count: 99, excerpt: 'exported summary', title: 'E2E Export Rename' },
+        overrideAccess: true,
       })
       createdTitles.push('E2E Export Rename')
 
@@ -1733,6 +1769,7 @@ test.describe('Import Export Plugin', () => {
         collection: 'posts-with-column-map-export',
         limit: 1,
         sort: '-createdAt',
+        overrideAccess: true,
       })
 
       expect(exports.docs).toHaveLength(1)
@@ -1752,6 +1789,7 @@ test.describe('Import Export Plugin', () => {
       await payload.delete({
         id: exportDoc.id,
         collection: 'posts-with-column-map-export',
+        overrideAccess: true,
       })
     })
   })
@@ -1765,6 +1803,7 @@ test.describe('Import Export Plugin', () => {
         const doc = await payload.create({
           collection: postsWithHooksSlug,
           data: { count: i, secret: `secret-${i}`, title: `Hook Preview Post ${i}` },
+          overrideAccess: true,
         })
         createdPostIds.push(doc.id)
       }
@@ -1772,7 +1811,9 @@ test.describe('Import Export Plugin', () => {
 
     test.afterAll(async () => {
       for (const id of createdPostIds) {
-        await payload.delete({ id, collection: postsWithHooksSlug }).catch(() => null)
+        await payload
+          .delete({ id, collection: postsWithHooksSlug, overrideAccess: true })
+          .catch(() => null)
       }
     })
 

--- a/test/plugin-import-export/field-hooks.int.spec.ts
+++ b/test/plugin-import-export/field-hooks.int.spec.ts
@@ -20,6 +20,7 @@ test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-l
     const loginResult = await payload.login({
       collection: 'users',
       data: { email: devUser.email, password: devUser.password },
+      overrideAccess: true,
     })
 
     user = loginResult.user!
@@ -30,9 +31,14 @@ test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-l
       collection: postsWithFieldHooksSlug,
       limit: 1000,
       pagination: false,
+      overrideAccess: true,
     })
     for (const doc of existing.docs) {
-      await payload.delete({ collection: postsWithFieldHooksSlug, id: doc.id })
+      await payload.delete({
+        collection: postsWithFieldHooksSlug,
+        id: doc.id,
+        overrideAccess: true,
+      })
     }
   })
 
@@ -45,6 +51,7 @@ test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-l
       const post = await payload.create({
         collection: postsWithFieldHooksSlug,
         data: { customExport: 'raw value', title: 'Field Export Test' },
+        overrideAccess: true,
       })
 
       let exportDoc = await payload.create({
@@ -55,11 +62,13 @@ test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-l
           where: { id: { equals: post.id } },
         },
         user,
+        overrideAccess: true,
       })
 
       exportDoc = await payload.findByID({
         id: exportDoc.id,
         collection: 'posts-with-field-hooks-export',
+        overrideAccess: true,
       })
 
       const csvPath = path.join(dirname, 'uploads', exportDoc.filename as string)
@@ -73,6 +82,7 @@ test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-l
       const post = await payload.create({
         collection: postsWithFieldHooksSlug,
         data: { customExport: 'test', title: 'Format CSV Test' },
+        overrideAccess: true,
       })
 
       let exportDoc = await payload.create({
@@ -83,11 +93,13 @@ test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-l
           where: { id: { equals: post.id } },
         },
         user,
+        overrideAccess: true,
       })
 
       exportDoc = await payload.findByID({
         id: exportDoc.id,
         collection: 'posts-with-field-hooks-export',
+        overrideAccess: true,
       })
 
       const csvPath = path.join(dirname, 'uploads', exportDoc.filename as string)
@@ -101,6 +113,7 @@ test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-l
       const post = await payload.create({
         collection: postsWithFieldHooksSlug,
         data: { customExport: 'test', title: 'Format JSON Test' },
+        overrideAccess: true,
       })
 
       let exportDoc = await payload.create({
@@ -111,11 +124,13 @@ test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-l
           where: { id: { equals: post.id } },
         },
         user,
+        overrideAccess: true,
       })
 
       exportDoc = await payload.findByID({
         id: exportDoc.id,
         collection: 'posts-with-field-hooks-export',
+        overrideAccess: true,
       })
 
       const jsonPath = path.join(dirname, 'uploads', exportDoc.filename as string)
@@ -134,6 +149,7 @@ test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-l
           group: { namedTab: { deepField: 'deep value' } },
           title: 'Deep Field Test',
         },
+        overrideAccess: true,
       })
 
       let exportDoc = await payload.create({
@@ -144,11 +160,13 @@ test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-l
           where: { id: { equals: post.id } },
         },
         user,
+        overrideAccess: true,
       })
 
       exportDoc = await payload.findByID({
         id: exportDoc.id,
         collection: 'posts-with-field-hooks-export',
+        overrideAccess: true,
       })
 
       const csvPath = path.join(dirname, 'uploads', exportDoc.filename as string)
@@ -168,6 +186,7 @@ test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-l
           group: { namedTab: { deepField: 'preview deep value' } },
           title: 'Preview Deep Field Test',
         },
+        overrideAccess: true,
       })
 
       const previewResponse = await restClient
@@ -211,11 +230,13 @@ test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-l
         data: { collectionSlug: postsWithFieldHooksSlug, importMode: 'create' },
         file,
         user,
+        overrideAccess: true,
       })
 
       importDoc = await payload.findByID({
         id: importDoc.id,
         collection: 'posts-with-field-hooks-import',
+        overrideAccess: true,
       })
 
       expect(importDoc.status).toBe('completed')
@@ -224,6 +245,7 @@ test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-l
       const imported = await payload.find({
         collection: postsWithFieldHooksSlug,
         where: { customImport: { equals: 'original_value_imported_csv' } },
+        overrideAccess: true,
       })
       expect(imported.docs).toHaveLength(1)
     })
@@ -250,11 +272,13 @@ test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-l
         },
         file,
         user,
+        overrideAccess: true,
       })
 
       importDoc = await payload.findByID({
         id: importDoc.id,
         collection: 'posts-with-field-hooks-import',
+        overrideAccess: true,
       })
 
       expect(importDoc.status).toBe('completed')
@@ -263,6 +287,7 @@ test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-l
       const imported = await payload.find({
         collection: postsWithFieldHooksSlug,
         where: { customImport: { equals: 'json_value_imported_json' } },
+        overrideAccess: true,
       })
       expect(imported.docs).toHaveLength(1)
     })
@@ -279,6 +304,7 @@ test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-l
       const existing = await payload.create({
         collection: postsWithFieldHooksSlug,
         data: { count: 5, title: 'Empty Cell Update Number Test' },
+        overrideAccess: true,
       })
 
       const csvContent = `id,title,count\n${existing.id},"Empty Cell Update Number Test",`
@@ -298,11 +324,13 @@ test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-l
         },
         file,
         user,
+        overrideAccess: true,
       })
 
       importDoc = await payload.findByID({
         id: importDoc.id,
         collection: 'posts-with-field-hooks-import',
+        overrideAccess: true,
       })
 
       expect(importDoc.status).toBe('completed')
@@ -310,6 +338,7 @@ test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-l
       const after = await payload.findByID({
         id: existing.id,
         collection: postsWithFieldHooksSlug,
+        overrideAccess: true,
       })
 
       expect(after.count).toBe(5)
@@ -331,6 +360,7 @@ test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-l
       const post = await payload.create({
         collection: postsWithFieldHooksSlug,
         data: { customExport: 'raw', title: 'Order Test' },
+        overrideAccess: true,
       })
 
       let exportDoc = await payload.create({
@@ -341,11 +371,13 @@ test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-l
           where: { id: { equals: post.id } },
         },
         user,
+        overrideAccess: true,
       })
 
       exportDoc = await payload.findByID({
         id: exportDoc.id,
         collection: 'posts-with-field-hooks-export',
+        overrideAccess: true,
       })
 
       const csvPath = path.join(dirname, 'uploads', exportDoc.filename as string)
@@ -366,6 +398,7 @@ test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-l
       const post = await payload.create({
         collection: postsWithFieldHooksSlug,
         data: { email: 'USER@EXAMPLE.COM', title: 'Reusable Field Test' },
+        overrideAccess: true,
       })
 
       let exportDoc = await payload.create({
@@ -376,11 +409,13 @@ test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-l
           where: { id: { equals: post.id } },
         },
         user,
+        overrideAccess: true,
       })
 
       exportDoc = await payload.findByID({
         id: exportDoc.id,
         collection: 'posts-with-field-hooks-export',
+        overrideAccess: true,
       })
 
       const csvPath = path.join(dirname, 'uploads', exportDoc.filename as string)
@@ -403,6 +438,7 @@ test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-l
       const post = await payload.create({
         collection: postsWithFieldHooksSlug,
         data: { secret: 'plain-text', title: 'Default Behavior Test' },
+        overrideAccess: true,
       })
 
       let exportDoc = await payload.create({
@@ -413,11 +449,13 @@ test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-l
           where: { id: { equals: post.id } },
         },
         user,
+        overrideAccess: true,
       })
 
       exportDoc = await payload.findByID({
         id: exportDoc.id,
         collection: 'posts-with-field-hooks-export',
+        overrideAccess: true,
       })
 
       const csvPath = path.join(dirname, 'uploads', exportDoc.filename as string)
@@ -442,6 +480,7 @@ test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-l
           items: [{ note: 'first' }, { note: 'second' }],
           title: 'Array Export CSV',
         },
+        overrideAccess: true,
       })
 
       let exportDoc = await payload.create({
@@ -452,11 +491,13 @@ test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-l
           where: { id: { equals: post.id } },
         },
         user,
+        overrideAccess: true,
       })
 
       exportDoc = await payload.findByID({
         id: exportDoc.id,
         collection: 'posts-with-field-hooks-export',
+        overrideAccess: true,
       })
 
       const csvPath = path.join(dirname, 'uploads', exportDoc.filename as string)
@@ -475,6 +516,7 @@ test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-l
           items: [{ note: 'alpha' }, { note: 'beta' }],
           title: 'Array Export JSON',
         },
+        overrideAccess: true,
       })
 
       let exportDoc = await payload.create({
@@ -485,11 +527,13 @@ test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-l
           where: { id: { equals: post.id } },
         },
         user,
+        overrideAccess: true,
       })
 
       exportDoc = await payload.findByID({
         id: exportDoc.id,
         collection: 'posts-with-field-hooks-export',
+        overrideAccess: true,
       })
 
       const jsonPath = path.join(dirname, 'uploads', exportDoc.filename as string)
@@ -515,11 +559,13 @@ test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-l
         data: { collectionSlug: postsWithFieldHooksSlug, importMode: 'create' },
         file,
         user,
+        overrideAccess: true,
       })
 
       importDoc = await payload.findByID({
         id: importDoc.id,
         collection: 'posts-with-field-hooks-import',
+        overrideAccess: true,
       })
 
       expect(importDoc.status).toBe('completed')
@@ -527,6 +573,7 @@ test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-l
       const imported = await payload.find({
         collection: postsWithFieldHooksSlug,
         where: { title: { equals: 'Array Import CSV' } },
+        overrideAccess: true,
       })
       expect(imported.docs).toHaveLength(1)
       expect((imported.docs[0] as any).items[0].note).toBe('one_array_imported')
@@ -555,11 +602,13 @@ test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-l
         },
         file,
         user,
+        overrideAccess: true,
       })
 
       importDoc = await payload.findByID({
         id: importDoc.id,
         collection: 'posts-with-field-hooks-import',
+        overrideAccess: true,
       })
 
       expect(importDoc.status).toBe('completed')
@@ -567,6 +616,7 @@ test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-l
       const imported = await payload.find({
         collection: postsWithFieldHooksSlug,
         where: { title: { equals: 'Array Import JSON' } },
+        overrideAccess: true,
       })
       expect(imported.docs).toHaveLength(1)
       expect((imported.docs[0] as any).items[0].note).toBe('uno_array_imported')
@@ -585,6 +635,7 @@ test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-l
           ],
           title: 'Blocks Export CSV',
         },
+        overrideAccess: true,
       })
 
       let exportDoc = await payload.create({
@@ -595,11 +646,13 @@ test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-l
           where: { id: { equals: post.id } },
         },
         user,
+        overrideAccess: true,
       })
 
       exportDoc = await payload.findByID({
         id: exportDoc.id,
         collection: 'posts-with-field-hooks-export',
+        overrideAccess: true,
       })
 
       const csvPath = path.join(dirname, 'uploads', exportDoc.filename as string)
@@ -616,6 +669,7 @@ test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-l
           content: [{ blockType: 'textBlock', body: 'foo' }],
           title: 'Blocks Export JSON',
         },
+        overrideAccess: true,
       })
 
       let exportDoc = await payload.create({
@@ -626,11 +680,13 @@ test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-l
           where: { id: { equals: post.id } },
         },
         user,
+        overrideAccess: true,
       })
 
       exportDoc = await payload.findByID({
         id: exportDoc.id,
         collection: 'posts-with-field-hooks-export',
+        overrideAccess: true,
       })
 
       const jsonPath = path.join(dirname, 'uploads', exportDoc.filename as string)
@@ -653,11 +709,13 @@ test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-l
         data: { collectionSlug: postsWithFieldHooksSlug, importMode: 'create' },
         file,
         user,
+        overrideAccess: true,
       })
 
       importDoc = await payload.findByID({
         id: importDoc.id,
         collection: 'posts-with-field-hooks-import',
+        overrideAccess: true,
       })
 
       expect(importDoc.status).toBe('completed')
@@ -665,6 +723,7 @@ test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-l
       const imported = await payload.find({
         collection: postsWithFieldHooksSlug,
         where: { title: { equals: 'Blocks Import CSV' } },
+        overrideAccess: true,
       })
       expect(imported.docs).toHaveLength(1)
       expect((imported.docs[0] as any).content[0].body).toBe('csv-body_block_imported')
@@ -693,11 +752,13 @@ test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-l
         },
         file,
         user,
+        overrideAccess: true,
       })
 
       importDoc = await payload.findByID({
         id: importDoc.id,
         collection: 'posts-with-field-hooks-import',
+        overrideAccess: true,
       })
 
       expect(importDoc.status).toBe('completed')
@@ -705,6 +766,7 @@ test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-l
       const imported = await payload.find({
         collection: postsWithFieldHooksSlug,
         where: { title: { equals: 'Blocks Import JSON' } },
+        overrideAccess: true,
       })
       expect(imported.docs).toHaveLength(1)
       expect((imported.docs[0] as any).content[0].body).toBe('json-body_block_imported')
@@ -745,11 +807,13 @@ test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-l
         },
         file,
         user,
+        overrideAccess: true,
       })
 
       importDoc = await payload.findByID({
         id: importDoc.id,
         collection: 'posts-with-field-hooks-import',
+        overrideAccess: true,
       })
 
       expect(importDoc.status).toBe('completed')
@@ -757,6 +821,7 @@ test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-l
       const imported = await payload.find({
         collection: postsWithFieldHooksSlug,
         where: { title: { equals: 'Sibling Echo Test' } },
+        overrideAccess: true,
       })
       expect(imported.docs).toHaveLength(1)
       expect((imported.docs[0] as any).metadata.siblingEcho).toBe('start:my-slug')
@@ -790,11 +855,13 @@ test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-l
         data: { collectionSlug: postsWithFieldHooksSlug, importMode: 'create' },
         file,
         user,
+        overrideAccess: true,
       })
 
       importDoc = await payload.findByID({
         id: importDoc.id,
         collection: 'posts-with-field-hooks-import',
+        overrideAccess: true,
       })
 
       expect(importDoc.status).toBe('completed')
@@ -803,6 +870,7 @@ test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-l
         collection: postsWithFieldHooksSlug,
         sort: 'title',
         where: { title: { in: ['Crash Row 1', 'Crash Row 2', 'Crash Row 3'] } },
+        overrideAccess: true,
       })
 
       expect(imported.docs).toHaveLength(3)
@@ -836,11 +904,13 @@ test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-l
         },
         file,
         user,
+        overrideAccess: true,
       })
 
       importDoc = await payload.findByID({
         id: importDoc.id,
         collection: 'posts-with-field-hooks-import',
+        overrideAccess: true,
       })
 
       expect(importDoc.status).toBe('completed')
@@ -849,6 +919,7 @@ test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-l
         collection: postsWithFieldHooksSlug,
         sort: 'title',
         where: { title: { in: ['JSON Crash 1', 'JSON Crash 2', 'JSON Crash 3'] } },
+        overrideAccess: true,
       })
 
       expect(imported.docs).toHaveLength(3)
@@ -865,14 +936,17 @@ test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-l
         payload.create({
           collection: postsWithFieldHooksSlug,
           data: { mayCrash: 'safe-a', title: 'Export Crash A' },
+          overrideAccess: true,
         }),
         payload.create({
           collection: postsWithFieldHooksSlug,
           data: { mayCrash: 'CRASH', title: 'Export Crash B' },
+          overrideAccess: true,
         }),
         payload.create({
           collection: postsWithFieldHooksSlug,
           data: { mayCrash: 'safe-c', title: 'Export Crash C' },
+          overrideAccess: true,
         }),
       ])
 
@@ -884,11 +958,13 @@ test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-l
           where: { id: { in: docs.map((d) => d.id) } },
         },
         user,
+        overrideAccess: true,
       })
 
       exportDoc = await payload.findByID({
         id: exportDoc.id,
         collection: 'posts-with-field-hooks-export',
+        overrideAccess: true,
       })
 
       const csvPath = path.join(dirname, 'uploads', exportDoc.filename as string)
@@ -908,14 +984,17 @@ test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-l
         payload.create({
           collection: postsWithFieldHooksSlug,
           data: { mayCrash: 'json-safe-a', title: 'JSON Export Crash A' },
+          overrideAccess: true,
         }),
         payload.create({
           collection: postsWithFieldHooksSlug,
           data: { mayCrash: 'CRASH', title: 'JSON Export Crash B' },
+          overrideAccess: true,
         }),
         payload.create({
           collection: postsWithFieldHooksSlug,
           data: { mayCrash: 'json-safe-c', title: 'JSON Export Crash C' },
+          overrideAccess: true,
         }),
       ])
 
@@ -927,11 +1006,13 @@ test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-l
           where: { id: { in: docs.map((d) => d.id) } },
         },
         user,
+        overrideAccess: true,
       })
 
       exportDoc = await payload.findByID({
         id: exportDoc.id,
         collection: 'posts-with-field-hooks-export',
+        overrideAccess: true,
       })
 
       const jsonPath = path.join(dirname, 'uploads', exportDoc.filename as string)
@@ -961,6 +1042,7 @@ test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-l
       const post = await payload.create({
         collection: postsWithFieldHooksSlug,
         data: { rowField: 'inside-row', title: 'Row Wrapper Export' },
+        overrideAccess: true,
       })
 
       let exportDoc = await payload.create({
@@ -971,11 +1053,13 @@ test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-l
           where: { id: { equals: post.id } },
         },
         user,
+        overrideAccess: true,
       })
 
       exportDoc = await payload.findByID({
         id: exportDoc.id,
         collection: 'posts-with-field-hooks-export',
+        overrideAccess: true,
       })
 
       const csvPath = path.join(dirname, 'uploads', exportDoc.filename as string)
@@ -1000,11 +1084,13 @@ test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-l
         data: { collectionSlug: postsWithFieldHooksSlug, importMode: 'create' },
         file,
         user,
+        overrideAccess: true,
       })
 
       importDoc = await payload.findByID({
         id: importDoc.id,
         collection: 'posts-with-field-hooks-import',
+        overrideAccess: true,
       })
 
       expect(importDoc.status).toBe('completed')
@@ -1012,6 +1098,7 @@ test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-l
       const imported = await payload.find({
         collection: postsWithFieldHooksSlug,
         where: { title: { equals: 'Row Wrapper Import' } },
+        overrideAccess: true,
       })
       expect(imported.docs).toHaveLength(1)
       expect((imported.docs[0] as any).rowField).toBe('incoming_row_imported')
@@ -1023,6 +1110,7 @@ test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-l
       const post = await payload.create({
         collection: postsWithFieldHooksSlug,
         data: { collapsibleField: 'inside-collapsible', title: 'Collapsible Wrapper Export' },
+        overrideAccess: true,
       })
 
       let exportDoc = await payload.create({
@@ -1033,11 +1121,13 @@ test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-l
           where: { id: { equals: post.id } },
         },
         user,
+        overrideAccess: true,
       })
 
       exportDoc = await payload.findByID({
         id: exportDoc.id,
         collection: 'posts-with-field-hooks-export',
+        overrideAccess: true,
       })
 
       const csvPath = path.join(dirname, 'uploads', exportDoc.filename as string)
@@ -1062,11 +1152,13 @@ test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-l
         data: { collectionSlug: postsWithFieldHooksSlug, importMode: 'create' },
         file,
         user,
+        overrideAccess: true,
       })
 
       importDoc = await payload.findByID({
         id: importDoc.id,
         collection: 'posts-with-field-hooks-import',
+        overrideAccess: true,
       })
 
       expect(importDoc.status).toBe('completed')
@@ -1074,6 +1166,7 @@ test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-l
       const imported = await payload.find({
         collection: postsWithFieldHooksSlug,
         where: { title: { equals: 'Collapsible Wrapper Import' } },
+        overrideAccess: true,
       })
       expect(imported.docs).toHaveLength(1)
       expect((imported.docs[0] as any).collapsibleField).toBe('incoming_collapsible_imported')
@@ -1105,11 +1198,13 @@ test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-l
         },
         file,
         user,
+        overrideAccess: true,
       })
 
       importDoc = await payload.findByID({
         id: importDoc.id,
         collection: 'posts-with-field-hooks-import',
+        overrideAccess: true,
       })
 
       expect(importDoc.status).toBe('completed')
@@ -1117,6 +1212,7 @@ test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-l
       const imported = await payload.find({
         collection: postsWithFieldHooksSlug,
         where: { title: { equals: 'Top Doc Access' } },
+        overrideAccess: true,
       })
       expect(imported.docs).toHaveLength(1)
       expect((imported.docs[0] as any).metadata.slugFromTitle).toBe('top-doc-access')

--- a/test/plugin-import-export/hooks.int.spec.ts
+++ b/test/plugin-import-export/hooks.int.spec.ts
@@ -22,6 +22,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export — hook
     const loginResult = await payload.login({
       collection: 'users',
       data: { email: devUser.email, password: devUser.password },
+      overrideAccess: true,
     })
 
     user = loginResult.user!
@@ -31,7 +32,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export — hook
     resetHookSpies()
     for (const id of createdHookPostIDs) {
       await payload
-        .delete({ collection: postsWithHooksSlug, id })
+        .delete({ collection: postsWithHooksSlug, id, overrideAccess: true })
         .catch((err) => payload.logger.warn({ err, id, msg: 'hooks.int.spec cleanup failed' }))
     }
     createdHookPostIDs.length = 0
@@ -48,6 +49,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export — hook
       const post = await payload.create({
         collection: postsWithHooksSlug,
         data: { title: 'Hook Test', secret: 'top-secret', count: 1 },
+        overrideAccess: true,
       })
       createdHookPostIDs.push(post.id)
 
@@ -59,11 +61,13 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export — hook
           format: 'csv',
           where: { id: { equals: post.id } },
         },
+        overrideAccess: true,
       })
 
       exportDoc = await payload.findByID({
         collection: 'posts-with-hooks-export',
         id: exportDoc.id,
+        overrideAccess: true,
       })
 
       const csvPath = path.join(dirname, 'uploads', exportDoc.filename as string)
@@ -91,6 +95,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export — hook
       const post = await payload.create({
         collection: postsWithHooksSlug,
         data: { title: 'After Hook Test', secret: 'hidden', count: 2 },
+        overrideAccess: true,
       })
       createdHookPostIDs.push(post.id)
 
@@ -102,11 +107,13 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export — hook
           format: 'csv',
           where: { id: { equals: post.id } },
         },
+        overrideAccess: true,
       })
 
       exportDoc = await payload.findByID({
         collection: 'posts-with-hooks-export',
         id: exportDoc.id,
+        overrideAccess: true,
       })
 
       expect(hookCalls.exportAfter).toHaveLength(1)
@@ -126,6 +133,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export — hook
       const post = await payload.create({
         collection: postsWithHooksSlug,
         data: { title: 'JSON Hook Test', secret: 'json-secret', count: 3 },
+        overrideAccess: true,
       })
       createdHookPostIDs.push(post.id)
 
@@ -137,11 +145,13 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export — hook
           format: 'json',
           where: { id: { equals: post.id } },
         },
+        overrideAccess: true,
       })
 
       exportDoc = await payload.findByID({
         collection: 'posts-with-hooks-export',
         id: exportDoc.id,
+        overrideAccess: true,
       })
 
       const jsonPath = path.join(dirname, 'uploads', exportDoc.filename as string)
@@ -163,6 +173,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export — hook
           payload.create({
             collection: postsWithHooksSlug,
             data: { title: `Batch Post ${i}`, count: i },
+            overrideAccess: true,
           }),
         ),
       )
@@ -176,11 +187,13 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export — hook
           collectionSlug: postsWithHooksSlug,
           format: 'csv',
         },
+        overrideAccess: true,
       })
 
       exportDoc = await payload.findByID({
         collection: 'posts-with-hooks-export',
         id: exportDoc.id,
+        overrideAccess: true,
       })
 
       // Should have been called once per batch
@@ -198,6 +211,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export — hook
       const post = await payload.create({
         collection: postsWithHooksSlug,
         data: { title: 'Download Hook Test', secret: 'streamed-secret', count: 4 },
+        overrideAccess: true,
       })
       createdHookPostIDs.push(post.id)
 
@@ -241,11 +255,13 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export — hook
         user,
         data: { collectionSlug: postsWithHooksSlug, importMode: 'create' },
         file,
+        overrideAccess: true,
       })
 
       importDoc = await payload.findByID({
         collection: 'posts-with-hooks-import',
         id: importDoc.id,
+        overrideAccess: true,
       })
 
       expect(importDoc.status).toBe('completed')
@@ -266,6 +282,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export — hook
       const importedDocs = await payload.find({
         collection: postsWithHooksSlug,
         where: { title: { equals: 'Original Title_imported' } },
+        overrideAccess: true,
       })
       expect(importedDocs.docs).toHaveLength(1)
       importedDocs.docs.forEach((d) => createdHookPostIDs.push(d.id))
@@ -285,11 +302,13 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export — hook
         user,
         data: { collectionSlug: postsWithHooksSlug, importMode: 'create' },
         file,
+        overrideAccess: true,
       })
 
       importDoc = await payload.findByID({
         collection: 'posts-with-hooks-import',
         id: importDoc.id,
+        overrideAccess: true,
       })
 
       expect(importDoc.status).toBe('completed')
@@ -305,6 +324,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export — hook
       const imported = await payload.find({
         collection: postsWithHooksSlug,
         where: { title: { equals: 'After Hook Post_imported' } },
+        overrideAccess: true,
       })
       imported.docs.forEach((d) => createdHookPostIDs.push(d.id))
     })
@@ -325,11 +345,13 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export — hook
         user,
         data: { collectionSlug: postsWithHooksSlug, importMode: 'create' },
         file,
+        overrideAccess: true,
       })
 
       importDoc = await payload.findByID({
         collection: 'posts-with-hooks-import',
         id: importDoc.id,
+        overrideAccess: true,
       })
 
       expect(importDoc.status).toBe('completed')
@@ -343,6 +365,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export — hook
       const imported = await payload.find({
         collection: postsWithHooksSlug,
         where: { title: { equals: 'OriginalData Post_imported' } },
+        overrideAccess: true,
       })
       imported.docs.forEach((d) => createdHookPostIDs.push(d.id))
     })
@@ -361,11 +384,13 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export — hook
         user,
         data: { collectionSlug: postsWithHooksSlug, importMode: 'create', format: 'json' },
         file,
+        overrideAccess: true,
       })
 
       importDoc = await payload.findByID({
         collection: 'posts-with-hooks-import',
         id: importDoc.id,
+        overrideAccess: true,
       })
 
       expect(importDoc.status).toBe('completed')
@@ -375,6 +400,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export — hook
       const imported = await payload.find({
         collection: postsWithHooksSlug,
         where: { title: { equals: 'JSON Import Hook_imported' } },
+        overrideAccess: true,
       })
       expect(imported.docs).toHaveLength(1)
       imported.docs.forEach((d) => createdHookPostIDs.push(d.id))
@@ -403,11 +429,13 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export — hook
         user,
         data: { collectionSlug: postsWithHooksSlug, importMode: 'create', format: 'json' },
         file,
+        overrideAccess: true,
       })
 
       importDoc = await payload.findByID({
         collection: 'posts-with-hooks-import',
         id: importDoc.id,
+        overrideAccess: true,
       })
 
       expect(importDoc.status).toBe('completed')
@@ -429,6 +457,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export — hook
       const imported = await payload.find({
         collection: postsWithHooksSlug,
         where: { title: { equals: 'JSON Original Data Test_imported' } },
+        overrideAccess: true,
       })
       imported.docs.forEach((d) => createdHookPostIDs.push(d.id))
     })
@@ -452,11 +481,13 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export — hook
           importMode: 'create',
         },
         file,
+        overrideAccess: true,
       })
 
       importDoc = await payload.findByID({
         collection: 'posts-with-hooks-import',
         id: importDoc.id,
+        overrideAccess: true,
       })
 
       expect(importDoc.status).toBe('completed')
@@ -469,6 +500,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export — hook
         collection: postsWithHooksSlug,
         where: { title: { contains: 'Batch Import' } },
         limit: 10,
+        overrideAccess: true,
       })
       imported.docs.forEach((d) => createdHookPostIDs.push(d.id))
     })
@@ -479,7 +511,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export — hook
 
     test.afterEach(async ({ payload }) => {
       for (const id of createdIDs) {
-        await payload.delete({ collection: postsWithColumnMapSlug, id })
+        await payload.delete({ collection: postsWithColumnMapSlug, id, overrideAccess: true })
       }
       createdIDs.length = 0
     })
@@ -490,6 +522,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export — hook
       const post = await payload.create({
         collection: postsWithColumnMapSlug,
         data: { title: 'Rename Me', excerpt: 'Original excerpt', count: 42 },
+        overrideAccess: true,
       })
       createdIDs.push(post.id)
 
@@ -501,11 +534,13 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export — hook
           format: 'csv',
           where: { id: { equals: post.id } },
         },
+        overrideAccess: true,
       })
 
       exportDoc = await payload.findByID({
         collection: 'posts-with-column-map-export',
         id: exportDoc.id,
+        overrideAccess: true,
       })
 
       const csvPath = path.join(dirname, 'uploads', exportDoc.filename as string)
@@ -526,6 +561,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export — hook
       const post = await payload.create({
         collection: postsWithColumnMapSlug,
         data: { title: 'Field Rename', excerpt: 'x', count: 1, sharedName: 'shared value' },
+        overrideAccess: true,
       })
       createdIDs.push(post.id)
 
@@ -537,11 +573,13 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export — hook
           format: 'csv',
           where: { id: { equals: post.id } },
         },
+        overrideAccess: true,
       })
 
       exportDoc = await payload.findByID({
         collection: 'posts-with-column-map-export',
         id: exportDoc.id,
+        overrideAccess: true,
       })
 
       const csvPath = path.join(dirname, 'uploads', exportDoc.filename as string)
@@ -558,6 +596,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export — hook
       const post = await payload.create({
         collection: postsWithColumnMapSlug,
         data: { title: 'Preview Rename', excerpt: 'preview excerpt', count: 11 },
+        overrideAccess: true,
       })
       createdIDs.push(post.id)
 
@@ -598,6 +637,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export — hook
       const post = await payload.create({
         collection: postsWithColumnMapSlug,
         data: { title: 'JSON Preview Rename', excerpt: 'json preview', count: 22 },
+        overrideAccess: true,
       })
       createdIDs.push(post.id)
 
@@ -628,6 +668,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export — hook
       const post = await payload.create({
         collection: postsWithColumnMapSlug,
         data: { title: 'JSON Rename', excerpt: 'json excerpt', count: 7 },
+        overrideAccess: true,
       })
       createdIDs.push(post.id)
 
@@ -639,11 +680,13 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export — hook
           format: 'json',
           where: { id: { equals: post.id } },
         },
+        overrideAccess: true,
       })
 
       exportDoc = await payload.findByID({
         collection: 'posts-with-column-map-export',
         id: exportDoc.id,
+        overrideAccess: true,
       })
 
       const jsonPath = path.join(dirname, 'uploads', exportDoc.filename as string)
@@ -663,7 +706,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export — hook
     test.afterEach(async ({ payload }) => {
       for (const id of createdIDs) {
         await payload
-          .delete({ collection: postsWithColumnMapSlug, id })
+          .delete({ collection: postsWithColumnMapSlug, id, overrideAccess: true })
           .catch((err) => payload.logger.warn({ err, id, msg: 'column-map cleanup failed' }))
       }
       createdIDs.length = 0
@@ -691,6 +734,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export — hook
           importMode: 'create',
         },
         file,
+        overrideAccess: true,
       })
 
       expect(importDoc.id).toBeDefined()
@@ -699,6 +743,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export — hook
         collection: postsWithColumnMapSlug,
         sort: 'title',
         where: { title: { in: ['Imported A', 'Imported B'] } },
+        overrideAccess: true,
       })
 
       imported.docs.forEach((doc) => createdIDs.push(doc.id))
@@ -743,12 +788,14 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export — hook
           importMode: 'create',
         },
         file,
+        overrideAccess: true,
       })
 
       const imported = await payload.find({
         collection: postsWithColumnMapSlug,
         sort: 'title',
         where: { title: { in: ['JSON A', 'JSON B'] } },
+        overrideAccess: true,
       })
 
       imported.docs.forEach((doc) => createdIDs.push(doc.id))
@@ -844,11 +891,13 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export — hook
           importMode: 'create',
         },
         file,
+        overrideAccess: true,
       })
 
       const imported = await payload.find({
         collection: postsWithColumnMapSlug,
         where: { title: { equals: 'Dropped Test' } },
+        overrideAccess: true,
       })
 
       imported.docs.forEach((doc) => createdIDs.push(doc.id))

--- a/test/plugin-import-export/int.spec.ts
+++ b/test/plugin-import-export/int.spec.ts
@@ -28,6 +28,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         email: devUser.email,
         password: devUser.password,
       },
+      overrideAccess: true,
     })
 
     user = loginResult.user!
@@ -36,6 +37,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       where: {
         email: { equals: regularUser.email },
       },
+      overrideAccess: true,
     })
 
     if (userDocs.docs?.[0]) {
@@ -96,6 +98,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             title: { contains: 'Title ' },
           },
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -103,6 +106,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       doc = await payload.findByID({
         collection: 'exports',
         id: doc.id,
+        overrideAccess: true,
       })
 
       expect(doc.filename).toContain('pages.csv')
@@ -129,6 +133,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           format: 'csv',
           limit: 0,
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -136,10 +141,12 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       doc = await payload.findByID({
         collection: 'exports',
         id: doc.id,
+        overrideAccess: true,
       })
 
       const { totalDocs: totalNumberOfDocs } = await payload.count({
         collection: 'pages',
+        overrideAccess: true,
       })
 
       expect(doc.filename).toBeDefined()
@@ -159,6 +166,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           collectionSlug: 'pages',
           format: 'csv',
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -166,10 +174,12 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       doc = await payload.findByID({
         collection: 'exports',
         id: doc.id,
+        overrideAccess: true,
       })
 
       const { totalDocs: totalNumberOfDocs } = await payload.count({
         collection: 'pages',
+        overrideAccess: true,
       })
 
       expect(doc.filename).toBeDefined()
@@ -189,6 +199,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           limit: 100,
           page: 1,
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -196,12 +207,14 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       doc = await payload.findByID({
         collection: 'exports',
         id: doc.id,
+        overrideAccess: true,
       })
 
       const pages = await payload.find({
         collection: 'pages',
         limit: 100,
         page: 1,
+        overrideAccess: true,
       })
 
       const firstDocOnPage1 = pages.docs?.[0]
@@ -224,6 +237,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           limit: 100,
           page: 2,
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -231,12 +245,14 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       doc = await payload.findByID({
         collection: 'exports',
         id: doc.id,
+        overrideAccess: true,
       })
 
       const pages = await payload.find({
         collection: 'pages',
         limit: 100,
         page: 2,
+        overrideAccess: true,
       })
 
       const firstDocOnPage2 = pages.docs?.[0]
@@ -259,6 +275,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             format: 'csv',
             limit: -1,
           },
+          overrideAccess: true,
         }),
       ).rejects.toThrow(/Limit/)
     })
@@ -274,6 +291,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           format: 'csv',
           limit: 99,
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -281,6 +299,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       doc = await payload.findByID({
         collection: 'exports',
         id: doc.id,
+        overrideAccess: true,
       })
 
       expect(doc.filename).toBeDefined()
@@ -298,6 +317,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             or: [{ title: { contains: 'Title' } }, { title: { contains: 'Array' } }],
           },
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -305,6 +325,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       doc = await payload.findByID({
         collection: 'exports',
         id: doc.id,
+        overrideAccess: true,
       })
 
       expect(doc.filename).toBeDefined()
@@ -327,6 +348,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             or: [{ title: { contains: 'Title' } }, { title: { contains: 'Array' } }],
           },
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -334,6 +356,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       doc = await payload.findByID({
         collection: 'exports',
         id: doc.id,
+        overrideAccess: true,
       })
 
       expect(doc.filename).toBeDefined()
@@ -352,6 +375,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           title: 'Draft Page',
           _status: 'published',
         },
+        overrideAccess: true,
       })
 
       await payload.update({
@@ -361,6 +385,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           title: 'Draft Page Updated',
           _status: 'draft',
         },
+        overrideAccess: true,
       })
 
       let doc = await payload.create({
@@ -375,6 +400,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             title: { contains: 'Draft ' },
           },
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -382,6 +408,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       doc = await payload.findByID({
         collection: 'exports',
         id: doc.id,
+        overrideAccess: true,
       })
 
       expect(doc.filename).toBeDefined()
@@ -406,6 +433,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             title: { contains: 'Localized ' },
           },
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -413,6 +441,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       doc = await payload.findByID({
         collection: 'exports',
         id: doc.id,
+        overrideAccess: true,
       })
 
       expect(doc.filename).toBeDefined()
@@ -436,6 +465,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             title: { contains: 'Localized ' },
           },
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -443,6 +473,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       doc = await payload.findByID({
         collection: 'exports',
         id: doc.id,
+        overrideAccess: true,
       })
 
       expect(doc.filename).toBeDefined()
@@ -466,6 +497,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             title: { contains: 'Array ' },
           },
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -473,6 +505,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       doc = await payload.findByID({
         collection: 'exports',
         id: doc.id,
+        overrideAccess: true,
       })
 
       expect(doc.filename).toBeDefined()
@@ -500,6 +533,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             title: { contains: 'Title ' },
           },
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -507,6 +541,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       const exportDoc = await payload.findByID({
         collection: 'exports',
         id: doc.id,
+        overrideAccess: true,
       })
 
       expect(exportDoc.filename).toBeDefined()
@@ -534,6 +569,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             title: { contains: 'Virtual ' },
           },
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -541,6 +577,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       const exportDoc = await payload.findByID({
         collection: 'exports',
         id: doc.id,
+        overrideAccess: true,
       })
 
       expect(exportDoc.filename).toBeDefined()
@@ -563,6 +600,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             title: { contains: 'Array Subfield ' },
           },
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -570,6 +608,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       doc = await payload.findByID({
         collection: 'exports',
         id: doc.id,
+        overrideAccess: true,
       })
 
       expect(doc.filename).toBeDefined()
@@ -594,6 +633,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             title: { contains: 'hasMany Number ' },
           },
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -601,6 +641,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       doc = await payload.findByID({
         collection: 'exports',
         id: doc.id,
+        overrideAccess: true,
       })
 
       expect(doc.filename).toBeDefined()
@@ -626,6 +667,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             title: { contains: 'Blocks ' },
           },
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -633,6 +675,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       doc = await payload.findByID({
         collection: 'exports',
         id: doc.id,
+        overrideAccess: true,
       })
 
       expect(doc.filename).toBeDefined()
@@ -655,6 +698,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             title: { contains: 'Title ' },
           },
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -662,6 +706,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       const exportDoc = await payload.findByID({
         collection: 'exports',
         id: doc.id,
+        overrideAccess: true,
       })
 
       expect(exportDoc.filename).toBeDefined()
@@ -694,6 +739,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             title: { contains: 'Custom ' },
           },
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -701,6 +747,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       const exportDoc = await payload.findByID({
         collection: 'exports',
         id: doc.id,
+        overrideAccess: true,
       })
 
       expect(exportDoc.filename).toBeDefined()
@@ -730,6 +777,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             title: { contains: 'JSON ' },
           },
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -737,6 +785,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       doc = await payload.findByID({
         collection: 'exports',
         id: doc.id,
+        overrideAccess: true,
       })
 
       expect(doc.filename).toBeDefined()
@@ -784,6 +833,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           format: 'json',
           sort: 'title',
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -791,6 +841,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       doc = await payload.findByID({
         collection: 'exports',
         id: doc.id,
+        overrideAccess: true,
       })
 
       expect(doc.filename).toBeDefined()
@@ -816,6 +867,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             title: { contains: 'Jobs ' },
           },
         },
+        overrideAccess: true,
       })
 
       const {
@@ -823,6 +875,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       } = await payload.find({
         collection: 'payload-jobs',
         sort: '-createdAt',
+        overrideAccess: true,
       })
 
       expect(job).toBeDefined()
@@ -846,6 +899,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       const exportDoc = await payload.findByID({
         collection: 'exports' as CollectionSlug,
         id: doc.id,
+        overrideAccess: true,
       })
 
       expect(exportDoc.filename).toBeDefined()
@@ -864,6 +918,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           fields: ['id', 'title'],
           format: 'csv',
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -871,6 +926,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       const exportDoc = await payload.findByID({
         collection: 'exports',
         id: doc.id,
+        overrideAccess: true,
       })
 
       expect(exportDoc.filename).toBeDefined()
@@ -899,11 +955,13 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           format: 'csv',
           limit: 5,
         },
+        overrideAccess: true,
       })
 
       const exportDoc = await payload.findByID({
         collection: 'posts-export',
         id: doc.id,
+        overrideAccess: true,
       })
 
       expect(exportDoc.filename).toBeDefined()
@@ -927,11 +985,13 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           format: 'csv',
           limit: 1,
         },
+        overrideAccess: true,
       })
 
       const exportDoc = await payload.findByID({
         collection: 'posts-export',
         id: doc.id,
+        overrideAccess: true,
       })
 
       expect(exportDoc.filename).toBeDefined()
@@ -956,6 +1016,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             title: { contains: 'Polymorphic' },
           },
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -963,6 +1024,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       const exportDoc = await payload.findByID({
         collection: 'exports',
         id: doc.id,
+        overrideAccess: true,
       })
 
       expect(exportDoc.filename).toBeDefined()
@@ -992,6 +1054,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             title: { contains: 'Polymorphic' },
           },
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -999,6 +1062,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       const exportDoc = await payload.findByID({
         collection: 'exports',
         id: doc.id,
+        overrideAccess: true,
       })
 
       expect(exportDoc.filename).toBeDefined()
@@ -1029,6 +1093,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             title: { contains: 'Monomorphic' },
           },
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -1036,6 +1101,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       const exportDoc = await payload.findByID({
         collection: 'exports',
         id: doc.id,
+        overrideAccess: true,
       })
 
       expect(exportDoc.filename).toBeDefined()
@@ -1070,6 +1136,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
                 },
               ],
             },
+            overrideAccess: true,
           }),
         )
         if (promises.length >= 500) {
@@ -1090,6 +1157,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           fields: ['id', 'blocks'],
           format: 'csv',
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -1097,6 +1165,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       doc = await payload.findByID({
         collection: 'exports',
         id: doc.id,
+        overrideAccess: true,
       })
 
       expect(doc.filename).toBeDefined()
@@ -1122,6 +1191,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
               title: { equals: 'Title 0' },
             },
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
@@ -1129,6 +1199,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         doc = await payload.findByID({
           collection: 'exports',
           id: doc.id,
+          overrideAccess: true,
         })
 
         expect(doc.filename).toBeDefined()
@@ -1158,6 +1229,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
               title: { contains: 'Localized ' },
             },
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
@@ -1165,6 +1237,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         doc = await payload.findByID({
           collection: 'exports',
           id: doc.id,
+          overrideAccess: true,
         })
 
         expect(doc.filename).toBeDefined()
@@ -1189,6 +1262,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
               title: { equals: 'nonexistent-title-xyz' },
             },
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
@@ -1196,6 +1270,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         doc = await payload.findByID({
           collection: 'exports',
           id: doc.id,
+          overrideAccess: true,
         })
 
         expect(doc.filename).toBeDefined()
@@ -1221,6 +1296,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
               title: { contains: 'Virtual ' },
             },
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
@@ -1228,6 +1304,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         doc = await payload.findByID({
           collection: 'exports',
           id: doc.id,
+          overrideAccess: true,
         })
 
         expect(doc.filename).toBeDefined()
@@ -1252,6 +1329,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             excerpt: 'test excerpt',
             _status: 'published',
           },
+          overrideAccess: true,
         })
 
         const fields = ['id', 'title', 'customRelationship', 'excerpt']
@@ -1264,11 +1342,12 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             format: 'csv',
             where: { id: { equals: page.id } },
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
 
-        doc = await payload.findByID({ collection: 'exports', id: doc.id })
+        doc = await payload.findByID({ collection: 'exports', id: doc.id, overrideAccess: true })
         const csvPath = path.join(dirname, './uploads', doc.filename as string)
         const data = await readCSV(csvPath)
         const columns = Object.keys(data[0])
@@ -1288,7 +1367,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         expect(emailIdx).toBe(titleIdx + 2)
         expect(excerptIdx).toBeGreaterThan(emailIdx)
 
-        await payload.delete({ collection: 'pages', id: page.id })
+        await payload.delete({ collection: 'pages', id: page.id, overrideAccess: true })
       })
 
       test('should remove original column when beforeExport hook writes _name and _email (no _id)', async ({
@@ -1302,6 +1381,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             excerpt: 'test excerpt',
             _status: 'published',
           },
+          overrideAccess: true,
         })
 
         const fields = ['id', 'title', 'customRelNameEmail', 'excerpt']
@@ -1314,11 +1394,12 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             format: 'csv',
             where: { id: { equals: page.id } },
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
 
-        doc = await payload.findByID({ collection: 'exports', id: doc.id })
+        doc = await payload.findByID({ collection: 'exports', id: doc.id, overrideAccess: true })
         const csvPath = path.join(dirname, './uploads', doc.filename as string)
         const data = await readCSV(csvPath)
         const columns = Object.keys(data[0])
@@ -1340,7 +1421,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         expect(data[0].customRelNameEmail_name).toBe('name value')
         expect(data[0].customRelNameEmail_email).toBe(user.email)
 
-        await payload.delete({ collection: 'pages', id: page.id })
+        await payload.delete({ collection: 'pages', id: page.id, overrideAccess: true })
       })
 
       test('should remove original column when beforeExport hook writes _id and _locationName', async ({
@@ -1354,6 +1435,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             excerpt: 'test excerpt',
             _status: 'published',
           },
+          overrideAccess: true,
         })
 
         const fields = ['id', 'title', 'customRelIdName', 'excerpt']
@@ -1366,11 +1448,12 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             format: 'csv',
             where: { id: { equals: page.id } },
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
 
-        doc = await payload.findByID({ collection: 'exports', id: doc.id })
+        doc = await payload.findByID({ collection: 'exports', id: doc.id, overrideAccess: true })
         const csvPath = path.join(dirname, './uploads', doc.filename as string)
         const data = await readCSV(csvPath)
         const columns = Object.keys(data[0])
@@ -1392,7 +1475,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         expect(data[0].customRelIdName_id).toBe(String(user.id))
         expect(data[0].customRelIdName_locationName).toBe('name value')
 
-        await payload.delete({ collection: 'pages', id: page.id })
+        await payload.delete({ collection: 'pages', id: page.id, overrideAccess: true })
       })
 
       test('should keep derived columns before trailing fields and match preview column order', async ({
@@ -1407,6 +1490,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             excerpt: 'trailing field value',
             _status: 'published',
           },
+          overrideAccess: true,
         })
 
         const fields = ['id', 'title', 'customRelationship', 'excerpt']
@@ -1421,11 +1505,12 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             format: 'csv',
             where: { id: { equals: page.id } },
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
 
-        doc = await payload.findByID({ collection: 'exports', id: doc.id })
+        doc = await payload.findByID({ collection: 'exports', id: doc.id, overrideAccess: true })
         const csvPath = path.join(dirname, './uploads', doc.filename as string)
         const data = await readCSV(csvPath)
         const exportColumns = Object.keys(data[0])
@@ -1457,7 +1542,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
 
         expect(previewResponse.columns).toStrictEqual(exportColumns)
 
-        await payload.delete({ collection: 'pages', id: page.id })
+        await payload.delete({ collection: 'pages', id: page.id, overrideAccess: true })
       })
 
       test('should respect custom field order with beforeExport field first and match preview column order', async ({
@@ -1472,6 +1557,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             excerpt: 'some excerpt',
             _status: 'published',
           },
+          overrideAccess: true,
         })
 
         // Put the beforeExport relationship field first
@@ -1487,11 +1573,12 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             format: 'csv',
             where: { id: { equals: page.id } },
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
 
-        doc = await payload.findByID({ collection: 'exports', id: doc.id })
+        doc = await payload.findByID({ collection: 'exports', id: doc.id, overrideAccess: true })
         const csvPath = path.join(dirname, './uploads', doc.filename as string)
         const data = await readCSV(csvPath)
         const exportColumns = Object.keys(data[0])
@@ -1524,7 +1611,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
 
         expect(previewResponse.columns).toStrictEqual(exportColumns)
 
-        await payload.delete({ collection: 'pages', id: page.id })
+        await payload.delete({ collection: 'pages', id: page.id, overrideAccess: true })
       })
     })
 
@@ -1538,6 +1625,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             date: dateValue,
             _status: 'published',
           },
+          overrideAccess: true,
         })
 
         let doc = await payload.create({
@@ -1549,23 +1637,25 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             format: 'csv',
             where: { id: { equals: page.id } },
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
 
-        doc = await payload.findByID({ collection: 'exports', id: doc.id })
+        doc = await payload.findByID({ collection: 'exports', id: doc.id, overrideAccess: true })
         const csvPath = path.join(dirname, './uploads', doc.filename as string)
         const data = await readCSV(csvPath)
 
         expect(data[0].date).toBe('2026-01-22T00:00:00.000Z')
 
-        await payload.delete({ collection: 'pages', id: page.id })
+        await payload.delete({ collection: 'pages', id: page.id, overrideAccess: true })
       })
 
       test('should handle null date values', async ({ payload }) => {
         const page = await payload.create({
           collection: 'pages',
           data: { title: 'Null Date Test', date: null, _status: 'published' },
+          overrideAccess: true,
         })
 
         let doc = await payload.create({
@@ -1577,17 +1667,18 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             format: 'csv',
             where: { id: { equals: page.id } },
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
 
-        doc = await payload.findByID({ collection: 'exports', id: doc.id })
+        doc = await payload.findByID({ collection: 'exports', id: doc.id, overrideAccess: true })
         const csvPath = path.join(dirname, './uploads', doc.filename as string)
         const data = await readCSV(csvPath)
 
         expect(data[0].date).toBe('')
 
-        await payload.delete({ collection: 'pages', id: page.id })
+        await payload.delete({ collection: 'pages', id: page.id, overrideAccess: true })
       })
 
       test('should not include timezone column when only date field is selected', async ({
@@ -1601,6 +1692,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             dateWithTimezone_tz: 'Europe/London',
             _status: 'published',
           },
+          overrideAccess: true,
         })
 
         let doc = await payload.create({
@@ -1612,11 +1704,12 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             format: 'csv',
             where: { id: { equals: page.id } },
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
 
-        doc = await payload.findByID({ collection: 'exports', id: doc.id })
+        doc = await payload.findByID({ collection: 'exports', id: doc.id, overrideAccess: true })
         const csvPath = path.join(dirname, './uploads', doc.filename as string)
         const csvContent = fs.readFileSync(csvPath, 'utf-8')
         const headerLine = csvContent.split('\n')[0]
@@ -1624,7 +1717,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         expect(headerLine).toContain('dateWithTimezone')
         expect(headerLine).not.toContain('dateWithTimezone_tz')
 
-        await payload.delete({ collection: 'pages', id: page.id })
+        await payload.delete({ collection: 'pages', id: page.id, overrideAccess: true })
       })
 
       test('should not create duplicate columns when selecting both date and timezone fields', async ({
@@ -1638,6 +1731,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             dateWithTimezone_tz: 'Europe/London',
             _status: 'published',
           },
+          overrideAccess: true,
         })
 
         let doc = await payload.create({
@@ -1649,11 +1743,12 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             format: 'csv',
             where: { id: { equals: page.id } },
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
 
-        doc = await payload.findByID({ collection: 'exports', id: doc.id })
+        doc = await payload.findByID({ collection: 'exports', id: doc.id, overrideAccess: true })
         const csvPath = path.join(dirname, './uploads', doc.filename as string)
         const csvContent = fs.readFileSync(csvPath, 'utf-8')
         const headerLine = csvContent.split('\n')[0]
@@ -1666,7 +1761,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         expect(data[0].dateWithTimezone).toBe('2026-01-25T12:00:00.000Z')
         expect(data[0].dateWithTimezone_tz).toBe('Europe/London')
 
-        await payload.delete({ collection: 'pages', id: page.id })
+        await payload.delete({ collection: 'pages', id: page.id, overrideAccess: true })
       })
     })
 
@@ -1734,6 +1829,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
               },
             ],
           },
+          overrideAccess: true,
         })
 
         let exportDoc = await payload.create({
@@ -1746,6 +1842,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
               id: { equals: testPage.id },
             },
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
@@ -1753,6 +1850,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         exportDoc = await payload.findByID({
           collection: 'exports',
           id: exportDoc.id,
+          overrideAccess: true,
         })
 
         const csvPath = path.join(dirname, './uploads', exportDoc.filename as string)
@@ -1794,6 +1892,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         await payload.delete({
           collection: 'pages',
           id: testPage.id,
+          overrideAccess: true,
         })
       })
 
@@ -1825,6 +1924,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
               },
             ],
           },
+          overrideAccess: true,
         })
 
         let exportDoc = await payload.create({
@@ -1837,6 +1937,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
               id: { equals: testPage.id },
             },
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
@@ -1844,6 +1945,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         exportDoc = await payload.findByID({
           collection: 'exports',
           id: exportDoc.id,
+          overrideAccess: true,
         })
 
         const csvPath = path.join(dirname, './uploads', exportDoc.filename as string)
@@ -1851,6 +1953,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         await payload.delete({
           collection: 'pages',
           id: testPage.id,
+          overrideAccess: true,
         })
 
         let importDoc = await payload.create({
@@ -1866,6 +1969,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             name: 'json-roundtrip.csv',
             size: fs.statSync(csvPath).size,
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
@@ -1873,6 +1977,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         importDoc = await payload.findByID({
           collection: 'imports',
           id: importDoc.id,
+          overrideAccess: true,
         })
 
         expect(importDoc.status).toBe('completed')
@@ -1883,6 +1988,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           where: {
             title: { equals: 'JSON Roundtrip CSV Test' },
           },
+          overrideAccess: true,
         })
 
         expect(importedPages.docs).toHaveLength(1)
@@ -1907,6 +2013,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           where: {
             title: { equals: 'JSON Roundtrip CSV Test' },
           },
+          overrideAccess: true,
         })
       })
 
@@ -1927,6 +2034,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
               },
             ],
           },
+          overrideAccess: true,
         })
 
         let exportDoc = await payload.create({
@@ -1937,15 +2045,16 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             format: 'csv',
             where: { id: { equals: testPage.id } },
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
 
-        exportDoc = await payload.findByID({ collection: 'exports', id: exportDoc.id })
+        exportDoc = await payload.findByID({ collection: 'exports', id: exportDoc.id, overrideAccess: true })
 
         const csvPath = path.join(dirname, './uploads', exportDoc.filename as string)
 
-        await payload.delete({ collection: 'pages', id: testPage.id })
+        await payload.delete({ collection: 'pages', id: testPage.id, overrideAccess: true })
 
         let importDoc = await payload.create({
           collection: 'imports',
@@ -1957,17 +2066,19 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             name: 'faq-roundtrip.csv',
             size: fs.statSync(csvPath).size,
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
 
-        importDoc = await payload.findByID({ collection: 'imports', id: importDoc.id })
+        importDoc = await payload.findByID({ collection: 'imports', id: importDoc.id, overrideAccess: true })
         expect(importDoc.status).toBe('completed')
         expect(importDoc.summary?.imported).toBe(1)
 
         const importedPages = await payload.find({
           collection: 'pages',
           where: { title: { equals: 'FAQ Block Roundtrip Test' } },
+          overrideAccess: true,
         })
 
         expect(importedPages.docs).toHaveLength(1)
@@ -1991,6 +2102,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         await payload.delete({
           collection: 'pages',
           where: { title: { equals: 'FAQ Block Roundtrip Test' } },
+          overrideAccess: true,
         })
       })
 
@@ -2015,6 +2127,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
               ],
             },
           },
+          overrideAccess: true,
         })
 
         let exportDoc = await payload.create({
@@ -2027,6 +2140,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
               id: { equals: testPage.id },
             },
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
@@ -2034,6 +2148,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         exportDoc = await payload.findByID({
           collection: 'exports',
           id: exportDoc.id,
+          overrideAccess: true,
         })
 
         const csvPath = path.join(dirname, './uploads', exportDoc.filename as string)
@@ -2056,6 +2171,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         await payload.delete({
           collection: 'pages',
           id: testPage.id,
+          overrideAccess: true,
         })
 
         let importDoc = await payload.create({
@@ -2071,6 +2187,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             name: 'nested-array-test.csv',
             size: fs.statSync(csvPath).size,
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
@@ -2078,6 +2195,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         importDoc = await payload.findByID({
           collection: 'imports',
           id: importDoc.id,
+          overrideAccess: true,
         })
 
         expect(importDoc.status).toBe('completed')
@@ -2087,6 +2205,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           where: {
             title: { equals: 'Nested Array Test' },
           },
+          overrideAccess: true,
         })
 
         expect(importedPages.docs).toHaveLength(1)
@@ -2108,6 +2227,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           where: {
             title: { equals: 'Nested Array Test' },
           },
+          overrideAccess: true,
         })
       })
 
@@ -2122,6 +2242,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             jsonField: initialJson,
             richTextField: richTextData,
           },
+          overrideAccess: true,
         })
 
         expect(existingPage.jsonField).toEqual(initialJson)
@@ -2146,6 +2267,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             name: 'json-update-test.csv',
             size: csvBuffer.length,
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
@@ -2153,6 +2275,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         importDoc = await payload.findByID({
           collection: 'imports',
           id: importDoc.id,
+          overrideAccess: true,
         })
 
         expect(importDoc.status).toBe('completed')
@@ -2162,6 +2285,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         const updatedPage = await payload.findByID({
           collection: 'pages',
           id: existingPage.id,
+          overrideAccess: true,
         })
 
         expect(updatedPage.jsonField).toEqual(updatedJson)
@@ -2170,6 +2294,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         await payload.delete({
           collection: 'pages',
           id: existingPage.id,
+          overrideAccess: true,
         })
       })
 
@@ -2186,6 +2311,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             jsonField: existingJson,
             richTextField: richTextData,
           },
+          overrideAccess: true,
         })
 
         const csvContent =
@@ -2209,6 +2335,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             name: 'json-upsert-test.csv',
             size: csvBuffer.length,
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
@@ -2216,6 +2343,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         importDoc = await payload.findByID({
           collection: 'imports',
           id: importDoc.id,
+          overrideAccess: true,
         })
 
         expect(importDoc.status).toBe('completed')
@@ -2226,6 +2354,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         const updatedPage = await payload.findByID({
           collection: 'pages',
           id: existingPage.id,
+          overrideAccess: true,
         })
 
         expect(updatedPage.jsonField).toEqual(updatedExistingJson)
@@ -2235,6 +2364,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           where: {
             title: { equals: `JSON Upsert New ${timestamp}` },
           },
+          overrideAccess: true,
         })
 
         expect(newPages.docs).toHaveLength(1)
@@ -2249,6 +2379,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
               { title: { equals: `JSON Upsert New ${timestamp}` } },
             ],
           },
+          overrideAccess: true,
         })
       })
 
@@ -2280,6 +2411,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             name: 'manual-json-csv.csv',
             size: csvBuffer.length,
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
@@ -2287,6 +2419,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         importDoc = await payload.findByID({
           collection: 'imports',
           id: importDoc.id,
+          overrideAccess: true,
         })
 
         expect(importDoc.status).toBe('completed')
@@ -2297,6 +2430,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           where: {
             title: { equals: 'Manual CSV Import' },
           },
+          overrideAccess: true,
         })
 
         expect(importedPage.docs).toHaveLength(1)
@@ -2307,6 +2441,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           where: {
             title: { equals: 'Manual CSV Import' },
           },
+          overrideAccess: true,
         })
       })
 
@@ -2321,6 +2456,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             title: 'Sequential Import Test',
             jsonField: jsonV1,
           },
+          overrideAccess: true,
         })
 
         let csvContent =
@@ -2343,6 +2479,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             name: 'sequential-1.csv',
             size: csvBuffer.length,
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
@@ -2350,6 +2487,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         let updatedPage = await payload.findByID({
           collection: 'pages',
           id: page.id,
+          overrideAccess: true,
         })
         expect(updatedPage.jsonField).toEqual(jsonV2)
 
@@ -2373,6 +2511,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             name: 'sequential-2.csv',
             size: csvBuffer.length,
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
@@ -2380,12 +2519,14 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         updatedPage = await payload.findByID({
           collection: 'pages',
           id: page.id,
+          overrideAccess: true,
         })
         expect(updatedPage.jsonField).toEqual(jsonV3)
 
         await payload.delete({
           collection: 'pages',
           id: page.id,
+          overrideAccess: true,
         })
       })
     })
@@ -2399,6 +2540,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             excerpt: 'Testing BOM presence',
             _status: 'published',
           },
+          overrideAccess: true,
         })
 
         let doc = await payload.create({
@@ -2410,11 +2552,12 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             format: 'csv',
             where: { id: { equals: page.id } },
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
 
-        doc = await payload.findByID({ collection: 'exports', id: doc.id })
+        doc = await payload.findByID({ collection: 'exports', id: doc.id, overrideAccess: true })
         const csvPath = path.join(dirname, './uploads', doc.filename as string)
         const buffer = fs.readFileSync(csvPath)
 
@@ -2422,7 +2565,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         expect(buffer[1]).toBe(0xbb)
         expect(buffer[2]).toBe(0xbf)
 
-        await payload.delete({ collection: 'pages', id: page.id })
+        await payload.delete({ collection: 'pages', id: page.id, overrideAccess: true })
       })
 
       test('should correctly encode UTF-8 characters for Excel', async ({ payload }) => {
@@ -2436,6 +2579,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             excerpt: unicodeExcerpt,
             _status: 'published',
           },
+          overrideAccess: true,
         })
 
         let doc = await payload.create({
@@ -2447,11 +2591,12 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             format: 'csv',
             where: { id: { equals: page.id } },
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
 
-        doc = await payload.findByID({ collection: 'exports', id: doc.id })
+        doc = await payload.findByID({ collection: 'exports', id: doc.id, overrideAccess: true })
         const csvPath = path.join(dirname, './uploads', doc.filename as string)
 
         const rawContent = fs.readFileSync(csvPath, 'utf-8')
@@ -2464,7 +2609,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         expect(data[0].title).toBe(unicodeTitle)
         expect(data[0].excerpt).toBe(unicodeExcerpt)
 
-        await payload.delete({ collection: 'pages', id: page.id })
+        await payload.delete({ collection: 'pages', id: page.id, overrideAccess: true })
       })
 
       test('should handle special CSV characters that could break Excel parsing', async ({
@@ -2480,6 +2625,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             excerpt: specialCharsExcerpt,
             _status: 'published',
           },
+          overrideAccess: true,
         })
 
         let doc = await payload.create({
@@ -2491,18 +2637,19 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             format: 'csv',
             where: { id: { equals: page.id } },
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
 
-        doc = await payload.findByID({ collection: 'exports', id: doc.id })
+        doc = await payload.findByID({ collection: 'exports', id: doc.id, overrideAccess: true })
         const csvPath = path.join(dirname, './uploads', doc.filename as string)
         const data = await readCSV(csvPath)
 
         expect(data[0].title).toBe(specialCharsTitle)
         expect(data[0].excerpt).toBe(specialCharsExcerpt)
 
-        await payload.delete({ collection: 'pages', id: page.id })
+        await payload.delete({ collection: 'pages', id: page.id, overrideAccess: true })
       })
 
       test('should preserve Hebrew characters in CSV download via streaming endpoint', async ({
@@ -2520,6 +2667,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             _status: 'published',
           },
           locale: 'he',
+          overrideAccess: true,
         })
 
         const response = await restClient.POST('/exports/download', {
@@ -2553,7 +2701,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         const content = buffer.toString('utf-8')
         expect(content).toContain(hebrewLocalized)
 
-        await payload.delete({ collection: 'pages', id: page.id })
+        await payload.delete({ collection: 'pages', id: page.id, overrideAccess: true })
       })
 
       test('should preserve Hebrew characters in job-created CSV export', async ({ payload }) => {
@@ -2568,6 +2716,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             _status: 'published',
           },
           locale: 'he',
+          overrideAccess: true,
         })
 
         let doc = await payload.create({
@@ -2580,11 +2729,12 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             locale: 'he',
             where: { id: { equals: page.id } },
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
 
-        doc = await payload.findByID({ collection: 'exports', id: doc.id })
+        doc = await payload.findByID({ collection: 'exports', id: doc.id, overrideAccess: true })
 
         // Verify filename includes collection slug and csv extension
         expect(doc.filename).toContain('-pages')
@@ -2607,7 +2757,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         const data = await readCSV(csvPath)
         expect(data[0].localized).toBe(hebrewLocalized)
 
-        await payload.delete({ collection: 'pages', id: page.id })
+        await payload.delete({ collection: 'pages', id: page.id, overrideAccess: true })
       })
 
       test('should preserve Hebrew characters in hook-created CSV export (no jobs queue)', async ({
@@ -2623,6 +2773,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             content: richTextData,
             _status: 'published',
           },
+          overrideAccess: true,
         })
 
         const doc = await payload.create({
@@ -2634,11 +2785,13 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             format: 'csv',
             where: { id: { equals: post.id } },
           },
+          overrideAccess: true,
         })
 
         const exportDoc = await payload.findByID({
           collection: 'posts-export',
           id: doc.id,
+          overrideAccess: true,
         })
 
         // Verify filename includes collection slug and csv extension
@@ -2662,7 +2815,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         const data = await readCSV(csvPath)
         expect(data[0].title).toBe(hebrewTitle)
 
-        await payload.delete({ collection: 'posts', id: post.id })
+        await payload.delete({ collection: 'posts', id: post.id, overrideAccess: true })
       })
     })
 
@@ -2677,11 +2830,12 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             format: 'csv',
             where: { title: { contains: 'Checkbox ' } },
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
 
-        doc = await payload.findByID({ collection: 'exports', id: doc.id })
+        doc = await payload.findByID({ collection: 'exports', id: doc.id, overrideAccess: true })
         const data = await readCSV(path.join(dirname, './uploads', doc.filename as string))
 
         expect(data).toHaveLength(3)
@@ -2702,11 +2856,12 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             format: 'csv',
             where: { title: { contains: 'Select ' } },
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
 
-        doc = await payload.findByID({ collection: 'exports', id: doc.id })
+        doc = await payload.findByID({ collection: 'exports', id: doc.id, overrideAccess: true })
         const data = await readCSV(path.join(dirname, './uploads', doc.filename as string))
 
         expect(data).toHaveLength(3)
@@ -2725,11 +2880,12 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             format: 'csv',
             where: { title: { contains: 'SelectMany ' } },
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
 
-        doc = await payload.findByID({ collection: 'exports', id: doc.id })
+        doc = await payload.findByID({ collection: 'exports', id: doc.id, overrideAccess: true })
         const data = await readCSV(path.join(dirname, './uploads', doc.filename as string))
 
         expect(data).toHaveLength(3)
@@ -2747,11 +2903,12 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             format: 'csv',
             where: { title: { contains: 'Radio ' } },
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
 
-        doc = await payload.findByID({ collection: 'exports', id: doc.id })
+        doc = await payload.findByID({ collection: 'exports', id: doc.id, overrideAccess: true })
         const data = await readCSV(path.join(dirname, './uploads', doc.filename as string))
 
         expect(data).toHaveLength(3)
@@ -2770,11 +2927,12 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             format: 'csv',
             where: { title: { contains: 'Email ' } },
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
 
-        doc = await payload.findByID({ collection: 'exports', id: doc.id })
+        doc = await payload.findByID({ collection: 'exports', id: doc.id, overrideAccess: true })
         const data = await readCSV(path.join(dirname, './uploads', doc.filename as string))
 
         expect(data).toHaveLength(3)
@@ -2792,11 +2950,12 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             format: 'csv',
             where: { title: { contains: 'Textarea ' } },
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
 
-        doc = await payload.findByID({ collection: 'exports', id: doc.id })
+        doc = await payload.findByID({ collection: 'exports', id: doc.id, overrideAccess: true })
         const data = await readCSV(path.join(dirname, './uploads', doc.filename as string))
 
         expect(data).toHaveLength(3)
@@ -2815,11 +2974,12 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             format: 'csv',
             where: { title: { contains: 'Code ' } },
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
 
-        doc = await payload.findByID({ collection: 'exports', id: doc.id })
+        doc = await payload.findByID({ collection: 'exports', id: doc.id, overrideAccess: true })
         const data = await readCSV(path.join(dirname, './uploads', doc.filename as string))
 
         expect(data).toHaveLength(3)
@@ -2836,11 +2996,12 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             format: 'csv',
             where: { title: { contains: 'Point ' } },
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
 
-        doc = await payload.findByID({ collection: 'exports', id: doc.id })
+        doc = await payload.findByID({ collection: 'exports', id: doc.id, overrideAccess: true })
         const data = await readCSV(path.join(dirname, './uploads', doc.filename as string))
 
         expect(data).toHaveLength(3)
@@ -2857,11 +3018,12 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             format: 'csv',
             where: { title: { contains: 'TextMany ' } },
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
 
-        doc = await payload.findByID({ collection: 'exports', id: doc.id })
+        doc = await payload.findByID({ collection: 'exports', id: doc.id, overrideAccess: true })
         const data = await readCSV(path.join(dirname, './uploads', doc.filename as string))
 
         expect(data).toHaveLength(3)
@@ -2878,11 +3040,12 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             format: 'csv',
             where: { title: { contains: 'Upload ' } },
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
 
-        doc = await payload.findByID({ collection: 'exports', id: doc.id })
+        doc = await payload.findByID({ collection: 'exports', id: doc.id, overrideAccess: true })
         const data = await readCSV(path.join(dirname, './uploads', doc.filename as string))
 
         expect(data).toHaveLength(3)
@@ -2902,6 +3065,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             await payload.delete({
               collection: customIdPagesSlug as CollectionSlug,
               id,
+              overrideAccess: true,
             })
           } catch {
             // Ignore cleanup errors
@@ -2917,6 +3081,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             id: 'export-custom-1',
             title: 'Export Custom Page 1',
           },
+          overrideAccess: true,
         })
 
         await payload.create({
@@ -2925,6 +3090,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             id: 'export-custom-2',
             title: 'Export Custom Page 2',
           },
+          overrideAccess: true,
         })
 
         createdCustomIdPages.push('export-custom-1', 'export-custom-2')
@@ -2940,6 +3106,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
               id: { in: ['export-custom-1', 'export-custom-2'] },
             },
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
@@ -2947,6 +3114,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         exportDoc = await payload.findByID({
           collection: 'exports',
           id: exportDoc.id,
+          overrideAccess: true,
         })
 
         expect(exportDoc.filename).toContain('.csv')
@@ -2971,6 +3139,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             id: 'export-json-1',
             title: 'Export JSON Page 1',
           },
+          overrideAccess: true,
         })
 
         await payload.create({
@@ -2979,6 +3148,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             id: 'export-json-2',
             title: 'Export JSON Page 2',
           },
+          overrideAccess: true,
         })
 
         createdCustomIdPages.push('export-json-1', 'export-json-2')
@@ -2994,6 +3164,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
               id: { in: ['export-json-1', 'export-json-2'] },
             },
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
@@ -3001,6 +3172,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         exportDoc = await payload.findByID({
           collection: 'exports',
           id: exportDoc.id,
+          overrideAccess: true,
         })
 
         expect(exportDoc.filename).toContain('.json')
@@ -3027,6 +3199,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         where: {
           id: { exists: true },
         },
+        overrideAccess: true,
       })
 
       await payload.delete({
@@ -3034,6 +3207,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         where: {
           id: { exists: true },
         },
+        overrideAccess: true,
       })
     })
 
@@ -3049,6 +3223,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
               array: [{ field1: `test ${i}` }],
             },
           },
+          overrideAccess: true,
         })
         createdPages.push(page)
       }
@@ -3064,6 +3239,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             title: { contains: 'Import Test ' },
           },
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -3071,6 +3247,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       const exportedDoc = await payload.findByID({
         collection: 'exports',
         id: exportDoc.id,
+        overrideAccess: true,
       })
 
       const csvPath = path.join(dirname, './uploads', exportedDoc.filename as string)
@@ -3080,6 +3257,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         where: {
           title: { contains: 'Import Test ' },
         },
+        overrideAccess: true,
       })
 
       let importDoc = await payload.create({
@@ -3095,6 +3273,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           name: 'import-test.csv',
           size: fs.statSync(csvPath).size,
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -3102,6 +3281,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       importDoc = await payload.findByID({
         collection: 'imports',
         id: importDoc.id,
+        overrideAccess: true,
       })
 
       if (importDoc.status !== 'completed') {
@@ -3121,6 +3301,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           title: { contains: 'Import Test ' },
         },
         sort: 'title',
+        overrideAccess: true,
       })
 
       expect(importedPages.docs).toHaveLength(3)
@@ -3160,6 +3341,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           name: 'import-test.json',
           size: jsonBuffer.length,
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -3167,6 +3349,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       importDoc = await payload.findByID({
         collection: 'imports',
         id: importDoc.id,
+        overrideAccess: true,
       })
 
       expect(importDoc.status).toBe('completed')
@@ -3179,6 +3362,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           title: { contains: 'JSON Import ' },
         },
         sort: 'title',
+        overrideAccess: true,
       })
 
       expect(importedPages.docs).toHaveLength(2)
@@ -3195,6 +3379,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             value: 'initial value 1',
           },
         },
+        overrideAccess: true,
       })
 
       const page2 = await payload.create({
@@ -3205,6 +3390,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             value: 'initial value 2',
           },
         },
+        overrideAccess: true,
       })
 
       const updateData = [
@@ -3240,6 +3426,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           name: 'update-test.csv',
           size: csvBuffer.length,
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -3247,6 +3434,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       importDoc = await payload.findByID({
         collection: 'imports',
         id: importDoc.id,
+        overrideAccess: true,
       })
 
       expect(importDoc.status).toBe('completed')
@@ -3257,6 +3445,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       const updatedPage1 = await payload.findByID({
         collection: 'pages',
         id: page1.id,
+        overrideAccess: true,
       })
 
       expect(updatedPage1.title).toBe('Updated Test 1')
@@ -3273,6 +3462,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           excerpt: 'existing',
           _status: 'published',
         },
+        overrideAccess: true,
       })
 
       const upsertData = [
@@ -3308,6 +3498,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           name: 'upsert-test.csv',
           size: csvBuffer.length,
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -3315,6 +3506,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       const importDoc = await payload.findByID({
         collection: 'imports',
         id: initialImportDoc.id,
+        overrideAccess: true,
       })
 
       expect(importDoc.status).toBe('completed')
@@ -3347,6 +3539,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         where: {
           title: { equals: `Upsert Test ${timestamp} New` },
         },
+        overrideAccess: true,
       })
       expect(newPages.docs).toHaveLength(1)
       expect(newPages.docs[0]?.excerpt).toBe('new')
@@ -3373,6 +3566,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           name: 'localized-single-test.csv',
           size: csvBuffer.length,
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -3380,6 +3574,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       importDoc = await payload.findByID({
         collection: 'imports',
         id: importDoc.id,
+        overrideAccess: true,
       })
 
       expect(importDoc.status).toBe('completed')
@@ -3393,6 +3588,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         },
         locale: 'en',
         sort: 'title',
+        overrideAccess: true,
       })
 
       expect(importedPages.docs).toHaveLength(2)
@@ -3405,6 +3601,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         where: {
           title: { contains: 'Localized ' },
         },
+        overrideAccess: true,
       })
 
       const csvContent =
@@ -3427,6 +3624,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           name: 'localized-multi-test.csv',
           size: csvBuffer.length,
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -3434,6 +3632,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       importDoc = await payload.findByID({
         collection: 'imports',
         id: importDoc.id,
+        overrideAccess: true,
       })
 
       expect(importDoc.status).toBe('completed')
@@ -3447,6 +3646,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         },
         locale: 'en',
         sort: 'title',
+        overrideAccess: true,
       })
 
       expect(importedPagesEn.docs).toHaveLength(2)
@@ -3459,6 +3659,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         },
         locale: 'es',
         sort: 'title',
+        overrideAccess: true,
       })
 
       expect(importedPagesEs.docs).toHaveLength(2)
@@ -3490,6 +3691,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           name: 'locale-order-test.csv',
           size: csvBuffer.length,
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -3497,6 +3699,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       importDoc = await payload.findByID({
         collection: 'imports',
         id: importDoc.id,
+        overrideAccess: true,
       })
 
       expect(importDoc.status).toBe('completed')
@@ -3511,6 +3714,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         },
         locale: 'en',
         sort: 'title',
+        overrideAccess: true,
       })
 
       expect(importedPagesEn.docs).toHaveLength(2)
@@ -3525,6 +3729,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         },
         locale: 'de',
         sort: 'title',
+        overrideAccess: true,
       })
 
       expect(importedPagesDe.docs).toHaveLength(2)
@@ -3539,6 +3744,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         },
         locale: 'es',
         sort: 'title',
+        overrideAccess: true,
       })
 
       expect(importedPagesEs.docs).toHaveLength(2)
@@ -3551,6 +3757,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         where: {
           title: { contains: 'Locale Order Test ' },
         },
+        overrideAccess: true,
       })
     })
 
@@ -3575,6 +3782,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           name: 'array-import-test.csv',
           size: csvBuffer.length,
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -3582,6 +3790,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       importDoc = await payload.findByID({
         collection: 'imports',
         id: importDoc.id,
+        overrideAccess: true,
       })
 
       expect(importDoc.status).toBe('completed')
@@ -3594,6 +3803,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           title: { contains: 'Array Import ' },
         },
         sort: 'title',
+        overrideAccess: true,
       })
 
       expect(importedPages.docs).toHaveLength(2)
@@ -3624,6 +3834,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           name: 'blocks-import-test.csv',
           size: csvBuffer.length,
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -3631,6 +3842,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       importDoc = await payload.findByID({
         collection: 'imports',
         id: importDoc.id,
+        overrideAccess: true,
       })
 
       expect(importDoc.status).toBe('completed')
@@ -3642,6 +3854,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         where: {
           title: { equals: 'Blocks Import 1' },
         },
+        overrideAccess: true,
       })
 
       expect(importedPages.docs).toHaveLength(1)
@@ -3682,6 +3895,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           name: 'hasmany-import-test.csv',
           size: csvBuffer.length,
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -3689,6 +3903,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       importDoc = await payload.findByID({
         collection: 'imports',
         id: importDoc.id,
+        overrideAccess: true,
       })
 
       if (importDoc.status !== 'completed') {
@@ -3708,6 +3923,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           title: { contains: 'HasMany ' },
         },
         sort: 'title',
+        overrideAccess: true,
       })
 
       expect(importedPages.docs).toHaveLength(5)
@@ -3737,6 +3953,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       const users = await payload.find({
         collection: 'users',
         limit: 3,
+        overrideAccess: true,
       })
       const userId1 = users.docs[0]?.id
       const userId2 = users.docs[1]?.id || userId1 // Fallback if only one user
@@ -3762,6 +3979,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           name: 'relationship-import-test.csv',
           size: csvBuffer.length,
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -3769,6 +3987,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       importDoc = await payload.findByID({
         collection: 'imports',
         id: importDoc.id,
+        overrideAccess: true,
       })
 
       expect(importDoc.status).toBe('completed')
@@ -3781,6 +4000,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           title: { contains: 'Relationship Import ' },
         },
         depth: 1,
+        overrideAccess: true,
       })
 
       expect(importedPages.docs).toHaveLength(2)
@@ -3797,8 +4017,8 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
     test('should handle explicit null vs empty polymorphic relationships in import', async ({
       payload,
     }) => {
-      const users = await payload.find({ collection: 'users', limit: 1 })
-      const posts = await payload.find({ collection: 'posts', limit: 1 })
+      const users = await payload.find({ collection: 'users', limit: 1, overrideAccess: true })
+      const posts = await payload.find({ collection: 'posts', limit: 1, overrideAccess: true })
       const userId = users.docs[0]?.id
       const postId = posts.docs[0]?.id
 
@@ -3816,6 +4036,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             value: 'Original Group Value',
           },
         },
+        overrideAccess: true,
       })
 
       const csvUpdate = [
@@ -3837,6 +4058,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           name: 'update-polymorphic-test.csv',
           size: csvUpdate.length,
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -3844,6 +4066,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       importDoc = await payload.findByID({
         collection: 'imports',
         id: importDoc.id,
+        overrideAccess: true,
       })
 
       expect(importDoc.status).toBe('completed')
@@ -3853,6 +4076,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       const updatedPage = await payload.findByID({
         collection: 'pages',
         id: existingPage.id,
+        overrideAccess: true,
       })
 
       expect(updatedPage.title).toBe('Updated Title')
@@ -3863,6 +4087,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       await payload.delete({
         collection: 'pages',
         id: existingPage.id,
+        overrideAccess: true,
       })
     })
 
@@ -3870,10 +4095,12 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       const users = await payload.find({
         collection: 'users',
         limit: 1,
+        overrideAccess: true,
       })
       const posts = await payload.find({
         collection: 'posts',
         limit: 2,
+        overrideAccess: true,
       })
       const userId = users.docs[0]?.id
       const postId1 = posts.docs[0]?.id
@@ -3898,6 +4125,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           name: 'polymorphic-import-test.csv',
           size: csvBuffer.length,
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -3905,6 +4133,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       importDoc = await payload.findByID({
         collection: 'imports',
         id: importDoc.id,
+        overrideAccess: true,
       })
 
       expect(importDoc.status).toBe('completed')
@@ -3917,6 +4146,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           title: { equals: 'Polymorphic Import 1' },
         },
         depth: 0,
+        overrideAccess: true,
       })
 
       expect(importedPages.docs).toHaveLength(1)
@@ -3956,6 +4186,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           name: 'virtual-import-test.csv',
           size: csvBuffer.length,
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -3963,6 +4194,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       importDoc = await payload.findByID({
         collection: 'imports',
         id: importDoc.id,
+        overrideAccess: true,
       })
 
       expect(importDoc.status).toBe('completed')
@@ -3974,6 +4206,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         where: {
           title: { equals: 'Virtual Import Test' },
         },
+        overrideAccess: true,
       })
 
       expect(importedPages.docs).toHaveLength(1)
@@ -4004,6 +4237,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           name: 'status-import-test.csv',
           size: csvBuffer.length,
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -4011,6 +4245,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       importDoc = await payload.findByID({
         collection: 'imports',
         id: importDoc.id,
+        overrideAccess: true,
       })
 
       expect(importDoc.status).toBe('completed')
@@ -4023,6 +4258,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           title: { contains: 'Draft Import ' },
         },
         draft: true,
+        overrideAccess: true,
       })
 
       expect(draftPages.docs).toHaveLength(2)
@@ -4033,7 +4269,8 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         where: {
           title: { contains: 'Published Import ' },
         },
-        draft: false, // Query for published documents only
+        draft: false,
+        overrideAccess: true, // Query for published documents only
       })
 
       expect(publishedPages.docs).toHaveLength(1)
@@ -4064,6 +4301,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           name: 'default-status-test.csv',
           size: csvBuffer.length,
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -4071,6 +4309,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       importDoc = await payload.findByID({
         collection: 'imports',
         id: importDoc.id,
+        overrideAccess: true,
       })
 
       expect(importDoc.status).toBe('completed')
@@ -4082,7 +4321,8 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         where: {
           title: { contains: 'Default Status Test ' },
         },
-        draft: false, // Query for published documents
+        draft: false,
+        overrideAccess: true, // Query for published documents
       })
 
       expect(pages.docs).toHaveLength(2)
@@ -4107,6 +4347,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           name: 'missing-field-test.csv',
           size: missingFieldBuffer.length,
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -4114,6 +4355,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       importDoc1 = await payload.findByID({
         collection: 'imports',
         id: importDoc1.id,
+        overrideAccess: true,
       })
 
       expect(importDoc1.status).toBe('completed')
@@ -4136,6 +4378,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           name: 'invalid-type-test.csv',
           size: invalidTypeBuffer.length,
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -4143,6 +4386,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       importDoc2 = await payload.findByID({
         collection: 'imports',
         id: importDoc2.id,
+        overrideAccess: true,
       })
 
       expect(importDoc2.status).toBe('completed')
@@ -4166,6 +4410,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           name: 'non-existent-test.csv',
           size: nonExistentBuffer.length,
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -4173,6 +4418,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       importDoc3 = await payload.findByID({
         collection: 'imports',
         id: importDoc3.id,
+        overrideAccess: true,
       })
 
       expect(importDoc3.status).toBe('failed')
@@ -4204,6 +4450,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           name: 'mixed-import-test.csv',
           size: mixedBuffer.length,
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -4211,6 +4458,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       importDoc = await payload.findByID({
         collection: 'imports',
         id: importDoc.id,
+        overrideAccess: true,
       })
 
       expect(importDoc.status).toBe('partial')
@@ -4285,6 +4533,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           name: 'nested-group-test.csv',
           size: csvBuffer.length,
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -4292,6 +4541,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       importDoc = await payload.findByID({
         collection: 'imports',
         id: importDoc.id,
+        overrideAccess: true,
       })
 
       expect(importDoc.status).toBe('completed')
@@ -4303,6 +4553,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         where: {
           title: { equals: 'Nested Group Import' },
         },
+        overrideAccess: true,
       })
 
       expect(importedPages.docs).toHaveLength(1)
@@ -4334,6 +4585,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           name: 'tabs-collapsible-test.csv',
           size: csvBuffer.length,
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -4341,6 +4593,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       importDoc = await payload.findByID({
         collection: 'imports',
         id: importDoc.id,
+        overrideAccess: true,
       })
 
       expect(importDoc.status).toBe('completed')
@@ -4352,6 +4605,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         where: {
           title: { equals: 'Tab Import Test' },
         },
+        overrideAccess: true,
       })
 
       expect(importedPages.docs).toHaveLength(1)
@@ -4391,6 +4645,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           name: 'disabled-fields-test.csv',
           size: csvBuffer.length,
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -4398,6 +4653,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       importDoc = await payload.findByID({
         collection: 'imports',
         id: importDoc.id,
+        overrideAccess: true,
       })
 
       expect(importDoc.status).toBe('completed')
@@ -4409,6 +4665,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         where: {
           title: { equals: 'Disabled Fields Test' },
         },
+        overrideAccess: true,
       })
 
       expect(importedPages.docs).toHaveLength(1)
@@ -4443,6 +4700,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           name: 'jobs-import-test.csv',
           size: csvBuffer.length,
         },
+        overrideAccess: true,
       })
 
       const { docs: jobs } = await payload.find({
@@ -4450,6 +4708,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         where: {
           taskSlug: { equals: 'createCollectionImport' },
         },
+        overrideAccess: true,
       })
 
       expect(jobs.length).toBeGreaterThan(0)
@@ -4475,6 +4734,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       const importDoc = await payload.findByID({
         collection: 'imports' as CollectionSlug,
         id: doc.id,
+        overrideAccess: true,
       })
 
       interface ImportDocWithStatus {
@@ -4491,7 +4751,8 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         where: {
           title: { contains: 'Jobs Import ' },
         },
-        sort: 'title', // Sort by title to ensure consistent order
+        sort: 'title',
+        overrideAccess: true, // Sort by title to ensure consistent order
       })
 
       expect(importedPages.docs).toHaveLength(2)
@@ -4518,6 +4779,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             },
             customRelationship: user.id,
           },
+          overrideAccess: true,
         })
         createdPages.push(page)
       }
@@ -4541,6 +4803,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             title: { contains: 'Roundtrip Test ' },
           },
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -4548,6 +4811,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       const exportedDoc = await payload.findByID({
         collection: 'exports',
         id: exportDoc.id,
+        overrideAccess: true,
       })
 
       const csvPath = path.join(dirname, './uploads', exportedDoc.filename as string)
@@ -4561,6 +4825,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         where: {
           title: { contains: 'Roundtrip Test ' },
         },
+        overrideAccess: true,
       })
 
       let importDoc = await payload.create({
@@ -4576,6 +4841,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           name: 'roundtrip-test.csv',
           size: fs.statSync(csvPath).size,
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -4583,6 +4849,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       importDoc = await payload.findByID({
         collection: 'imports',
         id: importDoc.id,
+        overrideAccess: true,
       })
 
       expect(importDoc.status).toBe('completed')
@@ -4596,6 +4863,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         },
         sort: 'title',
         depth: 1,
+        overrideAccess: true,
       })
 
       expect(importedPages.docs).toHaveLength(3)
@@ -4608,12 +4876,14 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       const testUser = await payload.find({
         collection: 'users',
         limit: 1,
+        overrideAccess: true,
       })
       const testPost = await payload.create({
         collection: 'posts',
         data: {
           title: 'Test Post for Roundtrip',
         },
+        overrideAccess: true,
       })
 
       const testPage = await payload.create({
@@ -4660,6 +4930,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           },
           _status: 'published',
         },
+        overrideAccess: true,
       })
 
       const exportDoc = await payload.create({
@@ -4674,6 +4945,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             id: { equals: testPage.id },
           },
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -4681,6 +4953,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       const exportedDoc = await payload.findByID({
         collection: 'exports',
         id: exportDoc.id,
+        overrideAccess: true,
       })
 
       const csvPath = path.join(dirname, './uploads', exportedDoc.filename as string)
@@ -4688,6 +4961,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       await payload.delete({
         collection: 'pages',
         id: testPage.id,
+        overrideAccess: true,
       })
 
       let importDoc = await payload.create({
@@ -4703,6 +4977,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           name: 'complete-roundtrip.csv',
           size: fs.statSync(csvPath).size,
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -4710,6 +4985,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       importDoc = await payload.findByID({
         collection: 'imports',
         id: importDoc.id,
+        overrideAccess: true,
       })
 
       expect(importDoc.status).toBe('completed')
@@ -4722,6 +4998,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           title: { equals: 'Complete Roundtrip Test' },
         },
         depth: 0,
+        overrideAccess: true,
       })
 
       expect(importedPages.docs).toHaveLength(1)
@@ -4748,6 +5025,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       await payload.delete({
         collection: 'posts',
         id: testPost.id,
+        overrideAccess: true,
       })
     })
 
@@ -4773,6 +5051,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             name: 'batch-test.csv',
             size: csvBuffer.length,
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
@@ -4780,6 +5059,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         importDoc = await payload.findByID({
           collection: 'imports',
           id: importDoc.id,
+          overrideAccess: true,
         })
 
         expect(importDoc.status).toBe('completed')
@@ -4792,6 +5072,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             title: { contains: 'Batch Test ' },
           },
           limit: 300,
+          overrideAccess: true,
         })
 
         expect(importedPages.totalDocs).toBe(250)
@@ -4801,6 +5082,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           where: {
             title: { contains: 'Batch Test ' },
           },
+          overrideAccess: true,
         })
       })
 
@@ -4827,6 +5109,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             name: 'batch-errors-test.csv',
             size: csvBuffer.length,
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
@@ -4834,6 +5117,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         importDoc = await payload.findByID({
           collection: 'imports',
           id: importDoc.id,
+          overrideAccess: true,
         })
 
         expect(importDoc.status).toBe('partial')
@@ -4845,6 +5129,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           where: {
             title: { contains: 'Valid Doc ' },
           },
+          overrideAccess: true,
         })
       })
 
@@ -4852,6 +5137,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         const testUser = await payload.find({
           collection: 'users',
           limit: 1,
+          overrideAccess: true,
         })
         const userId = testUser.docs[0]?.id
 
@@ -4876,6 +5162,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             name: 'row-numbers-test.csv',
             size: csvBuffer.length,
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
@@ -4883,6 +5170,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         importDoc = await payload.findByID({
           collection: 'imports',
           id: importDoc.id,
+          overrideAccess: true,
         })
 
         expect(importDoc.summary?.imported).toBe(3)
@@ -4900,6 +5188,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           where: {
             title: { contains: 'Row ' },
           },
+          overrideAccess: true,
         })
       })
 
@@ -4924,6 +5213,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             name: 'batch-localized-test.csv',
             size: csvBuffer.length,
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
@@ -4931,6 +5221,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         importDoc = await payload.findByID({
           collection: 'imports',
           id: importDoc.id,
+          overrideAccess: true,
         })
 
         expect(importDoc.status).toBe('completed')
@@ -4944,6 +5235,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           },
           locale: 'en',
           limit: 200,
+          overrideAccess: true,
         })
 
         expect(importedPagesEn.totalDocs).toBe(150)
@@ -4956,6 +5248,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           },
           locale: 'es',
           limit: 200,
+          overrideAccess: true,
         })
 
         expect(importedPagesEs.docs[0]?.localized).toContain('Spanish')
@@ -4965,6 +5258,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           where: {
             title: { contains: 'Batch Localized ' },
           },
+          overrideAccess: true,
         })
       })
 
@@ -4988,6 +5282,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             name: 'default-status-test.csv',
             size: csvBuffer.length,
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
@@ -4995,6 +5290,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         importDoc = await payload.findByID({
           collection: 'imports',
           id: importDoc.id,
+          overrideAccess: true,
         })
 
         expect(importDoc.status).toBe('completed')
@@ -5007,6 +5303,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             title: { contains: 'Default Status Test ' },
           },
           draft: false,
+          overrideAccess: true,
         })
 
         expect(publishedPages.totalDocs).toBe(2)
@@ -5019,6 +5316,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           where: {
             title: { contains: 'Default Status Test ' },
           },
+          overrideAccess: true,
         })
       })
 
@@ -5042,6 +5340,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             name: 'explicit-draft-test.csv',
             size: csvBuffer.length,
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
@@ -5049,6 +5348,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         importDoc = await payload.findByID({
           collection: 'imports',
           id: importDoc.id,
+          overrideAccess: true,
         })
 
         expect(importDoc.status).toBe('completed')
@@ -5061,6 +5361,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             title: { contains: 'Explicit Draft Test ' },
           },
           draft: true,
+          overrideAccess: true,
         })
 
         expect(draftPages.totalDocs).toBe(2)
@@ -5073,6 +5374,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           where: {
             title: { contains: 'Explicit Draft Test ' },
           },
+          overrideAccess: true,
         })
       })
 
@@ -5097,6 +5399,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             name: 'upsert-new-published-test.csv',
             size: csvBuffer.length,
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
@@ -5104,6 +5407,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         importDoc = await payload.findByID({
           collection: 'imports',
           id: importDoc.id,
+          overrideAccess: true,
         })
 
         expect(importDoc.status).toBe('completed')
@@ -5116,6 +5420,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             title: { contains: 'Upsert New Published Test ' },
           },
           draft: false,
+          overrideAccess: true,
         })
 
         expect(publishedPages.totalDocs).toBe(2)
@@ -5128,6 +5433,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           where: {
             title: { contains: 'Upsert New Published Test ' },
           },
+          overrideAccess: true,
         })
       })
 
@@ -5151,6 +5457,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             name: 'manual-locale-test.csv',
             size: csvBuffer.length,
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
@@ -5158,6 +5465,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         importDoc = await payload.findByID({
           collection: 'imports',
           id: importDoc.id,
+          overrideAccess: true,
         })
 
         expect(importDoc.status).toBe('completed')
@@ -5169,6 +5477,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           where: {
             title: { contains: 'Manual Locale Test ' },
           },
+          overrideAccess: true,
         })
 
         expect(importedPages.totalDocs).toBe(2)
@@ -5184,6 +5493,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           where: {
             title: { contains: 'Manual Locale Test ' },
           },
+          overrideAccess: true,
         })
       })
     })
@@ -5212,11 +5522,12 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             name: 'checkbox-import.csv',
             size: csvBuffer.length,
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
 
-        importDoc = await payload.findByID({ collection: 'imports', id: importDoc.id })
+        importDoc = await payload.findByID({ collection: 'imports', id: importDoc.id, overrideAccess: true })
 
         expect(importDoc.status).toBe('completed')
         expect(importDoc.summary?.imported).toBe(4)
@@ -5225,6 +5536,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           collection: 'pages',
           where: { title: { contains: 'Checkbox Import ' } },
           sort: 'title',
+          overrideAccess: true,
         })
 
         expect(importedPages.docs).toHaveLength(4)
@@ -5242,6 +5554,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         await payload.delete({
           collection: 'pages',
           where: { title: { contains: 'Checkbox Import ' } },
+          overrideAccess: true,
         })
       })
 
@@ -5267,11 +5580,12 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             name: 'select-import.csv',
             size: csvBuffer.length,
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
 
-        importDoc = await payload.findByID({ collection: 'imports', id: importDoc.id })
+        importDoc = await payload.findByID({ collection: 'imports', id: importDoc.id, overrideAccess: true })
 
         expect(importDoc.status).toBe('completed')
         expect(importDoc.summary?.imported).toBe(3)
@@ -5280,6 +5594,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           collection: 'pages',
           where: { title: { contains: 'Select Import ' } },
           sort: 'title',
+          overrideAccess: true,
         })
 
         expect(importedPages.docs).toHaveLength(3)
@@ -5296,6 +5611,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         await payload.delete({
           collection: 'pages',
           where: { title: { contains: 'Select Import ' } },
+          overrideAccess: true,
         })
       })
 
@@ -5321,11 +5637,12 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             name: 'radio-import.csv',
             size: csvBuffer.length,
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
 
-        importDoc = await payload.findByID({ collection: 'imports', id: importDoc.id })
+        importDoc = await payload.findByID({ collection: 'imports', id: importDoc.id, overrideAccess: true })
 
         expect(importDoc.status).toBe('completed')
         expect(importDoc.summary?.imported).toBe(3)
@@ -5334,6 +5651,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           collection: 'pages',
           where: { title: { contains: 'Radio Import ' } },
           sort: 'title',
+          overrideAccess: true,
         })
 
         expect(importedPages.docs).toHaveLength(3)
@@ -5344,6 +5662,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         await payload.delete({
           collection: 'pages',
           where: { title: { contains: 'Radio Import ' } },
+          overrideAccess: true,
         })
       })
 
@@ -5368,11 +5687,12 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             name: 'email-import.csv',
             size: csvBuffer.length,
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
 
-        importDoc = await payload.findByID({ collection: 'imports', id: importDoc.id })
+        importDoc = await payload.findByID({ collection: 'imports', id: importDoc.id, overrideAccess: true })
 
         expect(importDoc.status).toBe('completed')
         expect(importDoc.summary?.imported).toBe(2)
@@ -5381,6 +5701,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           collection: 'pages',
           where: { title: { contains: 'Email Import ' } },
           sort: 'title',
+          overrideAccess: true,
         })
 
         expect(importedPages.docs).toHaveLength(2)
@@ -5394,6 +5715,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         await payload.delete({
           collection: 'pages',
           where: { title: { contains: 'Email Import ' } },
+          overrideAccess: true,
         })
       })
 
@@ -5415,11 +5737,12 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             name: 'textarea-import.csv',
             size: csvBuffer.length,
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
 
-        importDoc = await payload.findByID({ collection: 'imports', id: importDoc.id })
+        importDoc = await payload.findByID({ collection: 'imports', id: importDoc.id, overrideAccess: true })
 
         expect(importDoc.status).toBe('completed')
         expect(importDoc.summary?.imported).toBe(1)
@@ -5427,6 +5750,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         const importedPages = await payload.find({
           collection: 'pages',
           where: { title: { equals: 'Textarea Import 1' } },
+          overrideAccess: true,
         })
 
         expect(importedPages.docs).toHaveLength(1)
@@ -5436,6 +5760,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         await payload.delete({
           collection: 'pages',
           where: { title: { equals: 'Textarea Import 1' } },
+          overrideAccess: true,
         })
       })
 
@@ -5457,11 +5782,12 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             name: 'code-import.csv',
             size: csvBuffer.length,
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
 
-        importDoc = await payload.findByID({ collection: 'imports', id: importDoc.id })
+        importDoc = await payload.findByID({ collection: 'imports', id: importDoc.id, overrideAccess: true })
 
         expect(importDoc.status).toBe('completed')
         expect(importDoc.summary?.imported).toBe(1)
@@ -5469,6 +5795,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         const importedPages = await payload.find({
           collection: 'pages',
           where: { title: { equals: 'Code Import 1' } },
+          overrideAccess: true,
         })
 
         expect(importedPages.docs).toHaveLength(1)
@@ -5477,6 +5804,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         await payload.delete({
           collection: 'pages',
           where: { title: { equals: 'Code Import 1' } },
+          overrideAccess: true,
         })
       })
 
@@ -5501,11 +5829,12 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             name: 'point-import.csv',
             size: csvBuffer.length,
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
 
-        importDoc = await payload.findByID({ collection: 'imports', id: importDoc.id })
+        importDoc = await payload.findByID({ collection: 'imports', id: importDoc.id, overrideAccess: true })
 
         expect(importDoc.status).toBe('completed')
         expect(importDoc.summary?.imported).toBe(2)
@@ -5514,6 +5843,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           collection: 'pages',
           where: { title: { contains: 'Point Import ' } },
           sort: 'title',
+          overrideAccess: true,
         })
 
         expect(importedPages.docs).toHaveLength(2)
@@ -5527,6 +5857,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         await payload.delete({
           collection: 'pages',
           where: { title: { contains: 'Point Import ' } },
+          overrideAccess: true,
         })
       })
 
@@ -5554,11 +5885,12 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             name: 'select-hasmany-import.csv',
             size: csvBuffer.length,
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
 
-        importDoc = await payload.findByID({ collection: 'imports', id: importDoc.id })
+        importDoc = await payload.findByID({ collection: 'imports', id: importDoc.id, overrideAccess: true })
 
         expect(importDoc.status).toBe('completed')
         expect(importDoc.summary?.imported).toBe(3)
@@ -5567,6 +5899,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           collection: 'pages',
           where: { title: { contains: 'SelectHasMany Import ' } },
           sort: 'title',
+          overrideAccess: true,
         })
 
         expect(importedPages.docs).toHaveLength(3)
@@ -5583,6 +5916,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         await payload.delete({
           collection: 'pages',
           where: { title: { contains: 'SelectHasMany Import ' } },
+          overrideAccess: true,
         })
       })
 
@@ -5608,11 +5942,12 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             name: 'text-hasmany-import.csv',
             size: csvBuffer.length,
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
 
-        importDoc = await payload.findByID({ collection: 'imports', id: importDoc.id })
+        importDoc = await payload.findByID({ collection: 'imports', id: importDoc.id, overrideAccess: true })
 
         expect(importDoc.status).toBe('completed')
         expect(importDoc.summary?.imported).toBe(3)
@@ -5621,6 +5956,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           collection: 'pages',
           where: { title: { contains: 'TextHasMany Import ' } },
           sort: 'title',
+          overrideAccess: true,
         })
 
         expect(importedPages.docs).toHaveLength(3)
@@ -5637,6 +5973,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         await payload.delete({
           collection: 'pages',
           where: { title: { contains: 'TextHasMany Import ' } },
+          overrideAccess: true,
         })
       })
 
@@ -5653,6 +5990,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             ...imageFile,
             name: 'import-test-media.png',
           } as File,
+          overrideAccess: true,
         })
 
         const csvContent = `title,upload\n"Upload Import 1","${media.id}"\n"Upload Import 2","${media.id}"`
@@ -5672,11 +6010,12 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             name: 'upload-import.csv',
             size: csvBuffer.length,
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
 
-        importDoc = await payload.findByID({ collection: 'imports', id: importDoc.id })
+        importDoc = await payload.findByID({ collection: 'imports', id: importDoc.id, overrideAccess: true })
 
         expect(importDoc.status).toBe('completed')
         expect(importDoc.summary?.imported).toBe(2)
@@ -5686,6 +6025,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           where: { title: { contains: 'Upload Import ' } },
           sort: 'title',
           depth: 0,
+          overrideAccess: true,
         })
 
         expect(importedPages.docs).toHaveLength(2)
@@ -5695,10 +6035,12 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         await payload.delete({
           collection: 'pages',
           where: { title: { contains: 'Upload Import ' } },
+          overrideAccess: true,
         })
         await payload.delete({
           collection: 'media',
           id: media.id,
+          overrideAccess: true,
         })
       })
     })
@@ -5712,6 +6054,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             await payload.delete({
               collection: customIdPagesSlug as CollectionSlug,
               id,
+              overrideAccess: true,
             })
           } catch {
             // Ignore cleanup errors
@@ -5742,6 +6085,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             name: 'custom-id-import.json',
             size: jsonBuffer.length,
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
@@ -5749,6 +6093,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         const completedImport = await payload.findByID({
           collection: 'imports',
           id: importDoc.id,
+          overrideAccess: true,
         })
 
         expect(completedImport.status).toBe('completed')
@@ -5758,6 +6103,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         const importedPages = await payload.find({
           collection: customIdPagesSlug as CollectionSlug,
           sort: 'id',
+          overrideAccess: true,
         })
 
         expect(importedPages.docs).toHaveLength(3)
@@ -5786,6 +6132,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             name: 'custom-id-import.csv',
             size: csvBuffer.length,
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
@@ -5793,6 +6140,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         const completedImport = await payload.findByID({
           collection: 'imports',
           id: importDoc.id,
+          overrideAccess: true,
         })
 
         expect(completedImport.status).toBe('completed')
@@ -5804,6 +6152,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             id: { in: ['custom-csv-1', 'custom-csv-2'] },
           },
           sort: 'id',
+          overrideAccess: true,
         })
 
         expect(importedPages.docs).toHaveLength(2)
@@ -5837,6 +6186,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             name: 'upsert-custom-id.json',
             size: jsonBuffer.length,
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
@@ -5844,6 +6194,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         const completedImport = await payload.findByID({
           collection: 'imports',
           id: importDoc.id,
+          overrideAccess: true,
         })
 
         expect(completedImport.status).toBe('completed')
@@ -5855,6 +6206,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             id: { in: ['upsert-custom-1', 'upsert-custom-2'] },
           },
           sort: 'id',
+          overrideAccess: true,
         })
 
         expect(importedPages.docs).toHaveLength(2)
@@ -5873,6 +6225,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             id: 'existing-custom-1',
             title: 'Original Title',
           },
+          overrideAccess: true,
         })
 
         createdCustomIdPages.push('existing-custom-1')
@@ -5895,6 +6248,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             name: 'upsert-update-custom-id.json',
             size: jsonBuffer.length,
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
@@ -5902,6 +6256,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         const completedImport = await payload.findByID({
           collection: 'imports',
           id: importDoc.id,
+          overrideAccess: true,
         })
 
         expect(completedImport.status).toBe('completed')
@@ -5910,6 +6265,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         const updatedPage = await payload.findByID({
           collection: customIdPagesSlug as CollectionSlug,
           id: 'existing-custom-1',
+          overrideAccess: true,
         })
 
         expect(updatedPage.title).toBe('Updated Title via Upsert')
@@ -5924,6 +6280,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             id: 'update-mode-custom-1',
             title: 'Original Title for Update Mode',
           },
+          overrideAccess: true,
         })
 
         createdCustomIdPages.push('update-mode-custom-1')
@@ -5946,6 +6303,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             size: jsonBuffer.length,
           },
           user,
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
@@ -5953,6 +6311,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         const completedImport = await payload.findByID({
           id: importDoc.id,
           collection: 'imports',
+          overrideAccess: true,
         })
 
         expect(completedImport.status).toBe('completed')
@@ -5961,6 +6320,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         const updatedPage = await payload.findByID({
           id: 'update-mode-custom-1',
           collection: customIdPagesSlug as CollectionSlug,
+          overrideAccess: true,
         })
 
         expect(updatedPage.title).toBe('Updated via Update Mode')
@@ -5987,6 +6347,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             size: jsonBuffer.length,
           },
           user,
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
@@ -5994,6 +6355,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         const completedImport = await payload.findByID({
           id: importDoc.id,
           collection: 'imports',
+          overrideAccess: true,
         })
 
         expect(completedImport.status).toBe('failed')
@@ -6068,6 +6430,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             collectionSlug: 'posts-exports-only',
             format: 'csv',
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
@@ -6075,6 +6438,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         const exportDoc = await payload.findByID({
           collection: 'exports',
           id: doc.id,
+          overrideAccess: true,
         })
 
         expect(exportDoc.filename).toBeDefined()
@@ -6096,6 +6460,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             collectionSlug: 'posts-exports-only',
             format: 'csv',
           },
+          overrideAccess: true,
         })
 
         const {
@@ -6104,6 +6469,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           collection: 'payload-jobs',
           sort: '-createdAt',
           limit: 1,
+          overrideAccess: true,
         })
 
         expect(latestJob).toBeDefined()
@@ -6113,6 +6479,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         const exportDoc = await payload.findByID({
           collection: 'exports',
           id: doc.id,
+          overrideAccess: true,
         })
 
         const expectedPath = path.join(dirname, './uploads', exportDoc.filename as string)
@@ -6142,6 +6509,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             name: 'sync-import-test.csv',
             size: csvBuffer.length,
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
@@ -6149,6 +6517,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         importDoc = await payload.findByID({
           collection: 'imports',
           id: importDoc.id,
+          overrideAccess: true,
         })
 
         expect(importDoc.status).toBe('completed')
@@ -6160,6 +6529,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           where: {
             title: { contains: 'Sync Import Test' },
           },
+          overrideAccess: true,
         })
 
         expect(importedDocs.totalDocs).toBe(3)
@@ -6169,6 +6539,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           where: {
             title: { contains: 'Sync Import Test' },
           },
+          overrideAccess: true,
         })
       })
 
@@ -6191,6 +6562,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             name: 'restricted-import-test.csv',
             size: csvBuffer.length,
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
@@ -6210,6 +6582,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           where: {
             title: { contains: 'Restricted Import Test' },
           },
+          overrideAccess: true,
         })
 
         expect(importedDocs.totalDocs).toBe(0)
@@ -6235,6 +6608,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             name: 'default-draft-config-test.csv',
             size: csvBuffer.length,
           },
+          overrideAccess: true,
         })
 
         await payload.jobs.run()
@@ -6242,6 +6616,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         importDoc = await payload.findByID({
           collection: 'imports',
           id: importDoc.id,
+          overrideAccess: true,
         })
 
         expect(importDoc.status).toBe('completed')
@@ -6254,6 +6629,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             title: { contains: 'Default Draft Config Test' },
           },
           draft: true,
+          overrideAccess: true,
         })
 
         expect(draftDocs.totalDocs).toBe(2)
@@ -6267,6 +6643,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             title: { equals: 'Default Draft Config Override Test' },
           },
           draft: false,
+          overrideAccess: true,
         })
 
         expect(publishedDocs.totalDocs).toBe(1)
@@ -6280,6 +6657,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
               { title: { equals: 'Default Draft Config Override Test' } },
             ],
           },
+          overrideAccess: true,
         })
       })
     })
@@ -6293,6 +6671,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           data: {
             title: `Access Control Export Test ${i}`,
           },
+          overrideAccess: true,
         })
       }
 
@@ -6304,6 +6683,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           format: 'csv',
           limit: 100,
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -6311,6 +6691,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       const exportDoc = await payload.findByID({
         collection: 'exports',
         id: doc.id,
+        overrideAccess: true,
       })
 
       expect(exportDoc.filename).toBeDefined()
@@ -6337,6 +6718,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           name: 'jobs-queue-import-test.csv',
           size: csvBuffer.length,
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -6344,6 +6726,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       const updatedImportDoc = await payload.findByID({
         collection: 'imports',
         id: importDoc.id,
+        overrideAccess: true,
       })
 
       expect(updatedImportDoc.status).toBe('completed')
@@ -6354,6 +6737,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         where: {
           title: { contains: 'Jobs Queue Import' },
         },
+        overrideAccess: true,
       })
 
       expect(importedDocs.totalDocs).toBe(2)
@@ -6363,6 +6747,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         where: {
           title: { contains: 'Jobs Queue Import' },
         },
+        overrideAccess: true,
       })
     })
   })
@@ -6376,6 +6761,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           excerpt: 'Excerpt for preview 1',
           _status: 'published',
         },
+        overrideAccess: true,
       })
 
       await payload.create({
@@ -6385,6 +6771,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           excerpt: 'Excerpt for preview 2',
           _status: 'published',
         },
+        overrideAccess: true,
       })
 
       const response = await restClient
@@ -6415,6 +6802,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         where: {
           title: { contains: 'Preview Export Test' },
         },
+        overrideAccess: true,
       })
     })
 
@@ -6429,6 +6817,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           },
           _status: 'published',
         },
+        overrideAccess: true,
       })
 
       const response = await restClient
@@ -6457,6 +6846,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         where: {
           title: { equals: 'JSON Preview Export Test' },
         },
+        overrideAccess: true,
       })
     })
 
@@ -6534,6 +6924,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         data: {
           title: 'Preview field validation',
         },
+        overrideAccess: true,
       })
       const objectPrototypeBefore = Object.getOwnPropertyDescriptors(Object.prototype)
 
@@ -6555,6 +6946,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         const unchangedPost = await payload.findByID({
           collection: 'posts-imports-only',
           id: post.id,
+          overrideAccess: true,
         })
 
         expect(previewResponse.status).toBe(400)
@@ -6566,6 +6958,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         await payload.delete({
           collection: 'posts-imports-only',
           id: post.id,
+          overrideAccess: true,
         })
       }
     })
@@ -6584,6 +6977,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           excerpt: 'preview excerpt',
           _status: 'published',
         },
+        overrideAccess: true,
       })
 
       const response = await restClient
@@ -6635,7 +7029,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       // excerpt should still be present
       expect(doc.excerpt).toBe('preview excerpt')
 
-      await payload.delete({ collection: 'pages', id: page.id })
+      await payload.delete({ collection: 'pages', id: page.id, overrideAccess: true })
     })
 
     test('should remove replaced columns from preview when no fields are selected', async ({
@@ -6651,6 +7045,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           customRelIdName: user.id,
           _status: 'published',
         },
+        overrideAccess: true,
       })
 
       const response = await restClient
@@ -6690,7 +7085,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       expect(responseColumns).not.toContain('customRelIdName')
       expect(doc).not.toHaveProperty('customRelIdName')
 
-      await payload.delete({ collection: 'pages', id: page.id })
+      await payload.delete({ collection: 'pages', id: page.id, overrideAccess: true })
     })
 
     test('should handle invalid collection slug in import preview', async ({ restClient }) => {
@@ -6906,6 +7301,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             title: `Preview Limit Test ${i}`,
             _status: 'published',
           },
+          overrideAccess: true,
         })
       }
 
@@ -6932,6 +7328,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         where: {
           title: { contains: 'Preview Limit Test' },
         },
+        overrideAccess: true,
       })
     })
 
@@ -6946,6 +7343,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             title: `Preview Pagination Test ${i}`,
             _status: 'published',
           },
+          overrideAccess: true,
         })
       }
 
@@ -7018,6 +7416,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         where: {
           title: { contains: 'Preview Pagination Test' },
         },
+        overrideAccess: true,
       })
     })
 
@@ -7032,6 +7431,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             title: `Preview Boundary Test ${i}`,
             _status: 'published',
           },
+          overrideAccess: true,
         })
       }
 
@@ -7070,6 +7470,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         where: {
           title: { contains: 'Preview Boundary Test' },
         },
+        overrideAccess: true,
       })
     })
 
@@ -7101,11 +7502,13 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           format: 'csv',
           limit: 5,
         },
+        overrideAccess: true,
       })
 
       const finalExportDoc = await payload.findByID({
         collection: 'posts-export',
         id: exportDoc.id,
+        overrideAccess: true,
       })
 
       expect(finalExportDoc.filename).toBeDefined()
@@ -7148,11 +7551,13 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           format: 'csv',
           limit: 5,
         },
+        overrideAccess: true,
       })
 
       const finalExportDoc = await payload.findByID({
         collection: 'posts-export',
         id: exportDoc.id,
+        overrideAccess: true,
       })
 
       expect(finalExportDoc.filename).toBeDefined()
@@ -7181,6 +7586,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             },
           ],
         },
+        overrideAccess: true,
       })
 
       const exportDoc = await payload.create({
@@ -7193,6 +7599,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             id: { equals: page.id },
           },
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -7200,6 +7607,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       const exportedDoc = await payload.findByID({
         collection: 'exports',
         id: exportDoc.id,
+        overrideAccess: true,
       })
 
       const jsonPath = path.join(dirname, './uploads', exportedDoc.filename as string)
@@ -7213,6 +7621,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         where: {
           id: { equals: page.id },
         },
+        overrideAccess: true,
       })
 
       const jsonBuffer = Buffer.from(JSON.stringify(exportedData))
@@ -7229,6 +7638,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           name: 'rich-text-test.json',
           size: jsonBuffer.length,
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -7236,6 +7646,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       importDoc = await payload.findByID({
         collection: 'imports',
         id: importDoc.id,
+        overrideAccess: true,
       })
 
       expect(importDoc.status).toBe('completed')
@@ -7245,6 +7656,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         where: {
           title: { equals: 'Rich Text JSON Test' },
         },
+        overrideAccess: true,
       })
 
       expect(importedPage.docs).toHaveLength(1)
@@ -7258,6 +7670,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         where: {
           title: { equals: 'Rich Text JSON Test' },
         },
+        overrideAccess: true,
       })
     })
 
@@ -7274,6 +7687,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             },
           ],
         },
+        overrideAccess: true,
       })
 
       const exportDoc = await payload.create({
@@ -7286,6 +7700,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             id: { equals: page.id },
           },
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -7293,6 +7708,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       const exportedDoc = await payload.findByID({
         collection: 'exports',
         id: exportDoc.id,
+        overrideAccess: true,
       })
 
       const csvPath = path.join(dirname, './uploads', exportedDoc.filename as string)
@@ -7302,6 +7718,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         where: {
           id: { equals: page.id },
         },
+        overrideAccess: true,
       })
 
       let importDoc = await payload.create({
@@ -7317,6 +7734,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           name: 'rich-text-csv-test.csv',
           size: fs.statSync(csvPath).size,
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -7324,6 +7742,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       importDoc = await payload.findByID({
         collection: 'imports',
         id: importDoc.id,
+        overrideAccess: true,
       })
 
       expect(importDoc.status).toBe('completed')
@@ -7333,6 +7752,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         where: {
           title: { equals: 'Rich Text CSV Block Test' },
         },
+        overrideAccess: true,
       })
 
       expect(importedPage.docs).toHaveLength(1)
@@ -7346,6 +7766,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         where: {
           title: { equals: 'Rich Text CSV Block Test' },
         },
+        overrideAccess: true,
       })
     })
   })
@@ -7374,6 +7795,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           name: 'error-recovery-test.csv',
           size: csvBuffer.length,
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -7381,6 +7803,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       importDoc = await payload.findByID({
         collection: 'imports',
         id: importDoc.id,
+        overrideAccess: true,
       })
 
       expect(importDoc.status).toBe('completed')
@@ -7391,6 +7814,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         where: {
           title: { contains: 'Error Recovery Test' },
         },
+        overrideAccess: true,
       })
 
       expect(importedDocs.totalDocs).toBeGreaterThanOrEqual(1)
@@ -7400,6 +7824,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         where: {
           title: { contains: 'Error Recovery Test' },
         },
+        overrideAccess: true,
       })
     })
 
@@ -7427,6 +7852,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           name: 'partial-fail-test.csv',
           size: csvBuffer.length,
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -7434,6 +7860,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       importDoc = await payload.findByID({
         collection: 'imports',
         id: importDoc.id,
+        overrideAccess: true,
       })
 
       expect(importDoc.status).toBe('completed')
@@ -7445,6 +7872,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         where: {
           title: { contains: 'Partial Fail Test' },
         },
+        overrideAccess: true,
       })
     })
 
@@ -7465,6 +7893,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           name: 'malformed-csv-test.csv',
           size: csvBuffer.length,
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -7472,6 +7901,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       importDoc = await payload.findByID({
         collection: 'imports',
         id: importDoc.id,
+        overrideAccess: true,
       })
 
       expect(['failed', 'completed', 'pending']).toContain(importDoc.status)
@@ -7486,6 +7916,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           title: 'ToCSV Undefined Test',
           custom: 'test value',
         },
+        overrideAccess: true,
       })
 
       const exportDoc = await payload.create({
@@ -7499,6 +7930,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             id: { equals: page.id },
           },
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -7506,6 +7938,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       const exportedDoc = await payload.findByID({
         collection: 'exports',
         id: exportDoc.id,
+        overrideAccess: true,
       })
 
       expect(exportedDoc.filename).toBeDefined()
@@ -7519,6 +7952,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         where: {
           id: { equals: page.id },
         },
+        overrideAccess: true,
       })
     })
 
@@ -7530,6 +7964,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           customRelationship: user.id,
           _status: 'published',
         },
+        overrideAccess: true,
       })
 
       const exportDoc = await payload.create({
@@ -7543,6 +7978,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             id: { equals: page.id },
           },
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -7550,6 +7986,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       const exportedDoc = await payload.findByID({
         collection: 'exports',
         id: exportDoc.id,
+        overrideAccess: true,
       })
 
       const csvPath = path.join(dirname, './uploads', exportedDoc.filename as string)
@@ -7563,6 +8000,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         where: {
           id: { equals: page.id },
         },
+        overrideAccess: true,
       })
 
       let importDoc = await payload.create({
@@ -7578,6 +8016,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           name: 'from-csv-test.csv',
           size: fs.statSync(csvPath).size,
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -7585,6 +8024,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       importDoc = await payload.findByID({
         collection: 'imports',
         id: importDoc.id,
+        overrideAccess: true,
       })
 
       expect(importDoc.status).toBe('completed')
@@ -7594,6 +8034,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         where: {
           title: { equals: 'FromCSV Relationship Test' },
         },
+        overrideAccess: true,
       })
 
       expect(importedPage.docs).toHaveLength(1)
@@ -7604,6 +8045,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         where: {
           title: { equals: 'FromCSV Relationship Test' },
         },
+        overrideAccess: true,
       })
     })
   })
@@ -7619,6 +8061,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             ignore: 'this field exists but is not disabled',
           },
         },
+        overrideAccess: true,
       })
 
       const exportDoc = await payload.create({
@@ -7632,6 +8075,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             id: { equals: page.id },
           },
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -7639,6 +8083,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       const exportedDoc = await payload.findByID({
         collection: 'exports',
         id: exportDoc.id,
+        overrideAccess: true,
       })
 
       const csvPath = path.join(dirname, './uploads', exportedDoc.filename as string)
@@ -7652,6 +8097,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         where: {
           id: { equals: page.id },
         },
+        overrideAccess: true,
       })
     })
   })
@@ -7692,6 +8138,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           name: 'deeply-nested-test.json',
           size: jsonBuffer.length,
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -7699,6 +8146,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       importDoc = await payload.findByID({
         collection: 'imports',
         id: importDoc.id,
+        overrideAccess: true,
       })
 
       expect(importDoc.status).toBe('completed')
@@ -7709,6 +8157,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         where: {
           title: { equals: 'Deeply Nested Test' },
         },
+        overrideAccess: true,
       })
 
       expect(importedPage.docs).toHaveLength(1)
@@ -7725,6 +8174,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         where: {
           title: { equals: 'Deeply Nested Test' },
         },
+        overrideAccess: true,
       })
     })
 
@@ -7748,6 +8198,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           },
         },
         locale: 'en',
+        overrideAccess: true,
       })
 
       const exportDoc = await payload.create({
@@ -7760,6 +8211,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             id: { equals: page.id },
           },
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -7767,6 +8219,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       const exportedDoc = await payload.findByID({
         collection: 'exports',
         id: exportDoc.id,
+        overrideAccess: true,
       })
 
       const jsonPath = path.join(dirname, './uploads', exportedDoc.filename as string)
@@ -7781,6 +8234,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         where: {
           id: { equals: page.id },
         },
+        overrideAccess: true,
       })
 
       const jsonBuffer = Buffer.from(JSON.stringify(exportedData))
@@ -7797,6 +8251,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           name: 'json-roundtrip-test.json',
           size: jsonBuffer.length,
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -7804,6 +8259,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       importDoc = await payload.findByID({
         collection: 'imports',
         id: importDoc.id,
+        overrideAccess: true,
       })
 
       expect(importDoc.status).toBe('completed')
@@ -7813,6 +8269,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         where: {
           title: { equals: 'JSON Roundtrip Test' },
         },
+        overrideAccess: true,
       })
 
       expect(importedPage.docs).toHaveLength(1)
@@ -7827,6 +8284,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         where: {
           title: { equals: 'JSON Roundtrip Test' },
         },
+        overrideAccess: true,
       })
     })
   })
@@ -7836,10 +8294,12 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       await payload.create({
         collection: 'pages',
         data: { title: 'Pagination Test 1', _status: 'published' },
+        overrideAccess: true,
       })
       await payload.create({
         collection: 'pages',
         data: { title: 'Pagination Test 2', _status: 'published' },
+        overrideAccess: true,
       })
 
       const exportDoc = await payload.create({
@@ -7854,6 +8314,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             title: { contains: 'Pagination Test' },
           },
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -7861,6 +8322,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       const exportedDoc = await payload.findByID({
         collection: 'exports',
         id: exportDoc.id,
+        overrideAccess: true,
       })
 
       expect(exportedDoc.filename).toBeDefined()
@@ -7874,6 +8336,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         where: {
           title: { contains: 'Pagination Test' },
         },
+        overrideAccess: true,
       })
     })
 
@@ -7882,6 +8345,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         await payload.create({
           collection: 'pages',
           data: { title: `Large Limit Test ${i}` },
+          overrideAccess: true,
         })
       }
 
@@ -7896,6 +8360,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             title: { contains: 'Large Limit Test' },
           },
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -7903,6 +8368,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       const exportedDoc = await payload.findByID({
         collection: 'exports',
         id: exportDoc.id,
+        overrideAccess: true,
       })
 
       expect(exportedDoc.filename).toBeDefined()
@@ -7916,6 +8382,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         where: {
           title: { contains: 'Large Limit Test' },
         },
+        overrideAccess: true,
       })
     })
 
@@ -7923,10 +8390,12 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       await payload.create({
         collection: 'pages',
         data: { title: 'Single Limit Test 1' },
+        overrideAccess: true,
       })
       await payload.create({
         collection: 'pages',
         data: { title: 'Single Limit Test 2' },
+        overrideAccess: true,
       })
 
       const exportDoc = await payload.create({
@@ -7940,6 +8409,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             title: { contains: 'Single Limit Test' },
           },
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -7947,6 +8417,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       const exportedDoc = await payload.findByID({
         collection: 'exports',
         id: exportDoc.id,
+        overrideAccess: true,
       })
 
       const csvPath = path.join(dirname, './uploads', exportedDoc.filename as string)
@@ -7959,6 +8430,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         where: {
           title: { contains: 'Single Limit Test' },
         },
+        overrideAccess: true,
       })
     })
   })
@@ -7975,6 +8447,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
               excerpt: `Excerpt for stream test ${i}`,
               _status: 'published',
             },
+            overrideAccess: true,
           }),
         )
       }
@@ -7990,6 +8463,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             title: { contains: 'Stream Test' },
           },
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -7997,6 +8471,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       const exportedDoc = await payload.findByID({
         collection: 'exports',
         id: exportDoc.id,
+        overrideAccess: true,
       })
 
       expect(exportedDoc.filename).toBeDefined()
@@ -8010,6 +8485,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         where: {
           title: { contains: 'Stream Test' },
         },
+        overrideAccess: true,
       })
     })
 
@@ -8024,6 +8500,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             title: { equals: 'NonExistent Document XYZ123' },
           },
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
@@ -8031,6 +8508,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       const exportedDoc = await payload.findByID({
         collection: 'exports',
         id: exportDoc.id,
+        overrideAccess: true,
       })
 
       expect(exportedDoc).toBeDefined()
@@ -8057,6 +8535,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           name: `concurrent-import-1-${timestamp}.csv`,
           size: csv1.length,
         },
+        overrideAccess: true,
       })
 
       const import2 = await payload.create({
@@ -8072,13 +8551,14 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           name: `concurrent-import-2-${timestamp}.csv`,
           size: csv2.length,
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
 
       const [finalImport1, finalImport2] = await Promise.all([
-        payload.findByID({ collection: 'imports', id: import1.id }),
-        payload.findByID({ collection: 'imports', id: import2.id }),
+        payload.findByID({ collection: 'imports', id: import1.id, overrideAccess: true }),
+        payload.findByID({ collection: 'imports', id: import2.id, overrideAccess: true }),
       ])
 
       expect(finalImport1.status).toBe('completed')
@@ -8094,6 +8574,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             { title: { contains: String(timestamp) } },
           ],
         },
+        overrideAccess: true,
       })
 
       expect(allDocs.totalDocs).toBe(4)
@@ -8103,6 +8584,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         where: {
           title: { contains: String(timestamp) },
         },
+        overrideAccess: true,
       })
     })
 
@@ -8111,6 +8593,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         await payload.create({
           collection: 'pages',
           data: { title: `Concurrent Export Source ${i}`, _status: 'published' },
+          overrideAccess: true,
         })
       }
 
@@ -8129,6 +8612,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           name: 'concurrent-test.csv',
           size: csvData.length,
         },
+        overrideAccess: true,
       })
 
       const exportDoc = await payload.create({
@@ -8141,13 +8625,14 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             title: { contains: 'Concurrent Export Source' },
           },
         },
+        overrideAccess: true,
       })
 
       await payload.jobs.run()
 
       const [finalImport, finalExport] = await Promise.all([
-        payload.findByID({ collection: 'imports', id: importDoc.id }),
-        payload.findByID({ collection: 'exports', id: exportDoc.id }),
+        payload.findByID({ collection: 'imports', id: importDoc.id, overrideAccess: true }),
+        payload.findByID({ collection: 'exports', id: exportDoc.id, overrideAccess: true }),
       ])
 
       expect(finalImport.status).toBe('completed')
@@ -8168,6 +8653,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             { title: { contains: 'Concurrent Import During Export' } },
           ],
         },
+        overrideAccess: true,
       })
     })
   })
@@ -8181,6 +8667,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         const doc = await payload.create({
           collection: 'posts-with-limits',
           data: { title: `Limit Test Post ${i}` },
+          overrideAccess: true,
         })
         createdPostIds.push(doc.id)
       }
@@ -8212,6 +8699,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             collectionSlug: 'posts-with-limits',
             format: 'csv',
           },
+          overrideAccess: true,
         })
 
         expect(exportDoc.filename).toBeDefined()
@@ -8233,6 +8721,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             format: 'csv',
             limit: 100,
           },
+          overrideAccess: true,
         })
 
         expect(exportDoc.filename).toBeDefined()
@@ -8252,6 +8741,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             format: 'csv',
             limit: 3,
           },
+          overrideAccess: true,
         })
 
         expect(exportDoc.filename).toBeDefined()
@@ -8308,6 +8798,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             collectionSlug: 'posts-with-limits',
             format: 'csv',
           },
+          overrideAccess: true,
         })
 
         expect(exportDoc.filename).toBeDefined()
@@ -8384,6 +8875,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             name: 'exceed-limit-import.csv',
             size: csvBuffer.length,
           },
+          overrideAccess: true,
         })
 
         expect(importDoc.status).toBe('failed')
@@ -8395,6 +8887,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           where: {
             title: { contains: 'Exceed Limit Import' },
           },
+          overrideAccess: true,
         })
 
         expect(importedDocs.totalDocs).toBe(0)
@@ -8420,6 +8913,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             name: 'exact-limit-import.csv',
             size: csvBuffer.length,
           },
+          overrideAccess: true,
         })
 
         expect(importDoc.status).toBe('completed')
@@ -8431,6 +8925,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           where: {
             title: { contains: 'Exact Limit Import' },
           },
+          overrideAccess: true,
         })
       })
 
@@ -8454,6 +8949,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             name: 'below-limit-import.csv',
             size: csvBuffer.length,
           },
+          overrideAccess: true,
         })
 
         expect(importDoc.status).toBe('completed')
@@ -8465,6 +8961,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           where: {
             title: { contains: 'Below Limit Import' },
           },
+          overrideAccess: true,
         })
       })
 
@@ -8532,6 +9029,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             name: 'predict-fail.csv',
             size: exceedsBuffer.length,
           },
+          overrideAccess: true,
         })
 
         expect(failedImport.status).toBe('failed')
@@ -8569,6 +9067,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             name: 'predict-success.csv',
             size: withinBuffer.length,
           },
+          overrideAccess: true,
         })
 
         expect(successImport.status).toBe('completed')
@@ -8579,6 +9078,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           where: {
             title: { contains: 'Predict Success' },
           },
+          overrideAccess: true,
         })
       })
     })
@@ -8591,6 +9091,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         const devUserDocs = await payload.find({
           collection: 'users',
           where: { email: { equals: devUser.email } },
+          overrideAccess: true,
         })
 
         const devUserId = devUserDocs.docs[0]?.id
@@ -8599,6 +9100,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           id: devUserId,
           collection: 'users',
           data: { limit: 7 },
+          overrideAccess: true,
         })
 
         // Use the user document directly (not login result) so req.user.limit is accessible
@@ -8609,6 +9111,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           const doc = await payload.create({
             collection: 'posts-with-limits',
             data: { title: `Dynamic Limit Post ${i}` },
+            overrideAccess: true,
           })
 
           createdPostIds.push(doc.id)
@@ -8664,6 +9167,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
               format: 'csv',
             },
             user: userWithDynamicLimit,
+            overrideAccess: true,
           })
 
           expect(exportDoc.filename).toBeDefined()
@@ -8683,6 +9187,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
               limit: 100,
             },
             user: userWithDynamicLimit,
+            overrideAccess: true,
           })
 
           expect(exportDoc.filename).toBeDefined()
@@ -8702,6 +9207,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
               limit: 4,
             },
             user: userWithDynamicLimit,
+            overrideAccess: true,
           })
 
           expect(exportDoc.filename).toBeDefined()
@@ -8759,6 +9265,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
               format: 'csv',
             },
             user: userWithDynamicLimit,
+            overrideAccess: true,
           })
 
           expect(exportDoc.filename).toBeDefined()
@@ -8840,6 +9347,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
               size: csvBuffer.length,
             },
             user: userWithDynamicLimit,
+            overrideAccess: true,
           })
 
           expect(importDoc.status).toBe('failed')
@@ -8850,6 +9358,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             where: {
               title: { contains: 'Dynamic Import Exceed' },
             },
+            overrideAccess: true,
           })
         })
 
@@ -8876,6 +9385,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
               size: csvBuffer.length,
             },
             user: userWithDynamicLimit,
+            overrideAccess: true,
           })
 
           expect(importDoc.status).toBe('completed')
@@ -8886,6 +9396,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             where: {
               title: { contains: 'Dynamic Import Within' },
             },
+            overrideAccess: true,
           })
         })
 
@@ -8938,6 +9449,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           await payload.delete({
             collection: postsWithS3Slug as CollectionSlug,
             id,
+            overrideAccess: true,
           })
         } catch {
           // Ignore cleanup errors
@@ -8964,6 +9476,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           name: 's3-import-test.csv',
           size: csvBuffer.length,
         },
+        overrideAccess: true,
       })
 
       expect((importDoc as any).status).toBe('completed')
@@ -8975,6 +9488,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         where: {
           title: { contains: 'S3 Import Test' },
         },
+        overrideAccess: true,
       })
 
       expect(posts.totalDocs).toBe(3)
@@ -8986,10 +9500,12 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         payload.create({
           collection: postsWithS3Slug as CollectionSlug,
           data: { title: 'S3 Export Test 1' },
+          overrideAccess: true,
         }),
         payload.create({
           collection: postsWithS3Slug as CollectionSlug,
           data: { title: 'S3 Export Test 2' },
+          overrideAccess: true,
         }),
       ])
 
@@ -9005,6 +9521,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
             title: { contains: 'S3 Export Test' },
           },
         },
+        overrideAccess: true,
       })
 
       expect((exportDoc as any).status).toBe('completed')
@@ -9040,6 +9557,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           name: 's3-import-error-test.csv',
           size: csvBuffer.length,
         },
+        overrideAccess: true,
       })
 
       expect((importDoc as any).status).toBe('failed')
@@ -9066,6 +9584,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
           name: 's3-json-import-test.json',
           size: jsonBuffer.length,
         },
+        overrideAccess: true,
       })
 
       expect((importDoc as any).status).toBe('completed')
@@ -9076,6 +9595,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
         where: {
           title: { contains: 'S3 JSON Import' },
         },
+        overrideAccess: true,
       })
 
       expect(posts.totalDocs).toBe(2)

--- a/test/plugin-import-export/seed/index.ts
+++ b/test/plugin-import-export/seed/index.ts
@@ -26,6 +26,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
         password: devUser.password,
         name: 'name value',
       },
+      overrideAccess: true,
     })
     const restricted = await payload.create({
       collection: 'users',
@@ -34,6 +35,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
         password: regularUser.password,
         name: 'restricted user',
       },
+      overrideAccess: true,
     })
     // Seed posts
     const posts = []
@@ -46,6 +48,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
           content: richTextData,
           _status: i % 2 === 0 ? 'published' : 'draft', // Evens published, odds draft
         },
+        overrideAccess: true,
       })
 
       if (i < 3) {
@@ -59,6 +62,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
         data: {
           title: `Doc ${i}`,
         },
+        overrideAccess: true,
       })
     }
 
@@ -71,6 +75,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
             array: [{ field1: 'test' }],
           },
         },
+        overrideAccess: true,
       })
     }
     for (let i = 0; i < 5; i++) {
@@ -81,6 +86,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
           localized: 'en test',
         },
         locale: 'en',
+        overrideAccess: true,
       })
       await payload.update({
         collection: 'pages',
@@ -89,6 +95,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
           localized: 'es test',
         },
         locale: 'es',
+        overrideAccess: true,
       })
       await payload.update({
         collection: 'pages',
@@ -97,6 +104,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
           localized: `בדיקה ${i}`,
         },
         locale: 'he',
+        overrideAccess: true,
       })
     }
 
@@ -109,6 +117,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
           localized: `בדיקה ${i}`,
         },
         locale: 'he',
+        overrideAccess: true,
       })
     }
     for (let i = 0; i < 5; i++) {
@@ -127,6 +136,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
             },
           ],
         },
+        overrideAccess: true,
       })
     }
     for (let i = 0; i < 5; i++) {
@@ -145,6 +155,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
             },
           ],
         },
+        overrideAccess: true,
       })
     }
 
@@ -155,6 +166,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
           author: user.id,
           title: `Virtual ${i}`,
         },
+        overrideAccess: true,
       })
     }
 
@@ -165,6 +177,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
           customRelationship: user.id,
           title: `Custom ${i}`,
         },
+        overrideAccess: true,
       })
     }
 
@@ -175,6 +188,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
           title: `hasMany Number ${i}`,
           hasManyNumber: [0, 1, 1, 2, 3, 5, 8, 13, 21],
         },
+        overrideAccess: true,
       })
     }
 
@@ -195,6 +209,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
             },
           ],
         },
+        overrideAccess: true,
       })
     }
 
@@ -204,6 +219,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
         data: {
           title: `JSON ${i}`,
         },
+        overrideAccess: true,
       })
     }
 
@@ -213,6 +229,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
         data: {
           title: `Jobs ${i}`,
         },
+        overrideAccess: true,
       })
     }
 
@@ -224,6 +241,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
           title: `Checkbox ${i}`,
           checkbox: i % 2 === 0,
         },
+        overrideAccess: true,
       })
     }
 
@@ -236,6 +254,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
           title: `Select ${i}`,
           select: options[i % 3],
         },
+        overrideAccess: true,
       })
     }
 
@@ -252,6 +271,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
           title: `SelectMany ${i}`,
           selectHasMany: tagSets[i],
         },
+        overrideAccess: true,
       })
     }
 
@@ -264,6 +284,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
           title: `Radio ${i}`,
           radio: radios[i % 3],
         },
+        overrideAccess: true,
       })
     }
 
@@ -275,6 +296,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
           title: `Email ${i}`,
           email: `test${i}@example.com`,
         },
+        overrideAccess: true,
       })
     }
 
@@ -286,6 +308,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
           title: `Textarea ${i}`,
           textarea: `Line 1 for textarea ${i}\nLine 2\nLine 3`,
         },
+        overrideAccess: true,
       })
     }
 
@@ -297,6 +320,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
           title: `Code ${i}`,
           code: `function test${i}() {\n  return ${i};\n}`,
         },
+        overrideAccess: true,
       })
     }
 
@@ -308,6 +332,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
           title: `Point ${i}`,
           point: [-122.4194 + i * 0.01, 37.7749 + i * 0.01],
         },
+        overrideAccess: true,
       })
     }
 
@@ -319,6 +344,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
           title: `TextMany ${i}`,
           textHasMany: [`tag${i}a`, `tag${i}b`, `tag${i}c`],
         },
+        overrideAccess: true,
       })
     }
 
@@ -337,6 +363,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
           ...imageFile,
           name: `test-media-${i}.png`,
         } as File,
+        overrideAccess: true,
       })
       mediaIds.push(media.id)
     }
@@ -349,6 +376,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
           title: `Upload ${i}`,
           upload: mediaIds[i % mediaIds.length],
         },
+        overrideAccess: true,
       })
     }
 
@@ -361,6 +389,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
             title: `Monomorphic ${i}`,
             hasManyMonomorphic: [posts[1].id],
           },
+          overrideAccess: true,
         })
       }
     }
@@ -387,6 +416,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
               },
             ],
           },
+          overrideAccess: true,
         })
       }
     }
@@ -398,6 +428,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
         data: {
           title: `Export Only Post ${i}`,
         },
+        overrideAccess: true,
       })
     }
 
@@ -408,6 +439,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
         data: {
           title: `Import Only Post ${i}`,
         },
+        overrideAccess: true,
       })
     }
 
@@ -417,6 +449,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
         data: {
           title: `Post with no jobs queue active ${i}`,
         },
+        overrideAccess: true,
       })
     }
 
@@ -426,6 +459,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
         data: {
           title: `Post with limit ${i}`,
         },
+        overrideAccess: true,
       })
     }
 

--- a/test/plugin-mcp/int.spec.ts
+++ b/test/plugin-mcp/int.spec.ts
@@ -746,6 +746,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
             equals: userId,
           },
         },
+        overrideAccess: true,
       })
       const modifiedPrompt = docs?.[0]
       expect(modifiedPrompt?.original).toBe('Hello, world!')
@@ -773,6 +774,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
             equals: userId,
           },
         },
+        overrideAccess: true,
       })
       const returnedResource = docs?.[0]
       expect(returnedResource?.uri).toBe('data://app')
@@ -798,6 +800,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
             equals: userId,
           },
         },
+        overrideAccess: true,
       })
       const returnedResource = docs?.[0]
       expect(returnedResource?.uri).toBe('data://app/1')
@@ -830,6 +833,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
             equals: userId,
           },
         },
+        overrideAccess: true,
       })
       const roll = docs?.[0]
       expect(roll?.sides).toBe(6)
@@ -1023,7 +1027,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
       }>(callResponse)
 
       const [storedPNG, storedJPEG] = await Promise.all(
-        result.docs.map(({ id }) => payload.findByID({ collection: 'media', id })),
+        result.docs.map(({ id }) => payload.findByID({ collection: 'media', id, overrideAccess: true })),
       )
       expect(result.errors).toEqual([])
       expect(storedPNG).toMatchObject({
@@ -1067,6 +1071,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
       const storedMedia = await payload.findByID({
         id: createdMedia.id,
         collection: 'media',
+        overrideAccess: true,
       })
       expect(storedMedia.alt).toBe('Uploaded from a URL through MCP')
       expect(storedMedia.filename).toBe('mcp-url.png')
@@ -1080,6 +1085,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
           alt: 'Original asset',
         },
         filePath: path.resolve(dirname, '../uploads/image.jpg'),
+        overrideAccess: true,
       })
       const image = await readFile(path.resolve(dirname, '../uploads/image.png'))
       const apiKey = await getApiKey()
@@ -1103,6 +1109,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
       const storedMedia = await payload.findByID({
         id: media.id,
         collection: 'media',
+        overrideAccess: true,
       })
       expect(storedMedia.alt).toBe('Replaced from base64 through MCP')
       expect(storedMedia.filename).toBe('mcp-replacement.png')
@@ -1181,7 +1188,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
         expect(updated.filename).toBe('mcp-updated.png')
       } finally {
         if (id !== undefined) {
-          await payload.delete({ id, collection: 'media' })
+          await payload.delete({ id, collection: 'media', overrideAccess: true })
         }
       }
     })
@@ -1240,6 +1247,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
         collection: 'posts',
         draft: false,
         locale: 'all',
+        overrideAccess: true,
       })
       expect(storedPost._status).toMatchObject({ en: 'published' })
     })
@@ -1317,6 +1325,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
       const storedMedia = await payload.findByID({
         id: createdMedia.id,
         collection: 'media',
+        overrideAccess: true,
       })
       expect(storedMedia.alt).toBe('Uploaded from base64 through MCP')
       expect(storedMedia.filename).toBe('mcp-base64.png')
@@ -1330,6 +1339,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
           content: 'Content for test post.',
           title: 'Test Post for Finding',
         },
+        overrideAccess: true,
       })
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
@@ -1364,6 +1374,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
           content: 'Content that should be omitted',
           title: 'Select Test Post',
         },
+        overrideAccess: true,
       })
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
@@ -1391,6 +1402,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
           price: 25,
           title: 'Countable Product',
         },
+        overrideAccess: true,
       })
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
@@ -1410,7 +1422,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
         totalDocs: number
       }>(callResponse)
       expect(result.totalDocs).toBeGreaterThanOrEqual(1)
-      await payload.delete({ id: product.id, collection: 'products' })
+      await payload.delete({ id: product.id, collection: 'products', overrideAccess: true })
     })
     it('should call duplicateDocument', async ({ mcp, getApiKey, payload }) => {
       const product = await payload.create({
@@ -1419,6 +1431,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
           price: 35,
           title: 'Original Product',
         },
+        overrideAccess: true,
       })
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
@@ -1439,8 +1452,8 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
       expect(duplicated.id).toBeDefined()
       expect(duplicated.id).not.toBe(product.id)
       expect(duplicated.title).toBe('Duplicated Product')
-      await payload.delete({ id: duplicated.id, collection: 'products' })
-      await payload.delete({ id: product.id, collection: 'products' })
+      await payload.delete({ id: duplicated.id, collection: 'products', overrideAccess: true })
+      await payload.delete({ id: product.id, collection: 'products', overrideAccess: true })
     })
     it('should not enable duplicateDocument for auth collections by default', async ({
       mcp,
@@ -1482,6 +1495,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
           price: 45,
           title: 'Distinct Product',
         },
+        overrideAccess: true,
       })
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
@@ -1498,7 +1512,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
         }>
       }>(callResponse)
       expect(result.values.some((value) => value.title === 'Distinct Product')).toBe(true)
-      await payload.delete({ id: product.id, collection: 'products' })
+      await payload.delete({ id: product.id, collection: 'products', overrideAccess: true })
     })
     it('should call collection version tools', async ({ mcp, getApiKey, payload }) => {
       const post = await payload.create({
@@ -1507,6 +1521,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
           content: 'Initial version content',
           title: 'Versioned Post',
         },
+        overrideAccess: true,
       })
       await payload.update({
         id: post.id,
@@ -1514,6 +1529,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
         data: {
           title: 'Versioned Post Updated',
         },
+        overrideAccess: true,
       })
       const versions = await payload.findVersions({
         collection: 'posts',
@@ -1524,6 +1540,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
             equals: post.id,
           },
         },
+        overrideAccess: true,
       })
       const versionID = String(versions.docs[0]!.id)
       const apiKey = await getApiKey()
@@ -1587,7 +1604,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
         id: number | string
       }>(restoreResponse)
       expect(restored.id).toBe(post.id)
-      await payload.delete({ id: post.id, collection: 'posts' })
+      await payload.delete({ id: post.id, collection: 'posts', overrideAccess: true })
     })
     it('should pass populate, joins, trash, and pagination to findDocuments list queries', async ({
       mcp,
@@ -1602,6 +1619,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
           content: 'Find options pass-through content',
           title: 'Find Options Pass Through',
         },
+        overrideAccess: true,
       })
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
@@ -1632,7 +1650,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
         )
       } finally {
         findSpy.mockRestore()
-        await payload.delete({ id: post.id, collection: 'posts' })
+        await payload.delete({ id: post.id, collection: 'posts', overrideAccess: true })
       }
     })
     it('should pass populate, joins, and trash to findDocuments ID queries', async ({
@@ -1648,6 +1666,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
           content: 'Find by ID options pass-through content',
           title: 'Find By ID Options Pass Through',
         },
+        overrideAccess: true,
       })
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
@@ -1675,7 +1694,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
         )
       } finally {
         findByIDSpy.mockRestore()
-        await payload.delete({ id: post.id, collection: 'posts' })
+        await payload.delete({ id: post.id, collection: 'posts', overrideAccess: true })
       }
     })
     it('should call updateDocument', async ({ mcp, getApiKey, payload }) => {
@@ -1685,6 +1704,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
           content: 'Content for test post to update.',
           title: 'Test Post for Updating',
         },
+        overrideAccess: true,
       })
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
@@ -1720,6 +1740,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
       const page = await payload.create({
         collection: 'pages',
         data: { title: 'Numeric ID' },
+        overrideAccess: true,
       })
 
       try {
@@ -1733,12 +1754,12 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
           },
           name: 'updateDocument',
         })
-        const updatedPage = await payload.findByID({ id: page.id, collection: 'pages' })
+        const updatedPage = await payload.findByID({ id: page.id, collection: 'pages', overrideAccess: true })
 
         expect(callResponse.isError).not.toBe(true)
         expect(updatedPage.title).toBe('Updated')
       } finally {
-        await payload.delete({ id: page.id, collection: 'pages' })
+        await payload.delete({ id: page.id, collection: 'pages', overrideAccess: true })
       }
     })
     it('should forward publishAllLocales when updating a document', async ({
@@ -1753,6 +1774,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
         },
         draft: true,
         locale: 'en',
+        overrideAccess: true,
       })
       try {
         await payload.update({
@@ -1761,6 +1783,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
           data: { title: 'Spanish draft title' },
           draft: true,
           locale: 'es',
+          overrideAccess: true,
         })
         const apiKey = await getApiKey()
         const client = await mcp.connect(apiKey)
@@ -1783,12 +1806,14 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
           collection: 'posts',
           draft: false,
           locale: 'all',
+          overrideAccess: true,
         })
         const spanishDraft = await payload.findByID({
           id: post.id,
           collection: 'posts',
           draft: true,
           locale: 'es',
+          overrideAccess: true,
         })
         expect(callResponse).toBeDefined()
         expect(publishedPost._status).toMatchObject({ en: 'published' })
@@ -1797,7 +1822,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
         expect(spanishDraft.title).toBe('Spanish draft title')
         expect(spanishDraft._status).toBe('draft')
       } finally {
-        await payload.delete({ collection: 'posts', id: post.id })
+        await payload.delete({ collection: 'posts', id: post.id, overrideAccess: true })
       }
     })
     it('should call updateDocument with nullable union type field set to null', async ({
@@ -1811,6 +1836,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
           content: 'Content to be cleared',
           title: 'Union Type Null Test',
         },
+        overrideAccess: true,
       })
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
@@ -1831,7 +1857,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
         'Document updated successfully in collection "posts"!',
       )
       expect(callResponse.content[0].text).toContain('"content":null')
-      await payload.delete({ id: post.id, collection: 'posts' })
+      await payload.delete({ id: post.id, collection: 'posts', overrideAccess: true })
     })
     it('should call updateDocument with relationship union type field', async ({
       mcp,
@@ -1844,6 +1870,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
         data: {
           title: 'Union Type Relationship Test',
         },
+        overrideAccess: true,
       })
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
@@ -1865,7 +1892,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
       )
       const updatedDoc = getToolDoc(callResponse)
       expect(updatedDoc.author).toBe(userId)
-      await payload.delete({ id: post.id, collection: 'posts' })
+      await payload.delete({ id: post.id, collection: 'posts', overrideAccess: true })
     })
     it('should call updateDocument with select to limit returned fields', async ({
       mcp,
@@ -1878,6 +1905,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
           content: 'Original content',
           title: 'Select Update Post',
         },
+        overrideAccess: true,
       })
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
@@ -1921,6 +1949,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
           content: 'Content for test post to delete.',
           title: 'Test Post for Deleting',
         },
+        overrideAccess: true,
       })
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
@@ -1952,6 +1981,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
           content: 'Original content',
           title: 'Where Object Update Match',
         },
+        overrideAccess: true,
       })
       const excluded = await payload.create({
         collection: 'posts',
@@ -1959,6 +1989,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
           content: 'Original content',
           title: 'Where Object Update Excluded',
         },
+        overrideAccess: true,
       })
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
@@ -1984,10 +2015,10 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
         { id: matching.id },
       ])
 
-      const untouched = await payload.findByID({ id: excluded.id, collection: 'posts' })
+      const untouched = await payload.findByID({ id: excluded.id, collection: 'posts', overrideAccess: true })
       expect(untouched.content).toBe('Original content')
-      await payload.delete({ id: matching.id, collection: 'posts' })
-      await payload.delete({ id: excluded.id, collection: 'posts' })
+      await payload.delete({ id: matching.id, collection: 'posts', overrideAccess: true })
+      await payload.delete({ id: excluded.id, collection: 'posts', overrideAccess: true })
     })
     it('should call deleteDocuments with object where clause', async ({
       mcp,
@@ -2000,6 +2031,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
           content: 'Content for object where delete.',
           title: 'Where Object Delete One',
         },
+        overrideAccess: true,
       })
       await payload.create({
         collection: 'posts',
@@ -2007,6 +2039,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
           content: 'Content for object where delete.',
           title: 'Where Object Delete Two',
         },
+        overrideAccess: true,
       })
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
@@ -2070,7 +2103,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
       expect(createdDoc.location).toEqual([-74.006, 40.7128])
       expect(callResponse.content[1].type).toBe('text')
       expect(callResponse.content[1].text).toContain('Override MCP response for Posts!')
-      await payload.delete({ id: createdDoc.id, collection: 'posts' })
+      await payload.delete({ id: createdDoc.id, collection: 'posts', overrideAccess: true })
     })
     it('should handle point fields with object format in updateDocument', async ({
       mcp,
@@ -2085,6 +2118,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
           location: [-118.2437, 34.0522],
           title: 'Post to Update Location',
         },
+        overrideAccess: true,
       })
       const callResponse = await client.callTool({
         arguments: {
@@ -2108,7 +2142,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
       expect(updatedDoc.location).toEqual([-0.1278, 51.5074])
       expect(callResponse.content[1].type).toBe('text')
       expect(callResponse.content[1].text).toContain('Override MCP response for Posts!')
-      await payload.delete({ id: createdPost.id, collection: 'posts' })
+      await payload.delete({ id: createdPost.id, collection: 'posts', overrideAccess: true })
     })
   })
   test.describe('Blocks fields', () => {
@@ -2176,6 +2210,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
           title: 'Page to Update',
           layout: [],
         },
+        overrideAccess: true,
       })
       createdPageIds.push(page.id)
       const apiKey = await getApiKey()
@@ -2209,6 +2244,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
       const updatedPage = await payload.findByID({
         collection: 'pages',
         id: page.id,
+        overrideAccess: true,
       })
       expect((updatedPage as any).layout).toHaveLength(2)
       expect((updatedPage as any).layout[0].blockType).toBe('hero')
@@ -2226,6 +2262,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
           title: 'Page with invalid update',
           layout: [],
         },
+        overrideAccess: true,
       })
 
       createdPageIds.push(page.id)
@@ -2300,7 +2337,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
         id: string
       }>(callResponse)
       if (createdId) {
-        await payload.delete({ id: createdId, collection: 'posts' })
+        await payload.delete({ id: createdId, collection: 'posts', overrideAccess: true })
       }
     })
     it('should ignore virtual fields when updating a post via MCP', async ({
@@ -2311,6 +2348,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
       const post = await payload.create({
         collection: 'posts',
         data: { title: 'Virtual Field Update Test' },
+        overrideAccess: true,
       })
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
@@ -2327,7 +2365,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
       expect(text).toContain('Document updated successfully')
       expect(text).toContain('"title":"Virtual Field Updated Title"')
       expect(text).not.toContain('"computedTitle"')
-      await payload.delete({ id: post.id, collection: 'posts' })
+      await payload.delete({ id: post.id, collection: 'posts', overrideAccess: true })
     })
   })
   test.describe('payloadAPI context', () => {
@@ -2342,6 +2380,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
           content: 'Content for test post.',
           title: 'Test Post for Finding',
         },
+        overrideAccess: true,
       })
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
@@ -2411,6 +2450,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
           siteDescription: 'Should be excluded by select',
           siteName: 'MCP Site',
         },
+        overrideAccess: true,
       })
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
@@ -2504,6 +2544,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
           siteDescription: 'Initial global version',
           siteName: 'Versioned Global',
         },
+        overrideAccess: true,
       })
       await payload.updateGlobal({
         slug: 'site-settings',
@@ -2512,11 +2553,13 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
           siteDescription: 'Updated global version',
           siteName: 'Versioned Global Updated',
         },
+        overrideAccess: true,
       })
       const versions = await payload.findGlobalVersions({
         slug: 'site-settings',
         limit: 1,
         sort: '-updatedAt',
+        overrideAccess: true,
       })
       const versionID = String(versions.docs[0]!.id)
       const apiKey = await getApiKey()
@@ -2877,6 +2920,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
           title: 'Minified JSON Test',
           content: 'Content for minified test.',
         },
+        overrideAccess: true,
       })
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
@@ -2927,6 +2971,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
           title: 'Minified JSON FindByID Test',
           content: 'Content for findByID minified test.',
         },
+        overrideAccess: true,
       })
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
@@ -3002,6 +3047,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
           content: 'English Content',
           title: 'English Title',
         },
+        overrideAccess: true,
       })
       // Update with Spanish translation via MCP
       const apiKey = await getApiKey()
@@ -3032,6 +3078,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
           content: 'English Content',
           title: 'English Post',
         },
+        overrideAccess: true,
       })
       await payload.update({
         id: post.id,
@@ -3041,6 +3088,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
           title: 'Publicación Española',
         },
         locale: 'es',
+        overrideAccess: true,
       })
       // Find in Spanish via MCP
       const apiKey = await getApiKey()
@@ -3067,6 +3115,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
           content: 'English Content',
           title: 'English Title',
         },
+        overrideAccess: true,
       })
       await payload.update({
         id: post.id,
@@ -3076,6 +3125,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
           title: 'Título Español',
         },
         locale: 'es',
+        overrideAccess: true,
       })
       await payload.update({
         id: post.id,
@@ -3085,6 +3135,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
           title: 'Titre Français',
         },
         locale: 'fr',
+        overrideAccess: true,
       })
       // Find with locale: all via MCP
       const apiKey = await getApiKey()
@@ -3119,6 +3170,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
           title: 'English Only Title',
         },
         locale: 'en',
+        overrideAccess: true,
       })
       // Try to find in French (which doesn't exist)
       const apiKey = await getApiKey()
@@ -3478,6 +3530,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
       })
       it('should find documents in field-types collection', async ({ mcp, getApiKey, payload }) => {
         const created = await (payload as any).create({
+          overrideAccess: true,
           collection: 'field-types',
           data: { textField: 'Findable doc', numberField: 7 },
         })
@@ -3500,6 +3553,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
     test.describe('Update', () => {
       it('should update document with group field', async ({ mcp, getApiKey, payload }) => {
         const created = await (payload as any).create({
+          overrideAccess: true,
           collection: 'field-types',
           data: {
             textField: 'Group update test',
@@ -3537,6 +3591,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
         payload,
       }) => {
         const created = await (payload as any).create({
+          overrideAccess: true,
           collection: 'field-types',
           data: {
             groupField: { groupText: 'Original', groupNumber: 1 },
@@ -3576,6 +3631,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
         payload,
       }) => {
         const created = await (payload as any).create({
+          overrideAccess: true,
           collection: 'field-types',
           data: {
             numberField: 1,
@@ -3617,6 +3673,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
         payload,
       }) => {
         const created = await (payload as any).create({
+          overrideAccess: true,
           collection: 'field-types',
           data: {
             textField: 'Collapsible update test',
@@ -3643,6 +3700,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
       })
       it('should update document with array field', async ({ mcp, getApiKey, payload }) => {
         const created = await (payload as any).create({
+          overrideAccess: true,
           collection: 'field-types',
           data: {
             textField: 'Array update test',

--- a/test/plugin-mcp/seed/index.ts
+++ b/test/plugin-mcp/seed/index.ts
@@ -10,12 +10,14 @@ export const seed = async (payload: Payload) => {
         equals: devUser.email,
       },
     },
+    overrideAccess: true,
   })
 
   if (!totalDocs) {
     await payload.create({
       collection: 'users',
       data: devUser,
+      overrideAccess: true,
     })
   }
 }

--- a/test/plugin-multi-tenant/config.base.ts
+++ b/test/plugin-multi-tenant/config.base.ts
@@ -147,6 +147,7 @@ export const baseConfig: Partial<Config> = {
         const fullTenant = await req.payload.findByID({
           collection: 'tenants',
           id: tenant,
+          overrideAccess: true,
         })
         if (
           fullTenant &&

--- a/test/plugin-multi-tenant/e2e.spec.ts
+++ b/test/plugin-multi-tenant/e2e.spec.ts
@@ -666,6 +666,7 @@ test.describe('Multi Tenant', () => {
             equals: globalTenant,
           },
         },
+        overrideAccess: true,
       })
       await expect.poll(() => autosaveGlobal?.totalDocs).toBe(1)
       await expect.poll(() => autosaveGlobal?.docs?.[0]?.tenant).toBeDefined()
@@ -1450,6 +1451,7 @@ async function getSelectedTenantFilterName({
           equals: tenantIDFromCookie,
         },
       },
+      overrideAccess: true,
     })
     return tenant?.docs?.[0]?.name || undefined
   }

--- a/test/plugin-multi-tenant/int.spec.ts
+++ b/test/plugin-multi-tenant/int.spec.ts
@@ -39,6 +39,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-multi-tenant', () => {
           name: 'tenant1',
           domain: 'tenant1.com',
         },
+        overrideAccess: true,
       })
 
       expect(tenant1).toHaveProperty('id')
@@ -58,6 +59,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-multi-tenant', () => {
               equals: 'Anchor Bar',
             },
           },
+          overrideAccess: true,
         })
 
         blueDogRelationships = await payload.find({
@@ -67,6 +69,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-multi-tenant', () => {
               equals: 'Blue Dog',
             },
           },
+          overrideAccess: true,
         })
 
         // @ts-expect-error unsafe access okay in test
@@ -90,6 +93,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-multi-tenant', () => {
           req: {
             headers: new Headers([['cookie', `payload-tenant=${anchorBarTenantID}`]]),
           },
+          overrideAccess: true,
         })
 
         // @ts-expect-error unsafe access okay in test
@@ -111,6 +115,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-multi-tenant', () => {
             req: {
               headers: new Headers([['cookie', `payload-tenant=${anchorBarTenantID}`]]),
             },
+            overrideAccess: true,
           }),
         ).rejects.toThrow('The following field is invalid: Relationship')
       })
@@ -129,6 +134,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-multi-tenant', () => {
               tenant: anchorBarTenantID,
             },
             req: {},
+            overrideAccess: true,
           }),
         ).rejects.toThrow('The following field is invalid: Relationship')
       })
@@ -147,16 +153,19 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-multi-tenant', () => {
           password: 'test',
           tenants: [],
         },
+        overrideAccess: true,
       })
 
       // Create a tenant and document for testing
       const tenant = await payload.create({
         collection: tenantsSlug,
         data: { name: 'Test Tenant', domain: 'test-tenant.test' },
+        overrideAccess: true,
       })
       const doc = await payload.create({
         collection: relationshipsSlug,
         data: { tenant: tenant.id, title: 'Test Doc' },
+        overrideAccess: true,
       })
 
       // User with no tenants should get a Forbidden error (clean rejection)
@@ -171,9 +180,9 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-multi-tenant', () => {
       ).rejects.toThrow('You are not allowed to perform this action.')
 
       // Cleanup
-      await payload.delete({ id: doc.id, collection: relationshipsSlug })
-      await payload.delete({ id: tenant.id, collection: tenantsSlug })
-      await payload.delete({ id: noTenantUser.id, collection: usersSlug })
+      await payload.delete({ id: doc.id, collection: relationshipsSlug, overrideAccess: true })
+      await payload.delete({ id: tenant.id, collection: tenantsSlug, overrideAccess: true })
+      await payload.delete({ id: noTenantUser.id, collection: usersSlug, overrideAccess: true })
     })
 
     test('should allow user with no tenants to access their own user document', async ({
@@ -187,6 +196,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-multi-tenant', () => {
           password: 'test',
           tenants: [],
         },
+        overrideAccess: true,
       })
 
       // User should be able to find themselves
@@ -201,7 +211,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-multi-tenant', () => {
       expect(result.docs[0]?.id).toBe(noTenantUser.id)
 
       // Cleanup
-      await payload.delete({ id: noTenantUser.id, collection: usersSlug })
+      await payload.delete({ id: noTenantUser.id, collection: usersSlug, overrideAccess: true })
     })
 
     test('should allow admin with empty tenants array to access all documents', async ({
@@ -216,16 +226,19 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-multi-tenant', () => {
           tenants: [],
           roles: ['admin'],
         },
+        overrideAccess: true,
       })
 
       // Create a tenant and document
       const tenant = await payload.create({
         collection: tenantsSlug,
         data: { name: 'Admin Test Tenant', domain: 'admin-test.test' },
+        overrideAccess: true,
       })
       const doc = await payload.create({
         collection: relationshipsSlug,
         data: { tenant: tenant.id, title: 'Admin Test Doc' },
+        overrideAccess: true,
       })
 
       // Admin should have access (userHasAccessToAllTenants returns true for super-admin)
@@ -239,9 +252,9 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-multi-tenant', () => {
       expect(result.docs).toHaveLength(1)
 
       // Cleanup
-      await payload.delete({ id: doc.id, collection: relationshipsSlug })
-      await payload.delete({ id: tenant.id, collection: tenantsSlug })
-      await payload.delete({ id: adminUser.id, collection: usersSlug })
+      await payload.delete({ id: doc.id, collection: relationshipsSlug, overrideAccess: true })
+      await payload.delete({ id: tenant.id, collection: tenantsSlug, overrideAccess: true })
+      await payload.delete({ id: adminUser.id, collection: usersSlug, overrideAccess: true })
     })
   })
 
@@ -253,10 +266,12 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-multi-tenant', () => {
       const tenantA = await payload.create({
         collection: tenantsSlug,
         data: { name: 'Tenant A', domain: 'tenant-a.test' },
+        overrideAccess: true,
       })
       const tenantB = await payload.create({
         collection: tenantsSlug,
         data: { name: 'Tenant B', domain: 'tenant-b.test' },
+        overrideAccess: true,
       })
 
       // Create a user assigned ONLY to Tenant A
@@ -267,12 +282,14 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-multi-tenant', () => {
           password: 'test',
           tenants: [{ tenant: tenantA.id }],
         },
+        overrideAccess: true,
       })
 
       // Create a document in Tenant B (user should NOT have access)
       const doc = await payload.create({
         collection: relationshipsSlug,
         data: { tenant: tenantB.id, title: 'Tenant B Doc' },
+        overrideAccess: true,
       })
 
       // Fetch user from database - this returns a user WITHOUT .collection property
@@ -280,6 +297,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-multi-tenant', () => {
       const fetchedUser = await payload.findByID({
         id: user.id,
         collection: usersSlug,
+        overrideAccess: true,
       })
 
       // User from Tenant A should NOT be able to access Tenant B's document
@@ -293,10 +311,10 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-multi-tenant', () => {
       expect(result.docs).toHaveLength(0)
 
       // Cleanup
-      await payload.delete({ id: doc.id, collection: relationshipsSlug })
-      await payload.delete({ id: user.id, collection: usersSlug })
-      await payload.delete({ id: tenantA.id, collection: tenantsSlug })
-      await payload.delete({ id: tenantB.id, collection: tenantsSlug })
+      await payload.delete({ id: doc.id, collection: relationshipsSlug, overrideAccess: true })
+      await payload.delete({ id: user.id, collection: usersSlug, overrideAccess: true })
+      await payload.delete({ id: tenantA.id, collection: tenantsSlug, overrideAccess: true })
+      await payload.delete({ id: tenantB.id, collection: tenantsSlug, overrideAccess: true })
     })
   })
 
@@ -307,20 +325,27 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-multi-tenant', () => {
       const tenant = await payload.create({
         collection: tenantsSlug,
         data: { name: 'Cleanup Tenant', domain: 'cleanup-tenant.test' },
+        overrideAccess: true,
       })
 
       await payload.create({
         collection: menuSlug,
         data: { tenant: tenant.id, title: 'Cleanup Menu' },
+        overrideAccess: true,
       })
 
-      const deletedTenant = await payload.delete({ id: tenant.id, collection: tenantsSlug })
+      const deletedTenant = await payload.delete({
+        id: tenant.id,
+        collection: tenantsSlug,
+        overrideAccess: true,
+      })
 
       expect(deletedTenant.id).toBe(tenant.id)
 
       const remainingTenants = await payload.find({
         collection: tenantsSlug,
         where: { id: { equals: tenant.id } },
+        overrideAccess: true,
       })
 
       expect(remainingTenants.docs).toHaveLength(0)
@@ -332,10 +357,12 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-multi-tenant', () => {
       const tenant1 = await payload.create({
         collection: tenantsSlug,
         data: { name: 'Tenant 1', domain: 'tenant1.test' },
+        overrideAccess: true,
       })
       const tenant2 = await payload.create({
         collection: tenantsSlug,
         data: { name: 'Tenant 2', domain: 'tenant2.test' },
+        overrideAccess: true,
       })
 
       // Create a post with multiple tenants (hasMany: true)
@@ -345,6 +372,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-multi-tenant', () => {
           title: 'Multi-tenant post',
           tenant: [tenant1.id, tenant2.id],
         },
+        overrideAccess: true,
       })
 
       // Get the parent relationship field
@@ -364,9 +392,9 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-multi-tenant', () => {
       expect(Array.isArray(filter.tenant.in[1])).toBe(false)
 
       // Cleanup
-      await payload.delete({ id: post.id, collection: multiTenantPostsSlug })
-      await payload.delete({ id: tenant1.id, collection: tenantsSlug })
-      await payload.delete({ id: tenant2.id, collection: tenantsSlug })
+      await payload.delete({ id: post.id, collection: multiTenantPostsSlug, overrideAccess: true })
+      await payload.delete({ id: tenant1.id, collection: tenantsSlug, overrideAccess: true })
+      await payload.delete({ id: tenant2.id, collection: tenantsSlug, overrideAccess: true })
     })
   })
 })

--- a/test/plugin-multi-tenant/seed/index.ts
+++ b/test/plugin-multi-tenant/seed/index.ts
@@ -11,6 +11,7 @@ export const seed = async (payload: Payload) => {
       name: 'Blue Dog',
       domain: 'bluedog.com',
     },
+    overrideAccess: true,
   })
   const steelCatTenant = await payload.create({
     collection: tenantsSlug,
@@ -18,6 +19,7 @@ export const seed = async (payload: Payload) => {
       name: 'Steel Cat',
       domain: 'steelcat.com',
     },
+    overrideAccess: true,
   })
   const anchorBarTenant = await payload.create({
     collection: tenantsSlug,
@@ -26,6 +28,7 @@ export const seed = async (payload: Payload) => {
       domain: 'anchorbar.com',
       selectedLocales: ['en'],
     },
+    overrideAccess: true,
   })
   const publicTenant = await payload.create({
     collection: tenantsSlug,
@@ -34,6 +37,7 @@ export const seed = async (payload: Payload) => {
       domain: 'public.com',
       isPublic: true,
     },
+    overrideAccess: true,
   })
 
   // Create folders for Blue Dog
@@ -43,6 +47,7 @@ export const seed = async (payload: Payload) => {
       name: 'Blue Dog Documents',
       tenant: blueDogTenant.id,
     },
+    overrideAccess: true,
   })
   const blueDogArchivesFolder = await payload.create({
     collection: foldersSlug,
@@ -50,6 +55,7 @@ export const seed = async (payload: Payload) => {
       name: 'Blue Dog Archives',
       tenant: blueDogTenant.id,
     },
+    overrideAccess: true,
   })
   const blueDogRecipesFolder = await payload.create({
     collection: foldersSlug,
@@ -58,6 +64,7 @@ export const seed = async (payload: Payload) => {
       folder: blueDogDocumentsFolder.id, // parentFieldName is 'folder' in config
       tenant: blueDogTenant.id,
     },
+    overrideAccess: true,
   })
 
   // Create folders for Steel Cat
@@ -67,6 +74,7 @@ export const seed = async (payload: Payload) => {
       name: 'Steel Cat Documents',
       tenant: steelCatTenant.id,
     },
+    overrideAccess: true,
   })
   const steelCatArchivesFolder = await payload.create({
     collection: foldersSlug,
@@ -74,6 +82,7 @@ export const seed = async (payload: Payload) => {
       name: 'Steel Cat Archives',
       tenant: steelCatTenant.id,
     },
+    overrideAccess: true,
   })
 
   // Create folders for Anchor Bar
@@ -83,6 +92,7 @@ export const seed = async (payload: Payload) => {
       name: 'Anchor Bar Files',
       tenant: anchorBarTenant.id,
     },
+    overrideAccess: true,
   })
 
   // Create blue dog menu items (some in folders, some at root)
@@ -93,6 +103,7 @@ export const seed = async (payload: Payload) => {
       folder: blueDogRecipesFolder.id,
       tenant: blueDogTenant.id,
     },
+    overrideAccess: true,
   })
   await payload.create({
     collection: menuItemsSlug,
@@ -101,6 +112,7 @@ export const seed = async (payload: Payload) => {
       folder: blueDogRecipesFolder.id,
       tenant: blueDogTenant.id,
     },
+    overrideAccess: true,
   })
   await payload.create({
     collection: menuItemsSlug,
@@ -109,6 +121,7 @@ export const seed = async (payload: Payload) => {
       folder: blueDogDocumentsFolder.id,
       tenant: blueDogTenant.id,
     },
+    overrideAccess: true,
   })
   // Menu items at root (no folder)
   await payload.create({
@@ -117,6 +130,7 @@ export const seed = async (payload: Payload) => {
       name: 'Veggie Wrap',
       tenant: blueDogTenant.id,
     },
+    overrideAccess: true,
   })
   await payload.create({
     collection: menuItemsSlug,
@@ -124,6 +138,7 @@ export const seed = async (payload: Payload) => {
       name: 'House Salad',
       tenant: blueDogTenant.id,
     },
+    overrideAccess: true,
   })
   await payload.create({
     collection: menuItemsSlug,
@@ -131,6 +146,7 @@ export const seed = async (payload: Payload) => {
       name: 'Draft Beer',
       tenant: blueDogTenant.id,
     },
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -139,6 +155,7 @@ export const seed = async (payload: Payload) => {
       title: 'Owned by blue dog',
       tenant: blueDogTenant.id,
     },
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -147,6 +164,7 @@ export const seed = async (payload: Payload) => {
       title: 'Owned by steelcat',
       tenant: steelCatTenant.id,
     },
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -155,6 +173,7 @@ export const seed = async (payload: Payload) => {
       title: 'Owned by bar with no ac',
       tenant: anchorBarTenant.id,
     },
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -163,6 +182,7 @@ export const seed = async (payload: Payload) => {
       title: 'Owned by public tenant',
       tenant: publicTenant.id,
     },
+    overrideAccess: true,
   })
 
   // Create steel cat menu items (in folders)
@@ -173,6 +193,7 @@ export const seed = async (payload: Payload) => {
       folder: steelCatDocumentsFolder.id,
       tenant: steelCatTenant.id,
     },
+    overrideAccess: true,
   })
   await payload.create({
     collection: menuItemsSlug,
@@ -181,6 +202,7 @@ export const seed = async (payload: Payload) => {
       folder: steelCatDocumentsFolder.id,
       tenant: steelCatTenant.id,
     },
+    overrideAccess: true,
   })
   await payload.create({
     collection: menuItemsSlug,
@@ -189,6 +211,7 @@ export const seed = async (payload: Payload) => {
       folder: steelCatArchivesFolder.id,
       tenant: steelCatTenant.id,
     },
+    overrideAccess: true,
   })
 
   // Create anchor bar menu items (in folders)
@@ -201,6 +224,7 @@ export const seed = async (payload: Payload) => {
       localizedName: 'Peanuts EN',
     },
     locale: 'en',
+    overrideAccess: true,
   })
   await payload.create({
     collection: menuItemsSlug,
@@ -211,6 +235,7 @@ export const seed = async (payload: Payload) => {
       localizedName: 'Pretzels EN',
     },
     locale: 'en',
+    overrideAccess: true,
   })
   await payload.create({
     collection: menuItemsSlug,
@@ -221,6 +246,7 @@ export const seed = async (payload: Payload) => {
       localizedName: 'Popcorn EN',
     },
     locale: 'en',
+    overrideAccess: true,
   })
 
   // Public tenant menu items
@@ -230,6 +256,7 @@ export const seed = async (payload: Payload) => {
       name: 'Free Pizza',
       tenant: publicTenant.id,
     },
+    overrideAccess: true,
   })
   await payload.create({
     collection: menuItemsSlug,
@@ -237,6 +264,7 @@ export const seed = async (payload: Payload) => {
       name: 'Free Dogs',
       tenant: publicTenant.id,
     },
+    overrideAccess: true,
   })
 
   // create users
@@ -246,6 +274,7 @@ export const seed = async (payload: Payload) => {
       ...credentials.admin,
       roles: ['admin'],
     },
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -259,6 +288,7 @@ export const seed = async (payload: Payload) => {
         },
       ],
     },
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -275,6 +305,7 @@ export const seed = async (payload: Payload) => {
         },
       ],
     },
+    overrideAccess: true,
   })
 
   // create menus
@@ -285,6 +316,7 @@ export const seed = async (payload: Payload) => {
       title: 'Blue Dog Menu',
       tenant: blueDogTenant.id,
     },
+    overrideAccess: true,
   })
   await payload.create({
     collection: menuSlug,
@@ -293,6 +325,7 @@ export const seed = async (payload: Payload) => {
       title: 'Steel Cat Menu',
       tenant: steelCatTenant.id,
     },
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -306,6 +339,7 @@ export const seed = async (payload: Payload) => {
         },
       ],
     },
+    overrideAccess: true,
   })
 
   // User with mixed tenant roles: admin for Steel Cat, member for Blue Dog
@@ -329,6 +363,7 @@ export const seed = async (payload: Payload) => {
         },
       ],
     },
+    overrideAccess: true,
   })
 
   // Create a user with no tenant associations
@@ -339,5 +374,6 @@ export const seed = async (payload: Payload) => {
       roles: ['user'],
       // tenants: [],
     },
+    overrideAccess: true,
   })
 }

--- a/test/plugin-nested-docs/config.ts
+++ b/test/plugin-nested-docs/config.ts
@@ -50,6 +50,7 @@ export default buildConfigWithDefaults({
         email: devUser.email,
         password: devUser.password,
       },
+      overrideAccess: true,
     })
 
     await seed(payload)

--- a/test/plugin-nested-docs/e2e.spec.ts
+++ b/test/plugin-nested-docs/e2e.spec.ts
@@ -44,6 +44,7 @@ describe('Nested Docs Plugin', () => {
           parent,
           title,
         },
+        overrideAccess: true,
       }) as unknown as Promise<PayloadPage>
     }
 

--- a/test/plugin-nested-docs/int.spec.ts
+++ b/test/plugin-nested-docs/int.spec.ts
@@ -16,6 +16,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-nested-docs', () => {
             equals: 'child-page',
           },
         },
+        overrideAccess: true,
       })
 
       expect(query.docs[0].breadcrumbs).toHaveLength(2)
@@ -29,6 +30,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-nested-docs', () => {
             equals: 'grandchild-page',
           },
         },
+        overrideAccess: true,
       })
 
       expect(query.docs[0].breadcrumbs).toHaveLength(3)
@@ -47,6 +49,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-nested-docs', () => {
           title: '11 children',
           slug: '11-children',
         },
+        overrideAccess: true,
       })
 
       // create 11 children docs
@@ -59,6 +62,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-nested-docs', () => {
             parent: parentDoc.id,
             _status: 'published',
           },
+          overrideAccess: true,
         })
       }
       // update parent doc
@@ -70,6 +74,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-nested-docs', () => {
           slug: '11-children-updated',
           _status: 'published',
         },
+        overrideAccess: true,
       })
 
       // read children docs
@@ -81,6 +86,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-nested-docs', () => {
             equals: parentDoc.id,
           },
         },
+        overrideAccess: true,
       })
 
       const firstUpdatedChildBreadcrumbs = docs[0]?.breadcrumbs
@@ -103,6 +109,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-nested-docs', () => {
           slug: 'parent-doc',
           _status: 'published',
         },
+        overrideAccess: true,
       })
 
       const childDoc = await payload.create({
@@ -113,6 +120,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-nested-docs', () => {
           parent: parentDoc.id,
           _status: 'published',
         },
+        overrideAccess: true,
       })
 
       // expect breadcrumbs to be an array
@@ -134,6 +142,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-nested-docs', () => {
           title: 'parent doc',
           slug: 'parent',
         },
+        overrideAccess: true,
       })
 
       const childDoc = await payload.create({
@@ -144,6 +153,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-nested-docs', () => {
           parent: parentDoc.id,
           _status: 'published',
         },
+        overrideAccess: true,
       })
 
       await payload.update({
@@ -154,6 +164,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-nested-docs', () => {
           slug: 'parent-updated',
           _status: 'published',
         },
+        overrideAccess: true,
       })
 
       const updatedChild = await payload
@@ -164,6 +175,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-nested-docs', () => {
               equals: childDoc.id,
             },
           },
+          overrideAccess: true,
         })
         .then(({ docs }) => docs[0])
 
@@ -185,7 +197,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-nested-docs', () => {
     test.afterEach(async ({ payload }) => {
       // Clean up in reverse order (children before parents)
       for (const id of [...createdPageIDs].reverse()) {
-        await payload.delete({ collection: 'pages', id })
+        await payload.delete({ collection: 'pages', id, overrideAccess: true })
       }
       createdPageIDs.length = 0
     })
@@ -201,6 +213,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-nested-docs', () => {
           slug: 'version-parent',
           _status: 'published',
         },
+        overrideAccess: true,
       })
       createdPageIDs.push(parentDoc.id)
 
@@ -213,6 +226,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-nested-docs', () => {
           parent: parentDoc.id,
           _status: 'published',
         },
+        overrideAccess: true,
       })
       createdPageIDs.push(childDoc.id)
 
@@ -221,6 +235,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-nested-docs', () => {
         id: childDoc.id,
         collection: 'pages',
         draft: false,
+        overrideAccess: true,
       })
       expect(initialPublished._status).toBe('published')
       expect(initialPublished.breadcrumbs).toHaveLength(2)
@@ -233,6 +248,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-nested-docs', () => {
           title: 'Version Child Draft Edit',
         },
         draft: true,
+        overrideAccess: true,
       })
 
       // Step 4: Re-publish the parent (triggers resaveChildren)
@@ -244,6 +260,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-nested-docs', () => {
           slug: 'version-parent-updated',
           _status: 'published',
         },
+        overrideAccess: true,
       })
 
       // Step 5: Verify the child's published version is still accessible
@@ -251,6 +268,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-nested-docs', () => {
         id: childDoc.id,
         collection: 'pages',
         draft: false,
+        overrideAccess: true,
       })
 
       expect(publishedChild).toBeDefined()
@@ -263,6 +281,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-nested-docs', () => {
         id: childDoc.id,
         collection: 'pages',
         draft: true,
+        overrideAccess: true,
       })
 
       expect(draftChild).toBeDefined()
@@ -279,6 +298,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-nested-docs', () => {
           slug: 'draft-parent',
           _status: 'published',
         },
+        overrideAccess: true,
       })
       createdPageIDs.push(parentDoc.id)
 
@@ -291,6 +311,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-nested-docs', () => {
           parent: parentDoc.id,
           _status: 'draft',
         },
+        overrideAccess: true,
       })
       createdPageIDs.push(draftChild.id)
 
@@ -305,6 +326,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-nested-docs', () => {
           slug: 'draft-parent-updated',
           _status: 'published',
         },
+        overrideAccess: true,
       })
 
       // Draft-only child should have updated breadcrumbs
@@ -312,6 +334,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-nested-docs', () => {
         id: draftChild.id,
         collection: 'pages',
         draft: true,
+        overrideAccess: true,
       })
 
       expect(updatedDraftChild.breadcrumbs).toHaveLength(2)
@@ -328,6 +351,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-nested-docs', () => {
           slug: 'breadcrumb-parent',
           _status: 'published',
         },
+        overrideAccess: true,
       })
       createdPageIDs.push(parent.id)
 
@@ -339,6 +363,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-nested-docs', () => {
           parent: parent.id,
           _status: 'published',
         },
+        overrideAccess: true,
       })
       createdPageIDs.push(child.id)
 
@@ -350,6 +375,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-nested-docs', () => {
           title: 'Breadcrumb Child Draft',
         },
         draft: true,
+        overrideAccess: true,
       })
 
       // Update parent slug
@@ -360,6 +386,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-nested-docs', () => {
           slug: 'breadcrumb-parent-updated',
           _status: 'published',
         },
+        overrideAccess: true,
       })
 
       // Published child has updated breadcrumbs and is accessible
@@ -367,6 +394,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-nested-docs', () => {
         id: child.id,
         collection: 'pages',
         draft: false,
+        overrideAccess: true,
       })
 
       expect(published._status).toBe('published')
@@ -377,6 +405,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-nested-docs', () => {
         id: child.id,
         collection: 'pages',
         draft: true,
+        overrideAccess: true,
       })
 
       expect(draft._status).toBe('draft')
@@ -396,6 +425,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-nested-docs', () => {
           slug: 'scheduled-page',
         },
         draft: true,
+        overrideAccess: true,
       })
 
       expect(draft._status).toBe('draft')
@@ -426,11 +456,12 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-nested-docs', () => {
         id: draft.id,
         collection: 'pages',
         draft: false,
+        overrideAccess: true,
       })
 
       expect(retrieved._status).toBe('published')
 
-      await payload.delete({ collection: 'pages', id: draft.id })
+      await payload.delete({ collection: 'pages', id: draft.id, overrideAccess: true })
     })
   })
 
@@ -468,6 +499,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-nested-docs', () => {
         data: {
           name: 'parent',
         },
+        overrideAccess: true,
       })
       const child = await payload.create({
         collection: 'categories',
@@ -475,6 +507,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-nested-docs', () => {
           name: 'child',
           owner: parent.id,
         },
+        overrideAccess: true,
       })
       const grandchild = await payload.create({
         collection: 'categories',
@@ -482,6 +515,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-nested-docs', () => {
           name: 'grandchild',
           owner: child.id,
         },
+        overrideAccess: true,
       })
 
       expect(grandchild.categorization[0].doc).toStrictEqual(parent.id)

--- a/test/plugin-nested-docs/seed/index.ts
+++ b/test/plugin-nested-docs/seed/index.ts
@@ -10,6 +10,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
         email: 'demo@payloadcms.com',
         password: 'demo',
       },
+      overrideAccess: true,
     })
 
     const { id: parentID } = await payload.create({
@@ -19,6 +20,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
         title: 'Parent page',
         _status: 'published',
       },
+      overrideAccess: true,
     })
 
     const { id: childID } = await payload.create({
@@ -29,6 +31,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
         title: 'Child page',
         _status: 'published',
       },
+      overrideAccess: true,
     })
 
     await payload.create({
@@ -39,6 +42,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
         title: 'Grandchild page',
         _status: 'published',
       },
+      overrideAccess: true,
     })
 
     await payload.create({
@@ -48,6 +52,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
         title: 'Sister page',
         _status: 'published',
       },
+      overrideAccess: true,
     })
     return true
   } catch (err) {

--- a/test/plugin-redirects/config.ts
+++ b/test/plugin-redirects/config.ts
@@ -80,6 +80,7 @@ export default buildConfigWithDefaults({
         email: devUser.email,
         password: devUser.password,
       },
+      overrideAccess: true,
     })
 
     await seed(payload)

--- a/test/plugin-redirects/int.spec.ts
+++ b/test/plugin-redirects/int.spec.ts
@@ -15,6 +15,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-redirects', () => {
       data: {
         title: 'Test',
       },
+      overrideAccess: true,
     })
   })
 
@@ -23,6 +24,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-redirects', () => {
       collection: 'redirects',
       depth: 0,
       limit: 1,
+      overrideAccess: true,
     })
 
     expect(redirect).toBeTruthy()
@@ -42,6 +44,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-redirects', () => {
         },
         type: '301',
       },
+      overrideAccess: true,
     })
 
     expect(redirect).toBeTruthy()
@@ -60,6 +63,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-redirects', () => {
         },
         type: '301',
       },
+      overrideAccess: true,
     })
 
     expect(redirect).toBeTruthy()

--- a/test/plugin-redirects/seed/index.ts
+++ b/test/plugin-redirects/seed/index.ts
@@ -14,6 +14,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
         password: 'demo',
       },
       req,
+      overrideAccess: true,
     })
 
     return true

--- a/test/plugin-search/config.ts
+++ b/test/plugin-search/config.ts
@@ -128,6 +128,7 @@ export default buildConfigWithDefaults({
         email: devUser.email,
         password: devUser.password,
       },
+      overrideAccess: true,
     })
 
     await seed(payload)

--- a/test/plugin-search/int.spec.ts
+++ b/test/plugin-search/int.spec.ts
@@ -31,6 +31,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
           exists: true,
         },
       },
+      overrideAccess: true,
     })
     await Promise.all([
       payload.delete({
@@ -41,6 +42,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
             exists: true,
           },
         },
+        overrideAccess: true,
       }),
       payload.delete({
         collection: pagesSlug,
@@ -50,6 +52,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
             exists: true,
           },
         },
+        overrideAccess: true,
       }),
     ])
   })
@@ -59,6 +62,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
       collection: 'search',
       depth: 0,
       limit: 1,
+      overrideAccess: true,
     })
 
     expect(search).toBeTruthy()
@@ -72,6 +76,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
         excerpt: 'This is a test page',
         title: 'Hello, world!',
       },
+      overrideAccess: true,
     })
 
     const { docs: results } = await payload.find({
@@ -82,6 +87,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
           equals: pageToSync.id,
         },
       },
+      overrideAccess: true,
     })
 
     expect(results).toHaveLength(1)
@@ -98,6 +104,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
         excerpt: 'This is a test page',
         title: 'Hello, world!',
       },
+      overrideAccess: true,
     })
 
     // wait for the search document to be potentially created
@@ -112,6 +119,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
           equals: draftPage.id,
         },
       },
+      overrideAccess: true,
     })
 
     expect(results).toHaveLength(0)
@@ -126,6 +134,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
         _status: 'published',
         title: 'Published title!',
       },
+      overrideAccess: true,
     })
 
     // wait for the search document to be potentially created
@@ -140,6 +149,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
           equals: publishedPage.id,
         },
       },
+      overrideAccess: true,
     })
 
     expect(results).toHaveLength(1)
@@ -153,6 +163,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
         _status: 'draft',
         title: 'Draft title!',
       },
+      overrideAccess: true,
     })
 
     // This should remain with the published content
@@ -164,6 +175,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
           equals: publishedPage.id,
         },
       },
+      overrideAccess: true,
     })
 
     expect(updatedResults).toHaveLength(1)
@@ -175,6 +187,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
         _status: 'draft',
         title: 'Drafted again',
       },
+      overrideAccess: true,
     })
 
     // Should now be deleted given we've unpublished the page
@@ -186,6 +199,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
           equals: publishedPage.id,
         },
       },
+      overrideAccess: true,
     })
 
     expect(deletedResults).toHaveLength(0)
@@ -199,6 +213,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
         excerpt: 'This is a test page',
         title: 'Hello, world!',
       },
+      overrideAccess: true,
     })
 
     const { docs: results } = await payload.find({
@@ -209,6 +224,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
           equals: pageToReceiveUpdates.id,
         },
       },
+      overrideAccess: true,
     })
 
     expect(results).toHaveLength(1)
@@ -223,6 +239,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
         excerpt: 'This is a test page (updated)',
         title: 'Hello, world! (updated)',
       },
+      overrideAccess: true,
     })
 
     // wait for the search document to be potentially updated
@@ -238,6 +255,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
           equals: pageToReceiveUpdates.id,
         },
       },
+      overrideAccess: true,
     })
 
     expect(updatedResults).toHaveLength(1)
@@ -256,6 +274,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
         excerpt: 'This is a test page',
         title: 'Hello, world!',
       },
+      overrideAccess: true,
     })
 
     // wait for the search document to be created
@@ -270,6 +289,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
           equals: page.id,
         },
       },
+      overrideAccess: true,
     })
 
     expect(results).toHaveLength(1)
@@ -278,6 +298,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
     await payload.delete({
       id: page.id,
       collection: 'pages',
+      overrideAccess: true,
     })
 
     // wait for the search document to be potentially deleted
@@ -292,6 +313,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
           equals: results[0].id,
         },
       },
+      overrideAccess: true,
     })
 
     expect(deletedResults).toHaveLength(0)
@@ -303,11 +325,13 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
     const custom_id_1 = await payload.create({
       collection: 'custom-ids-1',
       data: { id: 'custom_id' },
+      overrideAccess: true,
     })
 
     await payload.create({
       collection: 'custom-ids-2',
       data: { id: 'custom_id' },
+      overrideAccess: true,
     })
 
     await wait(200)
@@ -319,11 +343,12 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
       where: { 'doc.value': { equals: 'custom_id' } },
       limit: 1,
       sort: 'createdAt',
+      overrideAccess: true,
     })
 
     expect(docBefore.doc.relationTo).toBe('custom-ids-1')
 
-    await payload.delete({ collection: 'custom-ids-1', id: custom_id_1.id })
+    await payload.delete({ collection: 'custom-ids-1', id: custom_id_1.id, overrideAccess: true })
 
     await wait(200)
 
@@ -334,6 +359,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
       where: { 'doc.value': { equals: 'custom_id' } },
       limit: 1,
       sort: 'createdAt',
+      overrideAccess: true,
     })
 
     expect(docAfter.doc.relationTo).toBe('custom-ids-2')
@@ -348,6 +374,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
         slug: 'es',
       },
       locale: 'es',
+      overrideAccess: true,
     })
 
     await payload.update({
@@ -359,6 +386,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
         slug: 'en',
       },
       locale: 'en',
+      overrideAccess: true,
     })
 
     const syncedSearchData = await payload.find({
@@ -373,6 +401,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
           },
         ],
       },
+      overrideAccess: true,
     })
 
     expect(syncedSearchData.docs[0].slug).toEqual('es')
@@ -390,6 +419,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
     await payload.create({
       collection: 'users',
       data: testCreds,
+      overrideAccess: true,
     })
 
     const testUserRes = await restClient.POST(`/users/login`, {
@@ -453,6 +483,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
         title: 'post_1',
         _status: 'published',
       },
+      overrideAccess: true,
     })
 
     await wait(200)
@@ -463,9 +494,10 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
         title: 'post_2',
         _status: 'published',
       },
+      overrideAccess: true,
     })
 
-    const { docs } = await payload.find({ collection: 'search' })
+    const { docs } = await payload.find({ collection: 'search', overrideAccess: true })
 
     await wait(200)
 
@@ -487,6 +519,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
           in: docs.map((doc) => doc.id),
         },
       },
+      overrideAccess: true,
     })
 
     // Should have no docs with these ID
@@ -502,6 +535,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
           title: 'Test page title',
           _status: 'published',
         },
+        overrideAccess: true,
       }),
       payload.create({
         collection: postsSlug,
@@ -509,6 +543,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
           title: 'Test page title',
           _status: 'published',
         },
+        overrideAccess: true,
       }),
     ])
 
@@ -516,6 +551,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
 
     const { totalDocs: totalBeforeReindex } = await payload.count({
       collection: 'search',
+      overrideAccess: true,
     })
 
     const endpointRes = await restClient.POST(`/search/reindex`, {
@@ -531,6 +567,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
 
     const { totalDocs: totalAfterReindex } = await payload.count({
       collection: 'search',
+      overrideAccess: true,
     })
 
     expect(totalAfterReindex).toBe(totalBeforeReindex)
@@ -544,14 +581,17 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
       payload.create({
         collection: postsSlug,
         data: { title: 'Post one', _status: 'published' },
+        overrideAccess: true,
       }),
       payload.create({
         collection: postsSlug,
         data: { title: 'Post two', _status: 'published' },
+        overrideAccess: true,
       }),
       payload.create({
         collection: pagesSlug,
         data: { title: 'Page one', _status: 'published' },
+        overrideAccess: true,
       }),
     ])
 
@@ -579,6 +619,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
       collection: postsSlug,
       data: { title: 'Locale test post', _status: 'published', slug: 'post-slug-en' },
       locale: 'en',
+      overrideAccess: true,
     })
 
     await payload.update({
@@ -586,18 +627,21 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
       id: postId,
       data: { slug: 'post-slug-es' },
       locale: 'es',
+      overrideAccess: true,
     })
     await payload.update({
       collection: postsSlug,
       id: postId,
       data: { slug: 'post-slug-de' },
       locale: 'de',
+      overrideAccess: true,
     })
 
     // Create a page so both collections are reindexed together, exercising the multi-collection path
     await payload.create({
       collection: pagesSlug,
       data: { title: 'Locale test page', _status: 'published' },
+      overrideAccess: true,
     })
 
     const endpointRes = await restClient.POST(`/search/reindex`, {
@@ -613,6 +657,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
       where: {
         and: [{ 'doc.relationTo': { equals: postsSlug } }, { 'doc.value': { equals: postId } }],
       },
+      overrideAccess: true,
     })
 
     expect(searchDocs).toHaveLength(1)
@@ -620,9 +665,24 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
     const searchDocId = searchDocs[0]!.id
 
     const [enDoc, esDoc, deDoc] = await Promise.all([
-      payload.findByID({ collection: 'search', id: searchDocId, locale: 'en' }),
-      payload.findByID({ collection: 'search', id: searchDocId, locale: 'es' }),
-      payload.findByID({ collection: 'search', id: searchDocId, locale: 'de' }),
+      payload.findByID({
+        collection: 'search',
+        id: searchDocId,
+        locale: 'en',
+        overrideAccess: true,
+      }),
+      payload.findByID({
+        collection: 'search',
+        id: searchDocId,
+        locale: 'es',
+        overrideAccess: true,
+      }),
+      payload.findByID({
+        collection: 'search',
+        id: searchDocId,
+        locale: 'de',
+        overrideAccess: true,
+      }),
     ])
 
     // With localization fallback: true, a missing locale update would silently fall back to 'en'
@@ -640,6 +700,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
           title: 'Test page published',
           _status: 'published',
         },
+        overrideAccess: true,
       }),
       payload.create({
         collection: pagesSlug,
@@ -647,6 +708,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
           title: 'Test page draft',
           _status: 'draft',
         },
+        overrideAccess: true,
       }),
     ])
 
@@ -654,6 +716,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
 
     const { totalDocs: totalBeforeReindex } = await payload.count({
       collection: 'search',
+      overrideAccess: true,
     })
 
     expect(totalBeforeReindex).toBe(1)
@@ -671,6 +734,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
 
     const { totalDocs: totalAfterReindex } = await payload.count({
       collection: 'search',
+      overrideAccess: true,
     })
 
     expect(totalAfterReindex).toBe(totalBeforeReindex)
@@ -693,6 +757,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
         _status: 'published',
         slug: 'test-en',
       },
+      overrideAccess: true,
     })
     await payload.update({
       collection: postsSlug,
@@ -702,6 +767,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
         _status: 'published',
         slug: 'test-es',
       },
+      overrideAccess: true,
     })
     await payload.update({
       collection: postsSlug,
@@ -711,6 +777,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
         _status: 'published',
         slug: 'test-de',
       },
+      overrideAccess: true,
     })
 
     const {
@@ -729,6 +796,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
       pagination: false,
       limit: 1,
       depth: 0,
+      overrideAccess: true,
     })
 
     expect(postBeforeReindex?.slug).not.toBeFalsy()
@@ -760,6 +828,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
       pagination: false,
       limit: 1,
       depth: 0,
+      overrideAccess: true,
     })
 
     expect(postAfterReindex?.slug).not.toBeFalsy()
@@ -775,6 +844,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
         excerpt: 'This post will be soft deleted',
         _status: 'published',
       },
+      overrideAccess: true,
     })
 
     // Wait for the search document to be created
@@ -789,6 +859,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
           equals: publishedPost.id,
         },
       },
+      overrideAccess: true,
     })
 
     expect(initialSearchResults).toHaveLength(1)
@@ -801,6 +872,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
       data: {
         deletedAt: new Date().toISOString(),
       },
+      overrideAccess: true,
     })
 
     // Wait for the search plugin to sync the trashed document
@@ -816,6 +888,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
           equals: publishedPost.id,
         },
       },
+      overrideAccess: true,
     })
 
     // The search document should still exist
@@ -826,6 +899,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
       collection: postsSlug,
       id: publishedPost.id,
       trash: true, // permanently delete
+      overrideAccess: true,
     })
   })
 
@@ -842,6 +916,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
           syncEnglishOnly: true,
         },
         locale: 'en',
+        overrideAccess: true,
       })
 
       // Query for ALL search docs with locale: 'all' to see total count
@@ -853,6 +928,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
             equals: enDoc.id,
           },
         },
+        overrideAccess: true,
       })
 
       // Should only have 1 search doc total (English only)
@@ -868,6 +944,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
             equals: enDoc.id,
           },
         },
+        overrideAccess: true,
       })
 
       expect(docs).toHaveLength(1)
@@ -883,6 +960,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
       await payload.delete({
         collection: 'filtered-locales',
         id: enDoc.id,
+        overrideAccess: true,
       })
     })
 
@@ -898,6 +976,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
           title: 'Test Post for All Locales',
         },
         locale: 'en',
+        overrideAccess: true,
       })
 
       // Update the post in Spanish locale
@@ -909,6 +988,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
           _status: 'published',
           title: 'Test Post para Todos los Locales',
         },
+        overrideAccess: true,
       })
 
       // Update the post in German locale
@@ -920,6 +1000,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
           _status: 'published',
           title: 'Testbeitrag für alle Sprachen',
         },
+        overrideAccess: true,
       })
 
       // Query for search doc with locale: 'all'
@@ -931,6 +1012,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
             equals: post.id,
           },
         },
+        overrideAccess: true,
       })
 
       // Should have 1 search doc with all locales embedded
@@ -945,6 +1027,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
       await payload.delete({
         collection: postsSlug,
         id: post.id,
+        overrideAccess: true,
       })
     })
 
@@ -959,6 +1042,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
           syncEnglishOnly: false,
         },
         locale: 'en',
+        overrideAccess: true,
       })
 
       // Verify search doc exists for English
@@ -970,6 +1054,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
             equals: doc.id,
           },
         },
+        overrideAccess: true,
       })
       expect(enSearchDocs).toHaveLength(1)
 
@@ -982,6 +1067,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
             equals: doc.id,
           },
         },
+        overrideAccess: true,
       })
       expect(esSearchDocs).toHaveLength(1)
 
@@ -994,6 +1080,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
             equals: doc.id,
           },
         },
+        overrideAccess: true,
       })
       expect(deSearchDocs).toHaveLength(1)
 
@@ -1001,6 +1088,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
       await payload.delete({
         collection: 'filtered-locales',
         id: doc.id,
+        overrideAccess: true,
       })
     })
   })

--- a/test/plugin-search/seed/index.ts
+++ b/test/plugin-search/seed/index.ts
@@ -12,6 +12,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
         password: 'demo',
       },
       req,
+      overrideAccess: true,
     })
 
     return true

--- a/test/plugin-sentry/config.ts
+++ b/test/plugin-sentry/config.ts
@@ -53,6 +53,7 @@ export default buildConfigWithDefaults({
         email: devUser.email,
         password: devUser.password,
       },
+      overrideAccess: true,
     })
   },
 })

--- a/test/plugin-seo/config.ts
+++ b/test/plugin-seo/config.ts
@@ -107,6 +107,7 @@ export default buildConfigWithDefaults({
         email: devUser.email,
         password: devUser.password,
       },
+      overrideAccess: true,
     })
 
     await seed(payload)

--- a/test/plugin-seo/e2e.spec.ts
+++ b/test/plugin-seo/e2e.spec.ts
@@ -47,6 +47,7 @@ describe('SEO Plugin', () => {
       collection: mediaSlug,
       data: {},
       file,
+      overrideAccess: true,
     })
 
     const createdPage = (await payload.create({
@@ -61,6 +62,7 @@ describe('SEO Plugin', () => {
         },
         title: 'Test Page',
       },
+      overrideAccess: true,
     })) as unknown as PayloadPage
     id = createdPage.id
   })

--- a/test/plugin-seo/int.spec.ts
+++ b/test/plugin-seo/int.spec.ts
@@ -27,6 +27,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-seo', () => {
       collection: mediaSlug,
       data: {},
       file,
+      overrideAccess: true,
     })
 
     page = await payload.create({
@@ -40,12 +41,14 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-seo', () => {
         },
       },
       depth: 0,
+      overrideAccess: true,
     })
 
     mediaDoc2 = await payload.create({
       collection: mediaSlug,
       data: {},
       file,
+      overrideAccess: true,
     })
   })
 
@@ -65,6 +68,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-seo', () => {
       },
       depth: 0,
       context,
+      overrideAccess: true,
     })
 
     // If identicalCount was incremented, it means previousValue === value incorrectly
@@ -82,6 +86,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-seo', () => {
         },
       },
       depth: 0,
+      overrideAccess: true,
     })
 
     expect(pageWithTitle).toHaveProperty('meta')
@@ -99,6 +104,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-seo', () => {
         },
       },
       depth: 0,
+      overrideAccess: true,
     })
 
     expect(pageWithDescription).toHaveProperty('meta')
@@ -116,6 +122,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-seo', () => {
         },
       },
       depth: 0,
+      overrideAccess: true,
     })
 
     expect(pageWithImage).toHaveProperty('meta')
@@ -133,6 +140,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-seo', () => {
         },
       },
       depth: 0,
+      overrideAccess: true,
     })
 
     expect(pageWithCustomField).toHaveProperty('meta')
@@ -152,6 +160,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-seo', () => {
       },
       locale: 'en',
       depth: 0,
+      overrideAccess: true,
     })
 
     const pageWithLocalizedMeta = await payload.update({
@@ -165,6 +174,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-seo', () => {
       },
       locale: 'es',
       depth: 0,
+      overrideAccess: true,
     })
 
     expect(pageWithLocalizedMeta).toHaveProperty('meta')
@@ -178,6 +188,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-seo', () => {
       collection: 'pages',
       id: page.id,
       depth: 0,
+      overrideAccess: true,
     })
 
     expect(pageInDefaultLocale).toHaveProperty('meta')

--- a/test/plugin-seo/seed/index.ts
+++ b/test/plugin-seo/seed/index.ts
@@ -21,6 +21,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
       collection: mediaSlug,
       data: {},
       file,
+      overrideAccess: true,
     })
 
     await payload.create({
@@ -36,6 +37,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
         title: 'Test Page',
       },
       req,
+      overrideAccess: true,
     })
 
     return true

--- a/test/plugin-stripe/config.ts
+++ b/test/plugin-stripe/config.ts
@@ -97,6 +97,7 @@ export default buildConfigWithDefaults({
         email: devUser.email,
         password: devUser.password,
       },
+      overrideAccess: true,
     })
 
     await seed(payload)

--- a/test/plugin-stripe/int.spec.ts
+++ b/test/plugin-stripe/int.spec.ts
@@ -10,6 +10,7 @@ test.suite({ config: './config.ts' })('Stripe Plugin', () => {
       data: {
         name: 'Test Product',
       },
+      overrideAccess: true,
     })
 
     expect(product).toHaveProperty('name', 'Test Product')

--- a/test/plugin-stripe/seed/index.ts
+++ b/test/plugin-stripe/seed/index.ts
@@ -12,6 +12,7 @@ export const seed = async (payload: Payload): Promise<boolean> => {
         password: 'demo',
       },
       req,
+      overrideAccess: true,
     })
 
     return true

--- a/test/plugin-stripe/webhooks/subscriptionCreatedOrUpdated.ts
+++ b/test/plugin-stripe/webhooks/subscriptionCreatedOrUpdated.ts
@@ -30,6 +30,7 @@ export const subscriptionCreatedOrUpdated = async (args) => {
           equals: plan.product,
         },
       },
+      overrideAccess: true,
     })
 
     payloadProductID = productQuery.docs?.[0]?.id
@@ -55,6 +56,7 @@ export const subscriptionCreatedOrUpdated = async (args) => {
       where: {
         stripeID: customerStripeID,
       },
+      overrideAccess: true,
     })
 
     const foundCustomer = customerReq.docs[0]
@@ -95,6 +97,7 @@ export const subscriptionCreatedOrUpdated = async (args) => {
             skipSync: true,
             subscriptions,
           },
+          overrideAccess: true,
         })
 
         payload.logger.info(`✅ Successfully updated subscription.`)

--- a/test/plugin-stripe/webhooks/subscriptionDeleted.ts
+++ b/test/plugin-stripe/webhooks/subscriptionDeleted.ts
@@ -31,6 +31,7 @@ export const subscriptionDeleted = async (args) => {
       where: {
         stripeID: customerStripeID,
       },
+      overrideAccess: true,
     })
 
     const foundCustomer = customerReq.docs[0]
@@ -55,6 +56,7 @@ export const subscriptionDeleted = async (args) => {
             skipSync: true,
             subscriptions,
           },
+          overrideAccess: true,
         })
 
         payload.logger.info(`✅ Successfully deleted subscription.`)

--- a/test/plugin-stripe/webhooks/syncPriceJSON.ts
+++ b/test/plugin-stripe/webhooks/syncPriceJSON.ts
@@ -22,6 +22,7 @@ export const syncPriceJSON = async (args) => {
           equals: eventID,
         },
       },
+      overrideAccess: true,
     })
 
     payloadProductID = productQuery.docs?.[0]?.id
@@ -47,6 +48,7 @@ export const syncPriceJSON = async (args) => {
         },
         skipSync: true,
       },
+      overrideAccess: true,
     })
 
     payload.logger.info(`✅ Successfully updated product price.`)

--- a/test/plugins/config.ts
+++ b/test/plugins/config.ts
@@ -107,6 +107,7 @@ export default buildConfigWithDefaults({
         email: devUser.email,
         password: devUser.password,
       },
+      overrideAccess: true,
     })
   },
 })

--- a/test/plugins/int.spec.ts
+++ b/test/plugins/int.spec.ts
@@ -13,6 +13,7 @@ test.suite({ config: './config.ts' })('Collections - Plugins', () => {
       data: {
         title: 'Test Page',
       },
+      overrideAccess: true,
     })
 
     expect(id).toBeDefined()

--- a/test/query-presets/e2e.spec.ts
+++ b/test/query-presets/e2e.spec.ts
@@ -74,6 +74,7 @@ describe('Query Presets', () => {
             in: ['Everyone', 'Only Me', 'Specific Users'],
           },
         },
+        overrideAccess: true,
       })
     ).docs
 
@@ -443,6 +444,7 @@ describe('Query Presets', () => {
     const posts = await payload.find({
       collection: 'posts',
       limit: 1,
+      overrideAccess: true,
     })
     const testPost = posts.docs[0]
 
@@ -489,6 +491,7 @@ describe('Query Presets', () => {
     const posts = await payload.find({
       collection: 'posts',
       limit: 2,
+      overrideAccess: true,
     })
     const [testPost1, testPost2] = posts.docs
 

--- a/test/query-presets/int.spec.ts
+++ b/test/query-presets/int.spec.ts
@@ -20,6 +20,7 @@ test.suite({ config: './config.ts' })('Query Presets', () => {
           email: devUser.email,
           password: devUser.password,
         },
+        overrideAccess: true,
       })
       ?.then((result) => result.user)
 
@@ -30,6 +31,7 @@ test.suite({ config: './config.ts' })('Query Presets', () => {
           email: regularUser.email,
           password: regularUser.password,
         },
+        overrideAccess: true,
       })
       ?.then((result) => result.user)
 
@@ -40,6 +42,7 @@ test.suite({ config: './config.ts' })('Query Presets', () => {
           email: 'public@email.com',
           password: regularUser.password,
         },
+        overrideAccess: true,
       })
       ?.then((result) => result.user)
   })
@@ -69,6 +72,7 @@ test.suite({ config: './config.ts' })('Query Presets', () => {
           title: 'Only Logged In Users',
           relatedCollection: 'pages',
         },
+        overrideAccess: true,
       })
 
       // read
@@ -107,6 +111,7 @@ test.suite({ config: './config.ts' })('Query Presets', () => {
           collection: queryPresetsCollectionSlug,
           depth: 0,
           id,
+          overrideAccess: true,
         })
 
         expect(preset.title).toBe('Only Logged In Users')
@@ -130,6 +135,7 @@ test.suite({ config: './config.ts' })('Query Presets', () => {
           collection: queryPresetsCollectionSlug,
           depth: 0,
           id,
+          overrideAccess: true,
         })
 
         expect(preset.title).toBe('Only Logged In Users')
@@ -714,6 +720,7 @@ test.suite({ config: './config.ts' })('Query Presets', () => {
             },
           },
         },
+        overrideAccess: true,
       })
 
       try {

--- a/test/queues/cli.int.spec.ts
+++ b/test/queues/cli.int.spec.ts
@@ -36,6 +36,7 @@ test.suite({ config: './config.ts', cron: false })('Queues - CLI', () => {
     const allSimples = await payload.find({
       collection: 'simple',
       limit: 100,
+      overrideAccess: true,
     })
 
     expect(allSimples.totalDocs).toBe(1)

--- a/test/queues/e2e.spec.ts
+++ b/test/queues/e2e.spec.ts
@@ -48,6 +48,7 @@ describe('Queues', () => {
       where: {
         id: { exists: true },
       },
+      overrideAccess: true,
     })
 
     // Clear jobs collection before each test
@@ -56,6 +57,7 @@ describe('Queues', () => {
       where: {
         id: { exists: true },
       },
+      overrideAccess: true,
     })
   })
 
@@ -82,6 +84,7 @@ describe('Queues', () => {
           },
           workflowSlug: 'externalWorkflow',
         },
+        overrideAccess: true,
       })
 
       // Run the job via the jobs endpoint (this runs within Next.js context)
@@ -99,6 +102,7 @@ describe('Queues', () => {
             const allSimples = await payload.find({
               collection: 'simple',
               limit: 100,
+              overrideAccess: true,
             })
             return allSimples.totalDocs
           },
@@ -109,6 +113,7 @@ describe('Queues', () => {
       const allSimples = await payload.find({
         collection: 'simple',
         limit: 100,
+        overrideAccess: true,
       })
       expect(allSimples.docs[0]?.title).toEqual('externalWorkflowE2E')
     })
@@ -128,6 +133,7 @@ describe('Queues', () => {
           },
           taskSlug: 'ExternalTask',
         },
+        overrideAccess: true,
       })
 
       const runResponse = await apiContext.get(`${serverURL}/api/payload-jobs/run?silent=true`)
@@ -140,6 +146,7 @@ describe('Queues', () => {
             const allSimples = await payload.find({
               collection: 'simple',
               limit: 100,
+              overrideAccess: true,
             })
             return allSimples.totalDocs
           },
@@ -150,6 +157,7 @@ describe('Queues', () => {
       const allSimples = await payload.find({
         collection: 'simple',
         limit: 100,
+        overrideAccess: true,
       })
       expect(allSimples.docs[0]?.title).toEqual('externalTaskE2E')
     })

--- a/test/queues/int.spec.ts
+++ b/test/queues/int.spec.ts
@@ -149,6 +149,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
 
       const unchangedJob = await payload.findByID({
         collection: 'payload-jobs',
+        overrideAccess: true,
         id: job.id,
       })
 
@@ -175,6 +176,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
 
       const unchangedJob = await payload.findByID({
         collection: 'payload-jobs',
+        overrideAccess: true,
         id: job.id,
       })
 
@@ -314,6 +316,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
       const jobAfterCancel = await payload.findByID({
         collection: 'payload-jobs',
         id: job.id,
+        overrideAccess: true,
       })
 
       expect(jobAfterCancel.hasError).toBe(false)
@@ -350,6 +353,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
       const jobAfterCancel = await payload.findByID({
         collection: 'payload-jobs',
         id: job.id,
+        overrideAccess: true,
       })
 
       expect(jobAfterCancel.hasError).toBe(true)
@@ -381,6 +385,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
       const jobAfterCancel = await payload.findByID({
         collection: 'payload-jobs',
         id: job.id,
+        overrideAccess: true,
       })
 
       expect(jobAfterCancel.hasError).toBe(false)
@@ -413,6 +418,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
       const jobAfterCancel = await payload.findByID({
         collection: 'payload-jobs',
         id: job.id,
+        overrideAccess: true,
       })
 
       expect(jobAfterCancel.hasError).toBe(true)
@@ -433,6 +439,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
           message: '1',
         },
       },
+      overrideAccess: true,
     })
     // @ts-expect-error
     expect(job.input.message).toBe('1')
@@ -445,6 +452,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
           message: '2',
         },
       },
+      overrideAccess: true,
     })
     // @ts-expect-error
     expect(updatedJob.input.message).toBe('2')
@@ -456,11 +464,13 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
       data: {
         title: 'my post',
       },
+      overrideAccess: true,
     })
 
     const retrievedPost = await payload.findByID({
       collection: 'posts',
       id: newPost.id,
+      overrideAccess: true,
     })
 
     expect(retrievedPost.jobStep1Ran).toBeFalsy()
@@ -471,6 +481,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
     const postAfterJobs = await payload.findByID({
       collection: 'posts',
       id: newPost.id,
+      overrideAccess: true,
     })
 
     expect(postAfterJobs.jobStep1Ran).toBe('hello')
@@ -486,11 +497,13 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
       context: {
         useJSONWorkflow: true,
       },
+      overrideAccess: true,
     })
 
     const retrievedPost = await payload.findByID({
       collection: 'posts',
       id: newPost.id,
+      overrideAccess: true,
     })
 
     expect(retrievedPost.jobStep1Ran).toBeFalsy()
@@ -501,6 +514,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
     const postAfterJobs = await payload.findByID({
       collection: 'posts',
       id: newPost.id,
+      overrideAccess: true,
     })
 
     expect(postAfterJobs.jobStep1Ran).toBe('hello')
@@ -530,6 +544,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
     const allSimples = await payload.find({
       collection: 'simple',
       limit: 100,
+      overrideAccess: true,
     })
 
     expect(allSimples.totalDocs).toBe(1)
@@ -537,6 +552,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
     const jobAfterRun = await payload.findByID({
       collection: 'payload-jobs',
       id: job.id,
+      overrideAccess: true,
     })
 
     // @ts-expect-error amountRetried is new arbitrary data and not in the type
@@ -565,6 +581,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
     const allSimples = await payload.find({
       collection: 'simple',
       limit: 100,
+      overrideAccess: true,
     })
 
     expect(allSimples.totalDocs).toBe(1)
@@ -572,6 +589,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
     const jobAfterRun = await payload.findByID({
       collection: 'payload-jobs',
       id: job.id,
+      overrideAccess: true,
     })
 
     // @ts-expect-error amountRetried is new arbitrary data and not in the type
@@ -600,6 +618,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
     const allSimples = await payload.find({
       collection: 'simple',
       limit: 100,
+      overrideAccess: true,
     })
 
     expect(allSimples.totalDocs).toBe(1)
@@ -607,6 +626,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
     const jobAfterRun = await payload.findByID({
       collection: 'payload-jobs',
       id: job.id,
+      overrideAccess: true,
     })
 
     // @ts-expect-error amountRetried is new arbitrary data and not in the type
@@ -637,6 +657,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
     const allSimples = await payload.find({
       collection: 'simple',
       limit: 100,
+      overrideAccess: true,
     })
 
     expect(allSimples.totalDocs).toBe(1)
@@ -644,6 +665,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
     const jobAfterRun = await payload.findByID({
       collection: 'payload-jobs',
       id: job.id,
+      overrideAccess: true,
     })
 
     // @ts-expect-error amountRetried is new arbitrary data and not in the type
@@ -674,6 +696,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
     const allSimples = await payload.find({
       collection: 'simple',
       limit: 100,
+      overrideAccess: true,
     })
 
     expect(allSimples.totalDocs).toBe(1)
@@ -681,6 +704,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
     const jobAfterRun = await payload.findByID({
       collection: 'payload-jobs',
       id: job.id,
+      overrideAccess: true,
     })
 
     // @ts-expect-error amountRetried is new arbitrary data and not in the type
@@ -711,6 +735,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
     const allSimples = await payload.find({
       collection: 'simple',
       limit: 100,
+      overrideAccess: true,
     })
 
     expect(allSimples.totalDocs).toBe(1)
@@ -718,6 +743,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
     const jobAfterRun = await payload.findByID({
       collection: 'payload-jobs',
       id: job.id,
+      overrideAccess: true,
     })
 
     // @ts-expect-error amountRetried is new arbitrary data and not in the type
@@ -748,6 +774,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
     const allSimples = await payload.find({
       collection: 'simple',
       limit: 100,
+      overrideAccess: true,
     })
 
     expect(allSimples.totalDocs).toBe(1)
@@ -755,6 +782,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
     const jobAfterRun = await payload.findByID({
       collection: 'payload-jobs',
       id: job.id,
+      overrideAccess: true,
     })
 
     // @ts-expect-error amountRetried is new arbitrary data and not in the type
@@ -783,6 +811,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
     const allSimples = await payload.find({
       collection: 'simple',
       limit: 100,
+      overrideAccess: true,
     })
 
     expect(allSimples.totalDocs).toBe(1) // Failure happens after task creates a simple document, but still within the task => any document creation should be rolled back
@@ -790,6 +819,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
     const jobAfterRun = await payload.findByID({
       collection: 'payload-jobs',
       id: job.id,
+      overrideAccess: true,
     })
 
     // @ts-expect-error amountRetried is new arbitrary data and not in the type
@@ -836,6 +866,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
     const allSimples = await payload.find({
       collection: 'simple',
       limit: 100,
+      overrideAccess: true,
     })
 
     expect(allSimples.totalDocs).toBe(1)
@@ -843,6 +874,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
     const jobAfterRun = await payload.findByID({
       collection: 'payload-jobs',
       id: job.id,
+      overrideAccess: true,
     })
     expect(jobAfterRun.totalTried).toBe(5)
     expect((jobAfterRun.taskStatus as JobTaskStatus).inline?.['1']?.totalTried).toBe(5)
@@ -915,6 +947,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
           equals: message,
         },
       },
+      overrideAccess: true,
     })
     expect(createdDocuments.totalDocs).toBe(1)
 
@@ -953,6 +986,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
           equals: message,
         },
       },
+      overrideAccess: true,
     })
     expect(createdDocuments.totalDocs).toBe(1)
 
@@ -986,6 +1020,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
       collection: 'simple',
       limit: 100,
       sort: 'createdAt',
+      overrideAccess: true,
     })
 
     expect(allSimples.totalDocs).toBe(2)
@@ -1020,6 +1055,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
       collection: 'simple',
       limit: 100,
       sort: 'createdAt',
+      overrideAccess: true,
     })
 
     expect(allSimples.totalDocs).toBe(2)
@@ -1058,6 +1094,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
       collection: 'simple',
       limit: 100,
       sort: 'createdAt',
+      overrideAccess: true,
     })
 
     expect(allSimples.totalDocs).toBe(2)
@@ -1078,6 +1115,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
     const allSimples = await payload.find({
       collection: 'simple',
       limit: 100,
+      overrideAccess: true,
     })
 
     expect(allSimples.totalDocs).toBe(1)
@@ -1092,12 +1130,22 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
       },
     })
 
-    const before = await payload.findByID({ collection: 'payload-jobs', id, disableErrors: true })
+    const before = await payload.findByID({
+      collection: 'payload-jobs',
+      id,
+      disableErrors: true,
+      overrideAccess: true,
+    })
     expect(before?.id).toBe(id)
 
     await payload.jobs.run({ silent: true })
 
-    const after = await payload.findByID({ collection: 'payload-jobs', id, disableErrors: true })
+    const after = await payload.findByID({
+      collection: 'payload-jobs',
+      id,
+      disableErrors: true,
+      overrideAccess: true,
+    })
     expect(after).toBeNull()
   })
 
@@ -1107,12 +1155,22 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
       input: {},
     })
 
-    const before = await payload.findByID({ collection: 'payload-jobs', id, disableErrors: true })
+    const before = await payload.findByID({
+      collection: 'payload-jobs',
+      id,
+      disableErrors: true,
+      overrideAccess: true,
+    })
     expect(before?.id).toBe(id)
 
     await payload.jobs.run({ silent: true })
 
-    const after = await payload.findByID({ collection: 'payload-jobs', id, disableErrors: true })
+    const after = await payload.findByID({
+      collection: 'payload-jobs',
+      id,
+      disableErrors: true,
+      overrideAccess: true,
+    })
     expect(after?.id).toBe(id)
     expect(after?.processingUntil).toBeFalsy()
     expect(after?.processingToken).toBeFalsy()
@@ -1127,12 +1185,22 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
       },
     })
 
-    const before = await payload.findByID({ collection: 'payload-jobs', id, disableErrors: true })
+    const before = await payload.findByID({
+      collection: 'payload-jobs',
+      id,
+      disableErrors: true,
+      overrideAccess: true,
+    })
     expect(before?.id).toBe(id)
 
     await payload.jobs.run({ silent: true })
 
-    const after = await payload.findByID({ collection: 'payload-jobs', id, disableErrors: true })
+    const after = await payload.findByID({
+      collection: 'payload-jobs',
+      id,
+      disableErrors: true,
+      overrideAccess: true,
+    })
     expect(after?.id).toBe(id)
     expect(after?.processingUntil).toBeFalsy()
     expect(after?.processingToken).toBeFalsy()
@@ -1151,6 +1219,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
     const allSimples = await payload.find({
       collection: 'simple',
       limit: 100,
+      overrideAccess: true,
     })
 
     expect(allSimples.totalDocs).toBe(1)
@@ -1188,6 +1257,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
       const jobAfterRun = await payload.findByID({
         collection: 'payload-jobs',
         id: job.id,
+        overrideAccess: true,
       })
 
       expect(jobAfterRun.hasError).toBe(true)
@@ -1214,6 +1284,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
       const jobAfterRun = await payload.findByID({
         collection: 'payload-jobs',
         id: job.id,
+        overrideAccess: true,
       })
 
       expect(jobAfterRun.hasError).toBe(true)
@@ -1237,6 +1308,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
     const jobAfterRun = await payload.findByID({
       collection: 'payload-jobs',
       id: job.id,
+      overrideAccess: true,
     })
 
     expect(jobAfterRun.hasError).toBe(true)
@@ -1265,6 +1337,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
     const jobAfterRun = await payload.findByID({
       collection: 'payload-jobs',
       id: job.id,
+      overrideAccess: true,
     })
 
     // Initial attempt + 1 retry = 2. Once hasError is true the queue stops picking it up,
@@ -1338,6 +1411,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
               const currentJob = await payload.findByID({
                 id: job.id,
                 collection: 'payload-jobs',
+                overrideAccess: true,
               })
 
               processingUntil = currentJob.processingUntil
@@ -1369,10 +1443,12 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
           const completedJob = await payload.findByID({
             id: job.id,
             collection: 'payload-jobs',
+            overrideAccess: true,
           })
           const createdPosts = await payload.find({
             collection: 'posts',
             where: { title: { equals: postTitle } },
+            overrideAccess: true,
           })
 
           expect(replacementWorkerResult.jobStatus?.[job.id]?.status).toBe('success')
@@ -1417,6 +1493,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
               await payload.findByID({
                 id: job.id,
                 collection: 'payload-jobs',
+                overrideAccess: true,
               })
             ).processingToken,
         )
@@ -1439,10 +1516,12 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
       const completedJob = await payload.findByID({
         id: job.id,
         collection: 'payload-jobs',
+        overrideAccess: true,
       })
       const createdPosts = await payload.find({
         collection: 'posts',
         where: { title: { equals: postTitle } },
+        overrideAccess: true,
       })
       const workersThatRecoveredTheJob = replacementWorkers.filter(
         (result) => result.jobStatus?.[job.id],
@@ -1481,6 +1560,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
               await payload.findByID({
                 id: job.id,
                 collection: 'payload-jobs',
+                overrideAccess: true,
               })
             ).processingToken,
         )
@@ -1493,10 +1573,12 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
       const completedJob = await payload.findByID({
         id: job.id,
         collection: 'payload-jobs',
+        overrideAccess: true,
       })
       const createdPosts = await payload.find({
         collection: 'posts',
         where: { title: { equals: postTitle } },
+        overrideAccess: true,
       })
       Object.assign(payload.config.jobs.processingLease, processingLeaseDefaults)
 
@@ -1527,10 +1609,12 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
       const completedJob = await payload.findByID({
         id: job.id,
         collection: 'payload-jobs',
+        overrideAccess: true,
       })
       const createdPosts = await payload.find({
         collection: 'posts',
         where: { title: { equals: postTitle } },
+        overrideAccess: true,
       })
 
       expect(unresponsiveWorkerResult.jobStatus?.[job.id]).toBeUndefined()
@@ -1563,6 +1647,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
               await payload.findByID({
                 id: job.id,
                 collection: 'payload-jobs',
+                overrideAccess: true,
               })
             ).processingToken,
         )
@@ -1576,10 +1661,12 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
       const completedJob = await payload.findByID({
         id: job.id,
         collection: 'payload-jobs',
+        overrideAccess: true,
       })
       const createdPosts = await payload.find({
         collection: 'posts',
         where: { title: { equals: postTitle } },
+        overrideAccess: true,
       })
 
       expect(timedOutWorkerResult.jobStatus?.[job.id]).toBeUndefined()
@@ -1614,6 +1701,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
     const allSimples = await payload.find({
       collection: 'simple',
       limit: 100,
+      overrideAccess: true,
     })
 
     expect(allSimples.totalDocs).toBe(1)
@@ -1633,6 +1721,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
           },
           taskSlug: 'CreateSimple',
         },
+        overrideAccess: true,
       })
 
       const _req = await createLocalReq({}, payload)
@@ -1652,6 +1741,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
           processingUntil: new Date(Date.now() + 60_000).toISOString(),
           taskSlug: 'CreateSimple',
         },
+        overrideAccess: true,
       })
 
       /**
@@ -1674,6 +1764,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
           processingUntil: new Date(Date.now() + 60_000).toISOString(),
           taskSlug: 'CreateSimple',
         },
+        overrideAccess: true,
       })
 
       await payload.create({
@@ -1682,6 +1773,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
         data: {
           title: 'from single task',
         },
+        overrideAccess: true,
       })
 
       await payload.update({
@@ -1695,6 +1787,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
           processingUntil: new Date(Date.now() + 60_000).toISOString(),
           taskSlug: 'CreateSimple',
         },
+        overrideAccess: true,
       })
 
       await commitTransaction(t2Req)
@@ -1714,6 +1807,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
           processingUntil: new Date(Date.now() + 60_000).toISOString(),
           taskSlug: 'CreateSimple',
         },
+        overrideAccess: true,
       })
       await commitTransaction(t1Req)
     }
@@ -1727,6 +1821,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
     const allSimples = await payload.find({
       collection: 'simple',
       limit: 100,
+      overrideAccess: true,
     })
 
     expect(allSimples.totalDocs).toBe(30)
@@ -1747,6 +1842,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
     const allSimples = await payload.find({
       collection: 'simple',
       limit: 100,
+      overrideAccess: true,
     })
 
     expect(allSimples.totalDocs).toBe(8)
@@ -1780,6 +1876,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
     const allSimples = await payload.find({
       collection: 'simple',
       limit: numberOfTasks,
+      overrideAccess: true,
     })
 
     expect(allSimples.totalDocs).toBe(numberOfTasks) // Default limit: 10
@@ -1802,6 +1899,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
     const allSimples = await payload.find({
       collection: 'simple',
       limit: 1000,
+      overrideAccess: true,
     })
 
     expect(allSimples.totalDocs).toBe(10) // Default limit: 10
@@ -1827,6 +1925,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
     const allSimples = await payload.find({
       collection: 'simple',
       limit: 1000,
+      overrideAccess: true,
     })
 
     expect(allSimples.totalDocs).toBe(42) // Default limit: 10
@@ -1862,6 +1961,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
     const allSimples = await payload.find({
       collection: 'simple',
       limit: 100,
+      overrideAccess: true,
     })
 
     expect(allSimples.totalDocs).toBe(9)
@@ -1894,6 +1994,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
     const allSimples = await payload.find({
       collection: 'simple',
       limit: 100,
+      overrideAccess: true,
     })
 
     expect(allSimples.totalDocs).toBe(1)
@@ -1913,6 +2014,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
     const allSimples = await payload.find({
       collection: 'simple',
       limit: 100,
+      overrideAccess: true,
     })
 
     expect(allSimples.totalDocs).toBe(1)
@@ -1944,6 +2046,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
     const allSimples = await payload.find({
       collection: 'simple',
       limit: 100,
+      overrideAccess: true,
     })
 
     expect(allSimples.totalDocs).toBe(1)
@@ -1957,6 +2060,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
           exists: true,
         },
       },
+      overrideAccess: true,
     })
 
     expect(allCompletedJobs.totalDocs).toBe(1)
@@ -1994,6 +2098,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
     const allSimples = await payload.find({
       collection: 'simple',
       limit: 100,
+      overrideAccess: true,
     })
 
     expect(allSimples.totalDocs).toBe(1)
@@ -2007,6 +2112,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
           exists: true,
         },
       },
+      overrideAccess: true,
     })
 
     expect(allCompletedJobs.totalDocs).toBe(1)
@@ -2039,6 +2145,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
     const allSimples = await payload.find({
       collection: 'simple',
       limit: 100,
+      overrideAccess: true,
     })
 
     expect(allSimples.totalDocs).toBe(1)
@@ -2052,6 +2159,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
           exists: true,
         },
       },
+      overrideAccess: true,
     })
 
     expect(allCompletedJobs.totalDocs).toBe(1)
@@ -2072,6 +2180,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
     const allSimples = await payload.find({
       collection: 'simple',
       limit: 100,
+      overrideAccess: true,
     })
 
     expect(allSimples.totalDocs).toBe(2)
@@ -2081,6 +2190,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
     const jobAfterRun = await payload.findByID({
       collection: 'payload-jobs',
       id: job.id,
+      overrideAccess: true,
     })
 
     expect(jobAfterRun?.log?.[0]?.taskID).toBe('create doc 1')
@@ -2121,6 +2231,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
     const allSimples = await payload.find({
       collection: 'simple',
       limit: 100,
+      overrideAccess: true,
     })
 
     expect(allSimples.totalDocs).toBe(1)
@@ -2129,6 +2240,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
     const jobAfterRun = await payload.findByID({
       collection: 'payload-jobs',
       id: job.id,
+      overrideAccess: true,
     })
 
     // @ts-expect-error
@@ -2152,6 +2264,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
       collection: 'payload-jobs',
       id: job.id,
       depth: 0,
+      overrideAccess: true,
     })
     expect(jobAfterRunProcessing.processingUntil).toBeTruthy()
     expect(jobAfterRunProcessing.processingToken).toBeTruthy()
@@ -2171,6 +2284,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
       collection: 'payload-jobs',
       id: job.id,
       depth: 0,
+      overrideAccess: true,
     })
 
     expect(Boolean(jobAfterRun.completedAt)).toBe(false)
@@ -2215,6 +2329,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
       collection: 'payload-jobs',
       id: job.id,
       depth: 0,
+      overrideAccess: true,
     })
 
     expect(Boolean(jobAfterRun.completedAt)).toBe(false)
@@ -2248,6 +2363,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
         collection: 'payload-jobs',
         id: job.id,
         depth: 0,
+        overrideAccess: true,
       })
 
       // @ts-expect-error error is not typed
@@ -2263,6 +2379,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
         collection: 'payload-jobs',
         id: job.id,
         depth: 0,
+        overrideAccess: true,
       })
 
       expect(jobAfterRun2.totalTried).toBe(2)
@@ -2300,6 +2417,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
         collection: 'payload-jobs',
         id: job.id,
         depth: 0,
+        overrideAccess: true,
       })
 
       expect(Boolean(jobAfterRun.completedAt)).toBe(false)
@@ -2317,6 +2435,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
         collection: 'payload-jobs',
         id: job.id,
         depth: 0,
+        overrideAccess: true,
       })
 
       expect(jobAfterRun2.totalTried).toBe(jobAfterRun.totalTried)
@@ -2347,6 +2466,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
         collection: 'payload-jobs',
         id: job.id,
         depth: 0,
+        overrideAccess: true,
       })
 
       expect(jobAfterRun.log?.length).toBe(1)
@@ -2362,6 +2482,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
         collection: 'payload-jobs',
         id: job.id,
         depth: 0,
+        overrideAccess: true,
       })
 
       expect(jobAfterRun2.totalTried).toBe(2)
@@ -2401,6 +2522,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
         collection: 'payload-jobs',
         id: job.id,
         depth: 0,
+        overrideAccess: true,
       })
 
       expect(Boolean(jobAfterRun.completedAt)).toBe(false)
@@ -2418,6 +2540,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
         collection: 'payload-jobs',
         id: job.id,
         depth: 0,
+        overrideAccess: true,
       })
 
       expect(jobAfterRun2.totalTried).toBe(jobAfterRun.totalTried)
@@ -2438,6 +2561,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
     const jobAfterRun = await payload.findByID({
       collection: 'payload-jobs',
       id: job.id,
+      overrideAccess: true,
     })
 
     expect(jobAfterRun.hasError).toBe(true)
@@ -2466,6 +2590,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
     const jobAfterRun = await payload.findByID({
       collection: 'payload-jobs',
       id: job.id,
+      overrideAccess: true,
     })
 
     // error can be defined while hasError is true, as hasError: true is only set if the job cannot retry anymore.
@@ -2477,6 +2602,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
       collection: 'simple',
       limit: amount,
       depth: 0,
+      overrideAccess: true,
     })
     expect(simpleDocs.docs).toHaveLength(amount)
 
@@ -2508,6 +2634,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
     const jobAfterRun = await payload.findByID({
       collection: 'payload-jobs',
       id: job.id,
+      overrideAccess: true,
     })
 
     // error can be defined while hasError is true, as hasError: true is only set if the job cannot retry anymore.
@@ -2533,6 +2660,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
     const allSimples = await payload.find({
       collection: 'simple',
       limit: 100,
+      overrideAccess: true,
     })
 
     expect(allSimples.totalDocs).toBe(1)
@@ -2597,10 +2725,12 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
       const job1After = await payload.findByID({
         collection: 'payload-jobs',
         id: job1.id,
+        overrideAccess: true,
       })
       const job2After = await payload.findByID({
         collection: 'payload-jobs',
         id: job2.id,
+        overrideAccess: true,
       })
 
       expect(job1After.completedAt).toBeDefined()
@@ -2640,10 +2770,12 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
       const job1After = await payload.findByID({
         collection: 'payload-jobs',
         id: job1.id,
+        overrideAccess: true,
       })
       const job2After = await payload.findByID({
         collection: 'payload-jobs',
         id: job2.id,
+        overrideAccess: true,
       })
 
       // First job should be completed
@@ -2658,6 +2790,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
       const job2Final = await payload.findByID({
         collection: 'payload-jobs',
         id: job2.id,
+        overrideAccess: true,
       })
 
       expect(job2Final.completedAt).toBeDefined()
@@ -2691,6 +2824,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
           payload.findByID({
             collection: 'payload-jobs',
             id: job.id,
+            overrideAccess: true,
           }),
         ),
       )
@@ -2706,6 +2840,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
           payload.findByID({
             collection: 'payload-jobs',
             id: job.id,
+            overrideAccess: true,
           }),
         ),
       )
@@ -2721,6 +2856,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
           payload.findByID({
             collection: 'payload-jobs',
             id: job.id,
+            overrideAccess: true,
           }),
         ),
       )
@@ -2762,10 +2898,12 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
       const job1After = await payload.findByID({
         collection: 'payload-jobs',
         id: job1.id,
+        overrideAccess: true,
       })
       const job2After = await payload.findByID({
         collection: 'payload-jobs',
         id: job2.id,
+        overrideAccess: true,
       })
 
       expect(job1After.completedAt).toBeDefined()
@@ -2802,10 +2940,26 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
       await payload.jobs.run({ silent: true, limit: 10 })
 
       const results = await Promise.all([
-        payload.findByID({ collection: 'payload-jobs', id: concurrentJob1.id }),
-        payload.findByID({ collection: 'payload-jobs', id: concurrentJob2.id }),
-        payload.findByID({ collection: 'payload-jobs', id: differentKeyJob.id }),
-        payload.findByID({ collection: 'payload-jobs', id: noConcurrencyJob.id }),
+        payload.findByID({
+          collection: 'payload-jobs',
+          id: concurrentJob1.id,
+          overrideAccess: true,
+        }),
+        payload.findByID({
+          collection: 'payload-jobs',
+          id: concurrentJob2.id,
+          overrideAccess: true,
+        }),
+        payload.findByID({
+          collection: 'payload-jobs',
+          id: differentKeyJob.id,
+          overrideAccess: true,
+        }),
+        payload.findByID({
+          collection: 'payload-jobs',
+          id: noConcurrencyJob.id,
+          overrideAccess: true,
+        }),
       ])
 
       // concurrentJob1 should complete (first with shared-key)
@@ -2823,6 +2977,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
       const concurrentJob2After = await payload.findByID({
         collection: 'payload-jobs',
         id: concurrentJob2.id,
+        overrideAccess: true,
       })
       expect(concurrentJob2After.completedAt).toBeDefined()
     })
@@ -2852,9 +3007,9 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
       await payload.jobs.run({ silent: true, limit: 10 })
 
       let results = await Promise.all([
-        payload.findByID({ collection: 'payload-jobs', id: jobA.id }),
-        payload.findByID({ collection: 'payload-jobs', id: jobB.id }),
-        payload.findByID({ collection: 'payload-jobs', id: jobC.id }),
+        payload.findByID({ collection: 'payload-jobs', id: jobA.id, overrideAccess: true }),
+        payload.findByID({ collection: 'payload-jobs', id: jobB.id, overrideAccess: true }),
+        payload.findByID({ collection: 'payload-jobs', id: jobC.id, overrideAccess: true }),
       ])
 
       expect(results[0].completedAt).toBeDefined() // A completed
@@ -2865,9 +3020,9 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
       await payload.jobs.run({ silent: true, limit: 10 })
 
       results = await Promise.all([
-        payload.findByID({ collection: 'payload-jobs', id: jobA.id }),
-        payload.findByID({ collection: 'payload-jobs', id: jobB.id }),
-        payload.findByID({ collection: 'payload-jobs', id: jobC.id }),
+        payload.findByID({ collection: 'payload-jobs', id: jobA.id, overrideAccess: true }),
+        payload.findByID({ collection: 'payload-jobs', id: jobB.id, overrideAccess: true }),
+        payload.findByID({ collection: 'payload-jobs', id: jobC.id, overrideAccess: true }),
       ])
 
       expect(results[0].completedAt).toBeDefined() // A completed
@@ -2878,9 +3033,9 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
       await payload.jobs.run({ silent: true, limit: 10 })
 
       results = await Promise.all([
-        payload.findByID({ collection: 'payload-jobs', id: jobA.id }),
-        payload.findByID({ collection: 'payload-jobs', id: jobB.id }),
-        payload.findByID({ collection: 'payload-jobs', id: jobC.id }),
+        payload.findByID({ collection: 'payload-jobs', id: jobA.id, overrideAccess: true }),
+        payload.findByID({ collection: 'payload-jobs', id: jobB.id, overrideAccess: true }),
+        payload.findByID({ collection: 'payload-jobs', id: jobC.id, overrideAccess: true }),
       ])
 
       expect(results[0].completedAt).toBeDefined() // A completed
@@ -2918,9 +3073,9 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
       await payload.jobs.run({ silent: true, limit: 10, queue: 'lifo' })
 
       let results = await Promise.all([
-        payload.findByID({ collection: 'payload-jobs', id: jobA.id }),
-        payload.findByID({ collection: 'payload-jobs', id: jobB.id }),
-        payload.findByID({ collection: 'payload-jobs', id: jobC.id }),
+        payload.findByID({ collection: 'payload-jobs', id: jobA.id, overrideAccess: true }),
+        payload.findByID({ collection: 'payload-jobs', id: jobB.id, overrideAccess: true }),
+        payload.findByID({ collection: 'payload-jobs', id: jobC.id, overrideAccess: true }),
       ])
 
       expect(results[0].completedAt).toBeFalsy() // A waiting
@@ -2931,9 +3086,9 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
       await payload.jobs.run({ silent: true, limit: 10, queue: 'lifo' })
 
       results = await Promise.all([
-        payload.findByID({ collection: 'payload-jobs', id: jobA.id }),
-        payload.findByID({ collection: 'payload-jobs', id: jobB.id }),
-        payload.findByID({ collection: 'payload-jobs', id: jobC.id }),
+        payload.findByID({ collection: 'payload-jobs', id: jobA.id, overrideAccess: true }),
+        payload.findByID({ collection: 'payload-jobs', id: jobB.id, overrideAccess: true }),
+        payload.findByID({ collection: 'payload-jobs', id: jobC.id, overrideAccess: true }),
       ])
 
       expect(results[0].completedAt).toBeFalsy() // A still waiting
@@ -2944,9 +3099,9 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
       await payload.jobs.run({ silent: true, limit: 10, queue: 'lifo' })
 
       results = await Promise.all([
-        payload.findByID({ collection: 'payload-jobs', id: jobA.id }),
-        payload.findByID({ collection: 'payload-jobs', id: jobB.id }),
-        payload.findByID({ collection: 'payload-jobs', id: jobC.id }),
+        payload.findByID({ collection: 'payload-jobs', id: jobA.id, overrideAccess: true }),
+        payload.findByID({ collection: 'payload-jobs', id: jobB.id, overrideAccess: true }),
+        payload.findByID({ collection: 'payload-jobs', id: jobC.id, overrideAccess: true }),
       ])
 
       expect(results[0].completedAt).toBeDefined() // A completed
@@ -2984,6 +3139,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
       const pendingJobStatus = await payload.findByID({
         collection: 'payload-jobs',
         id: pendingJob.id,
+        overrideAccess: true,
       })
 
       expect(pendingJobStatus.completedAt).toBeFalsy()
@@ -2998,6 +3154,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
       const pendingJobFinal = await payload.findByID({
         collection: 'payload-jobs',
         id: pendingJob.id,
+        overrideAccess: true,
       })
 
       expect(pendingJobFinal.completedAt).toBeDefined()
@@ -3033,8 +3190,12 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
       ])
 
       const results = await Promise.all([
-        payload.findByID({ collection: 'payload-jobs', id: defaultQueueJob.id }),
-        payload.findByID({ collection: 'payload-jobs', id: lifoQueueJob.id }),
+        payload.findByID({
+          collection: 'payload-jobs',
+          id: defaultQueueJob.id,
+          overrideAccess: true,
+        }),
+        payload.findByID({ collection: 'payload-jobs', id: lifoQueueJob.id, overrideAccess: true }),
       ])
 
       // Both should complete because they have different concurrency keys
@@ -3067,6 +3228,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
           .findByID({
             collection: 'payload-jobs',
             id: jobA.id,
+            overrideAccess: true,
           })
           .catch(() => null)
 
@@ -3074,12 +3236,14 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
           .findByID({
             collection: 'payload-jobs',
             id: jobB.id,
+            overrideAccess: true,
           })
           .catch(() => null)
 
         const jobCAfter = await payload.findByID({
           collection: 'payload-jobs',
           id: jobC.id,
+          overrideAccess: true,
         })
 
         // A and B should be deleted
@@ -3115,6 +3279,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
         const runningJobAfter = await payload.findByID({
           collection: 'payload-jobs',
           id: runningJob.id,
+          overrideAccess: true,
         })
 
         expect(runningJobAfter).not.toBeNull()
@@ -3124,6 +3289,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
         const newJobAfter = await payload.findByID({
           collection: 'payload-jobs',
           id: newJob.id,
+          overrideAccess: true,
         })
 
         expect(newJobAfter).not.toBeNull()
@@ -3135,8 +3301,8 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
         await payload.jobs.run({ silent: true, limit: 10 })
 
         const finalResults = await Promise.all([
-          payload.findByID({ collection: 'payload-jobs', id: runningJob.id }),
-          payload.findByID({ collection: 'payload-jobs', id: newJob.id }),
+          payload.findByID({ collection: 'payload-jobs', id: runningJob.id, overrideAccess: true }),
+          payload.findByID({ collection: 'payload-jobs', id: newJob.id, overrideAccess: true }),
         ])
 
         // Both should have completed
@@ -3183,6 +3349,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
             .findByID({
               collection: 'payload-jobs',
               id: job.id,
+              overrideAccess: true,
             })
             .catch(() => null)
 
@@ -3203,6 +3370,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
         const finalJob = await payload.findByID({
           collection: 'payload-jobs',
           id: lastExistingJob.id,
+          overrideAccess: true,
         })
 
         expect(finalJob.completedAt).toBeDefined()
@@ -3241,18 +3409,21 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
         const runningJobCheck = await payload.findByID({
           collection: 'payload-jobs',
           id: runningJob.id,
+          overrideAccess: true,
         })
 
         const middleJobCheck = await payload
           .findByID({
             collection: 'payload-jobs',
             id: middleJob.id,
+            overrideAccess: true,
           })
           .catch(() => null)
 
         const latestJobCheck = await payload.findByID({
           collection: 'payload-jobs',
           id: latestJob.id,
+          overrideAccess: true,
         })
 
         // Running job should still exist and be processing
@@ -3270,8 +3441,8 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
         await payload.jobs.run({ silent: true, limit: 10 })
 
         const finalResults = await Promise.all([
-          payload.findByID({ collection: 'payload-jobs', id: runningJob.id }),
-          payload.findByID({ collection: 'payload-jobs', id: latestJob.id }),
+          payload.findByID({ collection: 'payload-jobs', id: runningJob.id, overrideAccess: true }),
+          payload.findByID({ collection: 'payload-jobs', id: latestJob.id, overrideAccess: true }),
         ])
 
         // Both running and latest jobs should complete
@@ -3283,6 +3454,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
           .findByID({
             collection: 'payload-jobs',
             id: middleJob.id,
+            overrideAccess: true,
           })
           .catch(() => null)
 
@@ -3309,6 +3481,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
       const baselineDocs = await payload.find({
         collection: 'simple',
         where: { title: { equals: 'baseline-job' } },
+        overrideAccess: true,
       })
       expect(baselineDocs.totalDocs).toBe(1)
 
@@ -3355,6 +3528,7 @@ test.suite({ config: './config.ts' })('Queues - Payload', () => {
       const afterRecoveryDocs = await payload.find({
         collection: 'simple',
         where: { title: { equals: 'after-recovery' } },
+        overrideAccess: true,
       })
       expect(afterRecoveryDocs.totalDocs).toBe(1)
 

--- a/test/queues/runners/externalTask.ts
+++ b/test/queues/runners/externalTask.ts
@@ -7,6 +7,7 @@ export const externalTaskHandler: TaskHandler<'ExternalTask'> = async ({ input, 
     data: {
       title: input.message,
     },
+    overrideAccess: true,
   })
   return {
     output: {

--- a/test/queues/runners/updatePost.ts
+++ b/test/queues/runners/updatePost.ts
@@ -15,6 +15,7 @@ export const updatePostStep1: TaskHandler<'UpdatePost'> = async ({ req, input })
     data: {
       jobStep1Ran: input.message,
     },
+    overrideAccess: true,
   })
 
   return {
@@ -39,6 +40,7 @@ export const updatePostStep2: TaskHandler<'UpdatePostStep2'> = async ({ req, inp
     data: {
       jobStep2Ran: input.messageTwice + job.taskStatus.UpdatePost?.['1']?.output?.messageTwice,
     },
+    overrideAccess: true,
   })
 
   return {

--- a/test/queues/schedules-autocron.int.spec.ts
+++ b/test/queues/schedules-autocron.int.spec.ts
@@ -78,6 +78,7 @@ test.suite({ config: './config.schedules-autocron.ts' })(
       const allSimples = await payload.find({
         collection: 'simple',
         limit: 100,
+        overrideAccess: true,
       })
 
       expect(allSimples.totalDocs).toBeGreaterThanOrEqual(minJobsCompleted)

--- a/test/queues/schedules.int.spec.ts
+++ b/test/queues/schedules.int.spec.ts
@@ -65,6 +65,7 @@ test.suite({ config: './config.schedules.ts' })(
       const allSimples = await payload.find({
         collection: 'simple',
         limit: 100,
+        overrideAccess: true,
       })
 
       expect(allSimples.totalDocs).toBe(1)
@@ -88,6 +89,7 @@ test.suite({ config: './config.schedules.ts' })(
       const allSimples = await payload.find({
         collection: 'simple',
         limit: 100,
+        overrideAccess: true,
       })
 
       expect(allSimples.totalDocs).toBe(1)
@@ -111,6 +113,7 @@ test.suite({ config: './config.schedules.ts' })(
       const allSimples = await payload.find({
         collection: 'simple',
         limit: 100,
+        overrideAccess: true,
       })
 
       expect(allSimples.totalDocs).toBe(0)
@@ -138,6 +141,7 @@ test.suite({ config: './config.schedules.ts' })(
       const allSimples = await payload.find({
         collection: 'simple',
         limit: 100,
+        overrideAccess: true,
       })
 
       expect(allSimples.totalDocs).toBe(1)
@@ -164,6 +168,7 @@ test.suite({ config: './config.schedules.ts' })(
       const allSimples = await payload.find({
         collection: 'simple',
         limit: 100,
+        overrideAccess: true,
       })
 
       expect(allSimples.totalDocs).toBe(1)
@@ -190,6 +195,7 @@ test.suite({ config: './config.schedules.ts' })(
       const allSimples = await payload.find({
         collection: 'simple',
         limit: 100,
+        overrideAccess: true,
       })
 
       expect(allSimples.totalDocs).toBe(0)
@@ -213,6 +219,7 @@ test.suite({ config: './config.schedules.ts' })(
       const allSimples = await payload.find({
         collection: 'simple',
         limit: 100,
+        overrideAccess: true,
       })
 
       expect(allSimples.totalDocs).toBe(1)
@@ -246,6 +253,7 @@ test.suite({ config: './config.schedules.ts' })(
       const allSimples = await payload.find({
         collection: 'simple',
         limit: 100,
+        overrideAccess: true,
       })
 
       expect(allSimples.totalDocs).toBe(3)
@@ -280,6 +288,7 @@ test.suite({ config: './config.schedules.ts' })(
       const allSimples = await payload.find({
         collection: 'simple',
         limit: 100,
+        overrideAccess: true,
       })
 
       expect(allSimples.totalDocs).toBe(2) // Would be 4 by default, if only scheduled jobs were respected in handleSchedules condition
@@ -305,6 +314,7 @@ test.suite({ config: './config.schedules.ts' })(
       const allSimples = await payload.find({
         collection: 'simple',
         limit: 100,
+        overrideAccess: true,
       })
 
       expect(allSimples.totalDocs).toBe(2)
@@ -332,6 +342,7 @@ test.suite({ config: './config.schedules.ts' })(
       const allSimples = await payload.find({
         collection: 'simple',
         limit: 100,
+        overrideAccess: true,
       })
 
       expect(allSimples.totalDocs).toBe(3)
@@ -366,6 +377,7 @@ test.suite({ config: './config.schedules.ts' })(
             equals: 'This task runs every second - max 2 per second',
           },
         },
+        overrideAccess: true,
       })
 
       expect(allSimples.totalDocs).toBe(6)
@@ -381,6 +393,7 @@ test.suite({ config: './config.schedules.ts' })(
       const allSimples = await payload.find({
         collection: 'simple',
         limit: 100,
+        overrideAccess: true,
       })
 
       expect(allSimples.totalDocs).toBe(0)

--- a/test/queues/tasks/CreateSimpleRetries0Task.ts
+++ b/test/queues/tasks/CreateSimpleRetries0Task.ts
@@ -31,6 +31,7 @@ export const CreateSimpleRetries0Task: TaskConfig<'CreateSimpleRetries0'> = {
       data: {
         title: input.message,
       },
+      overrideAccess: true,
     })
     return {
       output: {

--- a/test/queues/tasks/CreateSimpleRetriesUndefinedTask.ts
+++ b/test/queues/tasks/CreateSimpleRetriesUndefinedTask.ts
@@ -30,6 +30,7 @@ export const CreateSimpleRetriesUndefinedTask: TaskConfig<'CreateSimpleRetriesUn
       data: {
         title: input.message,
       },
+      overrideAccess: true,
     })
     return {
       output: {

--- a/test/queues/tasks/CreateSimpleTask.ts
+++ b/test/queues/tasks/CreateSimpleTask.ts
@@ -31,6 +31,7 @@ export const CreateSimpleTask: TaskConfig<'CreateSimple'> = {
       data: {
         title: input.message,
       },
+      overrideAccess: true,
     })
     return {
       output: {

--- a/test/queues/tasks/CreateSimpleWithDuplicateMessageTask.ts
+++ b/test/queues/tasks/CreateSimpleWithDuplicateMessageTask.ts
@@ -32,6 +32,7 @@ export const CreateSimpleWithDuplicateMessageTask: TaskConfig<'CreateSimpleWithD
         data: {
           title: input.message + input.message,
         },
+        overrideAccess: true,
       })
       return {
         output: {

--- a/test/queues/tasks/EverySecondMax2Task.ts
+++ b/test/queues/tasks/EverySecondMax2Task.ts
@@ -59,6 +59,7 @@ export const EverySecondMax2Task: TaskConfig<'EverySecondMax2'> = {
         title: input.message,
       },
       req,
+      overrideAccess: true,
     })
     return {
       output: {},

--- a/test/queues/tasks/EverySecondTask.ts
+++ b/test/queues/tasks/EverySecondTask.ts
@@ -46,6 +46,7 @@ export const EverySecondTask: TaskConfig<'EverySecond'> = {
         title: input.message,
       },
       req,
+      overrideAccess: true,
     })
     return {
       output: {},

--- a/test/queues/workflows/exclusiveConcurrency.ts
+++ b/test/queues/workflows/exclusiveConcurrency.ts
@@ -33,6 +33,7 @@ export const exclusiveConcurrencyWorkflow: WorkflowConfig<'exclusiveConcurrency'
           data: {
             title: `started:${job.input.resourceId}:${job.id}`,
           },
+          overrideAccess: true,
         })
 
         // Simulate some work
@@ -50,6 +51,7 @@ export const exclusiveConcurrencyWorkflow: WorkflowConfig<'exclusiveConcurrency'
           data: {
             title: `completed:${job.input.resourceId}:${job.id}`,
           },
+          overrideAccess: true,
         })
 
         return { output: {} }

--- a/test/queues/workflows/inlineTaskTest.ts
+++ b/test/queues/workflows/inlineTaskTest.ts
@@ -18,6 +18,7 @@ export const inlineTaskTestWorkflow: WorkflowConfig<'inlineTaskTest'> = {
           data: {
             title: input.message,
           },
+          overrideAccess: true,
         })
         return {
           output: {

--- a/test/queues/workflows/inlineTaskTestDelayed.ts
+++ b/test/queues/workflows/inlineTaskTestDelayed.ts
@@ -21,6 +21,7 @@ export const inlineTaskTestDelayedWorkflow: WorkflowConfig<'inlineTaskTestDelaye
           data: {
             title: input.message,
           },
+          overrideAccess: true,
         })
         await new Promise((resolve) => setTimeout(resolve, 100))
 

--- a/test/queues/workflows/longRunning.ts
+++ b/test/queues/workflows/longRunning.ts
@@ -33,6 +33,7 @@ export const longRunningWorkflow: WorkflowConfig<'longRunning'> = {
           title: job.input.postTitle,
         },
         req,
+        overrideAccess: true,
       })
     }
   },

--- a/test/queues/workflows/noConcurrency.ts
+++ b/test/queues/workflows/noConcurrency.ts
@@ -31,6 +31,7 @@ export const noConcurrencyWorkflow: WorkflowConfig<'noConcurrency'> = {
           data: {
             title: `started:${job.input.resourceId}:${job.id}`,
           },
+          overrideAccess: true,
         })
 
         // Simulate some work
@@ -48,6 +49,7 @@ export const noConcurrencyWorkflow: WorkflowConfig<'noConcurrency'> = {
           data: {
             title: `completed:${job.input.resourceId}:${job.id}`,
           },
+          overrideAccess: true,
         })
 
         return { output: {} }

--- a/test/queues/workflows/noRetriesSet.ts
+++ b/test/queues/workflows/noRetriesSet.ts
@@ -21,6 +21,7 @@ export const noRetriesSetWorkflow: WorkflowConfig<'workflowNoRetriesSet'> = {
         },
       },
       id: job.id,
+      overrideAccess: true,
     })
 
     job.input = updatedJob.input as any

--- a/test/queues/workflows/queueSpecificConcurrency.ts
+++ b/test/queues/workflows/queueSpecificConcurrency.ts
@@ -32,6 +32,7 @@ export const queueSpecificConcurrencyWorkflow: WorkflowConfig<'queueSpecificConc
           data: {
             title: `started:${job.queue}:${job.input.resourceId}:${job.id}`,
           },
+          overrideAccess: true,
         })
 
         await wait(delayMs)
@@ -47,6 +48,7 @@ export const queueSpecificConcurrencyWorkflow: WorkflowConfig<'queueSpecificConc
           data: {
             title: `completed:${job.queue}:${job.input.resourceId}:${job.id}`,
           },
+          overrideAccess: true,
         })
 
         return { output: {} }

--- a/test/queues/workflows/retries0.ts
+++ b/test/queues/workflows/retries0.ts
@@ -22,6 +22,7 @@ export const retries0Workflow: WorkflowConfig<'workflowRetries0'> = {
         },
       },
       id: job.id,
+      overrideAccess: true,
     })
     job.input = updatedJob.input as any
 

--- a/test/queues/workflows/retriesBackoffTest.ts
+++ b/test/queues/workflows/retriesBackoffTest.ts
@@ -21,6 +21,7 @@ export const retriesBackoffTestWorkflow: WorkflowConfig<'retriesBackoffTest'> = 
         },
       },
       id: job.id,
+      overrideAccess: true,
     })
     job.input = newJob.input as any
 
@@ -34,6 +35,7 @@ export const retriesBackoffTestWorkflow: WorkflowConfig<'retriesBackoffTest'> = 
           data: {
             title: 'should not exist',
           },
+          overrideAccess: true,
         })
 
         // @ts-expect-error timeTried is new arbitrary data and not in the type
@@ -51,6 +53,7 @@ export const retriesBackoffTestWorkflow: WorkflowConfig<'retriesBackoffTest'> = 
             input: job.input,
           },
           id: job.id,
+          overrideAccess: true,
         })
         job.input = updated.input as any
 
@@ -60,6 +63,7 @@ export const retriesBackoffTestWorkflow: WorkflowConfig<'retriesBackoffTest'> = 
             collection: 'simple',
             id,
             req,
+            overrideAccess: true,
           })
 
           // Last try it should succeed

--- a/test/queues/workflows/retriesRollbackTest.ts
+++ b/test/queues/workflows/retriesRollbackTest.ts
@@ -21,6 +21,7 @@ export const retriesRollbackTestWorkflow: WorkflowConfig<'retriesRollbackTest'> 
         },
       },
       id: job.id,
+      overrideAccess: true,
     })
 
     await inlineTask('1', {
@@ -31,6 +32,7 @@ export const retriesRollbackTestWorkflow: WorkflowConfig<'retriesRollbackTest'> 
           data: {
             title: job.input.message,
           },
+          overrideAccess: true,
         })
         return {
           output: {
@@ -48,6 +50,7 @@ export const retriesRollbackTestWorkflow: WorkflowConfig<'retriesRollbackTest'> 
           data: {
             title: 'should not exist',
           },
+          overrideAccess: true,
         })
         // Fail afterwards, so that we can also test that transactions work (i.e. the job is rolled back)
 

--- a/test/queues/workflows/retriesTest.ts
+++ b/test/queues/workflows/retriesTest.ts
@@ -21,6 +21,7 @@ export const retriesTestWorkflow: WorkflowConfig<'retriesTest'> = {
         },
       },
       id: job.id,
+      overrideAccess: true,
     })
     job.input = updatedJob.input as any
 

--- a/test/queues/workflows/retriesWorkflowLevelTest.ts
+++ b/test/queues/workflows/retriesWorkflowLevelTest.ts
@@ -22,6 +22,7 @@ export const retriesWorkflowLevelTestWorkflow: WorkflowConfig<'retriesWorkflowLe
         },
       },
       id: job.id,
+      overrideAccess: true,
     })
     job.input = updatedJob.input as any
 

--- a/test/queues/workflows/subTask.ts
+++ b/test/queues/workflows/subTask.ts
@@ -20,6 +20,7 @@ export const subTaskWorkflow: WorkflowConfig<'subTask'> = {
               data: {
                 title: input.message,
               },
+              overrideAccess: true,
             })
             return {
               output: {
@@ -37,6 +38,7 @@ export const subTaskWorkflow: WorkflowConfig<'subTask'> = {
               data: {
                 title: input.message,
               },
+              overrideAccess: true,
             })
             return {
               output: {

--- a/test/queues/workflows/subTaskFails.ts
+++ b/test/queues/workflows/subTaskFails.ts
@@ -21,6 +21,7 @@ export const subTaskFailsWorkflow: WorkflowConfig<'subTaskFails'> = {
               data: {
                 title: input.message,
               },
+              overrideAccess: true,
             })
 
             const updatedJob = await req.payload.update({
@@ -37,6 +38,7 @@ export const subTaskFailsWorkflow: WorkflowConfig<'subTaskFails'> = {
                 },
               },
               id: job.id,
+              overrideAccess: true,
             })
             job.input = updatedJob.input as any
 
@@ -64,6 +66,7 @@ export const subTaskFailsWorkflow: WorkflowConfig<'subTaskFails'> = {
                 },
               },
               id: job.id,
+              overrideAccess: true,
             })
             job.input = updatedJob.input as any
 

--- a/test/queues/workflows/supersedesConcurrency.ts
+++ b/test/queues/workflows/supersedesConcurrency.ts
@@ -35,6 +35,7 @@ export const supersedesConcurrencyWorkflow: WorkflowConfig<'supersedesConcurrenc
           data: {
             title: `started:${job.input.resourceId}:${job.id}`,
           },
+          overrideAccess: true,
         })
 
         await wait(delayMs)
@@ -50,6 +51,7 @@ export const supersedesConcurrencyWorkflow: WorkflowConfig<'supersedesConcurrenc
           data: {
             title: `completed:${job.input.resourceId}:${job.id}`,
           },
+          overrideAccess: true,
         })
 
         return { output: {} }

--- a/test/queues/workflows/workflowAndTasksRetriesUndefined.ts
+++ b/test/queues/workflows/workflowAndTasksRetriesUndefined.ts
@@ -22,6 +22,7 @@ export const workflowAndTasksRetriesUndefinedWorkflow: WorkflowConfig<'workflowA
           },
         },
         id: job.id,
+        overrideAccess: true,
       })
       job.input = updatedJob.input as any
 

--- a/test/queues/workflows/workflowRetries2TasksRetries0.ts
+++ b/test/queues/workflows/workflowRetries2TasksRetries0.ts
@@ -23,6 +23,7 @@ export const workflowRetries2TasksRetries0Workflow: WorkflowConfig<'workflowRetr
           },
         },
         id: job.id,
+        overrideAccess: true,
       })
       job.input = updatedJob.input as any
 

--- a/test/queues/workflows/workflowRetries2TasksRetriesUndefined.ts
+++ b/test/queues/workflows/workflowRetries2TasksRetriesUndefined.ts
@@ -23,6 +23,7 @@ export const workflowRetries2TasksRetriesUndefinedWorkflow: WorkflowConfig<'work
           },
         },
         id: job.id,
+        overrideAccess: true,
       })
       job.input = updatedJob.input as any
 

--- a/test/relationships/int.spec.ts
+++ b/test/relationships/int.spec.ts
@@ -58,6 +58,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
           data: {
             name: nameToQuery,
           },
+          overrideAccess: true,
         })
 
         filteredRelation = await payload.create({
@@ -66,6 +67,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
             name: nameToQuery,
             disableRelation: false,
           },
+          overrideAccess: true,
         })
 
         defaultAccessRelation = await payload.create({
@@ -73,6 +75,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
           data: {
             name: 'default access',
           },
+          overrideAccess: true,
         })
 
         chained3 = await payload.create({
@@ -80,6 +83,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
           data: {
             name: 'chain3',
           },
+          overrideAccess: true,
         })
 
         chained2 = await payload.create({
@@ -88,6 +92,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
             name: 'chain2',
             relation: chained3.id,
           },
+          overrideAccess: true,
         })
 
         chained = await payload.create({
@@ -96,6 +101,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
             name: 'chain1',
             relation: chained2.id,
           },
+          overrideAccess: true,
         })
 
         chained3 = await payload.update({
@@ -105,6 +111,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
             name: 'chain3',
             relation: chained.id,
           },
+          overrideAccess: true,
         })
 
         generatedCustomId = `custom-${randomBytes(32).toString('hex').slice(0, 12)}`
@@ -114,6 +121,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
             id: generatedCustomId,
             name: 'custom-id',
           },
+          overrideAccess: true,
         })
 
         generatedCustomIdNumber = Math.floor(Math.random() * 1_000_000) + 1
@@ -123,6 +131,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
             id: generatedCustomIdNumber,
             name: 'custom-id-number',
           },
+          overrideAccess: true,
         })
 
         post = await createPost(
@@ -191,6 +200,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
         const user = (
           await payload.find({
             collection: 'users',
+            overrideAccess: true,
           })
         ).docs[0]
 
@@ -200,6 +210,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
             email: '1@test.com',
             password: 'fwefe',
           },
+          overrideAccess: true,
         })
         const user3 = await payload.create({
           collection: 'users',
@@ -207,6 +218,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
             email: '2@test.com',
             password: 'fwsefe',
           },
+          overrideAccess: true,
         })
         const user4 = await payload.create({
           collection: 'users',
@@ -214,6 +226,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
             email: '3@test.com',
             password: 'fwddsefe',
           },
+          overrideAccess: true,
         })
         await payload.create({
           collection: 'movieReviews',
@@ -222,6 +235,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
             movieReviewer: user.id,
             visibility: 'public',
           },
+          overrideAccess: true,
         })
         await payload.create({
           collection: 'movieReviews',
@@ -229,6 +243,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
             movieReviewer: user2.id,
             visibility: 'public',
           },
+          overrideAccess: true,
         })
 
         const query = await payload.find({
@@ -248,6 +263,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
               },
             ],
           },
+          overrideAccess: true,
         })
         expect(query.totalDocs).toEqual(2)
       })
@@ -262,6 +278,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
           data: {
             name: 'Quentin Tarantino',
           },
+          overrideAccess: true,
         })
 
         await payload.create({
@@ -269,6 +286,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
           data: {
             name: 'Pulp Fiction',
           },
+          overrideAccess: true,
         })
 
         await payload.create({
@@ -276,6 +294,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
           data: {
             name: 'Pulp Fiction',
           },
+          overrideAccess: true,
         })
 
         await payload.create({
@@ -283,6 +302,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
           data: {
             name: 'Harry Potter',
           },
+          overrideAccess: true,
         })
 
         await payload.create({
@@ -291,6 +311,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
             name: 'Lord of the Rings is boring',
             director: someDirector.id,
           },
+          overrideAccess: true,
         })
 
         // This causes the following error:
@@ -314,6 +335,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
               },
             ],
           },
+          overrideAccess: true,
         })
 
         expect(query.totalDocs).toEqual(3)
@@ -326,12 +348,14 @@ test.suite({ config: './config.ts' })('Relationships', () => {
         const director = await payload.create({
           collection: 'directors',
           data: { name: 'Director1', localized: 'Director1_Localized' },
+          overrideAccess: true,
         })
 
         const movie = await payload.create({
           collection: 'movies',
           data: { director: director.id },
           depth: 0,
+          overrideAccess: true,
         })
 
         const { docs: trueRes } = await payload.find({
@@ -341,6 +365,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
             'director.name': { equals: 'Director1' },
             'director.localized': { equals: 'Director1_Localized' },
           },
+          overrideAccess: true,
         })
 
         expect(trueRes).toStrictEqual([movie])
@@ -352,6 +377,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
             'director.name': { equals: 'Director1_Fake' },
             'director.localized': { equals: 'Director1_Localized' },
           },
+          overrideAccess: true,
         })
 
         expect(falseRes).toStrictEqual([])
@@ -364,6 +390,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
             name: 'test',
             disableRelation: false,
           },
+          overrideAccess: true,
         })
 
         const doc = await payload.create({
@@ -376,18 +403,20 @@ test.suite({ config: './config.ts' })('Relationships', () => {
               },
             ],
           },
+          overrideAccess: true,
         })
 
         const { docs } = await payload.find({
           collection: slug,
           where: { 'blocks.relationField': { equals: rel.id } },
+          overrideAccess: true,
         })
 
         expect(docs[0].id).toBe(doc.id)
       })
 
       test('should allow querying within tabs-blocks-tabs', async ({ payload }) => {
-        const movie = await payload.create({ collection: 'movies', data: { name: 'Pulp Fiction' } })
+        const movie = await payload.create({ collection: 'movies', data: { name: 'Pulp Fiction' }, overrideAccess: true })
 
         const { id } = await payload.create({
           collection: 'deep-nested',
@@ -403,6 +432,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
               ],
             },
           },
+          overrideAccess: true,
         })
 
         const result = await payload.find({
@@ -412,6 +442,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
               equals: movie.id,
             },
           },
+          overrideAccess: true,
         })
 
         expect(result.totalDocs).toBe(1)
@@ -419,15 +450,17 @@ test.suite({ config: './config.ts' })('Relationships', () => {
       })
 
       test('should allow query hasMany select in relationship', async ({ payload }) => {
-        const movie = await payload.create({ collection: 'movies', data: { select: ['a', 'b'] } })
+        const movie = await payload.create({ collection: 'movies', data: { select: ['a', 'b'] }, overrideAccess: true })
         const doc = await payload.create({
           collection: 'directors',
           data: { name: 'Mega Director', movie },
+          overrideAccess: true,
         })
 
         const res = await payload.find({
           collection: 'directors',
           where: { 'movie.select': { equals: 'a' } },
+          overrideAccess: true,
         })
         expect(res.docs).toHaveLength(1)
         expect(res.docs[0].id).toBe(doc.id)
@@ -439,14 +472,17 @@ test.suite({ config: './config.ts' })('Relationships', () => {
         const artist = await payload.create({
           collection: 'transitive-join-artists',
           data: {},
+          overrideAccess: true,
         })
         const album = await payload.create({
           collection: 'transitive-join-albums',
           data: { artist: artist.id },
+          overrideAccess: true,
         })
         const song = await payload.create({
           collection: 'transitive-join-songs',
           data: { albums: [album.id], name: 'Aliased song' },
+          overrideAccess: true,
         })
 
         const { docs } = await payload.find({
@@ -454,6 +490,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
           where: {
             'album.song.name': { equals: song.name },
           },
+          overrideAccess: true,
         })
 
         expect(docs).toHaveLength(1)
@@ -464,23 +501,28 @@ test.suite({ config: './config.ts' })('Relationships', () => {
         const movie_1 = await payload.create({
           collection: 'movies',
           data: { name: 'random_movie_1' },
+          overrideAccess: true,
         })
         const director_1 = await payload.create({
           collection: 'directors',
           data: { name: 'random_director_1', movie: movie_1.id },
+          overrideAccess: true,
         })
         const movie_2 = await payload.create({
           collection: 'movies',
           data: { name: 'random_movie_2', director: director_1.id },
+          overrideAccess: true,
         })
         const director_2 = await payload.create({
           collection: 'directors',
           data: { name: 'random_director_2', movie: movie_2.id },
+          overrideAccess: true,
         })
 
         const res = await payload.find({
           collection: 'directors',
           where: { 'movie.director.movie.name': { equals: 'random_movie_1' } },
+          overrideAccess: true,
         })
 
         expect(res.totalDocs).toBe(1)
@@ -495,6 +537,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
           const movie = await payload.create({
             collection: 'movies',
             data: { name: 'dup_test_movie' },
+            overrideAccess: true,
           })
 
           const Model = (payload.db as any).collections.directors
@@ -509,6 +552,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
             await payload.find({
               collection: 'directors',
               where: { 'movie.name': { equals: 'dup_test_movie' } },
+              overrideAccess: true,
             })
           } finally {
             Model.paginate = originalPaginate
@@ -516,7 +560,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
 
           expect(capturedQuery.$and[0].movie.$in).toHaveLength(1)
 
-          await payload.delete({ collection: 'movies', id: movie.id })
+          await payload.delete({ collection: 'movies', id: movie.id, overrideAccess: true })
         },
       )
 
@@ -533,11 +577,13 @@ test.suite({ config: './config.ts' })('Relationships', () => {
             const recallsMovie = await payload.create({
               collection: 'movies',
               data: { name: 'recalls', select: ['a'] },
+              overrideAccess: true,
             })
 
             const electricCarsMovie = await payload.create({
               collection: 'movies',
               data: { name: 'electric-cars', select: ['a', 'b'] },
+              overrideAccess: true,
             })
 
             recallsMovieID = recallsMovie.id
@@ -546,21 +592,25 @@ test.suite({ config: './config.ts' })('Relationships', () => {
             mixedDirector = await payload.create({
               collection: 'directors',
               data: { name: 'mixed', movies: [recallsMovie.id, electricCarsMovie.id] },
+              overrideAccess: true,
             })
 
             recallsDirector = await payload.create({
               collection: 'directors',
               data: { name: 'recalls', movies: [recallsMovie.id] },
+              overrideAccess: true,
             })
 
             electricCarsDirector = await payload.create({
               collection: 'directors',
               data: { name: 'electric-cars', movies: [electricCarsMovie.id] },
+              overrideAccess: true,
             })
 
             directorWithoutMovies = await payload.create({
               collection: 'directors',
               data: { name: 'empty', movies: [] },
+              overrideAccess: true,
             })
           })
 
@@ -573,6 +623,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
                   contains: { name: { equals: 'recalls' } },
                 },
               },
+              overrideAccess: true,
             })
 
             const foundDirectorIDs = docs.map(({ id }) => id)
@@ -590,6 +641,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
                   not_equals: { name: { equals: 'recalls' } },
                 },
               },
+              overrideAccess: true,
             })
 
             const foundDirectorIDs = docs.map(({ id }) => id)
@@ -609,6 +661,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
                   equals: { name: { equals: 'electric-cars' } },
                 },
               },
+              overrideAccess: true,
             })
 
             const foundDirectorIDs = docs.map(({ id }) => id)
@@ -644,6 +697,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
               where: {
                 movies: { not_equals: { id: { equals: recallsMovieID } } },
               },
+              overrideAccess: true,
             })
 
             const foundDirectorIDs = docs.map(({ id }) => id)
@@ -665,6 +719,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
                   },
                 },
               },
+              overrideAccess: true,
             })
 
             expect(docs).toHaveLength(0)
@@ -681,6 +736,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
                   equals: { select: { equals: 'a' } },
                 },
               },
+              overrideAccess: true,
             })
 
             expect(docs).toHaveLength(4)
@@ -699,6 +755,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
                   },
                 ],
               },
+              overrideAccess: true,
             })
 
             const electricCarsBlock = await payload.create({
@@ -706,11 +763,13 @@ test.suite({ config: './config.ts' })('Relationships', () => {
               data: {
                 blocks: [{ blockType: 'some', directors: [electricCarsDirector.id] }],
               },
+              overrideAccess: true,
             })
 
             const blockWithoutDirectors = await payload.create({
               collection: 'blocks',
               data: { blocks: [{ blockType: 'some', directors: [] }] },
+              overrideAccess: true,
             })
 
             const { docs } = await payload.find({
@@ -733,6 +792,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
                   },
                 ],
               },
+              overrideAccess: true,
             })
 
             const foundBlockIDs = docs.map(({ id }) => id)
@@ -748,11 +808,13 @@ test.suite({ config: './config.ts' })('Relationships', () => {
               const nearbyMovie = await payload.create({
                 collection: 'movies',
                 data: { name: 'nearby', location: [10, 20] },
+                overrideAccess: true,
               })
 
               const nearbyDirector = await payload.create({
                 collection: 'directors',
                 data: { name: 'nearby', movies: [nearbyMovie.id] },
+                overrideAccess: true,
               })
 
               const { docs } = await payload.find({
@@ -761,6 +823,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
                 where: {
                   movies: { equals: { location: { near: '10,20,100000' } } },
                 },
+                overrideAccess: true,
               })
 
               expect(docs.map(({ id }) => id)).toContain(nearbyDirector.id)
@@ -774,21 +837,25 @@ test.suite({ config: './config.ts' })('Relationships', () => {
           const alpha = await payload.create({
             collection: 'movies',
             data: { name: 'Alpha' },
+            overrideAccess: true,
           })
 
           const beta = await payload.create({
             collection: 'movies',
             data: { name: 'Beta' },
+            overrideAccess: true,
           })
 
           const child = await payload.create({
             collection: 'directors',
             data: { name: 'child', movies: [alpha.id, beta.id] },
+            overrideAccess: true,
           })
 
           const parent = await payload.create({
             collection: 'directors',
             data: { name: 'parent', directors: [child.id] },
+            overrideAccess: true,
           })
 
           const { docs } = await payload.find({
@@ -797,6 +864,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
             where: {
               'directors.movies.name': { equals: 'Alpha' },
             },
+            overrideAccess: true,
           })
 
           expect(docs.map(({ id }) => id)).toStrictEqual([parent.id])
@@ -806,20 +874,24 @@ test.suite({ config: './config.ts' })('Relationships', () => {
           const movie1 = await payload.create({
             collection: 'movies',
             data: {},
+            overrideAccess: true,
           })
           const movie2 = await payload.create({
             collection: 'movies',
             data: {},
+            overrideAccess: true,
           })
 
           const movie3 = await payload.create({
             collection: 'movies',
             data: { name: 'some-name' },
+            overrideAccess: true,
           })
 
           const movie4 = await payload.create({
             collection: 'movies',
             data: { name: 'some-name' },
+            overrideAccess: true,
           })
 
           await payload.create({
@@ -828,6 +900,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
               name: 'Quentin Tarantino',
               movies: [movie2.id, movie1.id, movie3.id, movie4.id],
             },
+            overrideAccess: true,
           })
 
           const res = await payload.find({
@@ -852,6 +925,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
                 },
               ],
             },
+            overrideAccess: true,
           })
 
           expect(res.totalDocs).toBe(1)
@@ -868,16 +942,18 @@ test.suite({ config: './config.ts' })('Relationships', () => {
                 },
               ],
             },
+            overrideAccess: true,
           })
 
           expect(res_2.totalDocs).toBe(1)
 
-          const dir_1 = await payload.create({ collection: 'directors', data: { name: 'dir' } })
-          const dir_2 = await payload.create({ collection: 'directors', data: { name: 'dir' } })
+          const dir_1 = await payload.create({ collection: 'directors', data: { name: 'dir' }, overrideAccess: true })
+          const dir_2 = await payload.create({ collection: 'directors', data: { name: 'dir' }, overrideAccess: true })
 
           const dir_3 = await payload.create({
             collection: 'directors',
             data: { directors: [dir_1.id, dir_2.id] },
+            overrideAccess: true,
           })
 
           const result = await payload.find({
@@ -885,6 +961,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
             where: {
               'directors.name': { equals: 'dir' },
             },
+            overrideAccess: true,
           })
 
           expect(result.totalDocs).toBe(1)
@@ -896,10 +973,12 @@ test.suite({ config: './config.ts' })('Relationships', () => {
           const movie1 = await payload.create({
             collection: 'movies',
             data: {},
+            overrideAccess: true,
           })
           const movie2 = await payload.create({
             collection: 'movies',
             data: {},
+            overrideAccess: true,
           })
 
           await payload.create({
@@ -908,6 +987,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
               name: 'Quentin Tarantino',
               movies: [movie2.id, movie1.id],
             },
+            overrideAccess: true,
           })
 
           await payload.create({
@@ -916,6 +996,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
               name: 'Quentin Tarantino',
               movies: [movie2.id],
             },
+            overrideAccess: true,
           })
 
           const query1 = await payload.find({
@@ -926,6 +1007,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
                 contains: movie1.id,
               },
             },
+            overrideAccess: true,
           })
           const query2 = await payload.find({
             collection: 'directors',
@@ -935,6 +1017,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
                 contains: movie2.id,
               },
             },
+            overrideAccess: true,
           })
 
           expect(query1.totalDocs).toStrictEqual(1)
@@ -944,13 +1027,14 @@ test.suite({ config: './config.ts' })('Relationships', () => {
         test.options({ db: 'mongo' })(
           'should treat an ObjectId as a relationship ID',
           async ({ payload }) => {
-            const movie = await payload.create({ collection: 'movies', data: {} })
+            const movie = await payload.create({ collection: 'movies', data: {}, overrideAccess: true })
 
             const director = await payload.create({
               collection: 'directors',
               data: {
                 movies: [movie.id],
               },
+              overrideAccess: true,
             })
 
             const { docs } = await payload.find({
@@ -961,6 +1045,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
                   contains: new Types.ObjectId(String(movie.id)),
                 },
               },
+              overrideAccess: true,
             })
 
             expect(docs).toHaveLength(1)
@@ -975,10 +1060,12 @@ test.suite({ config: './config.ts' })('Relationships', () => {
             const movie1 = await payload.create({
               collection: 'movies',
               data: {},
+              overrideAccess: true,
             })
             const movie2 = await payload.create({
               collection: 'movies',
               data: {},
+              overrideAccess: true,
             })
 
             await payload.create({
@@ -987,6 +1074,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
                 name: 'Quentin Tarantino',
                 movies: [movie2.id, movie1.id],
               },
+              overrideAccess: true,
             })
 
             await payload.create({
@@ -995,6 +1083,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
                 name: 'Quentin Tarantino',
                 movies: [movie2.id],
               },
+              overrideAccess: true,
             })
 
             const query1 = await payload.find({
@@ -1005,6 +1094,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
                   all: [movie1.id],
                 },
               },
+              overrideAccess: true,
             })
 
             expect(query1.totalDocs).toStrictEqual(1)
@@ -1017,6 +1107,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
             data: {
               text: 'Tree 1',
             },
+            overrideAccess: true,
           })
 
           const tree2 = await payload.create({
@@ -1025,6 +1116,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
               parent: tree1.id,
               text: 'Tree 2',
             },
+            overrideAccess: true,
           })
 
           const tree3 = await payload.create({
@@ -1033,6 +1125,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
               parent: tree2.id,
               text: 'Tree 3',
             },
+            overrideAccess: true,
           })
 
           const tree4 = await payload.create({
@@ -1041,6 +1134,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
               parent: tree3.id,
               text: 'Tree 4',
             },
+            overrideAccess: true,
           })
 
           const validParents = [tree2.id, tree3.id]
@@ -1054,6 +1148,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
                 in: validParents,
               },
             },
+            overrideAccess: true,
           })
           // should only return tree3 and tree4
 
@@ -1065,12 +1160,13 @@ test.suite({ config: './config.ts' })('Relationships', () => {
 
       test.describe('sorting by relationships', () => {
         test('should sort by a property of a relationship', async ({ payload }) => {
-          await payload.delete({ collection: 'directors', where: {} })
-          await payload.delete({ collection: 'movies', where: {} })
+          await payload.delete({ collection: 'directors', where: {}, overrideAccess: true })
+          await payload.delete({ collection: 'movies', where: {}, overrideAccess: true })
 
           const director_2 = await payload.create({
             collection: 'directors',
             data: { name: 'Mr. Dan', localized: 'Mr. Dan' },
+            overrideAccess: true,
           })
 
           await payload.update({
@@ -1078,11 +1174,13 @@ test.suite({ config: './config.ts' })('Relationships', () => {
             id: director_2.id,
             locale: 'de',
             data: { localized: 'Dan' },
+            overrideAccess: true,
           })
 
           const director_1 = await payload.create({
             collection: 'directors',
             data: { name: 'Dan', localized: 'Dan' },
+            overrideAccess: true,
           })
 
           await payload.update({
@@ -1090,29 +1188,34 @@ test.suite({ config: './config.ts' })('Relationships', () => {
             id: director_1.id,
             locale: 'de',
             data: { localized: 'Mr. Dan' },
+            overrideAccess: true,
           })
 
           const movie_1 = await payload.create({
             collection: 'movies',
             depth: 0,
             data: { director: director_1.id, name: 'Some Movie 1' },
+            overrideAccess: true,
           })
 
           const movie_2 = await payload.create({
             collection: 'movies',
             depth: 0,
             data: { director: director_2.id, name: 'Some Movie 2' },
+            overrideAccess: true,
           })
 
           const res_1 = await payload.find({
             collection: 'movies',
             sort: '-director.name',
             depth: 0,
+            overrideAccess: true,
           })
           const res_2 = await payload.find({
             collection: 'movies',
             sort: 'director.name',
             depth: 0,
+            overrideAccess: true,
           })
 
           expect(res_1.docs).toStrictEqual([movie_2, movie_1])
@@ -1123,12 +1226,14 @@ test.suite({ config: './config.ts' })('Relationships', () => {
             sort: '-director.name',
             depth: 0,
             draft: true,
+            overrideAccess: true,
           })
           const draft_res_2 = await payload.find({
             collection: 'movies',
             sort: 'director.name',
             depth: 0,
             draft: true,
+            overrideAccess: true,
           })
 
           expect(draft_res_1.docs).toStrictEqual([movie_2, movie_1])
@@ -1139,11 +1244,13 @@ test.suite({ config: './config.ts' })('Relationships', () => {
             sort: 'director.localized',
             depth: 0,
             locale: 'de',
+            overrideAccess: true,
           })
           const localized_res_2 = await payload.find({
             collection: 'movies',
             sort: 'director.localized',
             depth: 0,
+            overrideAccess: true,
           })
 
           expect(localized_res_1.docs).toStrictEqual([movie_2, movie_1])
@@ -1151,50 +1258,55 @@ test.suite({ config: './config.ts' })('Relationships', () => {
         })
 
         test('should sort by a property of a nested relationship', async ({ payload }) => {
-          await payload.delete({ collection: 'directors', where: {} })
-          await payload.delete({ collection: 'movies', where: {} })
+          await payload.delete({ collection: 'directors', where: {}, overrideAccess: true })
+          await payload.delete({ collection: 'movies', where: {}, overrideAccess: true })
 
-          const director = await payload.create({ collection: 'directors', data: {} })
+          const director = await payload.create({ collection: 'directors', data: {}, overrideAccess: true })
 
           const movie = await payload.create({
             collection: 'movies',
             data: { director: director.id, name: 'movie 1' },
+            overrideAccess: true,
           })
 
           await payload.update({
             collection: 'directors',
             id: director.id,
             data: { movie: movie.id },
+            overrideAccess: true,
           })
 
-          const director_2 = await payload.create({ collection: 'directors', data: {} })
+          const director_2 = await payload.create({ collection: 'directors', data: {}, overrideAccess: true })
 
           const movie_2 = await payload.create({
             collection: 'movies',
             data: { director: director_2.id, name: 'movie 2' },
+            overrideAccess: true,
           })
 
           await payload.update({
             collection: 'directors',
             id: director_2.id,
             data: { movie: movie_2.id },
+            overrideAccess: true,
           })
 
-          const res = await payload.find({ collection: 'movies', sort: 'director.movie.name' })
+          const res = await payload.find({ collection: 'movies', sort: 'director.movie.name', overrideAccess: true })
           expect(res.docs[0].id).toBe(movie.id)
           expect(res.docs[1].id).toBe(movie_2.id)
 
-          const res_2 = await payload.find({ collection: 'movies', sort: '-director.movie.name' })
+          const res_2 = await payload.find({ collection: 'movies', sort: '-director.movie.name', overrideAccess: true })
           expect(res_2.docs[0].id).toBe(movie_2.id)
           expect(res_2.docs[1].id).toBe(movie.id)
         })
 
         test('should sort by multiple properties of a relationship', async ({ payload }) => {
-          await payload.delete({ collection: 'directors', where: {} })
-          await payload.delete({ collection: 'movies', where: {} })
+          await payload.delete({ collection: 'directors', where: {}, overrideAccess: true })
+          await payload.delete({ collection: 'movies', where: {}, overrideAccess: true })
 
           const createDirector = {
             collection: 'directors',
+            overrideAccess: true,
             data: {
               name: 'Dan',
             },
@@ -1207,23 +1319,27 @@ test.suite({ config: './config.ts' })('Relationships', () => {
             collection: 'movies',
             depth: 0,
             data: { director: director_1.id, name: 'Some Movie 1' },
+            overrideAccess: true,
           })
 
           const movie_2 = await payload.create({
             collection: 'movies',
             depth: 0,
             data: { director: director_2.id, name: 'Some Movie 2' },
+            overrideAccess: true,
           })
 
           const res_1 = await payload.find({
             collection: 'movies',
             sort: ['director.name', 'director.createdAt'],
             depth: 0,
+            overrideAccess: true,
           })
           const res_2 = await payload.find({
             collection: 'movies',
             sort: ['director.name', '-director.createdAt'],
             depth: 0,
+            overrideAccess: true,
           })
 
           expect(res_1.docs).toStrictEqual([movie_1, movie_2])
@@ -1236,6 +1352,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
             data: {
               name: 'Pulp Fiction',
             },
+            overrideAccess: true,
           })
 
           const movie2 = await payload.create({
@@ -1243,9 +1360,10 @@ test.suite({ config: './config.ts' })('Relationships', () => {
             data: {
               name: 'Inception',
             },
+            overrideAccess: true,
           })
 
-          await payload.delete({ collection: 'directors', where: {} })
+          await payload.delete({ collection: 'directors', where: {}, overrideAccess: true })
 
           const director1 = await payload.create({
             collection: 'directors',
@@ -1253,6 +1371,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
               name: 'Quentin Tarantino',
               movies: [movie1.id],
             },
+            overrideAccess: true,
           })
           const director2 = await payload.create({
             collection: 'directors',
@@ -1260,12 +1379,14 @@ test.suite({ config: './config.ts' })('Relationships', () => {
               name: 'Christopher Nolan',
               movies: [movie2.id],
             },
+            overrideAccess: true,
           })
 
           const result = await payload.find({
             collection: 'directors',
             depth: 0,
             sort: '-movies.name',
+            overrideAccess: true,
           })
 
           expect(result.docs[0].id).toStrictEqual(director1.id)
@@ -1345,6 +1466,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
               where: {
                 id: { equals: post.id },
               },
+              overrideAccess: true,
             })
 
             const doc = result.docs[0]
@@ -1362,6 +1484,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
               where: {
                 id: { equals: post.id },
               },
+              overrideAccess: true,
             })
 
             const doc = result.docs[0]
@@ -1376,6 +1499,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
               where: {
                 id: { equals: post.id },
               },
+              overrideAccess: true,
             })
 
             const doc = result.docs[0]
@@ -1394,6 +1518,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
                 id: { equals: post.id },
               },
               req: { query: { depth: 5 } } as Partial<PayloadRequest> as PayloadRequest,
+              overrideAccess: true,
             })
 
             const doc = result.docs[0]
@@ -1413,6 +1538,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
                 id: { equals: post.id },
               },
               req: { query: { depth: 0 } } as Partial<PayloadRequest> as PayloadRequest,
+              overrideAccess: true,
             })
 
             const doc = result.docs[0]
@@ -1437,6 +1563,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
             data: {
               name: 'english',
             },
+            overrideAccess: true,
           })
 
           relation2 = await payload.create<Relation>({
@@ -1444,6 +1571,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
             data: {
               name: 'german',
             },
+            overrideAccess: true,
           })
 
           localizedPost1 = await payload.create<'postsLocalized'>({
@@ -1453,6 +1581,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
               relationField: relation1.id,
             },
             locale: 'en',
+            overrideAccess: true,
           })
 
           await payload.update({
@@ -1462,6 +1591,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
             data: {
               relationField: relation2.id,
             },
+            overrideAccess: true,
           })
 
           localizedPost2 = await payload.create({
@@ -1471,6 +1601,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
               relationField: relation2.id,
             },
             locale: 'de',
+            overrideAccess: true,
           })
         })
         test('should find two docs for german locale', async ({ payload }) => {
@@ -1482,6 +1613,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
                 equals: relation2.id,
               },
             },
+            overrideAccess: true,
           })
 
           const mappedIds = docs.map((doc) => doc?.id)
@@ -1500,6 +1632,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
                 equals: relation2.id,
               },
             },
+            overrideAccess: true,
           })
 
           expect(docs.map((doc) => doc?.id)).not.toContain(localizedPost2.id)
@@ -1511,17 +1644,20 @@ test.suite({ config: './config.ts' })('Relationships', () => {
           const movie = await payload.create({
             collection: 'movies',
             data: { name: 'Jackie Brown' },
+            overrideAccess: true,
           })
 
           const director = await payload.create({
             collection: 'directors',
             data: { name: 'Quentin Tarantino', movies: [movie.id] },
+            overrideAccess: true,
           })
 
           const post = await payload.create({
             collection: slugWithLocalizedRel,
             data: { localizedDirectors: [{ director: director.id }], title: 'english' },
             locale: 'en',
+            overrideAccess: true,
           })
 
           const { docs } = await payload.find({
@@ -1530,6 +1666,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
             where: {
               'localizedDirectors.director.movies.name': { equals: 'Jackie Brown' },
             },
+            overrideAccess: true,
           })
 
           expect(docs.map(({ id }) => id)).toStrictEqual([post.id])
@@ -1561,6 +1698,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
           data: {
             name: 'third',
           },
+          overrideAccess: true,
         })
 
         thirdLevelID = thirdLevelDoc.id
@@ -1571,6 +1709,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
             name: 'second',
             relation: thirdLevelID,
           },
+          overrideAccess: true,
         })
 
         secondLevelID = secondLevelDoc.id
@@ -1581,6 +1720,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
             name: 'first',
             relation: secondLevelID,
           },
+          overrideAccess: true,
         })
 
         firstLevelID = firstLevelDoc.id
@@ -1594,6 +1734,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
               equals: 'second',
             },
           },
+          overrideAccess: true,
         })
 
         expect(query1.docs).toHaveLength(1)
@@ -1606,6 +1747,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
               equals: 'third',
             },
           },
+          overrideAccess: true,
         })
 
         expect(query2.docs).toHaveLength(1)
@@ -1620,6 +1762,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
               equals: 'third',
             },
           },
+          overrideAccess: true,
         })
 
         expect(query.docs).toHaveLength(1)
@@ -1634,6 +1777,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
               equals: thirdLevelID,
             },
           },
+          overrideAccess: true,
         })
 
         expect(query.docs).toHaveLength(1)
@@ -1665,13 +1809,15 @@ test.suite({ config: './config.ts' })('Relationships', () => {
               },
             ],
           },
+          overrideAccess: true,
         })
 
-        const rel = await payload.create({ collection: 'rels-to-pages', data: { page: page.id } })
+        const rel = await payload.create({ collection: 'rels-to-pages', data: { page: page.id }, overrideAccess: true })
 
         const resEquals = await payload.find({
           collection: 'rels-to-pages',
           where: { 'page.menu.label': { equals: 'hello' } },
+          overrideAccess: true,
         })
 
         expect(resEquals.totalDocs).toBe(1)
@@ -1680,6 +1826,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
         const resIn = await payload.find({
           collection: 'rels-to-pages',
           where: { 'page.menu.label': { in: ['hello'] } },
+          overrideAccess: true,
         })
 
         expect(resIn.totalDocs).toBe(1)
@@ -1691,26 +1838,31 @@ test.suite({ config: './config.ts' })('Relationships', () => {
       const director = await payload.create({
         collection: 'directors',
         data: { name: 'Test Director' },
+        overrideAccess: true,
       })
 
       const director_false = await payload.create({
         collection: 'directors',
         data: { name: 'False Director' },
+        overrideAccess: true,
       })
 
       const doc = await payload.create({
         collection: 'blocks',
         data: { blocks: [{ blockType: 'some', director: director.id }] },
+        overrideAccess: true,
       })
 
       await payload.create({
         collection: 'blocks',
         data: { blocks: [{ blockType: 'some', director: director_false.id }] },
+        overrideAccess: true,
       })
 
       const result = await payload.find({
         collection: 'blocks',
         where: { 'blocks.director.name': { equals: 'Test Director' } },
+        overrideAccess: true,
       })
 
       expect(result.totalDocs).toBe(1)
@@ -1721,15 +1873,18 @@ test.suite({ config: './config.ts' })('Relationships', () => {
       const director = await payload.create({
         collection: 'directors',
         data: { name: 'direcotr' },
+        overrideAccess: true,
       })
       const movie = await payload.create({
         collection: 'movies',
         data: { array: [{ polymorphic: { relationTo: 'directors', value: director.id } }] },
+        overrideAccess: true,
       })
 
       const res = await payload.find({
         collection: 'movies',
         where: { 'array.polymorphic': { equals: { value: director.id, relationTo: 'directors' } } },
+        overrideAccess: true,
       })
       expect(res.docs).toHaveLength(1)
       expect(res.docs[0].id).toBe(movie.id)
@@ -1739,20 +1894,24 @@ test.suite({ config: './config.ts' })('Relationships', () => {
       const director = await payload.create({
         collection: 'directors',
         data: { name: 'Test Director1337' },
+        overrideAccess: true,
       })
       const movie = await payload.create({
         collection: 'movies',
         data: { array: [{ director: [director.id] }] },
+        overrideAccess: true,
       })
       const res = await payload.find({
         collection: 'movies',
         where: { 'array.director': { equals: director.id } },
+        overrideAccess: true,
       })
       expect(res.docs).toHaveLength(1)
       expect(res.docs[0].id).toBe(movie.id)
       const res2 = await payload.find({
         collection: 'movies',
         where: { 'array.director.name': { equals: 'Test Director1337' } },
+        overrideAccess: true,
       })
       expect(res2.docs).toHaveLength(1)
       expect(res2.docs[0].id).toBe(movie.id)
@@ -1768,6 +1927,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
           data: {
             name: 'Quentin Tarantino',
           },
+          overrideAccess: true,
         })
 
         // 2. create a movie
@@ -1777,6 +1937,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
             name: 'Pulp Fiction',
             director: director.id,
           },
+          overrideAccess: true,
         })
 
         // 3. create a screening
@@ -1786,6 +1947,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
             name: 'Pulp Fiction Screening',
             movie: movie.id,
           },
+          overrideAccess: true,
         })
       })
 
@@ -1797,6 +1959,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
               equals: director.name,
             },
           },
+          overrideAccess: true,
         })
 
         expect(query.docs).toHaveLength(1)
@@ -1829,6 +1992,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
               data: {
                 name: movie,
               },
+              overrideAccess: true,
             })
           }),
         )
@@ -1838,6 +2002,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
         const allMovies = await payload.find({
           collection: 'movies',
           limit: 20,
+          overrideAccess: true,
         })
 
         const movieIDs = allMovies.docs.map((doc) => doc.id)
@@ -1848,6 +2013,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
             name: 'Quentin Tarantino',
             movies: movieIDs,
           },
+          overrideAccess: true,
         })
 
         const director = await payload.find({
@@ -1857,6 +2023,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
               equals: 'Quentin Tarantino',
             },
           },
+          overrideAccess: true,
         })
 
         expect(director.docs[0].movies.length).toBeGreaterThan(10)
@@ -1867,6 +2034,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
           collection: 'movies',
           depth: 0,
           limit: 5,
+          overrideAccess: true,
         })
 
         const movieIDs = fiveMovies.docs.map((doc) => doc.id)
@@ -1877,6 +2045,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
             name: 'Stanley Kubrick',
             movies: movieIDs,
           },
+          overrideAccess: true,
         })
 
         expect(stanley.movies).toHaveLength(5)
@@ -1887,6 +2056,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
           data: {
             movies: null,
           },
+          overrideAccess: true,
         })
 
         expect(stanleyNeverMadeMovies.movies).toHaveLength(0)
@@ -1903,6 +2073,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
           where: {
             parent: { equals: null },
           },
+          overrideAccess: true,
         })
         expect(count).toBe(1)
         expect(item.text).toBe('root')
@@ -1917,6 +2088,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
           where: {
             parent: { exists: false },
           },
+          overrideAccess: true,
         })
         expect(count).toBe(1)
         expect(item.text).toBe('root')
@@ -1931,6 +2103,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
           where: {
             parent: { not_equals: null },
           },
+          overrideAccess: true,
         })
         expect(count).toBe(1)
         expect(item.text).toBe('sub')
@@ -1945,6 +2118,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
           where: {
             parent: { exists: true },
           },
+          overrideAccess: true,
         })
         expect(count).toBe(1)
         expect(item.text).toBe('sub')
@@ -1965,6 +2139,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
             name: 'parent',
           },
           req,
+          overrideAccess: true,
         })
         const withRelation = await payload.create({
           collection: slug,
@@ -1972,6 +2147,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
             filteredRelation: related.id,
           },
           req,
+          overrideAccess: true,
         })
 
         if (req.transactionID) {
@@ -1984,7 +2160,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
 
     test.describe('With passing an object', () => {
       test('should create with passing an object', async ({ payload }) => {
-        const movie = await payload.create({ collection: 'movies', data: {} })
+        const movie = await payload.create({ collection: 'movies', data: {}, overrideAccess: true })
         const result = await payload.create({
           collection: 'object-writes',
           data: {
@@ -1996,6 +2172,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
               value: movie,
             },
           },
+          overrideAccess: true,
         })
 
         expect(result.many[0]).toStrictEqual(movie)
@@ -2005,8 +2182,8 @@ test.suite({ config: './config.ts' })('Relationships', () => {
       })
 
       test('should update with passing an object', async ({ payload }) => {
-        const movie = await payload.create({ collection: 'movies', data: {} })
-        const { id } = await payload.create({ collection: 'object-writes', data: {} })
+        const movie = await payload.create({ collection: 'movies', data: {}, overrideAccess: true })
+        const { id } = await payload.create({ collection: 'object-writes', data: {}, overrideAccess: true })
         const result = await payload.update({
           collection: 'object-writes',
           id,
@@ -2019,6 +2196,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
               value: movie,
             },
           },
+          overrideAccess: true,
         })
 
         expect(result.many[0]).toStrictEqual(movie)
@@ -2031,10 +2209,12 @@ test.suite({ config: './config.ts' })('Relationships', () => {
         const director1 = await payload.create({
           collection: 'directors',
           data: { name: 'director-1' },
+          overrideAccess: true,
         })
         const director2 = await payload.create({
           collection: 'directors',
           data: { name: 'director-2' },
+          overrideAccess: true,
         })
         const result = await payload.create({
           collection: 'blocks',
@@ -2046,6 +2226,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
               },
             ],
           },
+          overrideAccess: true,
         })
 
         expect(result.blocks[0]?.directors[0].id).toBe(director1.id)
@@ -2064,6 +2245,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
         data: {
           name: 'Pulp Fiction 2',
         },
+        overrideAccess: true,
       })
       await payload.create({
         collection: polymorphicRelationshipsSlug,
@@ -2073,6 +2255,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
             value: movie.id,
           },
         },
+        overrideAccess: true,
       })
 
       const queryOne = await restClient
@@ -2130,6 +2313,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
           data: {
             name: 'Pulp Fiction 2',
           },
+          overrideAccess: true,
         })
         await payload.create({
           collection: polymorphicRelationshipsSlug,
@@ -2139,6 +2323,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
               value: movie.id,
             },
           },
+          overrideAccess: true,
         })
 
         const queryOne = await restClient
@@ -2165,6 +2350,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
         data: {
           name: 'Pulp Fiction 2',
         },
+        overrideAccess: true,
       })
       await payload.create({
         collection: polymorphicRelationshipsSlug,
@@ -2174,6 +2360,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
             value: movie.id,
           },
         },
+        overrideAccess: true,
       })
 
       const res = await payload.find({
@@ -2186,6 +2373,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
             },
           },
         },
+        overrideAccess: true,
       })
 
       expect(res.docs).toHaveLength(1)
@@ -2201,6 +2389,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
             },
           },
         },
+        overrideAccess: true,
       })
       expect(res_2.docs).toHaveLength(0)
     })
@@ -2213,6 +2402,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
         data: {
           name: 'Pulp Fiction 2',
         },
+        overrideAccess: true,
       })
 
       const { id } = await payload.create({
@@ -2225,6 +2415,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
             },
           ],
         },
+        overrideAccess: true,
       })
 
       const res = await payload.find({
@@ -2237,6 +2428,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
             },
           },
         },
+        overrideAccess: true,
       })
 
       expect(res.docs).toHaveLength(1)
@@ -2251,6 +2443,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
         data: {
           name: 'Pulp Fiction 2',
         },
+        overrideAccess: true,
       })
 
       const { id } = await payload.create({
@@ -2261,6 +2454,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
             value: movie.id,
           },
         },
+        overrideAccess: true,
       })
 
       const res = await payload.find({
@@ -2273,6 +2467,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
             },
           },
         },
+        overrideAccess: true,
       })
 
       expect(res.docs).toHaveLength(1)
@@ -2287,6 +2482,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
         data: {
           name: 'Pulp Fiction 2',
         },
+        overrideAccess: true,
       })
 
       const { id } = await payload.create({
@@ -2299,6 +2495,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
             },
           ],
         },
+        overrideAccess: true,
       })
 
       const res = await payload.find({
@@ -2311,6 +2508,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
             },
           },
         },
+        overrideAccess: true,
       })
 
       expect(res.docs).toHaveLength(1)
@@ -2320,17 +2518,19 @@ test.suite({ config: './config.ts' })('Relationships', () => {
     test('should update document that polymorphicaly joined to another collection', async ({
       payload,
     }) => {
-      const item = await payload.create({ collection: 'items', data: { status: 'pending' } })
+      const item = await payload.create({ collection: 'items', data: { status: 'pending' }, overrideAccess: true })
 
       await payload.create({
         collection: 'relations',
         data: { item: { relationTo: 'items', value: item } },
+        overrideAccess: true,
       })
 
       const updated = await payload.update({
         collection: 'items',
         data: { status: 'completed' },
         id: item.id,
+        overrideAccess: true,
       })
 
       expect(updated.status).toBe('completed')
@@ -2366,16 +2566,19 @@ test.suite({ config: './config.ts' })('Relationships', () => {
       const customIDNumber = await payload.create({
         collection: 'custom-id-number',
         data: { id: 999 },
+        overrideAccess: true,
       })
 
       const customIDText = await payload.create({
         collection: 'custom-id',
         data: { id: 'custom-id' },
+        overrideAccess: true,
       })
 
       const page = await payload.create({
         collection: 'pages',
         data: {},
+        overrideAccess: true,
       })
 
       const relToCustomIdText = await payload.create({
@@ -2386,6 +2589,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
             value: customIDText.id,
           },
         },
+        overrideAccess: true,
       })
 
       const relToCustomIdNumber = await payload.create({
@@ -2396,6 +2600,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
             value: customIDNumber.id,
           },
         },
+        overrideAccess: true,
       })
 
       const relToPage = await payload.create({
@@ -2406,6 +2611,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
             value: page.id,
           },
         },
+        overrideAccess: true,
       })
 
       const pageResult = await payload.find({
@@ -2424,6 +2630,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
             },
           ],
         },
+        overrideAccess: true,
       })
 
       expect(pageResult.totalDocs).toBe(1)
@@ -2445,6 +2652,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
             },
           ],
         },
+        overrideAccess: true,
       })
 
       expect(customIDResult.totalDocs).toBe(1)
@@ -2466,6 +2674,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
             },
           ],
         },
+        overrideAccess: true,
       })
 
       expect(customIDNumberResult.totalDocs).toBe(1)
@@ -2478,6 +2687,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
             in: [page.id, customIDNumber.id],
           },
         },
+        overrideAccess: true,
       })
 
       expect(inResult_1.totalDocs).toBe(2)
@@ -2491,6 +2701,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
             in: [customIDNumber.id, customIDText.id],
           },
         },
+        overrideAccess: true,
       })
 
       expect(inResult_2.totalDocs).toBe(2)
@@ -2504,6 +2715,7 @@ test.suite({ config: './config.ts' })('Relationships', () => {
             in: [customIDNumber.id, customIDText.id, page.id],
           },
         },
+        overrideAccess: true,
       })
 
       expect(inResult_3.totalDocs).toBe(3)
@@ -2515,5 +2727,5 @@ test.suite({ config: './config.ts' })('Relationships', () => {
 })
 
 async function createPost({ payload }: { payload: Payload }, overrides?: Partial<Post>) {
-  return payload.create({ collection: slug, data: { title: 'title', ...overrides } })
+  return payload.create({ collection: slug, data: { title: 'title', ...overrides }, overrideAccess: true })
 }

--- a/test/relationships/seed.ts
+++ b/test/relationships/seed.ts
@@ -14,6 +14,7 @@ import {
 export const seed = async (_payload: Payload) => {
   await _payload.create({
     collection: 'users',
+    overrideAccess: true,
     data: {
       email: devUser.email,
       password: devUser.password,
@@ -22,6 +23,7 @@ export const seed = async (_payload: Payload) => {
 
   const rel1 = await _payload.create({
     collection: relationSlug,
+    overrideAccess: true,
     data: {
       name: 'name',
     },
@@ -29,6 +31,7 @@ export const seed = async (_payload: Payload) => {
 
   const filteredRelation = await _payload.create({
     collection: relationSlug,
+    overrideAccess: true,
     data: {
       name: 'filtered',
     },
@@ -36,6 +39,7 @@ export const seed = async (_payload: Payload) => {
 
   const defaultAccessRelation = await _payload.create({
     collection: defaultAccessRelSlug,
+    overrideAccess: true,
     data: {
       name: 'name',
     },
@@ -43,6 +47,7 @@ export const seed = async (_payload: Payload) => {
 
   const chained3 = await _payload.create({
     collection: chainedRelSlug,
+    overrideAccess: true,
     data: {
       name: 'chain3',
     },
@@ -50,6 +55,7 @@ export const seed = async (_payload: Payload) => {
 
   const chained2 = await _payload.create({
     collection: chainedRelSlug,
+    overrideAccess: true,
     data: {
       name: 'chain2',
       relation: chained3.id,
@@ -58,6 +64,7 @@ export const seed = async (_payload: Payload) => {
 
   const chained = await _payload.create({
     collection: chainedRelSlug,
+    overrideAccess: true,
     data: {
       name: 'chain1',
       relation: chained2.id,
@@ -67,6 +74,7 @@ export const seed = async (_payload: Payload) => {
   await _payload.update({
     id: chained3.id,
     collection: chainedRelSlug,
+    overrideAccess: true,
     data: {
       name: 'chain3',
       relation: chained.id,
@@ -75,6 +83,7 @@ export const seed = async (_payload: Payload) => {
 
   const customIdRelation = await _payload.create({
     collection: customIdSlug,
+    overrideAccess: true,
     data: {
       id: 'custommmm',
       name: 'custom-id',
@@ -83,6 +92,7 @@ export const seed = async (_payload: Payload) => {
 
   const customIdNumberRelation = await _payload.create({
     collection: customIdNumberSlug,
+    overrideAccess: true,
     data: {
       id: 908234892340,
       name: 'custom-id',
@@ -91,6 +101,7 @@ export const seed = async (_payload: Payload) => {
 
   await _payload.create({
     collection: slug,
+    overrideAccess: true,
     data: {
       chainedRelation: chained.id,
       customIdNumberRelation: customIdNumberRelation.id,
@@ -105,6 +116,7 @@ export const seed = async (_payload: Payload) => {
 
   const root = await _payload.create({
     collection: 'tree',
+    overrideAccess: true,
     data: {
       text: 'root',
     },
@@ -112,6 +124,7 @@ export const seed = async (_payload: Payload) => {
 
   await _payload.create({
     collection: 'tree',
+    overrideAccess: true,
     data: {
       parent: root.id,
       text: 'sub',

--- a/test/sdk/config.ts
+++ b/test/sdk/config.ts
@@ -52,6 +52,7 @@ export default buildConfigWithDefaults({
         email: devUser.email,
         password: devUser.password,
       },
+      overrideAccess: true,
     })
   },
 })

--- a/test/sdk/int.spec.ts
+++ b/test/sdk/int.spec.ts
@@ -23,16 +23,18 @@ const testUserCredentials = {
 
 test.suite({ config: './config.ts' })('@payloadcms/sdk', () => {
   test.beforeEach(async ({ payload }) => {
-    post = await payload.create({ collection: 'posts', data: { number: 1, number2: 3 } })
+    post = await payload.create({ collection: 'posts', data: { number: 1, number2: 3 }, overrideAccess: true })
     postTrash = await payload.create({
       collection: 'posts',
       data: { deletedAt: new Date().toISOString(), text: 'fixture-trash' },
+      overrideAccess: true,
     })
     await payload.create({
       collection: 'users',
       data: { ...testUserCredentials },
+      overrideAccess: true,
     })
-    await payload.updateGlobal({ slug: 'global', data: { text: 'some-global' } })
+    await payload.updateGlobal({ slug: 'global', data: { text: 'some-global' }, overrideAccess: true })
   })
 
   test('should execute find', async ({ payload, sdk }) => {
@@ -42,14 +44,14 @@ test.suite({ config: './config.ts' })('@payloadcms/sdk', () => {
 
     const ids = []
     for (let i = 0; i < 40; i++) {
-      const post = await payload.create({ collection: 'posts', data: {} })
+      const post = await payload.create({ collection: 'posts', data: {}, overrideAccess: true })
       ids.push(post.id)
     }
 
     const resultPaginationFalse = await sdk.find({ collection: 'posts', pagination: false })
     expect(resultPaginationFalse.docs).toHaveLength(41)
     expect(resultPaginationFalse.totalDocs).toBe(41)
-    await payload.delete({ collection: 'posts', where: { id: { in: ids } } })
+    await payload.delete({ collection: 'posts', where: { id: { in: ids } }, overrideAccess: true })
   })
 
   test('should return no docs for an empty array in `in` condition', async ({ sdk }) => {
@@ -117,7 +119,7 @@ test.suite({ config: './config.ts' })('@payloadcms/sdk', () => {
   test('should execute findVersionByID', async ({ payload, sdk }) => {
     const {
       docs: [version],
-    } = await payload.findVersions({ collection: 'posts', where: { parent: { equals: post.id } } })
+    } = await payload.findVersions({ collection: 'posts', where: { parent: { equals: post.id } }, overrideAccess: true })
 
     const result = await sdk.findVersionByID({ collection: 'posts', id: version.id })
 
@@ -131,6 +133,7 @@ test.suite({ config: './config.ts' })('@payloadcms/sdk', () => {
       collection: 'posts',
       trash: true,
       where: { parent: { equals: postTrash.id } },
+      overrideAccess: true,
     })
 
     expect(
@@ -216,13 +219,13 @@ test.suite({ config: './config.ts' })('@payloadcms/sdk', () => {
   })
 
   test('should execute delete (by ID)', async ({ payload, sdk }) => {
-    const post = await payload.create({ collection: 'posts', data: {} })
+    const post = await payload.create({ collection: 'posts', data: {}, overrideAccess: true })
 
     const result = await sdk.delete({ id: post.id, collection: 'posts' })
 
     expect(result.id).toBe(post.id)
     expect(
-      await payload.findByID({ collection: 'posts', id: post.id, disableErrors: true }),
+      await payload.findByID({ collection: 'posts', id: post.id, disableErrors: true, overrideAccess: true }),
     ).toBeNull()
   })
 
@@ -230,6 +233,7 @@ test.suite({ config: './config.ts' })('@payloadcms/sdk', () => {
     const trashed = await payload.create({
       collection: 'posts',
       data: { deletedAt: new Date().toISOString() },
+      overrideAccess: true,
     })
 
     await sdk.delete({ collection: 'posts', id: trashed.id, trash: true })
@@ -240,18 +244,19 @@ test.suite({ config: './config.ts' })('@payloadcms/sdk', () => {
         disableErrors: true,
         id: trashed.id,
         trash: true,
+        overrideAccess: true,
       }),
     ).toBeNull()
   })
 
   test('should execute delete (bulk)', async ({ payload, sdk }) => {
-    const post = await payload.create({ collection: 'posts', data: {} })
+    const post = await payload.create({ collection: 'posts', data: {}, overrideAccess: true })
 
     const result = await sdk.delete({ where: { id: { equals: post.id } }, collection: 'posts' })
 
     expect(result.docs[0].id).toBe(post.id)
     expect(
-      await payload.findByID({ collection: 'posts', id: post.id, disableErrors: true }),
+      await payload.findByID({ collection: 'posts', id: post.id, disableErrors: true, overrideAccess: true }),
     ).toBeNull()
   })
 
@@ -259,10 +264,12 @@ test.suite({ config: './config.ts' })('@payloadcms/sdk', () => {
     const trashedA = await payload.create({
       collection: 'posts',
       data: { deletedAt: new Date().toISOString(), text: 'bulk-perma-a' },
+      overrideAccess: true,
     })
     const trashedB = await payload.create({
       collection: 'posts',
       data: { deletedAt: new Date().toISOString(), text: 'bulk-perma-b' },
+      overrideAccess: true,
     })
 
     await sdk.delete({
@@ -277,6 +284,7 @@ test.suite({ config: './config.ts' })('@payloadcms/sdk', () => {
         disableErrors: true,
         id: trashedA.id,
         trash: true,
+        overrideAccess: true,
       }),
     ).toBeNull()
     expect(
@@ -285,18 +293,19 @@ test.suite({ config: './config.ts' })('@payloadcms/sdk', () => {
         disableErrors: true,
         id: trashedB.id,
         trash: true,
+        overrideAccess: true,
       }),
     ).toBeNull()
   })
 
   test('should execute restoreVersion', async ({ payload, sdk }) => {
-    const post = await payload.create({ collection: 'posts', data: { text: 'old' } })
+    const post = await payload.create({ collection: 'posts', data: { text: 'old' }, overrideAccess: true })
 
     const {
       docs: [currentVersion],
-    } = await payload.findVersions({ collection: 'posts', where: { parent: { equals: post.id } } })
+    } = await payload.findVersions({ collection: 'posts', where: { parent: { equals: post.id } }, overrideAccess: true })
 
-    await payload.update({ collection: 'posts', id: post.id, data: { text: 'new' } })
+    await payload.update({ collection: 'posts', id: post.id, data: { text: 'new' }, overrideAccess: true })
 
     const result = await sdk.restoreVersion({
       collection: 'posts',
@@ -305,7 +314,7 @@ test.suite({ config: './config.ts' })('@payloadcms/sdk', () => {
 
     expect(result.text).toBe('old')
 
-    const resultDB = await payload.findByID({ collection: 'posts', id: post.id })
+    const resultDB = await payload.findByID({ collection: 'posts', id: post.id, overrideAccess: true })
 
     expect(resultDB.text).toBe('old')
   })
@@ -328,6 +337,7 @@ test.suite({ config: './config.ts' })('@payloadcms/sdk', () => {
       docs: [version],
     } = await payload.findGlobalVersions({
       slug: 'global',
+      overrideAccess: true,
     })
 
     const result = await sdk.findGlobalVersionByID({ id: version.id, slug: 'global' })
@@ -341,15 +351,16 @@ test.suite({ config: './config.ts' })('@payloadcms/sdk', () => {
   })
 
   test('should execute restoreGlobalVersion', async ({ payload, sdk }) => {
-    await payload.updateGlobal({ slug: 'global', data: { text: 'old' } })
+    await payload.updateGlobal({ slug: 'global', data: { text: 'old' }, overrideAccess: true })
 
     const {
       docs: [currentVersion],
     } = await payload.findGlobalVersions({
       slug: 'global',
+      overrideAccess: true,
     })
 
-    await payload.updateGlobal({ slug: 'global', data: { text: 'new' } })
+    await payload.updateGlobal({ slug: 'global', data: { text: 'new' }, overrideAccess: true })
 
     const { version: result } = await sdk.restoreGlobalVersion({
       slug: 'global',
@@ -358,7 +369,7 @@ test.suite({ config: './config.ts' })('@payloadcms/sdk', () => {
 
     expect(result.text).toBe('old')
 
-    const resultDB = await payload.findGlobal({ slug: 'global' })
+    const resultDB = await payload.findGlobal({ slug: 'global', overrideAccess: true })
 
     expect(resultDB.text).toBe('old')
   })
@@ -404,6 +415,7 @@ test.suite({ config: './config.ts' })('@payloadcms/sdk', () => {
     const user = await payload.create({
       collection: 'users',
       data: { email: 'new@payloadcms.com', password: 'HOW TO rEmeMber this password' },
+      overrideAccess: true,
     })
 
     const resForgotPassword = await sdk.forgotPassword({
@@ -417,6 +429,7 @@ test.suite({ config: './config.ts' })('@payloadcms/sdk', () => {
       showHiddenFields: true,
       collection: 'users',
       id: user.id,
+      overrideAccess: true,
     })
 
     expect(afterForgotPassword.resetPasswordToken).toBeTruthy()
@@ -452,6 +465,7 @@ test.suite({ config: './config.ts' })('@payloadcms/sdk', () => {
       await payload.create({
         collection: emailsSlug,
         data: { email: testEmail },
+        overrideAccess: true,
       })
 
       let thrownError: null | PayloadSDKError = null
@@ -515,11 +529,13 @@ test.suite({ config: './config.ts' })('@payloadcms/sdk', () => {
       await payload.create({
         collection: emailsSlug,
         data: { email: testEmail },
+        overrideAccess: true,
       })
 
       const doc2 = await payload.create({
         collection: emailsSlug,
         data: { email: testEmail2 },
+        overrideAccess: true,
       })
 
       try {
@@ -580,6 +596,7 @@ test.suite({ config: './config.ts' })('@payloadcms/sdk', () => {
       await payload.create({
         collection: emailsSlug,
         data: { email: testEmail },
+        overrideAccess: true,
       })
 
       let thrownError: null | PayloadSDKError = null

--- a/test/select/getConfig.ts
+++ b/test/select/getConfig.ts
@@ -142,5 +142,6 @@ export const seed: NonNullable<Config['onInit']> = async (payload) => {
       email: devUser.email,
       password: devUser.password,
     },
+    overrideAccess: true,
   })
 }

--- a/test/select/int.spec.ts
+++ b/test/select/int.spec.ts
@@ -47,6 +47,7 @@ test.suite({ config: './config.ts' })('Select', () => {
           collection: 'posts',
           depth: 0,
           select: {},
+          overrideAccess: true,
         })
 
         expect(res).toStrictEqual({
@@ -62,6 +63,7 @@ test.suite({ config: './config.ts' })('Select', () => {
           collection: 'custom-ids',
           depth: 0,
           select: {},
+          overrideAccess: true,
         })
 
         expect(res).toStrictEqual({
@@ -77,6 +79,7 @@ test.suite({ config: './config.ts' })('Select', () => {
           select: {
             number: true,
           },
+          overrideAccess: true,
         })
 
         expect(res).toStrictEqual({
@@ -95,6 +98,7 @@ test.suite({ config: './config.ts' })('Select', () => {
           select: {
             text: true,
           },
+          overrideAccess: true,
         })
 
         expect(res).toStrictEqual({
@@ -111,6 +115,7 @@ test.suite({ config: './config.ts' })('Select', () => {
           select: {
             select: true,
           },
+          overrideAccess: true,
         })
 
         expect(res).toStrictEqual({
@@ -127,6 +132,7 @@ test.suite({ config: './config.ts' })('Select', () => {
           select: {
             selectMany: true,
           },
+          overrideAccess: true,
         })
 
         expect(res).toStrictEqual({
@@ -144,6 +150,7 @@ test.suite({ config: './config.ts' })('Select', () => {
             number: true,
             text: true,
           },
+          overrideAccess: true,
         })
 
         expect(res).toStrictEqual({
@@ -161,6 +168,7 @@ test.suite({ config: './config.ts' })('Select', () => {
           select: {
             hasManyUpload: true,
           },
+          overrideAccess: true,
         })
 
         expect(res_1).toStrictEqual({
@@ -175,6 +183,7 @@ test.suite({ config: './config.ts' })('Select', () => {
           select: {
             hasOne: true,
           },
+          overrideAccess: true,
         })
 
         expect(res_2).toStrictEqual({
@@ -189,6 +198,7 @@ test.suite({ config: './config.ts' })('Select', () => {
           select: {
             hasManyPoly: true,
           },
+          overrideAccess: true,
         })
 
         expect(res_3).toStrictEqual({
@@ -205,6 +215,7 @@ test.suite({ config: './config.ts' })('Select', () => {
           select: {
             group: true,
           },
+          overrideAccess: true,
         })
 
         expect(res).toStrictEqual({
@@ -223,6 +234,7 @@ test.suite({ config: './config.ts' })('Select', () => {
               text: true,
             },
           },
+          overrideAccess: true,
         })
 
         expect(res).toStrictEqual({
@@ -241,6 +253,7 @@ test.suite({ config: './config.ts' })('Select', () => {
           select: {
             tab: true,
           },
+          overrideAccess: true,
         })
 
         expect(res).toStrictEqual({
@@ -259,6 +272,7 @@ test.suite({ config: './config.ts' })('Select', () => {
               text: true,
             },
           },
+          overrideAccess: true,
         })
 
         expect(res).toStrictEqual({
@@ -277,6 +291,7 @@ test.suite({ config: './config.ts' })('Select', () => {
           select: {
             unnamedTabText: true,
           },
+          overrideAccess: true,
         })
 
         expect(res).toStrictEqual({
@@ -293,6 +308,7 @@ test.suite({ config: './config.ts' })('Select', () => {
           select: {
             array: {},
           },
+          overrideAccess: true,
         })
 
         expect(res).toStrictEqual({
@@ -309,6 +325,7 @@ test.suite({ config: './config.ts' })('Select', () => {
           select: {
             array: true,
           },
+          overrideAccess: true,
         })
 
         expect(res).toStrictEqual({
@@ -327,6 +344,7 @@ test.suite({ config: './config.ts' })('Select', () => {
               text: true,
             },
           },
+          overrideAccess: true,
         })
 
         expect(res).toStrictEqual({
@@ -346,6 +364,7 @@ test.suite({ config: './config.ts' })('Select', () => {
           select: {
             blocks: {},
           },
+          overrideAccess: true,
         })
 
         expect(res).toStrictEqual({
@@ -362,6 +381,7 @@ test.suite({ config: './config.ts' })('Select', () => {
           select: {
             blocks: true,
           },
+          overrideAccess: true,
         })
 
         expect(res).toStrictEqual({
@@ -380,6 +400,7 @@ test.suite({ config: './config.ts' })('Select', () => {
               cta: true,
             },
           },
+          overrideAccess: true,
         })
 
         expect(res).toStrictEqual({
@@ -405,6 +426,7 @@ test.suite({ config: './config.ts' })('Select', () => {
               cta: { ctaText: true },
             },
           },
+          overrideAccess: true,
         })
 
         expect(res).toStrictEqual({
@@ -429,6 +451,7 @@ test.suite({ config: './config.ts' })('Select', () => {
           id: pointId,
           collection: 'points',
           select: { point: true },
+          overrideAccess: true,
         })
 
         expect(res).toStrictEqual({
@@ -447,6 +470,7 @@ test.suite({ config: './config.ts' })('Select', () => {
           select: {
             text: false,
           },
+          overrideAccess: true,
         })
 
         const expected = { ...post }
@@ -466,6 +490,7 @@ test.suite({ config: './config.ts' })('Select', () => {
           select: {
             text: false,
           },
+          overrideAccess: true,
         })
 
         expect(res).toStrictEqual({
@@ -483,6 +508,7 @@ test.suite({ config: './config.ts' })('Select', () => {
           select: {
             number: false,
           },
+          overrideAccess: true,
         })
 
         const expected = { ...post }
@@ -500,6 +526,7 @@ test.suite({ config: './config.ts' })('Select', () => {
           select: {
             select: false,
           },
+          overrideAccess: true,
         })
 
         const expected = { ...post }
@@ -517,6 +544,7 @@ test.suite({ config: './config.ts' })('Select', () => {
           select: {
             selectMany: false,
           },
+          overrideAccess: true,
         })
 
         const expected = { ...post }
@@ -535,6 +563,7 @@ test.suite({ config: './config.ts' })('Select', () => {
             number: false,
             text: false,
           },
+          overrideAccess: true,
         })
 
         const expected = { ...post }
@@ -556,6 +585,7 @@ test.suite({ config: './config.ts' })('Select', () => {
             hasOne: false,
             hasOnePoly: false,
           },
+          overrideAccess: true,
         })
 
         const expected = { ...post }
@@ -576,6 +606,7 @@ test.suite({ config: './config.ts' })('Select', () => {
           select: {
             group: false,
           },
+          overrideAccess: true,
         })
 
         const expected = { ...post }
@@ -595,6 +626,7 @@ test.suite({ config: './config.ts' })('Select', () => {
               text: false,
             },
           },
+          overrideAccess: true,
         })
 
         const expected = deepCopyObject(post)
@@ -612,6 +644,7 @@ test.suite({ config: './config.ts' })('Select', () => {
           select: {
             array: false,
           },
+          overrideAccess: true,
         })
 
         const expected = { ...post }
@@ -631,6 +664,7 @@ test.suite({ config: './config.ts' })('Select', () => {
               text: false,
             },
           },
+          overrideAccess: true,
         })
 
         expect(res).toStrictEqual({
@@ -650,6 +684,7 @@ test.suite({ config: './config.ts' })('Select', () => {
           select: {
             blocks: false,
           },
+          overrideAccess: true,
         })
 
         const expected = { ...post }
@@ -671,6 +706,7 @@ test.suite({ config: './config.ts' })('Select', () => {
               cta: false,
             },
           },
+          overrideAccess: true,
         })
 
         expect(res).toStrictEqual({
@@ -691,6 +727,7 @@ test.suite({ config: './config.ts' })('Select', () => {
               cta: { ctaText: false },
             },
           },
+          overrideAccess: true,
         })
 
         const expectedPost = deepCopyObject(post)
@@ -714,6 +751,7 @@ test.suite({ config: './config.ts' })('Select', () => {
           id: pointId,
           collection: 'points',
           select: { point: false },
+          overrideAccess: true,
         })
 
         const copy = { ...point }
@@ -740,6 +778,7 @@ test.suite({ config: './config.ts' })('Select', () => {
           id: postId,
           collection: 'localized-posts',
           select: {},
+          overrideAccess: true,
         })
 
         expect(res).toStrictEqual({
@@ -754,6 +793,7 @@ test.suite({ config: './config.ts' })('Select', () => {
           select: {
             number: true,
           },
+          overrideAccess: true,
         })
 
         expect(res).toStrictEqual({
@@ -769,6 +809,7 @@ test.suite({ config: './config.ts' })('Select', () => {
           select: {
             select: true,
           },
+          overrideAccess: true,
         })
 
         expect(res).toStrictEqual({
@@ -784,6 +825,7 @@ test.suite({ config: './config.ts' })('Select', () => {
           select: {
             selectMany: true,
           },
+          overrideAccess: true,
         })
 
         expect(res).toStrictEqual({
@@ -800,6 +842,7 @@ test.suite({ config: './config.ts' })('Select', () => {
             number: true,
             text: true,
           },
+          overrideAccess: true,
         })
 
         expect(res).toStrictEqual({
@@ -816,6 +859,7 @@ test.suite({ config: './config.ts' })('Select', () => {
           select: {
             group: true,
           },
+          overrideAccess: true,
         })
 
         expect(res).toStrictEqual({
@@ -833,6 +877,7 @@ test.suite({ config: './config.ts' })('Select', () => {
               text: true,
             },
           },
+          overrideAccess: true,
         })
 
         expect(res).toStrictEqual({
@@ -852,6 +897,7 @@ test.suite({ config: './config.ts' })('Select', () => {
               text: true,
             },
           },
+          overrideAccess: true,
         })
 
         expect(res).toStrictEqual({
@@ -869,6 +915,7 @@ test.suite({ config: './config.ts' })('Select', () => {
           select: {
             array: {},
           },
+          overrideAccess: true,
         })
 
         expect(res).toStrictEqual({
@@ -884,6 +931,7 @@ test.suite({ config: './config.ts' })('Select', () => {
           select: {
             array: true,
           },
+          overrideAccess: true,
         })
 
         expect(res).toStrictEqual({
@@ -901,6 +949,7 @@ test.suite({ config: './config.ts' })('Select', () => {
               text: true,
             },
           },
+          overrideAccess: true,
         })
 
         expect(res).toStrictEqual({
@@ -921,6 +970,7 @@ test.suite({ config: './config.ts' })('Select', () => {
               text: true,
             },
           },
+          overrideAccess: true,
         })
 
         expect(res).toStrictEqual({
@@ -939,6 +989,7 @@ test.suite({ config: './config.ts' })('Select', () => {
           select: {
             blocks: {},
           },
+          overrideAccess: true,
         })
 
         expect(res).toStrictEqual({
@@ -954,6 +1005,7 @@ test.suite({ config: './config.ts' })('Select', () => {
           select: {
             blocks: true,
           },
+          overrideAccess: true,
         })
 
         expect(res).toStrictEqual({
@@ -971,6 +1023,7 @@ test.suite({ config: './config.ts' })('Select', () => {
               cta: true,
             },
           },
+          overrideAccess: true,
         })
 
         expect(res).toStrictEqual({
@@ -995,6 +1048,7 @@ test.suite({ config: './config.ts' })('Select', () => {
               cta: { ctaText: true },
             },
           },
+          overrideAccess: true,
         })
 
         expect(res).toStrictEqual({
@@ -1021,6 +1075,7 @@ test.suite({ config: './config.ts' })('Select', () => {
               second: { text: true },
             },
           },
+          overrideAccess: true,
         })
 
         expect(res).toStrictEqual({
@@ -1047,6 +1102,7 @@ test.suite({ config: './config.ts' })('Select', () => {
               first: { firstText: true },
             },
           },
+          overrideAccess: true,
         })
 
         expect(res).toStrictEqual({
@@ -1071,6 +1127,7 @@ test.suite({ config: './config.ts' })('Select', () => {
           select: {
             text: false,
           },
+          overrideAccess: true,
         })
 
         const expected = { ...post }
@@ -1087,6 +1144,7 @@ test.suite({ config: './config.ts' })('Select', () => {
           select: {
             number: false,
           },
+          overrideAccess: true,
         })
 
         const expected = { ...post }
@@ -1103,6 +1161,7 @@ test.suite({ config: './config.ts' })('Select', () => {
           select: {
             select: false,
           },
+          overrideAccess: true,
         })
 
         const expected = { ...post }
@@ -1119,6 +1178,7 @@ test.suite({ config: './config.ts' })('Select', () => {
           select: {
             selectMany: false,
           },
+          overrideAccess: true,
         })
 
         const expected = { ...post }
@@ -1136,6 +1196,7 @@ test.suite({ config: './config.ts' })('Select', () => {
             number: false,
             text: false,
           },
+          overrideAccess: true,
         })
 
         const expected = { ...post }
@@ -1153,6 +1214,7 @@ test.suite({ config: './config.ts' })('Select', () => {
           select: {
             group: false,
           },
+          overrideAccess: true,
         })
 
         const expected = { ...post }
@@ -1171,6 +1233,7 @@ test.suite({ config: './config.ts' })('Select', () => {
               text: false,
             },
           },
+          overrideAccess: true,
         })
 
         const expected = deepCopyObject(post)
@@ -1189,6 +1252,7 @@ test.suite({ config: './config.ts' })('Select', () => {
               text: false,
             },
           },
+          overrideAccess: true,
         })
 
         const expected = deepCopyObject(post)
@@ -1205,6 +1269,7 @@ test.suite({ config: './config.ts' })('Select', () => {
           select: {
             array: false,
           },
+          overrideAccess: true,
         })
 
         const expected = { ...post }
@@ -1223,6 +1288,7 @@ test.suite({ config: './config.ts' })('Select', () => {
               text: false,
             },
           },
+          overrideAccess: true,
         })
 
         expect(res).toStrictEqual({
@@ -1243,6 +1309,7 @@ test.suite({ config: './config.ts' })('Select', () => {
               text: false,
             },
           },
+          overrideAccess: true,
         })
 
         expect(res).toStrictEqual({
@@ -1261,6 +1328,7 @@ test.suite({ config: './config.ts' })('Select', () => {
           select: {
             blocks: false,
           },
+          overrideAccess: true,
         })
 
         const expected = { ...post }
@@ -1281,6 +1349,7 @@ test.suite({ config: './config.ts' })('Select', () => {
               cta: false,
             },
           },
+          overrideAccess: true,
         })
 
         expect(res).toStrictEqual({
@@ -1300,6 +1369,7 @@ test.suite({ config: './config.ts' })('Select', () => {
               cta: { ctaText: false },
             },
           },
+          overrideAccess: true,
         })
 
         const expectedPost = deepCopyObject(post)
@@ -1326,6 +1396,7 @@ test.suite({ config: './config.ts' })('Select', () => {
               second: { text: false },
             },
           },
+          overrideAccess: true,
         })
 
         const expectedPost = deepCopyObject(post)
@@ -1352,6 +1423,7 @@ test.suite({ config: './config.ts' })('Select', () => {
               first: { firstText: false },
             },
           },
+          overrideAccess: true,
         })
 
         const expectedPost = deepCopyObject(post)
@@ -1383,6 +1455,7 @@ test.suite({ config: './config.ts' })('Select', () => {
         id: postId,
         collection: 'deep-posts',
         select: { group: { array: { group: { text: true } } } },
+        overrideAccess: true,
       })
 
       expect(res).toStrictEqual({
@@ -1403,6 +1476,7 @@ test.suite({ config: './config.ts' })('Select', () => {
         id: postId,
         collection: 'deep-posts',
         select: { group: { array: { group: true } } },
+        overrideAccess: true,
       })
 
       expect(res).toStrictEqual({
@@ -1421,6 +1495,7 @@ test.suite({ config: './config.ts' })('Select', () => {
         id: postId,
         collection: 'deep-posts',
         select: { group: { blocks: { block: { text: true } } } },
+        overrideAccess: true,
       })
 
       expect(res).toStrictEqual({
@@ -1440,6 +1515,7 @@ test.suite({ config: './config.ts' })('Select', () => {
         id: postId,
         collection: 'deep-posts',
         select: { arrayTop: { arrayNested: { text: true } } },
+        overrideAccess: true,
       })
 
       expect(res).toStrictEqual({
@@ -1470,6 +1546,7 @@ test.suite({ config: './config.ts' })('Select', () => {
         collection: 'versioned-posts',
         draft: true,
         select: {},
+        overrideAccess: true,
       })
 
       expect(res).toStrictEqual({
@@ -1485,6 +1562,7 @@ test.suite({ config: './config.ts' })('Select', () => {
         select: {
           number: true,
         },
+        overrideAccess: true,
       })
 
       expect(res).toStrictEqual({
@@ -1501,6 +1579,7 @@ test.suite({ config: './config.ts' })('Select', () => {
         select: {
           number: false,
         },
+        overrideAccess: true,
       })
 
       const expected = { ...post }
@@ -1518,6 +1597,7 @@ test.suite({ config: './config.ts' })('Select', () => {
           number: true,
           text: true,
         },
+        overrideAccess: true,
       })
 
       expect(res).toStrictEqual({
@@ -1540,6 +1620,7 @@ test.suite({ config: './config.ts' })('Select', () => {
             equals: postId,
           },
         },
+        overrideAccess: true,
       })
 
       expect(res.docs[0]).toStrictEqual({
@@ -1561,6 +1642,7 @@ test.suite({ config: './config.ts' })('Select', () => {
             equals: postId,
           },
         },
+        overrideAccess: true,
       })
 
       expect(res.docs[0]).toStrictEqual({
@@ -1581,6 +1663,7 @@ test.suite({ config: './config.ts' })('Select', () => {
             equals: postId,
           },
         },
+        overrideAccess: true,
       })
 
       expect(res.docs[0]).toStrictEqual({
@@ -1600,6 +1683,7 @@ test.suite({ config: './config.ts' })('Select', () => {
         },
         sort: '-updatedAt',
         where: { parent: { equals: postId } },
+        overrideAccess: true,
       })
 
       // findVersions doesnt transform result with afterRead hook and so doesn't strip undefined values from the object
@@ -1621,6 +1705,7 @@ test.suite({ config: './config.ts' })('Select', () => {
         collection: 'versioned-posts',
         data: { _status: 'draft', text: 'draft-post' },
         draft: true,
+        overrideAccess: true,
       })
 
       const res = await payload.findByID({
@@ -1628,12 +1713,14 @@ test.suite({ config: './config.ts' })('Select', () => {
         collection: 'versioned-posts',
         draft: true,
         select: { text: true },
+        overrideAccess: true,
       })
       expect(res.text).toBe('draft-post')
       await payload.update({
         id: doc.id,
         collection: 'versioned-posts',
         data: { _status: 'published', text: 'published' },
+        overrideAccess: true,
       })
 
       const res_2 = await payload.findByID({
@@ -1641,6 +1728,7 @@ test.suite({ config: './config.ts' })('Select', () => {
         collection: 'versioned-posts',
         draft: true,
         select: { text: true },
+        overrideAccess: true,
       })
 
       expect(res_2).toStrictEqual({
@@ -1661,6 +1749,7 @@ test.suite({ config: './config.ts' })('Select', () => {
           text: 'updated text',
         },
         select: {},
+        overrideAccess: true,
       })
 
       // The update operation should only return the selected field
@@ -1674,6 +1763,7 @@ test.suite({ config: './config.ts' })('Select', () => {
         limit: 1,
         sort: '-updatedAt',
         where: { parent: { equals: postId } },
+        overrideAccess: true,
       })
 
       const latestVersion = versions.docs[0]
@@ -1696,6 +1786,7 @@ test.suite({ config: './config.ts' })('Select', () => {
           number: 2,
           text: '3',
         },
+        overrideAccess: true,
       })
     })
 
@@ -1705,6 +1796,7 @@ test.suite({ config: './config.ts' })('Select', () => {
         select: {
           text: true,
         },
+        overrideAccess: true,
       })
 
       expect(res).toStrictEqual({
@@ -1720,6 +1812,7 @@ test.suite({ config: './config.ts' })('Select', () => {
         select: {
           text: true,
         },
+        overrideAccess: true,
       })
 
       expect(res).toStrictEqual({
@@ -1740,6 +1833,7 @@ test.suite({ config: './config.ts' })('Select', () => {
         select: {
           text: true,
         },
+        overrideAccess: true,
       })
 
       expect(res).toStrictEqual({
@@ -1756,6 +1850,7 @@ test.suite({ config: './config.ts' })('Select', () => {
         collection: 'posts',
         data: {},
         select: { text: true },
+        overrideAccess: true,
       })
 
       expect(res).toStrictEqual({
@@ -1776,6 +1871,7 @@ test.suite({ config: './config.ts' })('Select', () => {
             equals: post.id,
           },
         },
+        overrideAccess: true,
       })
 
       assert(res.docs[0])
@@ -1793,6 +1889,7 @@ test.suite({ config: './config.ts' })('Select', () => {
         id: post.id,
         collection: 'posts',
         select: { text: true },
+        overrideAccess: true,
       })
 
       expect(res).toStrictEqual({
@@ -1812,6 +1909,7 @@ test.suite({ config: './config.ts' })('Select', () => {
             equals: post.id,
           },
         },
+        overrideAccess: true,
       })
 
       assert(res.docs[0])
@@ -1829,6 +1927,7 @@ test.suite({ config: './config.ts' })('Select', () => {
         id: post.id,
         collection: 'posts',
         select: { text: true },
+        overrideAccess: true,
       })
 
       expect(res).toStrictEqual({
@@ -2107,6 +2206,7 @@ test.suite({ config: './config.ts' })('Select', () => {
           content: [],
         },
         depth: 0,
+        overrideAccess: true,
       })
 
       expectedHomePage = {
@@ -2172,13 +2272,14 @@ test.suite({ config: './config.ts' })('Select', () => {
           ],
         },
         depth: 0,
+        overrideAccess: true,
       })
     })
 
     test('local API - should populate with the defaultPopulate select shape', async ({
       payload,
     }) => {
-      const result = await payload.findByID({ id: aboutPage.id, collection: 'pages', depth: 1 })
+      const result = await payload.findByID({ id: aboutPage.id, collection: 'pages', depth: 1, overrideAccess: true })
 
       const block = result.content![0]!
 
@@ -2294,7 +2395,7 @@ test.suite({ config: './config.ts' })('Select', () => {
       restClient,
     }) => {
       // Create a related document first
-      const rel = await payload.create({ collection: 'rels', data: { text: 'graphql-rel-test' } })
+      const rel = await payload.create({ collection: 'rels', data: { text: 'graphql-rel-test' }, overrideAccess: true })
 
       // Create a post with the relationship
       const testPost = await payload.create({
@@ -2306,6 +2407,7 @@ test.suite({ config: './config.ts' })('Select', () => {
           text: 'graphql-select-test',
         },
         depth: 0,
+        overrideAccess: true,
       })
 
       const testPostId = typeof testPost.id === 'string' ? `"${testPost.id}"` : testPost.id
@@ -2351,8 +2453,8 @@ test.suite({ config: './config.ts' })('Select', () => {
       expect(doc.hasMany[0].text).toBe('graphql-rel-test')
 
       // Cleanup
-      await payload.delete({ id: testPost.id, collection: 'posts' })
-      await payload.delete({ id: rel.id, collection: 'rels' })
+      await payload.delete({ id: testPost.id, collection: 'posts', overrideAccess: true })
+      await payload.delete({ id: rel.id, collection: 'rels', overrideAccess: true })
     })
 
     test('graphQL - should return polymorphic relationship fields when using select flag', async ({
@@ -2360,7 +2462,7 @@ test.suite({ config: './config.ts' })('Select', () => {
       restClient,
     }) => {
       // Create a related document
-      const rel = await payload.create({ collection: 'rels', data: { text: 'graphql-poly-test' } })
+      const rel = await payload.create({ collection: 'rels', data: { text: 'graphql-poly-test' }, overrideAccess: true })
 
       // Create a post with polymorphic relationships
       const testPost = await payload.create({
@@ -2372,6 +2474,7 @@ test.suite({ config: './config.ts' })('Select', () => {
           text: 'graphql-poly-select-test',
         },
         depth: 0,
+        overrideAccess: true,
       })
 
       const testPostId = typeof testPost.id === 'string' ? `"${testPost.id}"` : testPost.id
@@ -2429,8 +2532,8 @@ test.suite({ config: './config.ts' })('Select', () => {
       expect(doc.hasManyPoly[0].value.text).toBe('graphql-poly-test')
 
       // Cleanup
-      await payload.delete({ id: testPost.id, collection: 'posts' })
-      await payload.delete({ id: rel.id, collection: 'rels' })
+      await payload.delete({ id: testPost.id, collection: 'posts', overrideAccess: true })
+      await payload.delete({ id: rel.id, collection: 'rels', overrideAccess: true })
     })
 
     test('local API - should populate and override defaultSelect select shape from the populate arg', async ({
@@ -2445,6 +2548,7 @@ test.suite({ config: './config.ts' })('Select', () => {
             additional: true,
           },
         },
+        overrideAccess: true,
       })
 
       const {
@@ -2462,6 +2566,7 @@ test.suite({ config: './config.ts' })('Select', () => {
             equals: aboutPage.id,
           },
         },
+        overrideAccess: true,
       })
 
       expect(resultFind).toStrictEqual(result)
@@ -2536,20 +2641,24 @@ test.suite({ config: './config.ts' })('Select', () => {
       const page_1 = await payload.create({
         collection: 'pages',
         data: { slug: 'page-1', blocks: [{ blockType: 'some' }], relatedPage: null },
+        overrideAccess: true,
       })
       const page_2 = await payload.create({
         collection: 'pages',
         data: { slug: 'page-2', relatedPage: page_1.id },
+        overrideAccess: true,
       })
       const page_3 = await payload.create({
         collection: 'pages',
         data: { slug: 'page-3', relatedPage: page_2.id },
+        overrideAccess: true,
       })
       const result = await payload.findByID({
         id: page_3.id,
         collection: 'pages',
         depth: 3,
         populate: { pages: { slug: true, relatedPage: true } },
+        overrideAccess: true,
       })
 
       const relatedPage = result.relatedPage as Page
@@ -2569,6 +2678,7 @@ test.suite({ config: './config.ts' })('Select', () => {
     const { id } = await payload.create({
       collection: 'force-select',
       data: { field1: 'one', field2: 'two', text: 'control' },
+      overrideAccess: true,
     })
 
     // Caller selects `field1` → hook auto-selects `field2`.
@@ -2576,6 +2686,7 @@ test.suite({ config: './config.ts' })('Select', () => {
       id,
       collection: 'force-select',
       select: { field1: true },
+      overrideAccess: true,
     })
 
     expect(augmented).toStrictEqual({
@@ -2589,6 +2700,7 @@ test.suite({ config: './config.ts' })('Select', () => {
       id,
       collection: 'force-select',
       select: { text: true },
+      overrideAccess: true,
     })
 
     expect(notAugmented).toStrictEqual({
@@ -2596,18 +2708,20 @@ test.suite({ config: './config.ts' })('Select', () => {
       text: 'control',
     })
 
-    await payload.delete({ id, collection: 'force-select' })
+    await payload.delete({ id, collection: 'force-select', overrideAccess: true })
   })
 
   test('should auto-select field2 when caller selects field1 on globals', async ({ payload }) => {
     const { id } = await payload.updateGlobal({
       slug: 'force-select-global',
       data: { field1: 'one', field2: 'two', text: 'control' },
+      overrideAccess: true,
     })
 
     const augmented = await payload.findGlobal({
       slug: 'force-select-global',
       select: { field1: true },
+      overrideAccess: true,
     })
 
     expect(augmented).toStrictEqual({
@@ -2637,15 +2751,17 @@ test.suite({ config: './config.ts' })('Select', () => {
         collection: 'force-select',
         data: { field1: 'a', field2: 'b' },
         select: { field1: true },
+        overrideAccess: true,
       })
 
       await payload.findByID({
         id: created.id,
         collection: 'force-select',
         select: { field1: true },
+        overrideAccess: true,
       })
 
-      await payload.delete({ id: created.id, collection: 'force-select' })
+      await payload.delete({ id: created.id, collection: 'force-select', overrideAccess: true })
 
       const operations = calls.map((c) => c.operation)
       expect(operations).toContain('create')
@@ -2662,7 +2778,7 @@ test.suite({ config: './config.ts' })('Select', () => {
   test('should properly return relationships when using select on block with depth 0', async ({
     payload,
   }) => {
-    const rel_1 = await payload.create({ collection: 'rels', data: { text: 'rel-1' } })
+    const rel_1 = await payload.create({ collection: 'rels', data: { text: 'rel-1' }, overrideAccess: true })
     const doc = await payload.create({
       collection: 'relationships-blocks',
       data: {
@@ -2674,12 +2790,14 @@ test.suite({ config: './config.ts' })('Select', () => {
           },
         ],
       },
+      overrideAccess: true,
     })
     const result = await payload.findByID({
       id: doc.id,
       collection: 'relationships-blocks',
       depth: 0,
       select: { blocks: true },
+      overrideAccess: true,
     })
 
     expect(result.blocks[0]?.hasOne).toBe(rel_1.id)
@@ -2687,7 +2805,7 @@ test.suite({ config: './config.ts' })('Select', () => {
   })
 
   test('should populate relationships when using select on block', async ({ payload }) => {
-    const rel_1 = await payload.create({ collection: 'rels', data: { text: 'rel-1' } })
+    const rel_1 = await payload.create({ collection: 'rels', data: { text: 'rel-1' }, overrideAccess: true })
     const doc = await payload.create({
       collection: 'relationships-blocks',
       data: {
@@ -2699,6 +2817,7 @@ test.suite({ config: './config.ts' })('Select', () => {
           },
         ],
       },
+      overrideAccess: true,
     })
 
     const result = await payload.findByID({
@@ -2706,6 +2825,7 @@ test.suite({ config: './config.ts' })('Select', () => {
       collection: 'relationships-blocks',
       depth: 1,
       select: { blocks: true },
+      overrideAccess: true,
     })
 
     expect(result.blocks[0]?.hasOne.text).toBe('rel-1')
@@ -2718,12 +2838,14 @@ async function createPost({ payload }: { payload: Payload }) {
     collection: 'upload',
     data: {},
     filePath: path.resolve(dirname, 'image.jpg'),
+    overrideAccess: true,
   })
 
   const relation = await payload.create({
     collection: 'rels',
     data: {},
     depth: 0,
+    overrideAccess: true,
   })
 
   return payload.create({
@@ -2768,6 +2890,7 @@ async function createPost({ payload }: { payload: Payload }) {
       unnamedTabText: 'text2',
     },
     depth: 0,
+    overrideAccess: true,
   })
 }
 
@@ -2825,6 +2948,7 @@ function createLocalizedPost({ payload }: { payload: Payload }) {
       text: 'text',
     },
     depth: 0,
+    overrideAccess: true,
   })
 }
 
@@ -2838,6 +2962,7 @@ function createDeepPost({ payload }: { payload: Payload }) {
         blocks: [{ blockType: 'block', number: 3, text: 'text-4' }],
       },
     },
+    overrideAccess: true,
   })
 }
 
@@ -2850,15 +2975,16 @@ function createVersionedPost({ payload }: { payload: Payload }) {
       number: 2,
       text: 'text',
     },
+    overrideAccess: true,
   })
 }
 
 function createPoint({ payload }: { payload: Payload }) {
-  return payload.create({ collection: 'points', data: { point: [10, 20], text: 'some' } })
+  return payload.create({ collection: 'points', data: { point: [10, 20], text: 'some' }, overrideAccess: true })
 }
 
 let id = 1
 
 function createCustomID({ payload }: { payload: Payload }) {
-  return payload.create({ collection: 'custom-ids', data: { id: id++, text: randomUUID() } })
+  return payload.create({ collection: 'custom-ids', data: { id: id++, text: randomUUID() }, overrideAccess: true })
 }

--- a/test/select/postgreslogs.int.spec.ts
+++ b/test/select/postgreslogs.int.spec.ts
@@ -31,8 +31,8 @@ test.suite({ config: './config.postgreslogs.ts', db: (adapter) => adapter.starts
 
       // Clean up to safely mutate in each test
       test.afterEach(async ({ payload }) => {
-        await payload.delete({ id: postId, collection: 'posts' })
-        await payload.delete({ id: pointId, collection: 'points' })
+        await payload.delete({ id: postId, collection: 'posts', overrideAccess: true })
+        await payload.delete({ id: pointId, collection: 'points', overrideAccess: true })
       })
 
       test('ensure optimized db update is still used when using select', async ({ payload }) => {
@@ -80,6 +80,7 @@ test.suite({ config: './config.postgreslogs.ts', db: (adapter) => adapter.starts
               },
             ],
           },
+          overrideAccess: true,
         })
 
         // Count every console log
@@ -111,6 +112,7 @@ test.suite({ config: './config.postgreslogs.ts', db: (adapter) => adapter.starts
         const fullPage: any = await payload.findByID({
           collection: 'pages',
           id: page.id,
+          overrideAccess: true,
         })
 
         delete fullPage.createdAt
@@ -174,12 +176,14 @@ async function createPost({ payload }: { payload: Payload }) {
     collection: 'upload',
     data: {},
     filePath: path.resolve(dirname, 'image.jpg'),
+    overrideAccess: true,
   })
 
   const relation = await payload.create({
     depth: 0,
     collection: 'rels',
     data: {},
+    overrideAccess: true,
   })
 
   return payload.create({
@@ -224,9 +228,10 @@ async function createPost({ payload }: { payload: Payload }) {
       unnamedTabNumber: 2,
       unnamedTabText: 'text2',
     },
+    overrideAccess: true,
   })
 }
 
 function createPoint({ payload }: { payload: Payload }) {
-  return payload.create({ collection: 'points', data: { text: 'some', point: [10, 20] } })
+  return payload.create({ collection: 'points', data: { text: 'some', point: [10, 20] }, overrideAccess: true })
 }

--- a/test/server-url/config.ts
+++ b/test/server-url/config.ts
@@ -30,6 +30,7 @@ export default buildConfigWithDefaults({
         email: devUser.email,
         password: devUser.password,
       },
+      overrideAccess: true,
     })
   },
 })

--- a/test/sort/int.spec.ts
+++ b/test/sort/int.spec.ts
@@ -34,7 +34,8 @@ test.suite({ config: './config.ts' })('Sort', () => {
     test.describe('Default sort', () => {
       test('should sort posts by default definition in collection', async ({ payload }) => {
         const posts = await payload.find({
-          collection: 'default-sort', // 'number,-text'
+          collection: 'default-sort',
+          overrideAccess: true, // 'number,-text'
         })
 
         expect(posts.docs.map((post) => post.text)).toEqual([
@@ -51,6 +52,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
         const posts = await payload.find({
           collection: 'posts',
           sort: 'text',
+          overrideAccess: true,
         })
 
         expect(posts.docs.map((post) => post.text)).toEqual([
@@ -67,6 +69,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
         const posts = await payload.find({
           collection: 'posts',
           sort: '-text',
+          overrideAccess: true,
         })
 
         expect(posts.docs.map((post) => post.text)).toEqual([
@@ -83,6 +86,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
         const posts = await payload.find({
           collection: 'posts',
           sort: 'number',
+          overrideAccess: true,
         })
 
         expect(posts.docs.map((post) => post.text)).toEqual([
@@ -99,6 +103,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
         const posts = await payload.find({
           collection: 'posts',
           sort: '-number',
+          overrideAccess: true,
         })
 
         expect(posts.docs.map((post) => post.text)).toEqual([
@@ -119,6 +124,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
         const posts = await payload.find({
           collection: nonUniqueSortSlug,
           sort: 'order',
+          overrideAccess: true,
         })
 
         const initialMap = posts.docs.map((post) => post.title)
@@ -128,6 +134,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
             payload.find({
               collection: nonUniqueSortSlug,
               sort: 'order',
+              overrideAccess: true,
             }),
           ),
         )
@@ -149,6 +156,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
           sort: 'order',
           limit: 5,
           page: 2,
+          overrideAccess: true,
         })
 
         const initialMap = posts.docs.map((post) => post.title)
@@ -160,6 +168,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
               sort: 'order',
               limit: 5,
               page: 2,
+              overrideAccess: true,
             }),
           ),
         )
@@ -186,6 +195,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
               sort: 'order',
               page: 2,
               limit: 4,
+              overrideAccess: true,
             }),
           ),
         )
@@ -206,6 +216,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
       test('should always be consistent without sort params in the query', async ({ payload }) => {
         const posts = await payload.find({
           collection: nonUniqueSortSlug,
+          overrideAccess: true,
         })
 
         const initialMap = posts.docs.map((post) => post.title)
@@ -214,6 +225,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
           Array.from({ length: 3 }).map(() =>
             payload.find({
               collection: nonUniqueSortSlug,
+              overrideAccess: true,
             }),
           ),
         )
@@ -236,6 +248,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
           collection: nonUniqueSortSlug,
           page: 2,
           limit: 4,
+          overrideAccess: true,
         })
 
         const initialMap = posts.docs.map((post) => post.title)
@@ -246,6 +259,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
               collection: nonUniqueSortSlug,
               page: 2,
               limit: 4,
+              overrideAccess: true,
             }),
           ),
         )
@@ -267,6 +281,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
         const posts = await payload.find({
           collection: 'posts',
           sort: ['number2', 'number'],
+          overrideAccess: true,
         })
 
         expect(posts.docs.map((post) => post.text)).toEqual([
@@ -283,6 +298,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
         const posts = await payload.find({
           collection: 'posts',
           sort: ['number2', '-number'],
+          overrideAccess: true,
         })
 
         expect(posts.docs.map((post) => post.text)).toEqual([
@@ -299,6 +315,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
         const posts = await payload.find({
           collection: 'posts',
           sort: ['-group.number', '-number'],
+          overrideAccess: true,
         })
 
         expect(posts.docs.map((post) => post.text)).toEqual([
@@ -318,46 +335,54 @@ test.suite({ config: './config.ts' })('Sort', () => {
           collection: 'drafts',
           data: { text: 'Post 1 draft', number: 10 },
           draft: true,
+          overrideAccess: true,
         })
         await payload.update({
           collection: 'drafts',
           id: testData1.id,
           data: { text: 'Post 1 draft updated', number: 20 },
           draft: true,
+          overrideAccess: true,
         })
         await payload.update({
           collection: 'drafts',
           id: testData1.id,
           data: { text: 'Post 1 draft updated', number: 30 },
           draft: true,
+          overrideAccess: true,
         })
         await payload.update({
           collection: 'drafts',
           id: testData1.id,
           data: { text: 'Post 1 published', number: 15 },
           draft: false,
+          overrideAccess: true,
         })
         const testData2 = await payload.create({
           collection: 'drafts',
           data: { text: 'Post 2 draft', number: 1 },
           draft: true,
+          overrideAccess: true,
         })
         await payload.update({
           collection: 'drafts',
           id: testData2.id,
           data: { text: 'Post 2 published', number: 2 },
           draft: false,
+          overrideAccess: true,
         })
         await payload.update({
           collection: 'drafts',
           id: testData2.id,
           data: { text: 'Post 2 newdraft', number: 100 },
           draft: true,
+          overrideAccess: true,
         })
         await payload.create({
           collection: 'drafts',
           data: { text: 'Post 3 draft', number: 3 },
           draft: true,
+          overrideAccess: true,
         })
       })
 
@@ -366,6 +391,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
           collection: 'drafts',
           sort: 'number',
           draft: false,
+          overrideAccess: true,
         })
 
         expect(posts.docs.map((post) => post.text)).toEqual([
@@ -380,6 +406,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
           collection: 'drafts',
           sort: 'number',
           draft: true,
+          overrideAccess: true,
         })
 
         expect(posts.docs.map((post) => post.text)).toEqual([
@@ -394,6 +421,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
           collection: 'drafts',
           sort: 'version.number',
           draft: false,
+          overrideAccess: true,
         })
 
         expect(posts.docs.map((post) => post.version.text)).toEqual([
@@ -415,23 +443,27 @@ test.suite({ config: './config.ts' })('Sort', () => {
           collection: 'localized',
           data: { text: 'Post 1 english', number: 10 },
           locale: 'en',
+          overrideAccess: true,
         })
         await payload.update({
           collection: 'localized',
           id: testData1.id,
           data: { text: 'Post 1 norsk', number: 20 },
           locale: 'nb',
+          overrideAccess: true,
         })
         const testData2 = await payload.create({
           collection: 'localized',
           data: { text: 'Post 2 english', number: 25 },
           locale: 'en',
+          overrideAccess: true,
         })
         await payload.update({
           collection: 'localized',
           id: testData2.id,
           data: { text: 'Post 2 norsk', number: 5 },
           locale: 'nb',
+          overrideAccess: true,
         })
       })
 
@@ -440,6 +472,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
           collection: 'localized',
           sort: 'number',
           locale: 'en',
+          overrideAccess: true,
         })
 
         expect(englishPosts.docs.map((post) => post.text)).toEqual([
@@ -451,6 +484,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
           collection: 'localized',
           sort: 'number',
           locale: 'nb',
+          overrideAccess: true,
         })
 
         expect(norwegianPosts.docs.map((post) => post.text)).toEqual([
@@ -471,12 +505,14 @@ test.suite({ config: './config.ts' })('Sort', () => {
           data: {
             title: 'Orderable 1',
           },
+          overrideAccess: true,
         })
         orderable2 = await payload.create({
           collection: orderableSlug,
           data: {
             title: 'Orderable 2',
           },
+          overrideAccess: true,
         })
         orderableDraft1 = await payload.create({
           collection: draftsSlug,
@@ -484,6 +520,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
             text: 'Orderable 1',
             _status: 'draft',
           },
+          overrideAccess: true,
         })
         orderableDraft2 = await payload.create({
           collection: draftsSlug,
@@ -491,6 +528,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
             text: 'Orderable 2',
             _status: 'draft',
           },
+          overrideAccess: true,
         })
       })
 
@@ -502,6 +540,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
               contains: 'Orderable ',
             },
           },
+          overrideAccess: true,
         })
 
         expect(orderable1._order).toBeDefined()
@@ -534,6 +573,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
               contains: 'Orderable ',
             },
           },
+          overrideAccess: true,
         })
 
         expect(parseInt(ordered.docs[0]._order, 36)).toBeLessThan(
@@ -568,6 +608,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
               contains: 'Orderable ',
             },
           },
+          overrideAccess: true,
         })
 
         expect(ordered.docs).toHaveLength(2)
@@ -587,6 +628,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
             text: 'Published with newer draft',
             _status: 'published',
           },
+          overrideAccess: true,
         })
 
         const target = await payload.create({
@@ -595,6 +637,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
             text: 'Reorder target',
             _status: 'published',
           },
+          overrideAccess: true,
         })
 
         // Create a newer draft on top of the published version
@@ -605,11 +648,13 @@ test.suite({ config: './config.ts' })('Sort', () => {
             text: 'Published with newer draft - edited',
           },
           draft: true,
+          overrideAccess: true,
         })
 
         const beforeReorder = await payload.findByID({
           id: publishedDoc.id,
           collection: draftsSlug,
+          overrideAccess: true,
         })
 
         expect(beforeReorder._status).toBe('published')
@@ -632,6 +677,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
         const afterReorder = await payload.findByID({
           id: publishedDoc.id,
           collection: draftsSlug,
+          overrideAccess: true,
         })
 
         // Reordering must not unpublish the document
@@ -644,6 +690,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
               equals: publishedDoc.id,
             },
           },
+          overrideAccess: true,
         })
 
         expect(published.docs).toHaveLength(1)
@@ -653,12 +700,14 @@ test.suite({ config: './config.ts' })('Sort', () => {
         const doc = await payload.create({
           collection: 'orderable',
           data: { title: 'new document' },
+          overrideAccess: true,
         })
 
         const docDuplicated = await payload.create({
           duplicateFromID: doc.id,
           collection: 'orderable',
           data: {},
+          overrideAccess: true,
         })
         expect(docDuplicated.title).toBe('new document')
         expect(parseInt(doc._order, 36)).toBeLessThan(parseInt(docDuplicated._order, 36))
@@ -676,10 +725,11 @@ test.suite({ config: './config.ts' })('Sort', () => {
           }),
         })
 
-        const docAfterReorder = await payload.findByID({ collection: 'orderable', id: doc.id })
+        const docAfterReorder = await payload.findByID({ collection: 'orderable', id: doc.id, overrideAccess: true })
         const docDuplicatedAfterReorder = await payload.findByID({
           collection: 'orderable',
           id: docDuplicated.id,
+          overrideAccess: true,
         })
         expect(parseInt(docAfterReorder._order, 36)).toBeGreaterThan(
           parseInt(docDuplicatedAfterReorder._order, 36),
@@ -695,6 +745,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
             title: 'Base62 aa',
             _order: 'aa',
           },
+          overrideAccess: true,
         })
         const aA = await payload.create({
           collection,
@@ -702,6 +753,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
             title: 'Base62 aA',
             _order: 'aA',
           },
+          overrideAccess: true,
         })
         const a0 = await payload.create({
           collection,
@@ -709,6 +761,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
             title: 'Base62 a0',
             _order: 'a0',
           },
+          overrideAccess: true,
         })
 
         const orderableDoc = await payload.create({
@@ -716,6 +769,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
           data: {
             title: 'Base62 new',
           },
+          overrideAccess: true,
         })
 
         const res = await restClient.POST('/reorder', {
@@ -741,6 +795,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
               contains: 'Base62 ',
             },
           },
+          overrideAccess: true,
         })
 
         expect(docs).toHaveLength(4)
@@ -767,6 +822,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
           collection,
           sort: '_order',
           limit: 1,
+          overrideAccess: true,
         })
         expect(allDocs).toHaveLength(1)
         const firstDoc = allDocs[0]!
@@ -774,6 +830,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
         const newDoc = await payload.create({
           collection,
           data: { title: 'Move to first test' },
+          overrideAccess: true,
         })
 
         const res = await restClient.POST('/reorder', {
@@ -791,7 +848,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
 
         expect(res.status).toStrictEqual(200)
 
-        const newDocAfter = await payload.findByID({ collection, id: newDoc.id })
+        const newDocAfter = await payload.findByID({ collection, id: newDoc.id, overrideAccess: true })
 
         expect(newDocAfter._order).toMatch(/^\d/)
         expect(parseInt(newDocAfter._order, 36)).toBeLessThan(parseInt(firstDoc._order, 36))
@@ -807,6 +864,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
           collection,
           sort: '_order',
           limit: 1,
+          overrideAccess: true,
         })
         expect(initialDocs).toHaveLength(1)
         const originalFirst = initialDocs[0]!
@@ -814,11 +872,13 @@ test.suite({ config: './config.ts' })('Sort', () => {
         const docA = await payload.create({
           collection,
           data: { title: 'Multi first A' },
+          overrideAccess: true,
         })
 
         const docB = await payload.create({
           collection,
           data: { title: 'Multi first B' },
+          overrideAccess: true,
         })
 
         await restClient.POST('/reorder', {
@@ -834,7 +894,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
           }),
         })
 
-        const docAAfter = await payload.findByID({ collection, id: docA.id })
+        const docAAfter = await payload.findByID({ collection, id: docA.id, overrideAccess: true })
         expect(docAAfter._order).toMatch(/^\d/)
 
         const res = await restClient.POST('/reorder', {
@@ -852,7 +912,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
 
         expect(res.status).toStrictEqual(200)
 
-        const docBAfter = await payload.findByID({ collection, id: docB.id })
+        const docBAfter = await payload.findByID({ collection, id: docB.id, overrideAccess: true })
 
         expect(docBAfter._order).toMatch(/^\d/)
         expect(parseInt(docBAfter._order, 36)).toBeLessThan(parseInt(docAAfter._order, 36))
@@ -868,6 +928,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
           collection,
           sort: '_order',
           limit: 2,
+          overrideAccess: true,
         })
         expect(initialDocs.length).toBeGreaterThanOrEqual(2)
         const firstDoc = initialDocs[0]!
@@ -886,7 +947,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
           }),
         })
 
-        const firstDocMoved = await payload.findByID({ collection, id: firstDoc.id })
+        const firstDocMoved = await payload.findByID({ collection, id: firstDoc.id, overrideAccess: true })
         expect(parseInt(firstDocMoved._order, 36)).toBeGreaterThan(parseInt(secondDoc._order, 36))
 
         const res = await restClient.POST('/reorder', {
@@ -904,7 +965,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
 
         expect(res.status).toStrictEqual(200)
 
-        const firstDocBack = await payload.findByID({ collection, id: firstDoc.id })
+        const firstDocBack = await payload.findByID({ collection, id: firstDoc.id, overrideAccess: true })
         expect(parseInt(firstDocBack._order, 36)).toBeLessThan(parseInt(secondDoc._order, 36))
       })
     })
@@ -921,6 +982,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
           data: {
             title: 'test',
           },
+          overrideAccess: true,
         })
         orderable1 = await payload.create({
           collection: orderableSlug,
@@ -928,6 +990,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
             title: 'test 1',
             orderableField: related.id,
           },
+          overrideAccess: true,
         })
 
         orderable2 = await payload.create({
@@ -936,6 +999,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
             title: 'test 2',
             orderableField: related.id,
           },
+          overrideAccess: true,
         })
 
         orderable3 = await payload.create({
@@ -944,6 +1008,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
             title: 'test 3',
             orderableField: related.id,
           },
+          overrideAccess: true,
         })
       })
 
@@ -961,6 +1026,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
             orderableField: related.id,
             _orderable_orderableJoinField1_order: 'e4',
           },
+          overrideAccess: true,
         })
         const orderable4 = await payload.create({
           collection: orderableSlug,
@@ -969,6 +1035,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
             orderableField: related.id,
             _orderable_orderableJoinField1_order: 'e2',
           },
+          overrideAccess: true,
         })
         expect(orderable2._orderable_orderableJoinField1_order).toBe('e4')
         expect(orderable4._orderable_orderableJoinField1_order).toBe('e2')
@@ -979,6 +1046,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
           collection: orderableJoinSlug,
           id: related.id,
           depth: 1,
+          overrideAccess: true,
         })
         const orders = (related.orderableJoinField1 as { docs: Orderable[] }).docs.map((doc) =>
           parseInt(doc._orderable_orderableJoinField1_order, 36),
@@ -996,12 +1064,14 @@ test.suite({ config: './config.ts' })('Sort', () => {
           data: {
             title: 'scoped parent',
           },
+          overrideAccess: true,
         })
         const otherParent = await payload.create({
           collection: orderableJoinSlug,
           data: {
             title: 'other parent',
           },
+          overrideAccess: true,
         })
 
         const scopedTarget = await payload.create({
@@ -1011,6 +1081,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
             orderableField: scopedParent.id,
             _orderable_orderableJoinField1_order: 'a0',
           },
+          overrideAccess: true,
         })
 
         const scopedNeighbor = await payload.create({
@@ -1020,6 +1091,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
             orderableField: scopedParent.id,
             _orderable_orderableJoinField1_order: 'a2',
           },
+          overrideAccess: true,
         })
 
         const scopedMovedDoc = await payload.create({
@@ -1029,6 +1101,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
             orderableField: scopedParent.id,
             _orderable_orderableJoinField1_order: 'a3',
           },
+          overrideAccess: true,
         })
 
         await payload.create({
@@ -1038,6 +1111,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
             orderableField: otherParent.id,
             _orderable_orderableJoinField1_order: 'a1',
           },
+          overrideAccess: true,
         })
 
         const reorderResponse = await restClient.POST('/reorder', {
@@ -1062,6 +1136,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
         const scopedMovedDocAfter = await payload.findByID({
           collection: orderableSlug,
           id: scopedMovedDoc.id,
+          overrideAccess: true,
         })
 
         expect(scopedMovedDocAfter._orderable_orderableJoinField1_order).toBe('a1')
@@ -1084,6 +1159,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
           data: {
             title: 'localized parent en',
           },
+          overrideAccess: true,
         })
 
         const nbParent = await payload.create({
@@ -1091,6 +1167,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
           data: {
             title: 'localized parent nb',
           },
+          overrideAccess: true,
         })
 
         const otherNbParent = await payload.create({
@@ -1098,6 +1175,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
           data: {
             title: 'localized parent other nb',
           },
+          overrideAccess: true,
         })
 
         const localizedTarget = await payload.create({
@@ -1108,6 +1186,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
             orderableField: enParent.id,
             _orderable_orderableJoinField1_order: 'a0',
           },
+          overrideAccess: true,
         })
 
         await payload.update({
@@ -1117,6 +1196,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
           data: {
             orderableField: nbParent.id,
           },
+          overrideAccess: true,
         })
 
         const localizedNeighbor = await payload.create({
@@ -1127,6 +1207,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
             orderableField: enParent.id,
             _orderable_orderableJoinField1_order: 'a2',
           },
+          overrideAccess: true,
         })
 
         await payload.update({
@@ -1136,6 +1217,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
           data: {
             orderableField: nbParent.id,
           },
+          overrideAccess: true,
         })
 
         const localizedMovedDoc = await payload.create({
@@ -1146,6 +1228,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
             orderableField: enParent.id,
             _orderable_orderableJoinField1_order: 'a3',
           },
+          overrideAccess: true,
         })
 
         await payload.update({
@@ -1155,6 +1238,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
           data: {
             orderableField: nbParent.id,
           },
+          overrideAccess: true,
         })
 
         // This doc only pollutes the EN scope with `a1`.
@@ -1166,6 +1250,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
             orderableField: enParent.id,
             _orderable_orderableJoinField1_order: 'a1',
           },
+          overrideAccess: true,
         })
 
         await payload.update({
@@ -1175,6 +1260,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
             orderableField: otherNbParent.id,
           },
           locale: 'nb',
+          overrideAccess: true,
         })
 
         // Simulate "without req locale context": endpoint defaults to EN scope.
@@ -1203,6 +1289,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
           data: {
             _orderable_orderableJoinField1_order: 'a3',
           },
+          overrideAccess: true,
         })
 
         await payload.update({
@@ -1212,6 +1299,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
             orderableField: nbParent.id,
           },
           locale: 'nb',
+          overrideAccess: true,
         })
 
         // With locale in request context, scope is NB and result should be deterministic.
@@ -1236,6 +1324,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
         const localizedMovedDocAfter = await payload.findByID({
           collection: orderableSlug,
           id: localizedMovedDoc.id,
+          overrideAccess: true,
         })
 
         expect(localizedMovedDocAfter._orderable_orderableJoinField1_order).toBe('a1')
@@ -1404,6 +1493,6 @@ async function createData(
   data: Record<string, any>[],
 ) {
   for (const item of data) {
-    await payload.create({ collection, data: item })
+    await payload.create({ collection, data: item, overrideAccess: true })
   }
 }

--- a/test/sort/seed.ts
+++ b/test/sort/seed.ts
@@ -1,14 +1,18 @@
 import type { Payload } from 'payload'
 
-import { devUser } from '../credentials.js'
 import { executePromises } from '../__helpers/shared/executePromises.js'
+import { devUser } from '../credentials.js'
 import { nonUniqueSortSlug } from './collections/NonUniqueSort/index.js'
 
 export async function seedSortable(payload: Payload) {
-  await payload.delete({ collection: 'orderable', where: {} })
-  await payload.delete({ collection: 'orderable-join', where: {} })
+  await payload.delete({ collection: 'orderable', where: {}, overrideAccess: true })
+  await payload.delete({ collection: 'orderable-join', where: {}, overrideAccess: true })
 
-  const joinA = await payload.create({ collection: 'orderable-join', data: { title: 'Join A' } })
+  const joinA = await payload.create({
+    collection: 'orderable-join',
+    data: { title: 'Join A' },
+    overrideAccess: true,
+  })
 
   await executePromises(
     [
@@ -21,11 +25,16 @@ export async function seedSortable(payload: Payload) {
         payload.create({
           collection: 'orderable',
           data,
+          overrideAccess: true,
         }),
     ),
   )
 
-  await payload.create({ collection: 'orderable-join', data: { title: 'Join B' } })
+  await payload.create({
+    collection: 'orderable-join',
+    data: { title: 'Join B' },
+    overrideAccess: true,
+  })
 
   // Create 10 items to be sorted by non-unique field
   for (const i of Array.from({ length: 10 }, (_, index) => index)) {
@@ -44,6 +53,7 @@ export async function seedSortable(payload: Payload) {
         title: `Post ${i}`,
         order,
       },
+      overrideAccess: true,
     })
   }
 

--- a/test/storage-azure/client-uploads/config.ts
+++ b/test/storage-azure/client-uploads/config.ts
@@ -72,6 +72,7 @@ export default buildConfigWithDefaults({
         email: devUser.email,
         password: devUser.password,
       },
+      overrideAccess: true,
     })
   },
 })

--- a/test/storage-azure/client-uploads/int.spec.ts
+++ b/test/storage-azure/client-uploads/int.spec.ts
@@ -140,7 +140,7 @@ test.suite({ config: './config.ts' })('@payloadcms/storage-azure clientUploads',
 
     expect(blobKey).toBe('duplicate-target-1.png')
 
-    await payload.delete({ id: seedDoc.id, collection: mediaSlug })
+    await payload.delete({ id: seedDoc.id, collection: mediaSlug, overrideAccess: true })
   })
 
   test('preserves a user-defined prefix.defaultValue across the plugin', async ({ payload }) => {
@@ -148,6 +148,7 @@ test.suite({ config: './config.ts' })('@payloadcms/storage-azure clientUploads',
       collection: mediaWithDocPrefixSlug,
       data: {},
       filePath: path.resolve(dirname, '../../uploads/image.png'),
+      overrideAccess: true,
     })
 
     expect(upload.prefix).toMatch(/^doc-[a-z0-9]{1,8}$/)
@@ -176,7 +177,7 @@ test.suite({ config: './config.ts' })('@payloadcms/storage-azure clientUploads',
 
     test.afterEach(async ({ payload }) => {
       for (const id of createdIds) {
-        await payload.delete({ id, collection: mediaHeaderOnlySlug })
+        await payload.delete({ id, collection: mediaHeaderOnlySlug, overrideAccess: true })
       }
       createdIds.length = 0
     })
@@ -269,7 +270,7 @@ test.suite({ config: './config.ts' })('@payloadcms/storage-azure clientUploads',
 
     test.afterEach(async ({ payload }) => {
       for (const id of createdIds) {
-        await payload.delete({ id, collection: mediaHeaderOnlyWithSizesSlug })
+        await payload.delete({ id, collection: mediaHeaderOnlyWithSizesSlug, overrideAccess: true })
       }
       createdIds.length = 0
     })

--- a/test/storage-azure/config.ts
+++ b/test/storage-azure/config.ts
@@ -56,6 +56,7 @@ export default buildConfigWithDefaults({
         email: devUser.email,
         password: devUser.password,
       },
+      overrideAccess: true,
     })
   },
 })

--- a/test/storage-azure/int.spec.ts
+++ b/test/storage-azure/int.spec.ts
@@ -58,6 +58,7 @@ test.suite({ config: './config.ts' })('@payloadcms/storage-azure', () => {
       collection: mediaSlug,
       data: {},
       filePath: path.resolve(dirname, '../uploads/image.png'),
+      overrideAccess: true,
     })
 
     expect(upload.id).toBeTruthy()
@@ -70,6 +71,7 @@ test.suite({ config: './config.ts' })('@payloadcms/storage-azure', () => {
       collection: mediaWithPrefixSlug,
       data: {},
       filePath: path.resolve(dirname, '../uploads/image.png'),
+      overrideAccess: true,
     })
 
     expect(upload.id).toBeTruthy()
@@ -106,6 +108,7 @@ test.suite({ config: './config.ts' })('@payloadcms/storage-azure', () => {
     const uploadData = (await payload.findByID({
       collection: collectionSlug,
       id: uploadId,
+      overrideAccess: true,
     })) as unknown as { filename: string; sizes: Record<string, { filename: string }> }
 
     const fileKeys = Object.values(uploadData.sizes || {}).map(({ filename: rawFilename }) =>

--- a/test/storage-azure/streamingUploads.config.ts
+++ b/test/storage-azure/streamingUploads.config.ts
@@ -56,6 +56,7 @@ export default buildConfigWithDefaults({
         email: devUser.email,
         password: devUser.password,
       },
+      overrideAccess: true,
     })
   },
 })

--- a/test/storage-azure/streamingUploads.int.spec.ts
+++ b/test/storage-azure/streamingUploads.int.spec.ts
@@ -52,6 +52,7 @@ test.suite({ config: './config.ts' })('@payloadcms/storage-azure streamingUpload
       collection: mediaSlug,
       data: {},
       filePath: path.resolve(dirname, '../uploads/image.png'),
+      overrideAccess: true,
     })
 
     expect(upload.id).toBeTruthy()
@@ -64,6 +65,7 @@ test.suite({ config: './config.ts' })('@payloadcms/storage-azure streamingUpload
       collection: mediaWithPrefixSlug,
       data: {},
       filePath: path.resolve(dirname, '../uploads/image.png'),
+      overrideAccess: true,
     })
 
     expect(upload.id).toBeTruthy()
@@ -106,6 +108,7 @@ test.suite({ config: './config.ts' })('@payloadcms/storage-azure streamingUpload
     const uploadData = (await payload.findByID({
       collection: collectionSlug,
       id: uploadId,
+      overrideAccess: true,
     })) as unknown as { filename: string; sizes: Record<string, { filename: string }> }
 
     const fileKeys = Object.keys(uploadData.sizes || {}).map((key) => {

--- a/test/storage-gcs/config.ts
+++ b/test/storage-gcs/config.ts
@@ -55,6 +55,7 @@ export default buildConfigWithDefaults({
         email: devUser.email,
         password: devUser.password,
       },
+      overrideAccess: true,
     })
   },
 })

--- a/test/storage-r2/config.ts
+++ b/test/storage-r2/config.ts
@@ -67,6 +67,7 @@ export default buildConfigWithDefaults({
         email: devUser.email,
         password: devUser.password,
       },
+      overrideAccess: true,
     })
   },
 })

--- a/test/storage-s3/client-uploads/config.ts
+++ b/test/storage-s3/client-uploads/config.ts
@@ -82,6 +82,7 @@ export default buildConfigWithDefaults({
         email: devUser.email,
         password: devUser.password,
       },
+      overrideAccess: true,
     })
   },
 })

--- a/test/storage-s3/client-uploads/int.spec.ts
+++ b/test/storage-s3/client-uploads/int.spec.ts
@@ -287,7 +287,7 @@ test.suite({ config: './config.ts' })('@payloadcms/storage-s3 clientUploads', ()
 
     test.afterEach(async ({ payload }) => {
       for (const id of createdIds) {
-        await payload.delete({ id, collection: mediaHeaderOnlySlug })
+        await payload.delete({ id, collection: mediaHeaderOnlySlug, overrideAccess: true })
       }
       createdIds.length = 0
     })
@@ -344,7 +344,7 @@ test.suite({ config: './config.ts' })('@payloadcms/storage-s3 clientUploads', ()
 
     test.afterEach(async ({ payload }) => {
       for (const id of createdIds) {
-        await payload.delete({ id, collection: mediaHeaderOnlyWithSizesSlug })
+        await payload.delete({ id, collection: mediaHeaderOnlyWithSizesSlug, overrideAccess: true })
       }
       createdIds.length = 0
     })

--- a/test/storage-s3/config.ts
+++ b/test/storage-s3/config.ts
@@ -113,6 +113,7 @@ export default buildConfigWithDefaults({
         email: devUser.email,
         password: devUser.password,
       },
+      overrideAccess: true,
     })
   },
 })

--- a/test/storage-s3/int.spec.ts
+++ b/test/storage-s3/int.spec.ts
@@ -36,6 +36,7 @@ test.suite({ config: './config.ts' })('@payloadcms/storage-s3', () => {
       collection: mediaSlug,
       data: {},
       filePath: path.resolve(dirname, '../uploads/image.png'),
+      overrideAccess: true,
     })
 
     expect(upload.id).toBeTruthy()
@@ -54,6 +55,7 @@ test.suite({ config: './config.ts' })('@payloadcms/storage-s3', () => {
       collection: mediaWithPrefixSlug,
       data: {},
       filePath: path.resolve(dirname, '../uploads/image.png'),
+      overrideAccess: true,
     })
 
     expect(upload.id).toBeTruthy()
@@ -80,6 +82,7 @@ test.suite({ config: './config.ts' })('@payloadcms/storage-s3', () => {
         prefix: 'test',
       },
       filePath: path.resolve(dirname, '../uploads/image.png'),
+      overrideAccess: true,
     })
 
     expect(upload.id).toBeTruthy()
@@ -92,6 +95,7 @@ test.suite({ config: './config.ts' })('@payloadcms/storage-s3', () => {
       collection: mediaWithSignedDownloadsSlug,
       data: {},
       filePath: path.resolve(dirname, '../uploads/image.png'),
+      overrideAccess: true,
     })
 
     const response = await restClient.GET(`/${mediaWithSignedDownloadsSlug}/file/image.png`)
@@ -109,6 +113,7 @@ test.suite({ config: './config.ts' })('@payloadcms/storage-s3', () => {
       collection: mediaWithSignedDownloadsSlug,
       data: {},
       filePath: path.resolve(dirname, '../uploads/small.png'),
+      overrideAccess: true,
     })
 
     const response = await restClient.GET(`/${mediaWithSignedDownloadsSlug}/file/small.png`, {
@@ -131,6 +136,7 @@ test.suite({ config: './config.ts' })('@payloadcms/storage-s3', () => {
       collection: mediaWithSignedDownloadsSlug,
       data: {},
       filePath: path.resolve(dirname, '../uploads/temp.png'),
+      overrideAccess: true,
     })
 
     const response = await restClient.GET(`/${mediaWithSignedDownloadsSlug}/file/temp.png`, {
@@ -164,6 +170,7 @@ test.suite({ config: './config.ts' })('@payloadcms/storage-s3', () => {
         collection: mediaWithDirectAccessSlug,
         data: {},
         filePath: path.resolve(dirname, '../uploads/image with spaces.png'),
+        overrideAccess: true,
       })
 
       expect(upload.id).toBeTruthy()
@@ -206,6 +213,7 @@ test.suite({ config: './config.ts' })('@payloadcms/storage-s3', () => {
         collection: mediaWithDirectAccessSlug,
         data: {},
         filePath: path.resolve(dirname, '../uploads/image.png'),
+        overrideAccess: true,
       })
 
       expect(upload.id).toBeTruthy()
@@ -229,7 +237,11 @@ test.suite({ config: './config.ts' })('@payloadcms/storage-s3', () => {
       expect(dbDoc.sizes.thumbnail.url).toContain(getTestBucketName())
       expect(dbDoc.sizes.thumbnail.url).not.toMatch(/^\/api\//)
 
-      await payload.delete({ collection: mediaWithDirectAccessSlug, id: upload.id })
+      await payload.delete({
+        collection: mediaWithDirectAccessSlug,
+        id: upload.id,
+        overrideAccess: true,
+      })
     })
 
     test('should return direct S3 URL without encoding issues for normal filenames', async ({
@@ -239,6 +251,7 @@ test.suite({ config: './config.ts' })('@payloadcms/storage-s3', () => {
         collection: mediaWithDirectAccessSlug,
         data: {},
         filePath: path.resolve(dirname, '../uploads/image.png'),
+        overrideAccess: true,
       })
 
       expect(upload.id).toBeTruthy()
@@ -285,14 +298,17 @@ test.suite({ config: './config.ts' })('@payloadcms/storage-s3', () => {
       await payload.delete({
         collection: mediaWithPrefixSlug,
         where: {},
+        overrideAccess: true,
       })
       await payload.delete({
         collection: mediaSlug,
         where: {},
+        overrideAccess: true,
       })
       await payload.delete({
         collection: mediaWithAlwaysInsertFieldsSlug,
         where: {},
+        overrideAccess: true,
       })
     })
 
@@ -304,12 +320,14 @@ test.suite({ config: './config.ts' })('@payloadcms/storage-s3', () => {
         collection: mediaWithPrefixSlug,
         data: {},
         filePath: imageFile,
+        overrideAccess: true,
       })
 
       const upload2 = await payload.create({
         collection: mediaWithPrefixSlug,
         data: {},
         filePath: imageFile,
+        overrideAccess: true,
       })
 
       expect(upload1.filename).toBe('image.png')
@@ -326,12 +344,14 @@ test.suite({ config: './config.ts' })('@payloadcms/storage-s3', () => {
         collection: mediaSlug,
         data: {},
         filePath: imageFile,
+        overrideAccess: true,
       })
 
       const upload2 = await payload.create({
         collection: mediaSlug,
         data: {},
         filePath: imageFile,
+        overrideAccess: true,
       })
 
       expect(upload1.filename).toBe('image.png')
@@ -350,6 +370,7 @@ test.suite({ config: './config.ts' })('@payloadcms/storage-s3', () => {
         collection: mediaWithPrefixSlug,
         data: {},
         filePath: imageFile,
+        overrideAccess: true,
       })
 
       // Upload with different prefix
@@ -359,6 +380,7 @@ test.suite({ config: './config.ts' })('@payloadcms/storage-s3', () => {
           prefix: 'different-prefix',
         },
         filePath: imageFile,
+        overrideAccess: true,
       })
 
       expect(upload1.filename).toBe('image.png')
@@ -375,6 +397,7 @@ test.suite({ config: './config.ts' })('@payloadcms/storage-s3', () => {
         collection: mediaWithDynamicPrefixSlug,
         data: { tenant: 'a' },
         filePath: imageFile,
+        overrideAccess: true,
       })
 
       // Tenant B uploads logo.png
@@ -382,6 +405,7 @@ test.suite({ config: './config.ts' })('@payloadcms/storage-s3', () => {
         collection: mediaWithDynamicPrefixSlug,
         data: { tenant: 'b' },
         filePath: imageFile,
+        overrideAccess: true,
       })
 
       // Both should keep original filename

--- a/test/storage-s3/searchBeforeS3.config.ts
+++ b/test/storage-s3/searchBeforeS3.config.ts
@@ -65,6 +65,7 @@ export default buildConfigWithDefaults({
         email: devUser.email,
         password: devUser.password,
       },
+      overrideAccess: true,
     })
   },
 })

--- a/test/storage-s3/searchBeforeS3.int.spec.ts
+++ b/test/storage-s3/searchBeforeS3.int.spec.ts
@@ -28,12 +28,14 @@ test.suite({ config: './searchBeforeS3.config.ts' })(
       await payload.delete({
         collection: mediaSlug,
         where: { id: { exists: true } },
+        overrideAccess: true,
       })
       // Only delete from search if the collection exists
       if (payload.collections['search']) {
         await payload.delete({
           collection: 'search',
           where: { id: { exists: true } },
+          overrideAccess: true,
         })
       }
       await clearTestBucket()
@@ -56,6 +58,7 @@ test.suite({ config: './searchBeforeS3.config.ts' })(
         collection: mediaSlug,
         data: {},
         filePath: path.resolve(dirname, '../uploads/image.png'),
+        overrideAccess: true,
       })
 
       expect(upload.id).toBeTruthy()
@@ -73,6 +76,7 @@ test.suite({ config: './searchBeforeS3.config.ts' })(
         collection: mediaSlug,
         data: {},
         filePath: path.resolve(dirname, '../uploads/image.png'),
+        overrideAccess: true,
       })
 
       const { docs: searchDocs } = await payload.find({
@@ -81,6 +85,7 @@ test.suite({ config: './searchBeforeS3.config.ts' })(
           'doc.value': { equals: upload.id },
           'doc.relationTo': { equals: mediaSlug },
         },
+        overrideAccess: true,
       })
 
       expect(searchDocs.length).toBe(1)

--- a/test/storage-s3/test-utils.ts
+++ b/test/storage-s3/test-utils.ts
@@ -68,6 +68,7 @@ export async function verifyUploads({
   const uploadData = (await payload.findByID({
     collection: collectionSlug as CollectionSlug,
     id: uploadId,
+    overrideAccess: true,
   })) as unknown as { filename: string; sizes: Record<string, { filename: string }> }
 
   const fileKeys = Object.keys(uploadData.sizes || {}).map((key) => {

--- a/test/storage-vercel-blob/client-uploads/compositePrefixes.int.spec.ts
+++ b/test/storage-vercel-blob/client-uploads/compositePrefixes.int.spec.ts
@@ -24,6 +24,7 @@ test.suite({ config: './config.compositePrefixes.ts' })(
         await payload.delete({
           id,
           collection: mediaWithCompositePrefixesSlug,
+          overrideAccess: true,
         })
       }
 

--- a/test/storage-vercel-blob/client-uploads/config.compositePrefixes.ts
+++ b/test/storage-vercel-blob/client-uploads/config.compositePrefixes.ts
@@ -53,6 +53,7 @@ export default buildConfigWithDefaults({
         email: devUser.email,
         password: devUser.password,
       },
+      overrideAccess: true,
     })
   },
 })

--- a/test/storage-vercel-blob/client-uploads/config.ts
+++ b/test/storage-vercel-blob/client-uploads/config.ts
@@ -52,6 +52,7 @@ export default buildConfigWithDefaults({
         email: devUser.email,
         password: devUser.password,
       },
+      overrideAccess: true,
     })
   },
 })

--- a/test/storage-vercel-blob/config.ts
+++ b/test/storage-vercel-blob/config.ts
@@ -85,6 +85,7 @@ export default buildConfigWithDefaults({
         email: devUser.email,
         password: devUser.password,
       },
+      overrideAccess: true,
     })
   },
 })

--- a/test/storage-vercel-blob/int.spec.ts
+++ b/test/storage-vercel-blob/int.spec.ts
@@ -27,11 +27,15 @@ test.suite({ config: './config.ts' })('@payloadcms/storage-vercel-blob', () => {
   test.afterEach(async ({ payload }) => {
     await clearTestBlobs()
     await Promise.all([
-      payload.delete({ collection: mediaSlug, where: {} }),
-      payload.delete({ collection: mediaWithPrefixSlug, where: {} }),
-      payload.delete({ collection: mediaWithAlwaysInsertFieldsSlug, where: {} }),
-      payload.delete({ collection: mediaWithDirectAccessSlug, where: {} }),
-      payload.delete({ collection: mediaWithDynamicPrefixSlug, where: {} }),
+      payload.delete({ collection: mediaSlug, where: {}, overrideAccess: true }),
+      payload.delete({ collection: mediaWithPrefixSlug, where: {}, overrideAccess: true }),
+      payload.delete({
+        collection: mediaWithAlwaysInsertFieldsSlug,
+        where: {},
+        overrideAccess: true,
+      }),
+      payload.delete({ collection: mediaWithDirectAccessSlug, where: {}, overrideAccess: true }),
+      payload.delete({ collection: mediaWithDynamicPrefixSlug, where: {}, overrideAccess: true }),
     ])
   })
 
@@ -40,6 +44,7 @@ test.suite({ config: './config.ts' })('@payloadcms/storage-vercel-blob', () => {
       collection: mediaSlug,
       data: {},
       filePath: path.resolve(dirname, '../uploads/image.png'),
+      overrideAccess: true,
     })
 
     expect(upload.id).toBeTruthy()
@@ -58,6 +63,7 @@ test.suite({ config: './config.ts' })('@payloadcms/storage-vercel-blob', () => {
       collection: mediaWithPrefixSlug,
       data: {},
       filePath: path.resolve(dirname, '../uploads/image.png'),
+      overrideAccess: true,
     })
 
     expect(upload.id).toBeTruthy()
@@ -83,6 +89,7 @@ test.suite({ config: './config.ts' })('@payloadcms/storage-vercel-blob', () => {
         prefix: 'test',
       },
       filePath: path.resolve(dirname, '../uploads/image.png'),
+      overrideAccess: true,
     })
 
     expect(upload.id).toBeTruthy()
@@ -102,6 +109,7 @@ test.suite({ config: './config.ts' })('@payloadcms/storage-vercel-blob', () => {
       collection: mediaSlug,
       data: {},
       filePath: path.resolve(dirname, '../uploads/image.png'),
+      overrideAccess: true,
     })
 
     const response = await restClient.GET(`/${mediaSlug}/file/image.png`)
@@ -117,6 +125,7 @@ test.suite({ config: './config.ts' })('@payloadcms/storage-vercel-blob', () => {
       collection: mediaSlug,
       data: {},
       filePath: path.resolve(dirname, '../uploads/image.png'),
+      overrideAccess: true,
     })
 
     const first = await restClient.GET(`/${mediaSlug}/file/image.png`)
@@ -137,6 +146,7 @@ test.suite({ config: './config.ts' })('@payloadcms/storage-vercel-blob', () => {
         collection: mediaWithDirectAccessSlug,
         data: {},
         filePath: path.resolve(dirname, '../uploads/image.png'),
+        overrideAccess: true,
       })
 
       expect(upload.id).toBeTruthy()
@@ -154,6 +164,7 @@ test.suite({ config: './config.ts' })('@payloadcms/storage-vercel-blob', () => {
         collection: mediaWithDirectAccessSlug,
         data: {},
         filePath: path.resolve(dirname, '../uploads/image.png'),
+        overrideAccess: true,
       })
 
       expect(upload.sizes?.thumbnail?.url).toContain(process.env.STORAGE_VERCEL_BLOB_BASE_URL)
@@ -175,6 +186,7 @@ test.suite({ config: './config.ts' })('@payloadcms/storage-vercel-blob', () => {
         collection: mediaWithDirectAccessSlug,
         data: {},
         filePath: path.resolve(dirname, '../uploads/image with spaces.png'),
+        overrideAccess: true,
       })
 
       expect(upload.id).toBeTruthy()
@@ -190,9 +202,13 @@ test.suite({ config: './config.ts' })('@payloadcms/storage-vercel-blob', () => {
   test.describe('prefix collision detection', () => {
     test.beforeEach(async ({ payload }) => {
       await clearTestBlobs()
-      await payload.delete({ collection: mediaWithPrefixSlug, where: {} })
-      await payload.delete({ collection: mediaSlug, where: {} })
-      await payload.delete({ collection: mediaWithAlwaysInsertFieldsSlug, where: {} })
+      await payload.delete({ collection: mediaWithPrefixSlug, where: {}, overrideAccess: true })
+      await payload.delete({ collection: mediaSlug, where: {}, overrideAccess: true })
+      await payload.delete({
+        collection: mediaWithAlwaysInsertFieldsSlug,
+        where: {},
+        overrideAccess: true,
+      })
     })
 
     test('detects collision within same prefix', async ({ payload }) => {
@@ -202,12 +218,14 @@ test.suite({ config: './config.ts' })('@payloadcms/storage-vercel-blob', () => {
         collection: mediaWithPrefixSlug,
         data: {},
         filePath: imageFile,
+        overrideAccess: true,
       })
 
       const upload2 = await payload.create({
         collection: mediaWithPrefixSlug,
         data: {},
         filePath: imageFile,
+        overrideAccess: true,
       })
 
       expect(upload1.filename).toBe('image.png')
@@ -223,12 +241,14 @@ test.suite({ config: './config.ts' })('@payloadcms/storage-vercel-blob', () => {
         collection: mediaSlug,
         data: {},
         filePath: imageFile,
+        overrideAccess: true,
       })
 
       const upload2 = await payload.create({
         collection: mediaSlug,
         data: {},
         filePath: imageFile,
+        overrideAccess: true,
       })
 
       expect(upload1.filename).toBe('image.png')
@@ -246,12 +266,14 @@ test.suite({ config: './config.ts' })('@payloadcms/storage-vercel-blob', () => {
         collection: mediaWithPrefixSlug,
         data: {},
         filePath: imageFile,
+        overrideAccess: true,
       })
 
       const upload2 = await payload.create({
         collection: mediaWithPrefixSlug,
         data: { prefix: 'different-prefix' },
         filePath: imageFile,
+        overrideAccess: true,
       })
 
       expect(upload1.filename).toBe('image.png')
@@ -267,12 +289,14 @@ test.suite({ config: './config.ts' })('@payloadcms/storage-vercel-blob', () => {
         collection: mediaWithDynamicPrefixSlug,
         data: { tenant: 'a' },
         filePath: imageFile,
+        overrideAccess: true,
       })
 
       const tenantBUpload = await payload.create({
         collection: mediaWithDynamicPrefixSlug,
         data: { tenant: 'b' },
         filePath: imageFile,
+        overrideAccess: true,
       })
 
       expect(tenantAUpload.filename).toBe('image.png')

--- a/test/storage-vercel-blob/test-utils.ts
+++ b/test/storage-vercel-blob/test-utils.ts
@@ -25,6 +25,7 @@ export async function verifyUploads({
   const uploadData = (await payload.findByID({
     collection: collectionSlug as CollectionSlug,
     id: uploadId,
+    overrideAccess: true,
   })) as unknown as { filename: string; sizes: Record<string, { filename: string }> }
 
   const { blobs } = await list()

--- a/test/tags/config.ts
+++ b/test/tags/config.ts
@@ -160,6 +160,7 @@ export default buildConfigWithDefaults({
         email: devUser.email,
         password: devUser.password,
       },
+      overrideAccess: true,
     })
 
     try {

--- a/test/tags/e2e.spec.ts
+++ b/test/tags/e2e.spec.ts
@@ -68,7 +68,11 @@ test.describe('Tags', () => {
         data[`_h_${tagsSlug}`] = parentId
       }
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- hierarchy `_h_*` field is not in the generated type
-      const doc = await payload.create({ collection: tagsSlug, data: data as any })
+      const doc = await payload.create({
+        collection: tagsSlug,
+        data: data as any,
+        overrideAccess: true,
+      })
       created.push(doc)
       createdTagIds.push(doc.id)
       parentId = doc.id
@@ -94,6 +98,7 @@ test.describe('Tags', () => {
     const { docs } = await payload.find({
       collection: tagsSlug,
       where: { name: { equals: name } },
+      overrideAccess: true,
     })
     const createdTag = docs[0] as Tag
     createdTagIds.push(createdTag.id)
@@ -116,7 +121,7 @@ test.describe('Tags', () => {
 
   test.afterAll(async () => {
     for (const id of createdTagIds) {
-      await payload.delete({ id, collection: tagsSlug })
+      await payload.delete({ id, collection: tagsSlug, overrideAccess: true })
     }
   })
 

--- a/test/tags/seed.ts
+++ b/test/tags/seed.ts
@@ -14,94 +14,112 @@ export const seed = async (payload: Payload): Promise<void> => {
   const seasons = await payload.create({
     collection: tagsSlug as any,
     data: { name: 'Seasons', description: 'Seasonal recipes' } as any,
+    overrideAccess: true,
   })
 
   const spring = await payload.create({
     collection: tagsSlug as any,
     data: { name: 'Spring', [`_h_${tagsSlug}`]: seasons.id } as any,
+    overrideAccess: true,
   })
 
   const summer = await payload.create({
     collection: tagsSlug as any,
     data: { name: 'Summer', [`_h_${tagsSlug}`]: seasons.id } as any,
+    overrideAccess: true,
   })
 
   const fall = await payload.create({
     collection: tagsSlug as any,
     data: { name: 'Fall', [`_h_${tagsSlug}`]: seasons.id } as any,
+    overrideAccess: true,
   })
 
   const winter = await payload.create({
     collection: tagsSlug as any,
     data: { name: 'Winter', [`_h_${tagsSlug}`]: seasons.id } as any,
+    overrideAccess: true,
   })
 
   // Cuisines
   const cuisines = await payload.create({
     collection: tagsSlug as any,
     data: { name: 'Cuisines', description: 'World cuisines' } as any,
+    overrideAccess: true,
   })
 
   const italian = await payload.create({
     collection: tagsSlug as any,
     data: { name: 'Italian', [`_h_${tagsSlug}`]: cuisines.id } as any,
+    overrideAccess: true,
   })
 
   const mexican = await payload.create({
     collection: tagsSlug as any,
     data: { name: 'Mexican', [`_h_${tagsSlug}`]: cuisines.id } as any,
+    overrideAccess: true,
   })
 
   const asian = await payload.create({
     collection: tagsSlug as any,
     data: { name: 'Asian', [`_h_${tagsSlug}`]: cuisines.id } as any,
+    overrideAccess: true,
   })
 
   const american = await payload.create({
     collection: tagsSlug as any,
     data: { name: 'American', [`_h_${tagsSlug}`]: cuisines.id } as any,
+    overrideAccess: true,
   })
 
   // Meal Type
   const mealType = await payload.create({
     collection: tagsSlug as any,
     data: { name: 'Meal Type', description: 'Type of meal' } as any,
+    overrideAccess: true,
   })
 
   const breakfast = await payload.create({
     collection: tagsSlug as any,
     data: { name: 'Breakfast', [`_h_${tagsSlug}`]: mealType.id } as any,
+    overrideAccess: true,
   })
 
   const lunch = await payload.create({
     collection: tagsSlug as any,
     data: { name: 'Lunch', [`_h_${tagsSlug}`]: mealType.id } as any,
+    overrideAccess: true,
   })
 
   const dinner = await payload.create({
     collection: tagsSlug as any,
     data: { name: 'Dinner', [`_h_${tagsSlug}`]: mealType.id } as any,
+    overrideAccess: true,
   })
 
   const dessert = await payload.create({
     collection: tagsSlug as any,
     data: { name: 'Dessert', [`_h_${tagsSlug}`]: mealType.id } as any,
+    overrideAccess: true,
   })
 
   // Years
   const years = await payload.create({
     collection: tagsSlug as any,
     data: { name: 'Years', description: 'Recipe archive by year' } as any,
+    overrideAccess: true,
   })
 
   const year2023 = await payload.create({
     collection: tagsSlug as any,
     data: { name: '2023', [`_h_${tagsSlug}`]: years.id } as any,
+    overrideAccess: true,
   })
 
   const year2024 = await payload.create({
     collection: tagsSlug as any,
     data: { name: '2024', [`_h_${tagsSlug}`]: years.id } as any,
+    overrideAccess: true,
   })
 
   // Load image file for media uploads
@@ -117,6 +135,7 @@ export const seed = async (payload: Payload): Promise<void> => {
         'Nothing beats a warm bowl of risotto on a crisp autumn evening. This classic recipe uses arborio rice, white wine, and freshly grated parmesan.',
       title: 'Creamy Mushroom Risotto',
     } as any,
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -127,6 +146,7 @@ export const seed = async (payload: Payload): Promise<void> => {
         'Fire up the grill for these smoky carne asada tacos. Marinated flank steak with fresh pico de gallo and homemade guacamole.',
       title: 'Grilled Carne Asada Tacos',
     } as any,
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -137,6 +157,7 @@ export const seed = async (payload: Payload): Promise<void> => {
         'A light and refreshing poke bowl with sushi-grade tuna, edamame, cucumber, and a sesame ginger dressing.',
       title: 'Fresh Tuna Poke Bowl',
     } as any,
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -147,6 +168,7 @@ export const seed = async (payload: Payload): Promise<void> => {
         'Fluffy buttermilk pancakes stacked high with maple syrup, fresh berries, and a pat of butter. The ultimate weekend breakfast.',
       title: 'Classic Buttermilk Pancakes',
     } as any,
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -157,6 +179,7 @@ export const seed = async (payload: Payload): Promise<void> => {
         'Layers of espresso-soaked ladyfingers and mascarpone cream. This no-bake Italian classic is perfect for entertaining.',
       title: 'Traditional Tiramisu',
     } as any,
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -167,6 +190,7 @@ export const seed = async (payload: Payload): Promise<void> => {
         'Juicy smash burgers with crispy edges, melted cheese, and all the fixings. Better than any restaurant.',
       title: 'Ultimate Smash Burgers',
     } as any,
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -177,6 +201,7 @@ export const seed = async (payload: Payload): Promise<void> => {
         'Rich and comforting tonkotsu ramen with a silky pork broth, soft-boiled egg, and hand-pulled noodles.',
       title: 'Homemade Tonkotsu Ramen',
     } as any,
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -187,6 +212,7 @@ export const seed = async (payload: Payload): Promise<void> => {
         'Crispy tortillas topped with fried eggs, black beans, salsa verde, and crumbled queso fresco.',
       title: 'Huevos Rancheros',
     } as any,
+    overrideAccess: true,
   })
 
   // Pages (guides and about)
@@ -198,6 +224,7 @@ export const seed = async (payload: Payload): Promise<void> => {
         'Everything you need to know about Italian cooking: essential ingredients, techniques, and regional specialties.',
       title: 'Guide to Italian Cuisine',
     } as any,
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -208,6 +235,7 @@ export const seed = async (payload: Payload): Promise<void> => {
         'Our favorite recipes for hot summer days: refreshing salads, grilled favorites, and frozen treats.',
       title: 'Summer Cooking Collection',
     } as any,
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -218,6 +246,7 @@ export const seed = async (payload: Payload): Promise<void> => {
         'Start your day right with our curated breakfast recipes from quick weekday options to lazy weekend brunch.',
       title: 'Breakfast Ideas',
     } as any,
+    overrideAccess: true,
   })
 
   // Media items (food photos)
@@ -225,36 +254,42 @@ export const seed = async (payload: Payload): Promise<void> => {
     collection: mediaSlug as any,
     data: { [`_h_${tagsSlug}`]: [italian.id, dinner.id] } as any,
     file: { ...imageFile, name: 'mushroom-risotto.png' } as any,
+    overrideAccess: true,
   })
 
   await payload.create({
     collection: mediaSlug as any,
     data: { [`_h_${tagsSlug}`]: [mexican.id, summer.id] } as any,
     file: { ...imageFile, name: 'carne-asada-tacos.png' } as any,
+    overrideAccess: true,
   })
 
   await payload.create({
     collection: mediaSlug as any,
     data: { [`_h_${tagsSlug}`]: [asian.id, lunch.id] } as any,
     file: { ...imageFile, name: 'tuna-poke-bowl.png' } as any,
+    overrideAccess: true,
   })
 
   await payload.create({
     collection: mediaSlug as any,
     data: { [`_h_${tagsSlug}`]: [american.id, breakfast.id] } as any,
     file: { ...imageFile, name: 'buttermilk-pancakes.png' } as any,
+    overrideAccess: true,
   })
 
   await payload.create({
     collection: mediaSlug as any,
     data: { [`_h_${tagsSlug}`]: [dessert.id, italian.id] } as any,
     file: { ...imageFile, name: 'tiramisu.png' } as any,
+    overrideAccess: true,
   })
 
   await payload.create({
     collection: mediaSlug as any,
     data: { [`_h_${tagsSlug}`]: [asian.id, winter.id] } as any,
     file: { ...imageFile, name: 'tonkotsu-ramen.png' } as any,
+    overrideAccess: true,
   })
 
   payload.logger.info('Tags seed completed!')

--- a/test/trash/collections/Registrations/index.ts
+++ b/test/trash/collections/Registrations/index.ts
@@ -30,7 +30,9 @@ export const Registrations: CollectionConfig = {
         const postID = data?.post
 
         if (postID) {
-          await req.payload.findByID({ id: postID, collection: postsSlug, req }).catch(() => null)
+          await req.payload
+            .findByID({ id: postID, collection: postsSlug, req, overrideAccess: true })
+            .catch(() => null)
         }
 
         return doc

--- a/test/trash/e2e.spec.ts
+++ b/test/trash/e2e.spec.ts
@@ -54,6 +54,7 @@ describe('Trash', () => {
         depth: 0,
         limit: 1,
         pagination: false,
+        overrideAccess: true,
       })
     ).docs[0]!.id
     postsDocOneID = (
@@ -63,6 +64,7 @@ describe('Trash', () => {
           _status: 'published',
           title: 'Post 1',
         },
+        overrideAccess: true,
       })
     ).id
     postsDocTwoID = (
@@ -72,6 +74,7 @@ describe('Trash', () => {
           _status: 'published',
           title: 'Post 2',
         },
+        overrideAccess: true,
       })
     ).id
     await initPage({ page, serverURL })
@@ -298,6 +301,7 @@ describe('Trash', () => {
           id: trashedDoc.id,
           collection: postsSlug,
           trash: true,
+          overrideAccess: true,
         })
       })
 
@@ -374,6 +378,7 @@ describe('Trash', () => {
               where: {
                 title: { equals: 'Ready for restore' },
               },
+              overrideAccess: true,
             })
             return docs.length
           })
@@ -386,6 +391,7 @@ describe('Trash', () => {
               where: {
                 title: { equals: 'Ready for restore' },
               },
+              overrideAccess: true,
             })
             return docs.every((doc) => doc._status === 'draft')
           })
@@ -398,6 +404,7 @@ describe('Trash', () => {
               equals: 'Ready for restore',
             },
           },
+          overrideAccess: true,
         })
       })
 
@@ -449,6 +456,7 @@ describe('Trash', () => {
               where: {
                 title: { equals: 'Ready for restore' },
               },
+              overrideAccess: true,
             })
             return docs.length
           })
@@ -461,6 +469,7 @@ describe('Trash', () => {
               where: {
                 title: { equals: 'Ready for restore' },
               },
+              overrideAccess: true,
             })
             return docs.every((doc) => doc._status === 'published')
           })
@@ -473,6 +482,7 @@ describe('Trash', () => {
               equals: 'Ready for restore',
             },
           },
+          overrideAccess: true,
         })
       })
 
@@ -532,6 +542,7 @@ describe('Trash', () => {
                   },
                 ],
               },
+              overrideAccess: true,
             })
             return deletedPosts.docs.length
           })
@@ -575,6 +586,7 @@ describe('Trash', () => {
             id: doc.id,
             collection: postsSlug,
             trash: true, // Force permanent delete
+            overrideAccess: true,
           })
         })
       })
@@ -778,6 +790,7 @@ describe('Trash', () => {
                   },
                 ],
               },
+              overrideAccess: true,
             })
             return deletedPost.docs.length
           })
@@ -813,6 +826,7 @@ describe('Trash', () => {
               where: {
                 id: { equals: trashedPostDocOne.id },
               },
+              overrideAccess: true,
             })
             return docs.length
           })
@@ -825,6 +839,7 @@ describe('Trash', () => {
               where: {
                 id: { equals: trashedPostDocOne.id },
               },
+              overrideAccess: true,
             })
             return docs[0]?._status === 'draft'
           })
@@ -888,6 +903,7 @@ describe('Trash', () => {
           id: incomingTrashedDoc.id,
           collection: postsSlug,
           trash: true,
+          overrideAccess: true,
         })
       })
 
@@ -945,6 +961,7 @@ describe('Trash', () => {
           id: incomingTrashedDoc.id,
           collection: postsSlug,
           trash: true,
+          overrideAccess: true,
         })
       })
 
@@ -1004,6 +1021,7 @@ describe('Trash', () => {
           id: incomingTrashedDoc.id,
           collection: postsSlug,
           trash: true,
+          overrideAccess: true,
         })
       })
 
@@ -1053,6 +1071,7 @@ describe('Trash', () => {
           id: incomingTrashedDoc.id,
           collection: postsSlug,
           trash: true,
+          overrideAccess: true,
         })
       })
 
@@ -1109,6 +1128,7 @@ describe('Trash', () => {
           id: incomingTrashedDoc.id,
           collection: postsSlug,
           trash: true,
+          overrideAccess: true,
         })
       })
     })
@@ -1123,6 +1143,7 @@ describe('Trash', () => {
         pagination: false,
         trash: true,
         where: { name: { equals: 'Dev' } },
+        overrideAccess: true,
       })
       if (docs.length === 0) {
         throw new Error('Dev user not found! Ensure test seed data includes a Dev user.')
@@ -1138,6 +1159,7 @@ describe('Trash', () => {
         where: {
           and: [{ name: { equals: 'Dev' } }, { deletedAt: { exists: true } }],
         },
+        overrideAccess: true,
       })
 
       if (docs.length === 0) {
@@ -1146,6 +1168,7 @@ describe('Trash', () => {
           id: devUserID,
           collection: usersSlug,
           data: { deletedAt: new Date().toISOString() },
+          overrideAccess: true,
         })
       }
     }
@@ -1260,6 +1283,7 @@ describe('Trash', () => {
         _status: 'draft',
         title: 'Draft with Localized Field',
       },
+      overrideAccess: true,
     })
 
     await payload.update({
@@ -1271,6 +1295,7 @@ describe('Trash', () => {
       },
       draft: true,
       locale: 'en',
+      overrideAccess: true,
     })
 
     await payload.update({
@@ -1282,6 +1307,7 @@ describe('Trash', () => {
       },
       draft: true,
       locale: 'es',
+      overrideAccess: true,
     })
 
     await page.goto(postsUrl.edit(draftPost.id))
@@ -1323,6 +1349,7 @@ describe('Trash', () => {
         _status: 'draft',
         title: 'Draft with Localized Field',
       },
+      overrideAccess: true,
     })
 
     // Update en locale as draft - isSavingDraft = true skips updateOne on the main table,
@@ -1336,6 +1363,7 @@ describe('Trash', () => {
       },
       draft: true,
       locale: 'en',
+      overrideAccess: true,
     })
 
     // Update es locale as draft
@@ -1348,6 +1376,7 @@ describe('Trash', () => {
       },
       draft: true,
       locale: 'es',
+      overrideAccess: true,
     })
 
     await page.goto(postsUrl.list)
@@ -1401,6 +1430,7 @@ async function createPostDoc(data: RequiredDataFromCollectionSlug<'posts'>): Pro
   return payload.create({
     collection: postsSlug,
     data,
+    overrideAccess: true,
   }) as unknown as Promise<Post>
 }
 
@@ -1412,5 +1442,6 @@ async function createTrashedPostDoc(data: RequiredDataFromCollectionSlug<'posts'
       _status: 'published',
       deletedAt: new Date().toISOString(), // Set the post as trashed
     },
+    overrideAccess: true,
   }) as unknown as Promise<Post>
 }

--- a/test/trash/int.spec.ts
+++ b/test/trash/int.spec.ts
@@ -34,6 +34,7 @@ test.suite({ config: './config.ts' })('trash', () => {
         email: regularUser.email,
         password: regularUser.password,
       },
+      overrideAccess: true,
     })
 
     restrictedCollectionDoc = await payload.create({
@@ -41,6 +42,7 @@ test.suite({ config: './config.ts' })('trash', () => {
       data: {
         title: 'With Access Control one',
       },
+      overrideAccess: true,
     })
 
     postsDocOne = await payload.create({
@@ -48,6 +50,7 @@ test.suite({ config: './config.ts' })('trash', () => {
       data: {
         title: 'Doc one',
       },
+      overrideAccess: true,
     })
 
     postsDocTwo = await payload.create({
@@ -56,6 +59,7 @@ test.suite({ config: './config.ts' })('trash', () => {
         title: 'Doc two',
         deletedAt: new Date().toISOString(),
       },
+      overrideAccess: true,
     })
   })
 
@@ -68,6 +72,7 @@ test.suite({ config: './config.ts' })('trash', () => {
           exists: true,
         },
       },
+      overrideAccess: true,
     })
   })
 
@@ -139,6 +144,7 @@ test.suite({ config: './config.ts' })('trash', () => {
           email: devUser.email,
           password: devUser.password,
         },
+        overrideAccess: true,
       })
     })
 
@@ -150,6 +156,7 @@ test.suite({ config: './config.ts' })('trash', () => {
             collection: differentiatedTrashCollectionSlug as CollectionSlug,
             id,
             trash: true,
+            overrideAccess: true,
           })
         } catch (_e) {
           // Ignore errors from cleanup
@@ -164,6 +171,7 @@ test.suite({ config: './config.ts' })('trash', () => {
         const doc = await payload.create({
           collection: differentiatedTrashCollectionSlug as CollectionSlug,
           data: { title: 'Regular user trash test' },
+          overrideAccess: true,
         })
 
         createdDocIds.push(doc.id)
@@ -187,6 +195,7 @@ test.suite({ config: './config.ts' })('trash', () => {
         const doc = await payload.create({
           collection: differentiatedTrashCollectionSlug as CollectionSlug,
           data: { title: 'Admin trash test' },
+          overrideAccess: true,
         })
 
         createdDocIds.push(doc.id)
@@ -217,6 +226,7 @@ test.suite({ config: './config.ts' })('trash', () => {
             title: 'Regular user perm delete test',
             deletedAt: new Date().toISOString(),
           },
+          overrideAccess: true,
         })
 
         createdDocIds.push(doc.id)
@@ -245,6 +255,7 @@ test.suite({ config: './config.ts' })('trash', () => {
             title: 'Admin perm delete test',
             deletedAt: new Date().toISOString(),
           },
+          overrideAccess: true,
         })
 
         // Admin should be able to permanently delete
@@ -264,6 +275,7 @@ test.suite({ config: './config.ts' })('trash', () => {
             collection: differentiatedTrashCollectionSlug as CollectionSlug,
             id: doc.id,
             trash: true,
+            overrideAccess: true,
           }),
         ).rejects.toThrow('Not Found')
       })
@@ -275,11 +287,13 @@ test.suite({ config: './config.ts' })('trash', () => {
         const doc1 = await payload.create({
           collection: differentiatedTrashCollectionSlug as CollectionSlug,
           data: { title: 'Bulk trash test 1' },
+          overrideAccess: true,
         })
 
         const doc2 = await payload.create({
           collection: differentiatedTrashCollectionSlug as CollectionSlug,
           data: { title: 'Bulk trash test 2' },
+          overrideAccess: true,
         })
 
         createdDocIds.push(doc1.id, doc2.id)
@@ -313,6 +327,7 @@ test.suite({ config: './config.ts' })('trash', () => {
             title: 'Bulk perm delete test 1',
             deletedAt: new Date().toISOString(),
           },
+          overrideAccess: true,
         })
 
         const doc2 = await payload.create({
@@ -321,6 +336,7 @@ test.suite({ config: './config.ts' })('trash', () => {
             title: 'Bulk perm delete test 2',
             deletedAt: new Date().toISOString(),
           },
+          overrideAccess: true,
         })
 
         createdDocIds.push(doc1.id, doc2.id)
@@ -353,6 +369,7 @@ test.suite({ config: './config.ts' })('trash', () => {
               like: 'Bulk perm delete test',
             },
           },
+          overrideAccess: true,
         })
 
         expect(remaining.docs.length).toBe(2)
@@ -368,6 +385,7 @@ test.suite({ config: './config.ts' })('trash', () => {
             title: 'Admin bulk perm delete 1',
             deletedAt: new Date().toISOString(),
           },
+          overrideAccess: true,
         })
 
         const doc2 = await payload.create({
@@ -376,6 +394,7 @@ test.suite({ config: './config.ts' })('trash', () => {
             title: 'Admin bulk perm delete 2',
             deletedAt: new Date().toISOString(),
           },
+          overrideAccess: true,
         })
 
         // Admin should be able to bulk permanently delete
@@ -405,6 +424,7 @@ test.suite({ config: './config.ts' })('trash', () => {
               like: 'Admin bulk perm delete',
             },
           },
+          overrideAccess: true,
         })
 
         expect(remaining.docs.length).toBe(0)
@@ -420,6 +440,7 @@ test.suite({ config: './config.ts' })('trash', () => {
         const allDocs = await payload.find({
           collection: postsSlug,
           trash: true,
+          overrideAccess: true,
         })
 
         expect(allDocs.totalDocs).toEqual(2)
@@ -434,6 +455,7 @@ test.suite({ config: './config.ts' })('trash', () => {
             },
           },
           trash: true,
+          overrideAccess: true,
         })
 
         expect(trashedDocs.totalDocs).toEqual(1)
@@ -446,6 +468,7 @@ test.suite({ config: './config.ts' })('trash', () => {
         const normalDocs = await payload.find({
           collection: postsSlug,
           trash: false,
+          overrideAccess: true,
         })
 
         expect(normalDocs.totalDocs).toEqual(1)
@@ -462,11 +485,13 @@ test.suite({ config: './config.ts' })('trash', () => {
             deletedAt: null,
           },
           trash: true,
+          overrideAccess: true,
         })
 
         const result = await payload.find({
           collection: postsSlug,
-          trash: false, // Normal query should return it now
+          trash: false,
+          overrideAccess: true, // Normal query should return it now
         })
 
         const restored = result.docs.find(
@@ -486,11 +511,13 @@ test.suite({ config: './config.ts' })('trash', () => {
         await payload.create({
           collection: postsSlug,
           data: { title: 'Doc one' },
+          overrideAccess: true,
         })
 
         const result = await payload.findDistinct({
           collection: postsSlug,
           field: 'title',
+          overrideAccess: true,
         })
 
         const titles = result.values.map((v) => v.title)
@@ -506,6 +533,7 @@ test.suite({ config: './config.ts' })('trash', () => {
           collection: postsSlug,
           field: 'title',
           trash: true,
+          overrideAccess: true,
         })
 
         const titles = result.values.map((v) => v.title)
@@ -524,6 +552,7 @@ test.suite({ config: './config.ts' })('trash', () => {
           where: {
             deletedAt: { exists: true },
           },
+          overrideAccess: true,
         })
 
         const titles = result.values.map((v) => v.title)
@@ -538,6 +567,7 @@ test.suite({ config: './config.ts' })('trash', () => {
           where: {
             title: { equals: 'Doc two' },
           },
+          overrideAccess: true,
         })
 
         const titles = result.values.map((v) => v.title)
@@ -551,6 +581,7 @@ test.suite({ config: './config.ts' })('trash', () => {
           collection: postsSlug,
           id: postsDocTwo.id,
           trash: true,
+          overrideAccess: true,
         })
 
         expect(trashedPostDoc).toBeDefined()
@@ -566,6 +597,7 @@ test.suite({ config: './config.ts' })('trash', () => {
           payload.findByID({
             collection: postsSlug,
             id: postsDocTwo.id,
+            overrideAccess: true,
           }),
         ).rejects.toThrow('Not Found')
 
@@ -574,6 +606,7 @@ test.suite({ config: './config.ts' })('trash', () => {
             collection: postsSlug,
             id: postsDocTwo.id,
             trash: false,
+            overrideAccess: true,
           }),
         ).rejects.toThrow('Not Found')
       })
@@ -586,6 +619,7 @@ test.suite({ config: './config.ts' })('trash', () => {
         const allVersions = await payload.findVersions({
           collection: postsSlug,
           trash: true,
+          overrideAccess: true,
         })
 
         expect(allVersions.totalDocs).toEqual(2)
@@ -604,6 +638,7 @@ test.suite({ config: './config.ts' })('trash', () => {
             },
           },
           trash: true,
+          overrideAccess: true,
         })
 
         expect(trashedVersions.totalDocs).toEqual(1)
@@ -616,6 +651,7 @@ test.suite({ config: './config.ts' })('trash', () => {
         const normalVersions = await payload.findVersions({
           collection: postsSlug,
           trash: false,
+          overrideAccess: true,
         })
 
         expect(normalVersions.totalDocs).toEqual(1)
@@ -632,6 +668,7 @@ test.suite({ config: './config.ts' })('trash', () => {
             deletedAt: null,
           },
           trash: true,
+          overrideAccess: true,
         })
 
         const versions = await payload.findVersions({
@@ -642,6 +679,7 @@ test.suite({ config: './config.ts' })('trash', () => {
               equals: null,
             },
           },
+          overrideAccess: true,
         })
 
         expect(versions.docs.some((v) => v.parent === postsDocTwo.id)).toBe(true)
@@ -660,6 +698,7 @@ test.suite({ config: './config.ts' })('trash', () => {
             },
           },
           trash: true,
+          overrideAccess: true,
         })
 
         expect(trashedVersions.docs).toHaveLength(1)
@@ -670,6 +709,7 @@ test.suite({ config: './config.ts' })('trash', () => {
           collection: postsSlug,
           id: version!.id,
           trash: true,
+          overrideAccess: true,
         })
 
         expect(trashedVersionDoc).toBeDefined()
@@ -689,6 +729,7 @@ test.suite({ config: './config.ts' })('trash', () => {
             },
           },
           trash: true,
+          overrideAccess: true,
         })
 
         expect(trashedVersions.docs).toHaveLength(1)
@@ -699,6 +740,7 @@ test.suite({ config: './config.ts' })('trash', () => {
           payload.findVersionByID({
             collection: postsSlug,
             id: version!.id,
+            overrideAccess: true,
           }),
         ).rejects.toThrow('Not Found')
 
@@ -707,6 +749,7 @@ test.suite({ config: './config.ts' })('trash', () => {
             collection: postsSlug,
             id: version!.id,
             trash: false,
+            overrideAccess: true,
           }),
         ).rejects.toThrow('Not Found')
       })
@@ -721,6 +764,7 @@ test.suite({ config: './config.ts' })('trash', () => {
             title: 'Updated Doc Two',
           },
           trash: true,
+          overrideAccess: true,
         })
 
         expect(updatedPostDoc).toBeDefined()
@@ -740,6 +784,7 @@ test.suite({ config: './config.ts' })('trash', () => {
             data: {
               title: 'Updated Doc Two',
             },
+            overrideAccess: true,
           }),
         ).rejects.toThrow('Not Found')
 
@@ -751,6 +796,7 @@ test.suite({ config: './config.ts' })('trash', () => {
               title: 'Updated Doc Two',
             },
             trash: false,
+            overrideAccess: true,
           }),
         ).rejects.toThrow('Not Found')
       })
@@ -762,6 +808,7 @@ test.suite({ config: './config.ts' })('trash', () => {
           data: {
             title: 'Updated Doc One',
           },
+          overrideAccess: true,
         })
 
         expect(updatedPostDoc).toBeDefined()
@@ -780,6 +827,7 @@ test.suite({ config: './config.ts' })('trash', () => {
             deletedAt: null,
           },
           trash: true,
+          overrideAccess: true,
         })
 
         expect(restored.deletedAt).toBeNull()
@@ -788,6 +836,7 @@ test.suite({ config: './config.ts' })('trash', () => {
         const result = await payload.find({
           collection: postsSlug,
           trash: false,
+          overrideAccess: true,
         })
 
         const found = result.docs.find((doc) => doc.id === postsDocTwo.id)
@@ -809,6 +858,7 @@ test.suite({ config: './config.ts' })('trash', () => {
               exists: true,
             },
           },
+          overrideAccess: true,
         })
 
         expect(result.docs).toBeDefined()
@@ -835,6 +885,7 @@ test.suite({ config: './config.ts' })('trash', () => {
               exists: true,
             },
           },
+          overrideAccess: true,
         })
 
         expect(result.docs).toBeDefined()
@@ -859,6 +910,7 @@ test.suite({ config: './config.ts' })('trash', () => {
             title: 'Doc three',
             deletedAt: new Date().toISOString(),
           },
+          overrideAccess: true,
         })
 
         const result = await payload.update({
@@ -872,6 +924,7 @@ test.suite({ config: './config.ts' })('trash', () => {
               exists: true,
             },
           },
+          overrideAccess: true,
         })
         expect(result.docs).toBeDefined()
         expect(result.docs[0]?.id).toEqual(docThree.id)
@@ -886,6 +939,7 @@ test.suite({ config: './config.ts' })('trash', () => {
           collection: postsSlug,
           id: docThree.id,
           trash: true,
+          overrideAccess: true,
         })
       })
     })
@@ -902,11 +956,13 @@ test.suite({ config: './config.ts' })('trash', () => {
               exists: true,
             },
           },
+          overrideAccess: true,
         })
 
         const allDocs = await payload.find({
           collection: postsSlug,
           trash: true,
+          overrideAccess: true,
         })
 
         expect(allDocs.totalDocs).toEqual(0)
@@ -921,11 +977,13 @@ test.suite({ config: './config.ts' })('trash', () => {
               exists: true,
             },
           },
+          overrideAccess: true,
         })
 
         const allDocs = await payload.find({
           collection: postsSlug,
           trash: true,
+          overrideAccess: true,
         })
 
         expect(allDocs.totalDocs).toEqual(1)
@@ -945,6 +1003,7 @@ test.suite({ config: './config.ts' })('trash', () => {
             _status: 'draft',
           },
           draft: true,
+          overrideAccess: true,
         })
 
         expect(draftDoc.title).toBe('')
@@ -957,6 +1016,7 @@ test.suite({ config: './config.ts' })('trash', () => {
           data: {
             deletedAt: new Date().toISOString(),
           },
+          overrideAccess: true,
         })
 
         expect(trashedDoc.deletedAt).toBeDefined()
@@ -968,6 +1028,7 @@ test.suite({ config: './config.ts' })('trash', () => {
           collection: postsSlug,
           id: draftDoc.id,
           trash: true,
+          overrideAccess: true,
         })
       })
 
@@ -982,6 +1043,7 @@ test.suite({ config: './config.ts' })('trash', () => {
             _status: 'draft',
           },
           draft: true,
+          overrideAccess: true,
         })
 
         // Trash it
@@ -991,6 +1053,7 @@ test.suite({ config: './config.ts' })('trash', () => {
           data: {
             deletedAt: new Date().toISOString(),
           },
+          overrideAccess: true,
         })
 
         // Should be able to restore as draft without validation errors
@@ -1002,6 +1065,7 @@ test.suite({ config: './config.ts' })('trash', () => {
             _status: 'draft',
           },
           trash: true,
+          overrideAccess: true,
         })
 
         expect(restoredDoc.deletedAt).toBeNull()
@@ -1013,6 +1077,7 @@ test.suite({ config: './config.ts' })('trash', () => {
           collection: postsSlug,
           id: draftDoc.id,
           trash: true,
+          overrideAccess: true,
         })
       })
 
@@ -1027,6 +1092,7 @@ test.suite({ config: './config.ts' })('trash', () => {
             _status: 'draft',
           },
           draft: true,
+          overrideAccess: true,
         })
 
         // Trash it
@@ -1036,6 +1102,7 @@ test.suite({ config: './config.ts' })('trash', () => {
           data: {
             deletedAt: new Date().toISOString(),
           },
+          overrideAccess: true,
         })
 
         // Should NOT be able to restore as published - should fail validation
@@ -1048,6 +1115,7 @@ test.suite({ config: './config.ts' })('trash', () => {
               _status: 'published',
             },
             trash: true,
+            overrideAccess: true,
           }),
         ).rejects.toThrow(/invalid/i)
 
@@ -1056,6 +1124,7 @@ test.suite({ config: './config.ts' })('trash', () => {
           collection: postsSlug,
           id: draftDoc.id,
           trash: true,
+          overrideAccess: true,
         })
       })
     })
@@ -1068,6 +1137,7 @@ test.suite({ config: './config.ts' })('trash', () => {
           payload.delete({
             collection: postsSlug,
             id: postsDocTwo.id,
+            overrideAccess: true,
           }),
         ).rejects.toThrow('Not Found')
 
@@ -1076,6 +1146,7 @@ test.suite({ config: './config.ts' })('trash', () => {
             collection: postsSlug,
             id: postsDocTwo.id,
             trash: false,
+            overrideAccess: true,
           }),
         ).rejects.toThrow('Not Found')
       })
@@ -1085,11 +1156,13 @@ test.suite({ config: './config.ts' })('trash', () => {
           collection: postsSlug,
           id: postsDocTwo.id,
           trash: true,
+          overrideAccess: true,
         })
 
         const allDocs = await payload.find({
           collection: postsSlug,
           trash: true,
+          overrideAccess: true,
         })
 
         expect(allDocs.totalDocs).toEqual(1)
@@ -1107,11 +1180,13 @@ test.suite({ config: './config.ts' })('trash', () => {
           id: postsDocTwo.id,
           data: { title: 'Updated Before Restore Attempt' },
           trash: true,
+          overrideAccess: true,
         })
 
         const { docs: versions } = await payload.findVersions({
           collection: postsSlug,
           trash: true,
+          overrideAccess: true,
         })
         const version = versions.find((v) => v.parent === postsDocTwo.id)
 
@@ -1121,6 +1196,7 @@ test.suite({ config: './config.ts' })('trash', () => {
           payload.restoreVersion({
             collection: postsSlug,
             id: version!.id,
+            overrideAccess: true,
           }),
         ).rejects.toThrow(/Cannot restore a version of a trashed document/i)
       })
@@ -1132,6 +1208,7 @@ test.suite({ config: './config.ts' })('trash', () => {
       }) => {
         const result = await payload.count({
           collection: postsSlug,
+          overrideAccess: true,
         })
 
         expect(result.totalDocs).toEqual(1) // Only postsDocOne
@@ -1143,6 +1220,7 @@ test.suite({ config: './config.ts' })('trash', () => {
         const result = await payload.count({
           collection: postsSlug,
           trash: true,
+          overrideAccess: true,
         })
 
         expect(result.totalDocs).toEqual(2)
@@ -1155,6 +1233,7 @@ test.suite({ config: './config.ts' })('trash', () => {
           collection: postsSlug,
           trash: true,
           where: { deletedAt: { exists: true } },
+          overrideAccess: true,
         })
 
         expect(result.totalDocs).toEqual(1) // Only postsDocTwo
@@ -1173,6 +1252,7 @@ test.suite({ config: './config.ts' })('trash', () => {
           title: 'Draft with Localized Field',
           _status: 'draft',
         },
+        overrideAccess: true,
       })
 
       // Update en locale as draft - isSavingDraft = true skips updateOne on the main table,
@@ -1186,6 +1266,7 @@ test.suite({ config: './config.ts' })('trash', () => {
           _status: 'draft',
         },
         draft: true,
+        overrideAccess: true,
       })
 
       await payload.update({
@@ -1197,6 +1278,7 @@ test.suite({ config: './config.ts' })('trash', () => {
           _status: 'draft',
         },
         draft: true,
+        overrideAccess: true,
       })
 
       // Bulk trash the document (simulates list view "Move to Trash")
@@ -1211,6 +1293,7 @@ test.suite({ config: './config.ts' })('trash', () => {
             equals: post.id,
           },
         },
+        overrideAccess: true,
       })
 
       expect(trashResult.docs).toHaveLength(1)
@@ -1223,6 +1306,7 @@ test.suite({ config: './config.ts' })('trash', () => {
         locale: 'en',
         draft: true,
         trash: true,
+        overrideAccess: true,
       })
 
       const trashedDocES = await payload.findByID({
@@ -1231,6 +1315,7 @@ test.suite({ config: './config.ts' })('trash', () => {
         locale: 'es',
         draft: true,
         trash: true,
+        overrideAccess: true,
       })
 
       // localizedField should be preserved from the latest draft version for both locales,
@@ -1489,6 +1574,7 @@ test.suite({ config: './config.ts' })('trash', () => {
             title: 'Doc three',
             deletedAt: new Date().toISOString(),
           },
+          overrideAccess: true,
         })
 
         const res = await restClient.PATCH(`/${postsSlug}${query}`, {
@@ -1511,6 +1597,7 @@ test.suite({ config: './config.ts' })('trash', () => {
           collection: postsSlug,
           id: docThree.id,
           trash: true,
+          overrideAccess: true,
         })
       })
     })
@@ -1579,6 +1666,7 @@ test.suite({ config: './config.ts' })('trash', () => {
         const { docs: versions } = await payload.findVersions({
           collection: postsSlug,
           trash: true,
+          overrideAccess: true,
         })
         const version = versions.find((v) => v.parent === postsDocTwo.id)
 
@@ -2278,7 +2366,7 @@ test.suite({ config: './config.ts' })('trash', () => {
 
     test.afterEach(async ({ payload }) => {
       for (const id of createdPageIDs) {
-        await payload.delete({ collection: pagesSlug, id })
+        await payload.delete({ collection: pagesSlug, id, overrideAccess: true })
       }
       createdPageIDs.length = 0
     })
@@ -2293,6 +2381,7 @@ test.suite({ config: './config.ts' })('trash', () => {
           title: 'Page with related posts',
           relatedPosts: [postsDocOne.id, postsDocTwo.id],
         },
+        overrideAccess: true,
       })
       createdPageIDs.push(page.id)
 
@@ -2300,6 +2389,7 @@ test.suite({ config: './config.ts' })('trash', () => {
         collection: pagesSlug,
         id: page.id,
         depth: 1,
+        overrideAccess: true,
       })
 
       // The trashed post (postsDocTwo) should be absent from the relationship array
@@ -2318,6 +2408,7 @@ test.suite({ config: './config.ts' })('trash', () => {
           title: 'Page with featured post',
           featuredPost: postsDocTwo.id,
         },
+        overrideAccess: true,
       })
       createdPageIDs.push(page.id)
 
@@ -2325,6 +2416,7 @@ test.suite({ config: './config.ts' })('trash', () => {
         collection: pagesSlug,
         id: page.id,
         depth: 1,
+        overrideAccess: true,
       })
 
       expect(result.featuredPost).toBeNull()
@@ -2337,6 +2429,7 @@ test.suite({ config: './config.ts' })('trash', () => {
           title: 'Page with featured post',
           featuredPost: postsDocOne.id,
         },
+        overrideAccess: true,
       })
       createdPageIDs.push(page.id)
 
@@ -2344,6 +2437,7 @@ test.suite({ config: './config.ts' })('trash', () => {
         collection: pagesSlug,
         id: page.id,
         depth: 1,
+        overrideAccess: true,
       })
 
       expect((result.featuredPost as Post)?.id).toBe(postsDocOne.id)
@@ -2357,6 +2451,7 @@ test.suite({ config: './config.ts' })('trash', () => {
           title: 'Page with related posts depth 0',
           relatedPosts: [postsDocOne.id, postsDocTwo.id],
         },
+        overrideAccess: true,
       })
       createdPageIDs.push(page.id)
 
@@ -2364,6 +2459,7 @@ test.suite({ config: './config.ts' })('trash', () => {
         collection: pagesSlug,
         id: page.id,
         depth: 0,
+        overrideAccess: true,
       })
 
       // At depth=0, no population occurs - raw IDs are returned as stored
@@ -2379,7 +2475,7 @@ test.suite({ config: './config.ts' })('trash', () => {
 
     test.afterEach(async ({ payload }) => {
       for (const id of createdRegistrationIDs) {
-        await payload.delete({ id, collection: registrationsSlug })
+        await payload.delete({ id, collection: registrationsSlug, overrideAccess: true })
       }
       createdRegistrationIDs.length = 0
     })
@@ -2395,6 +2491,7 @@ test.suite({ config: './config.ts' })('trash', () => {
           post: postsDocTwo.id,
           title: 'Registration for a trashed post',
         },
+        overrideAccess: true,
       })
       createdRegistrationIDs.push(registration.id)
 
@@ -2405,6 +2502,7 @@ test.suite({ config: './config.ts' })('trash', () => {
             equals: registration.id,
           },
         },
+        overrideAccess: true,
       })
 
       expect(result.totalDocs).toBe(1)
@@ -2433,6 +2531,7 @@ test.suite({ config: './config.ts' })('trash', () => {
             equals: doc.id,
           },
         },
+        overrideAccess: true,
       })
 
       expect(result.totalDocs).toBe(1)

--- a/test/trash/seed.ts
+++ b/test/trash/seed.ts
@@ -13,6 +13,7 @@ export const seed = async (payload: Payload) => {
       name: 'Admin',
       roles: ['is_admin', 'is_user'],
     },
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -25,6 +26,7 @@ export const seed = async (payload: Payload) => {
       name: 'Dev',
       roles: ['is_user'],
     },
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -34,5 +36,6 @@ export const seed = async (payload: Payload) => {
     data: {
       title: 'Page',
     },
+    overrideAccess: true,
   })
 }

--- a/test/types/types.spec.ts
+++ b/test/types/types.spec.ts
@@ -102,93 +102,117 @@ describe('Types testing', () => {
   })
 
   test('payload.find', () => {
-    expect(payload.find({ collection: 'users' })).type.toBe<Promise<PaginatedDocs<User>>>()
-  })
-
-  test('payload.findByID', () => {
-    expect(payload.findByID({ id: 1, collection: 'users' })).type.toBe<Promise<User>>()
-  })
-
-  test('payload.findByID with disableErrors: true', () => {
-    expect(payload.findByID({ id: 1, collection: 'users', disableErrors: true })).type.toBe<
-      Promise<null | User>
+    expect(payload.find({ collection: 'users', overrideAccess: true })).type.toBe<
+      Promise<PaginatedDocs<User>>
     >()
   })
 
-  test('payload.create', () => {
-    expect(payload.create({ collection: 'users', data: { email: 'user@email.com' } })).type.toBe<
+  test('payload.findByID', () => {
+    expect(payload.findByID({ id: 1, collection: 'users', overrideAccess: true })).type.toBe<
       Promise<User>
     >()
   })
 
+  test('payload.findByID with disableErrors: true', () => {
+    expect(
+      payload.findByID({ id: 1, collection: 'users', disableErrors: true, overrideAccess: true }),
+    ).type.toBe<Promise<null | User>>()
+  })
+
+  test('payload.create', () => {
+    expect(
+      payload.create({
+        collection: 'users',
+        data: { email: 'user@email.com' },
+        overrideAccess: true,
+      }),
+    ).type.toBe<Promise<User>>()
+  })
+
   test('payload.update by ID', () => {
-    expect(payload.update({ id: 1, collection: 'users', data: {} })).type.toBe<Promise<User>>()
+    expect(
+      payload.update({ id: 1, collection: 'users', data: {}, overrideAccess: true }),
+    ).type.toBe<Promise<User>>()
   })
 
   test('payload.update many', () => {
-    expect(payload.update({ collection: 'users', data: {}, where: {} })).type.toBe<
-      Promise<BulkOperationResult<'users', SelectType>>
-    >()
+    expect(
+      payload.update({ collection: 'users', data: {}, where: {}, overrideAccess: true }),
+    ).type.toBe<Promise<BulkOperationResult<'users', SelectType>>>()
   })
 
   test('payload.delete by ID', () => {
-    expect(payload.delete({ id: 1, collection: 'users' })).type.toBe<Promise<User>>()
+    expect(payload.delete({ id: 1, collection: 'users', overrideAccess: true })).type.toBe<
+      Promise<User>
+    >()
   })
 
   test('payload.delete many', () => {
-    expect(payload.delete({ collection: 'users', where: {} })).type.toBe<
+    expect(payload.delete({ collection: 'users', where: {}, overrideAccess: true })).type.toBe<
       Promise<BulkOperationResult<'users', SelectType>>
     >()
   })
 
   test('payload.findGlobal', () => {
-    expect(payload.findGlobal({ slug: 'menu' })).type.toBe<Promise<Menu>>()
+    expect(payload.findGlobal({ slug: 'menu', overrideAccess: true })).type.toBe<Promise<Menu>>()
   })
 
   test('payload.updateGlobal', () => {
-    expect(payload.updateGlobal({ slug: 'menu', data: {} })).type.toBe<Promise<Menu>>()
+    expect(payload.updateGlobal({ slug: 'menu', data: {}, overrideAccess: true })).type.toBe<
+      Promise<Menu>
+    >()
   })
 
   test('payload.findVersions', () => {
-    expect(payload.findVersions({ collection: 'posts' })).type.toBe<
+    expect(payload.findVersions({ collection: 'posts', overrideAccess: true })).type.toBe<
       Promise<PaginatedDocs<TypeWithVersion<Post>>>
     >()
   })
 
   test('payload.findVersionByID', () => {
-    expect(payload.findVersionByID({ id: 'id', collection: 'posts' })).type.toBe<
-      Promise<TypeWithVersion<Post>>
-    >()
+    expect(
+      payload.findVersionByID({ id: 'id', collection: 'posts', overrideAccess: true }),
+    ).type.toBe<Promise<TypeWithVersion<Post>>>()
   })
 
   test('payload.findGlobalVersions', () => {
-    expect(payload.findGlobalVersions({ slug: 'menu' })).type.toBe<
+    expect(payload.findGlobalVersions({ slug: 'menu', overrideAccess: true })).type.toBe<
       Promise<PaginatedDocs<TypeWithVersion<Menu>>>
     >()
   })
 
   test('payload.findGlobalVersionByID', () => {
-    expect(payload.findGlobalVersionByID({ id: 'id', slug: 'menu' })).type.toBe<
-      Promise<TypeWithVersion<Menu>>
-    >()
+    expect(
+      payload.findGlobalVersionByID({ id: 'id', slug: 'menu', overrideAccess: true }),
+    ).type.toBe<Promise<TypeWithVersion<Menu>>>()
   })
 
   describe('select', () => {
     test('should include only ID if select is an empty object', () => {
-      expect(payload.findByID({ id: 'id', collection: 'posts', select: {} })).type.toBe<
-        Promise<{ id: Post['id'] }>
-      >()
+      expect(
+        payload.findByID({ id: 'id', collection: 'posts', select: {}, overrideAccess: true }),
+      ).type.toBe<Promise<{ id: Post['id'] }>>()
     })
 
     test('should include only title and ID', () => {
       expect(
-        payload.findByID({ id: 'id', collection: 'posts', select: { title: true } }),
+        payload.findByID({
+          id: 'id',
+          collection: 'posts',
+          select: { title: true },
+          overrideAccess: true,
+        }),
       ).type.toBe<Promise<{ id: Post['id']; title?: Post['title'] }>>()
     })
 
     test('should exclude title', () => {
       expect(
-        payload.findByID({ id: 'id', collection: 'posts', select: { title: false } }),
+        payload.findByID({
+          id: 'id',
+          collection: 'posts',
+          select: { title: false },
+          overrideAccess: true,
+        }),
       ).type.toBe<Promise<Omit<Post, 'title'>>>()
     })
   })
@@ -230,7 +254,7 @@ describe('Types testing', () => {
     })
 
     test('payload operations return users with collection property', async () => {
-      const user = await payload.findByID({ id: 'id', collection: 'users' })
+      const user = await payload.findByID({ id: 'id', collection: 'users', overrideAccess: true })
       expect(user.collection).type.toBe<'users'>()
     })
 
@@ -1501,6 +1525,7 @@ describe('Types testing', () => {
         const result = await payload.find({
           collection: 'draft-posts',
           draft: true,
+          overrideAccess: true,
         })
 
         const doc = result.docs[0]!
@@ -1518,6 +1543,7 @@ describe('Types testing', () => {
       test('non-draft find query returns required fields as required', async () => {
         const result = await payload.find({
           collection: 'draft-posts',
+          overrideAccess: true,
         })
 
         const doc = result.docs[0]!

--- a/test/untyped/types.spec.ts
+++ b/test/untyped/types.spec.ts
@@ -41,6 +41,7 @@ describe('Untyped Payload types', () => {
         data: {
           title: 'Example',
         },
+        overrideAccess: true,
       }),
     ).type.toBe<Promise<JsonObject & TypeWithID>>()
   })

--- a/test/uploads/e2e.spec.ts
+++ b/test/uploads/e2e.spec.ts
@@ -241,6 +241,7 @@ describe('Uploads', () => {
         depth: 0,
         limit: 1,
         pagination: false,
+        overrideAccess: true,
       })
     ).docs[0]
 
@@ -277,6 +278,7 @@ describe('Uploads', () => {
     const relationDoc = await payload.create({
       collection: relationSlug,
       data: {},
+      overrideAccess: true,
     })
 
     await page.goto(relationURL.edit(relationDoc.id))
@@ -308,6 +310,7 @@ describe('Uploads', () => {
             equals: relationDoc.id,
           },
         },
+        overrideAccess: true,
       })
     ).docs[0] as any
 
@@ -332,6 +335,7 @@ describe('Uploads', () => {
         depth: 0,
         limit: 1,
         pagination: false,
+        overrideAccess: true,
       })
     ).docs[0]
 
@@ -348,6 +352,7 @@ describe('Uploads', () => {
         depth: 0,
         limit: 1,
         pagination: false,
+        overrideAccess: true,
       })
     ).docs[0]
 
@@ -373,6 +378,7 @@ describe('Uploads', () => {
             equals: 'image/png',
           },
         },
+        overrideAccess: true,
       })
     ).docs[0]
 
@@ -392,6 +398,7 @@ describe('Uploads', () => {
         depth: 0,
         limit: 1,
         pagination: false,
+        overrideAccess: true,
       })
     ).docs[0]
 
@@ -425,6 +432,7 @@ describe('Uploads', () => {
         where: {
           mimeType: { contains: 'image/' },
         },
+        overrideAccess: true,
       })
     ).docs[0]
 
@@ -456,6 +464,7 @@ describe('Uploads', () => {
         where: {
           mimeType: { contains: 'image/' },
         },
+        overrideAccess: true,
       })
     ).docs[0]
 
@@ -488,6 +497,7 @@ describe('Uploads', () => {
         where: {
           mimeType: { contains: 'image/' },
         },
+        overrideAccess: true,
       })
     ).docs[0]
 
@@ -818,6 +828,7 @@ describe('Uploads', () => {
             equals: 'image/png',
           },
         },
+        overrideAccess: true,
       })
     ).docs[0]
 
@@ -941,6 +952,7 @@ describe('Uploads', () => {
           collection: audioSlug,
           depth: 0,
           pagination: false,
+          overrideAccess: true,
         })
       ).docs[0]
 
@@ -986,6 +998,7 @@ describe('Uploads', () => {
           collection: audioSlug,
           depth: 0,
           pagination: false,
+          overrideAccess: true,
         })
       ).docs[0]
 
@@ -1111,6 +1124,7 @@ describe('Uploads', () => {
             equals: 'image/png',
           },
         },
+        overrideAccess: true,
       })
     ).docs[0]
 
@@ -1138,6 +1152,7 @@ describe('Uploads', () => {
             equals: 'image/png',
           },
         },
+        overrideAccess: true,
       })
     ).docs[0]
 
@@ -1168,6 +1183,7 @@ describe('Uploads', () => {
         depth: 0,
         limit: 1,
         pagination: false,
+        overrideAccess: true,
       })
     ).docs[0]
 
@@ -2512,6 +2528,7 @@ describe('Uploads', () => {
       data: {
         title: 'test',
       },
+      overrideAccess: true,
     })
     await page.goto(hideFileInputOnCreateURL.edit(doc.id))
 
@@ -2647,8 +2664,13 @@ describe('Uploads', () => {
   })
 
   test('should be able to replace the file even if the user doesnt have delete access', async () => {
-    const docID = (await payload.find({ collection: mediaWithoutDeleteAccessSlug, limit: 1 }))
-      .docs[0]?.id as string
+    const docID = (
+      await payload.find({
+        collection: mediaWithoutDeleteAccessSlug,
+        limit: 1,
+        overrideAccess: true,
+      })
+    ).docs[0]?.id as string
     await gotoAndWaitForForm(page, mediaWithoutDeleteAccessURL.edit(docID))
     // Replacing the file is available even without delete access
     await page.locator('.file-toolbar__filename-btn').click()
@@ -2664,7 +2686,11 @@ describe('Uploads', () => {
     await expect(filename).toHaveValue('test-image.jpg')
     await saveDocAndAssert(page)
     const filenameFromAPI = (
-      await payload.find({ collection: mediaWithoutDeleteAccessSlug, limit: 1 })
+      await payload.find({
+        collection: mediaWithoutDeleteAccessSlug,
+        limit: 1,
+        overrideAccess: true,
+      })
     ).docs[0]?.filename
     expect(filenameFromAPI).toBe('test-image.jpg')
   })
@@ -2954,6 +2980,7 @@ describe('Uploads', () => {
       data: {
         title: 'Upload without file',
       },
+      overrideAccess: true,
     })
 
     const relationDoc = await payload.create({
@@ -2962,6 +2989,7 @@ describe('Uploads', () => {
         title: 'Relation document',
         uploadField: uploadDoc.id,
       },
+      overrideAccess: true,
     })
 
     await page.goto(relationToNoFilesRequiredURL.edit(relationDoc.id))
@@ -3016,6 +3044,7 @@ describe('Uploads', () => {
           depth: 0,
           limit: 1,
           where: { mimeType: { equals: 'image/png' } },
+          overrideAccess: true,
         })
       ).docs[0]
 
@@ -3033,6 +3062,7 @@ describe('Uploads', () => {
           depth: 0,
           limit: 1,
           where: { mimeType: { equals: 'audio/mpeg' } },
+          overrideAccess: true,
         })
       ).docs[0]
 
@@ -3052,6 +3082,7 @@ describe('Uploads', () => {
           depth: 0,
           limit: 1,
           where: { mimeType: { equals: 'application/pdf' } },
+          overrideAccess: true,
         })
       ).docs[0]
 
@@ -3071,6 +3102,7 @@ describe('Uploads', () => {
           depth: 0,
           limit: 1,
           where: { mimeType: { equals: 'audio/mpeg' } },
+          overrideAccess: true,
         })
       ).docs[0]
 
@@ -3090,6 +3122,7 @@ describe('Uploads', () => {
           depth: 0,
           limit: 1,
           where: { mimeType: { equals: 'video/mp4' } },
+          overrideAccess: true,
         })
       ).docs[0]
 
@@ -3109,6 +3142,7 @@ describe('Uploads', () => {
           depth: 0,
           limit: 1,
           where: { mimeType: { equals: 'image/png' } },
+          overrideAccess: true,
         })
       ).docs[0]
 
@@ -3129,6 +3163,7 @@ describe('Uploads', () => {
           depth: 0,
           limit: 1,
           where: { mimeType: { equals: 'image/png' } },
+          overrideAccess: true,
         })
       ).docs[0]
 
@@ -3146,6 +3181,7 @@ describe('Uploads', () => {
           depth: 0,
           limit: 1,
           where: { mimeType: { equals: 'audio/mpeg' } },
+          overrideAccess: true,
         })
       ).docs[0]
 
@@ -3165,6 +3201,7 @@ describe('Uploads', () => {
           depth: 0,
           limit: 1,
           where: { mimeType: { equals: 'audio/mpeg' } },
+          overrideAccess: true,
         })
       ).docs[0]
 
@@ -3182,6 +3219,7 @@ describe('Uploads', () => {
           depth: 0,
           limit: 1,
           where: { mimeType: { equals: 'application/pdf' } },
+          overrideAccess: true,
         })
       ).docs[0]
 
@@ -3198,6 +3236,7 @@ describe('Uploads', () => {
           depth: 0,
           limit: 1,
           where: { mimeType: { equals: 'image/png' } },
+          overrideAccess: true,
         })
       ).docs[0]
 
@@ -3216,6 +3255,7 @@ describe('Uploads', () => {
           depth: 0,
           limit: 1,
           where: { mimeType: { equals: 'video/mp4' } },
+          overrideAccess: true,
         })
       ).docs[0]
 

--- a/test/uploads/int.spec.ts
+++ b/test/uploads/int.spec.ts
@@ -107,7 +107,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
         expect(doc.width).toBeDefined()
         expect(doc.sizes.tablet.filename).toBeDefined()
 
-        await payload.delete({ id: doc.id, collection: mediaSlug })
+        await payload.delete({ id: doc.id, collection: mediaSlug, overrideAccess: true })
       })
 
       /**
@@ -288,6 +288,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
           collection: mediaSlug,
           data: {},
           file,
+          overrideAccess: true,
         })) as unknown as Media
 
         expect(mediaDoc.url).toBeDefined()
@@ -303,7 +304,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
         expect(mediaDoc.sizes?.icon?.url).toContain('%20')
         expect(mediaDoc.sizes?.icon?.url).not.toContain(' ')
 
-        await payload.delete({ collection: mediaSlug, id: mediaDoc.id })
+        await payload.delete({ collection: mediaSlug, id: mediaDoc.id, overrideAccess: true })
       })
 
       test('creates from form data given an svg', async ({ restClient }) => {
@@ -565,6 +566,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
           collection: mediaSlug,
           data: {},
           file,
+          overrideAccess: true,
         })) as unknown as Media
 
         const formData = new FormData()
@@ -600,6 +602,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
           collection: mediaSlug,
           data: {},
           file,
+          overrideAccess: true,
         })) as unknown as Media
 
         const formData = new FormData()
@@ -700,6 +703,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
           collection: mediaSlug,
           data: {},
           file,
+          overrideAccess: true,
         })
 
         expect(mediaDoc.url).toContain('%23')
@@ -713,7 +717,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
         expect(response.status).toBe(200)
         expect(response.headers.get('content-type')).toContain('image/png')
 
-        await payload.delete({ collection: mediaSlug, id: mediaDoc.id })
+        await payload.delete({ collection: mediaSlug, id: mediaDoc.id, overrideAccess: true })
       })
 
       test('should return the media document with the correct file type', async ({
@@ -728,6 +732,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
           collection: mediaSlug,
           data: {},
           file,
+          overrideAccess: true,
         })) as unknown as Media
 
         const response = await restClient.GET(`/${mediaSlug}/file/${mediaDoc.filename}`)
@@ -736,7 +741,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
 
         expect(response.headers.get('content-type')).toContain('image/png')
 
-        await payload.delete({ collection: mediaSlug, id: mediaDoc.id })
+        await payload.delete({ collection: mediaSlug, id: mediaDoc.id, overrideAccess: true })
       })
     })
   })
@@ -751,6 +756,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
           collection: svgOnlySlug as CollectionSlug,
           data: {},
           filePath: svgFilePath,
+          overrideAccess: true,
         })
 
         expect(await fileExists(path.join(expectedPath, doc.filename))).toBe(true)
@@ -770,11 +776,16 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
             name: 'svgWithXml.svg',
             size: fileBuffer.length,
           },
+          overrideAccess: true,
         })
 
         expect(await fileExists(path.join(expectedPath, doc.filename))).toBe(true)
 
-        await payload.delete({ collection: anyImagesSlug as CollectionSlug, id: doc.id })
+        await payload.delete({
+          collection: anyImagesSlug as CollectionSlug,
+          id: doc.id,
+          overrideAccess: true,
+        })
       })
 
       test('should create documents for JPEG XL files, which sharp cannot decode', async ({
@@ -795,6 +806,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
             name: 'test-image.jxl',
             size: fileBuffer.length,
           },
+          overrideAccess: true,
         })
 
         expect(await fileExists(path.join(expectedPath, doc.filename))).toBe(true)
@@ -802,7 +814,11 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
         expect(doc.width).toEqual(800)
         expect(doc.height).toEqual(800)
 
-        await payload.delete({ collection: anyImagesSlug as CollectionSlug, id: doc.id })
+        await payload.delete({
+          collection: anyImagesSlug as CollectionSlug,
+          id: doc.id,
+          overrideAccess: true,
+        })
       })
 
       test('should upload svg files', async ({ payload }) => {
@@ -813,6 +829,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
           collection: anyImagesSlug as CollectionSlug,
           data: {},
           filePath: svgFilePath,
+          overrideAccess: true,
         })
         expect(await fileExists(path.join(expectedPath, doc.filename))).toBe(true)
         expect(doc.mimeType).toEqual('image/svg+xml')
@@ -832,6 +849,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
             name: 'test-thumbnail.svg',
             size: fileBuffer.length,
           },
+          overrideAccess: true,
         })
 
         expect(doc.id).toBeDefined()
@@ -842,6 +860,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
         await payload.delete({
           collection: adminThumbnailSizeSlug as CollectionSlug,
           id: doc.id,
+          overrideAccess: true,
         })
       })
     })
@@ -857,6 +876,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
           collection: mediaSlug,
           data: {},
           file,
+          overrideAccess: true,
         })) as unknown as Media
 
         const expectedPath = path.join(dirname, './media')
@@ -874,13 +894,18 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
           id: mediaDoc.id,
           file: newFile,
           data: {},
+          overrideAccess: true,
         })) as unknown as Media
 
         // Check that the replacement file was created and the old one was removed
         expect(await fileExists(path.join(expectedPath, updatedMediaDoc.filename))).toBe(true)
         expect(await fileExists(path.join(expectedPath, mediaDoc.filename))).toBe(false)
 
-        await payload.delete({ collection: mediaSlug, id: updatedMediaDoc.id })
+        await payload.delete({
+          collection: mediaSlug,
+          id: updatedMediaDoc.id,
+          overrideAccess: true,
+        })
       })
 
       test('should remove existing media on re-upload - where query', async ({ payload }) => {
@@ -893,6 +918,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
           collection: mediaSlug,
           data: {},
           file,
+          overrideAccess: true,
         })) as unknown as Media
 
         const expectedPath = path.join(dirname, './media')
@@ -912,6 +938,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
           },
           file: newFile,
           data: {},
+          overrideAccess: true,
         })) as unknown as { docs: Media[] }
 
         // Check that the replacement file was created and the old one was removed
@@ -921,7 +948,11 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
         )
         expect(await fileExists(path.join(expectedPath, mediaDoc.filename))).toBe(false)
 
-        await payload.delete({ collection: mediaSlug, id: updatedMediaDoc.docs[0].id })
+        await payload.delete({
+          collection: mediaSlug,
+          id: updatedMediaDoc.docs[0].id,
+          overrideAccess: true,
+        })
       })
 
       test('should remove sizes that do not pertain to the new image - by ID', async ({
@@ -935,6 +966,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
           collection: mediaSlug,
           data: {},
           file,
+          overrideAccess: true,
         })
 
         const doc = (await payload.update({
@@ -942,6 +974,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
           id,
           data: {},
           file: small,
+          overrideAccess: true,
         })) as unknown as Media
 
         expect(doc.sizes.icon).toBeDefined()
@@ -959,6 +992,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
           collection: mediaSlug,
           data: {},
           file,
+          overrideAccess: true,
         })
 
         const doc = (await payload.update({
@@ -968,6 +1002,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
           },
           data: {},
           file: small,
+          overrideAccess: true,
         })) as unknown as { docs: Media[] }
 
         expect(doc.docs[0].sizes.icon).toBeDefined()
@@ -985,6 +1020,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
           collection: mediaSlug,
           data: {},
           file,
+          overrideAccess: true,
         })
 
         const related = await payload.create({
@@ -992,6 +1028,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
           data: {
             image: id,
           },
+          overrideAccess: true,
         })
 
         const doc = await payload.update({
@@ -1000,6 +1037,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
           data: {
             image: null,
           },
+          overrideAccess: true,
         })
 
         expect(doc.image).toBeFalsy()
@@ -1014,6 +1052,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
           collection: mediaSlug,
           data: {},
           file,
+          overrideAccess: true,
         })
 
         const related = await payload.create({
@@ -1021,6 +1060,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
           data: {
             image: id,
           },
+          overrideAccess: true,
         })
 
         const doc = await payload.update({
@@ -1031,6 +1071,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
           data: {
             image: null,
           },
+          overrideAccess: true,
         })
 
         expect(doc.docs[0].image).toBeFalsy()
@@ -1044,12 +1085,14 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
           collection: mediaSlug,
           data: {},
           file,
+          overrideAccess: true,
         })
 
         const { id: id_2 } = await payload.create({
           collection: mediaSlug,
           data: {},
           file,
+          overrideAccess: true,
         })
 
         const res = await payload.create({
@@ -1064,6 +1107,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
               },
             ],
           },
+          overrideAccess: true,
         })
 
         expect(res.blocks[0]?.media).toBe(id)
@@ -1083,6 +1127,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
               },
             ],
           },
+          overrideAccess: true,
         })
 
         expect(res_2.blocks[0]?.media).toBe(id_2)
@@ -1111,6 +1156,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
               cookie: testCookies,
             }),
           },
+          overrideAccess: true,
         })
 
         const [[, options]] = fetchSpy.mock.calls
@@ -1189,6 +1235,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
               cookie: testCookies,
             }),
           },
+          overrideAccess: true,
         })
 
         const [[, options]] = fetchSpy.mock.calls
@@ -1288,6 +1335,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
                 // to return the IP address we want to test.
                 url: 'https://www.payloadcms.com/test.png',
               },
+              overrideAccess: true,
             }),
           ).rejects.toThrow(
             expect.objectContaining({
@@ -1316,6 +1364,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
                 filename: 'test.png',
                 url,
               },
+              overrideAccess: true,
             }),
           ).rejects.toThrow(expect.objectContaining(directURLFailure))
         },
@@ -1328,6 +1377,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
               filename: 'test.png',
               url: 'http://127.0.0.1/file.png',
             },
+            overrideAccess: true,
           }),
           // We're expecting this to throw because the file doesn't exist -- not because the url is unsafe
         ).rejects.toThrow(
@@ -1346,6 +1396,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
               filename: 'test.png',
               url: 'http://127.0.0.1/file.png',
             },
+            overrideAccess: true,
           }),
           // We're expecting this to throw because the file doesn't exist -- not because the url is unsafe
         ).rejects.toThrow(
@@ -1370,6 +1421,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
             collection: restrictFileTypesSlug as CollectionSlug,
             data: {},
             file,
+            overrideAccess: true,
           }),
         ).rejects.toThrow(
           expect.objectContaining({
@@ -1387,6 +1439,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
             collection: noRestrictFileTypesSlug as CollectionSlug,
             data: {},
             file,
+            overrideAccess: true,
           }),
         ).resolves.not.toThrow()
       })
@@ -1399,6 +1452,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
             collection: noRestrictFileMimeTypesSlug as CollectionSlug,
             data: {},
             file,
+            overrideAccess: true,
           }),
         ).resolves.not.toThrow()
       })
@@ -1562,6 +1616,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
           focalY: 5,
         },
         file,
+        overrideAccess: true,
       })
 
       expect(doc.focalX).toEqual(5)
@@ -1574,6 +1629,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
           focalX: 10,
           focalY: 10,
         },
+        overrideAccess: true,
       })
 
       expect(updatedFocal.focalX).toEqual(10)
@@ -1583,13 +1639,14 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
         collection: focalOnlySlug,
         id: doc.id,
         data: {},
+        overrideAccess: true,
       })
 
       // Expect focal point to be the same
       expect(updateWithoutFocal.focalX).toEqual(10)
       expect(updateWithoutFocal.focalY).toEqual(10)
 
-      await payload.delete({ collection: focalOnlySlug, id: doc.id })
+      await payload.delete({ collection: focalOnlySlug, id: doc.id, overrideAccess: true })
     })
 
     test('should default focal point to 50, 50', async ({ payload }) => {
@@ -1599,6 +1656,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
           // No focal point
         },
         file,
+        overrideAccess: true,
       })
 
       expect(doc.focalX).toEqual(50)
@@ -1608,12 +1666,13 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
         collection: focalOnlySlug,
         id: doc.id,
         data: {},
+        overrideAccess: true,
       })
 
       expect(updateWithoutFocal.focalX).toEqual(50)
       expect(updateWithoutFocal.focalY).toEqual(50)
 
-      await payload.delete({ collection: focalOnlySlug, id: doc.id })
+      await payload.delete({ collection: focalOnlySlug, id: doc.id, overrideAccess: true })
     })
 
     test('should set focal point even if no sizes defined', async ({ payload }) => {
@@ -1623,12 +1682,13 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
           // No focal point
         },
         file,
+        overrideAccess: true,
       })
 
       expect(doc.focalX).toEqual(50)
       expect(doc.focalY).toEqual(50)
 
-      await payload.delete({ collection: focalNoSizesSlug, id: doc.id })
+      await payload.delete({ collection: focalNoSizesSlug, id: doc.id, overrideAccess: true })
     })
   })
 
@@ -1642,6 +1702,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
         collection: enlargeSlug,
         data: {},
         file: small,
+        overrideAccess: true,
       })
 
       expect(result).toBeTruthy()
@@ -1676,6 +1737,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
       await payload.delete({
         collection: enlargeSlug,
         id: result.id,
+        overrideAccess: true,
       })
     })
 
@@ -1689,6 +1751,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
         collection: enlargeSlug,
         data: {},
         file: small,
+        overrideAccess: true,
       })) as unknown as Enlarge
 
       expect(result).toBeTruthy()
@@ -1706,6 +1769,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
       await payload.delete({
         collection: enlargeSlug,
         id: result.id,
+        overrideAccess: true,
       })
     })
 
@@ -1718,6 +1782,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
         collection: reduceSlug,
         data: {},
         file: small,
+        overrideAccess: true,
       })
 
       expect(result).toBeTruthy()
@@ -1749,7 +1814,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
       expect(sizes.accidentalSameSize.mimeType).toBe('image/png')
       expect(sizes.accidentalSameSize.filename).toBe('small-320x80.png')
 
-      await payload.delete({ collection: reduceSlug, id: result.id })
+      await payload.delete({ collection: reduceSlug, id: result.id, overrideAccess: true })
     })
 
     test('should not enlarge image if `withoutEnlargement` is set to undefined and width or height is undefined when imageSizes are larger than the uploaded image', async ({
@@ -1761,6 +1826,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
         collection: enlargeSlug,
         data: {},
         file: small,
+        overrideAccess: true,
       })
 
       expect(result).toBeTruthy()
@@ -1779,6 +1845,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
       await payload.delete({
         collection: enlargeSlug,
         id: result.id,
+        overrideAccess: true,
       })
     })
   })
@@ -1790,6 +1857,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
       const successfulCreate = await payload.create({
         collection: 'optional-file',
         data: {},
+        overrideAccess: true,
       })
 
       expect(successfulCreate.id).toBeDefined()
@@ -1802,6 +1870,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
         payload.create({
           collection: 'required-file',
           data: {},
+          overrideAccess: true,
         }),
       ).rejects.toThrow(
         expect.objectContaining({
@@ -1817,6 +1886,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
         payload.create({
           collection: mediaSlug,
           data: {},
+          overrideAccess: true,
         }),
       ).rejects.toThrow(
         expect.objectContaining({
@@ -1837,6 +1907,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
         collection: 'media',
         data: {},
         file,
+        overrideAccess: true,
       })
 
       expect(mediaDoc).toBeDefined()
@@ -1844,14 +1915,15 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
       const duplicatedDoc = await payload.duplicate({
         collection: 'media',
         id: mediaDoc.id,
+        overrideAccess: true,
       })
 
       const expectedPath = path.join(dirname, './media')
 
       expect(await fileExists(path.join(expectedPath, duplicatedDoc.filename))).toBe(true)
 
-      await payload.delete({ collection: 'media', id: mediaDoc.id })
-      await payload.delete({ collection: 'media', id: duplicatedDoc.id })
+      await payload.delete({ collection: 'media', id: mediaDoc.id, overrideAccess: true })
+      await payload.delete({ collection: 'media', id: duplicatedDoc.id, overrideAccess: true })
     })
 
     test('should not leak req.file between sequential duplicate() calls on a shared req', async ({
@@ -1869,12 +1941,14 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
         collection: mediaSlug,
         data: {},
         file: file1,
+        overrideAccess: true,
       })
 
       const doc2 = await payload.create({
         collection: mediaSlug,
         data: {},
         file: file2,
+        overrideAccess: true,
       })
 
       // Use a shared req object to simulate batch operations within a transaction
@@ -1884,12 +1958,14 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
         collection: mediaSlug,
         id: doc1.id,
         req,
+        overrideAccess: true,
       })
 
       const dup2 = await payload.duplicate({
         collection: mediaSlug,
         id: doc2.id,
         req,
+        overrideAccess: true,
       })
 
       // dup1 should derive from alpha-leak-test.png
@@ -1898,10 +1974,10 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
       expect(dup2.filename).toContain('bravo-leak-test')
 
       // Clean up created docs
-      await payload.delete({ collection: mediaSlug, id: doc1.id })
-      await payload.delete({ collection: mediaSlug, id: doc2.id })
-      await payload.delete({ collection: mediaSlug, id: dup1.id })
-      await payload.delete({ collection: mediaSlug, id: dup2.id })
+      await payload.delete({ collection: mediaSlug, id: doc1.id, overrideAccess: true })
+      await payload.delete({ collection: mediaSlug, id: doc2.id, overrideAccess: true })
+      await payload.delete({ collection: mediaSlug, id: dup1.id, overrideAccess: true })
+      await payload.delete({ collection: mediaSlug, id: dup2.id, overrideAccess: true })
     })
   })
 
@@ -1924,6 +2000,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
           collection: mediaSlug,
           data: {},
           file,
+          overrideAccess: true,
         })) as unknown as Media
 
         expect(mediaDoc).toBeDefined()
@@ -1958,7 +2035,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
         expect(dbDoc.sizes?.icon?.url).not.toContain('http://local-images:3000')
         expect(dbDoc.sizes?.icon?.url).toMatch(/^\/api\/media\/file\//)
 
-        await payload.delete({ collection: mediaSlug, id: mediaDoc.id })
+        await payload.delete({ collection: mediaSlug, id: mediaDoc.id, overrideAccess: true })
       } finally {
         // Restore original serverURL
         payload.config.serverURL = originalServerURL
@@ -1983,6 +2060,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
           collection: mediaSlug,
           data: {},
           file,
+          overrideAccess: true,
         })) as unknown as Media
 
         expect(mediaDoc).toBeDefined()
@@ -1991,6 +2069,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
         const duplicatedDoc = (await payload.duplicate({
           collection: mediaSlug,
           id: mediaDoc.id,
+          overrideAccess: true,
         })) as unknown as Media
 
         expect(duplicatedDoc).toBeDefined()
@@ -2021,8 +2100,8 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
         expect(dbDoc.sizes?.tablet?.url).not.toContain('http://local-images:3000')
         expect(dbDoc.sizes?.tablet?.url).toMatch(/^\/api\/media\/file\//)
 
-        await payload.delete({ collection: mediaSlug, id: mediaDoc.id })
-        await payload.delete({ collection: mediaSlug, id: duplicatedDoc.id })
+        await payload.delete({ collection: mediaSlug, id: mediaDoc.id, overrideAccess: true })
+        await payload.delete({ collection: mediaSlug, id: duplicatedDoc.id, overrideAccess: true })
       } finally {
         // Restore original serverURL
         payload.config.serverURL = originalServerURL
@@ -2047,6 +2126,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
           collection: mediaSlug,
           data: {},
           file,
+          overrideAccess: true,
         })) as unknown as Media
 
         expect(mediaDoc).toBeDefined()
@@ -2059,6 +2139,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
             focalX: 75,
             focalY: 25,
           },
+          overrideAccess: true,
         })) as unknown as Media
 
         expect(updatedDoc).toBeDefined()
@@ -2085,7 +2166,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
         expect(dbDoc.sizes?.tablet?.url).not.toContain('http://local-images:3000')
         expect(dbDoc.sizes?.tablet?.url).toMatch(/^\/api\/media\/file\//)
 
-        await payload.delete({ collection: mediaSlug, id: mediaDoc.id })
+        await payload.delete({ collection: mediaSlug, id: mediaDoc.id, overrideAccess: true })
       } finally {
         // Restore original serverURL
         payload.config.serverURL = originalServerURL
@@ -2107,6 +2188,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
         collection: mediaSlug,
         data: {},
         file,
+        overrideAccess: true,
       })) as unknown as Media
 
       uploadedFilename = uploadedDoc.filename
@@ -2213,6 +2295,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
           await payloadInstance.delete({
             collection: noRestrictFileTypesSlug as CollectionSlug,
             id,
+            overrideAccess: true,
           })
         } catch {
           // ignore
@@ -2232,6 +2315,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
         collection: noRestrictFileTypesSlug as CollectionSlug,
         data: {},
         file,
+        overrideAccess: true,
       })) as unknown as Media
 
       docIDs.push(xssPayloadDoc.id)
@@ -2261,6 +2345,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
         collection: svgOnlySlug as CollectionSlug,
         data: {},
         file,
+        overrideAccess: true,
       })) as unknown as Media
 
       docIDs.push(safeDoc.id)
@@ -2318,6 +2403,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
               filename: 'malicious.jpg',
               url: `http://127.0.0.1:${attackerServerPort}/image.jpg`,
             },
+            overrideAccess: true,
           }),
         ).rejects.toThrow()
       } finally {
@@ -2351,6 +2437,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
             filename: 'cdn-image.png',
             url: `http://127.0.0.1:${cdnServerPort}/image.png`,
           },
+          overrideAccess: true,
         })
 
         expect(doc.filename).toBe('cdn-image.png')
@@ -2378,6 +2465,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
               filename: 'redirect-test.png',
               url: `http://127.0.0.1:${redirectServerPort}/image.png`,
             },
+            overrideAccess: true,
           }),
         ).rejects.toThrow()
       } finally {
@@ -2404,6 +2492,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
               filename: 'loop.png',
               url: `http://127.0.0.1:${redirectServerPort}/loop`,
             },
+            overrideAccess: true,
           }),
         ).rejects.toThrow(/Too many redirects/)
       } finally {
@@ -2492,7 +2581,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
     test.afterEach(async ({ payload }) => {
       for (const id of docIDs) {
         try {
-          await payload.delete({ collection: prefixMediaSlug, id })
+          await payload.delete({ collection: prefixMediaSlug, id, overrideAccess: true })
         } catch {
           // noop — file may already have been deleted
         }
@@ -2511,6 +2600,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
         collection: prefixMediaSlug,
         data: { prefix: 'abc123' },
         file,
+        overrideAccess: true,
       })
 
       docIDs.push(doc.id)
@@ -2533,6 +2623,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
         collection: prefixMediaSlug,
         data: { prefix: 'abc123' },
         file,
+        overrideAccess: true,
       })
 
       docIDs.push(doc.id)
@@ -2555,6 +2646,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
         collection: prefixMediaSlug,
         data: {},
         file,
+        overrideAccess: true,
       })
 
       docIDs.push(doc.id)
@@ -2575,6 +2667,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
         collection: prefixMediaSlug,
         data: {},
         file,
+        overrideAccess: true,
       })
 
       docIDs.push(doc.id)
@@ -2600,7 +2693,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
 
     test.afterEach(async ({ payload }) => {
       for (const id of createdIds) {
-        await payload.delete({ id, collection: clientUploadTempFileSlug })
+        await payload.delete({ id, collection: clientUploadTempFileSlug, overrideAccess: true })
       }
       createdIds.length = 0
     })
@@ -2667,7 +2760,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
 
     test.afterEach(async ({ payload }) => {
       for (const id of createdIds) {
-        await payload.delete({ id, collection: mediaSlug })
+        await payload.delete({ id, collection: mediaSlug, overrideAccess: true })
       }
       createdIds.length = 0
 
@@ -2700,6 +2793,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
           size: fileContents.length,
           tempFilePath,
         },
+        overrideAccess: true,
       })
 
       createdIds.push(doc.id)

--- a/test/uploads/seed.ts
+++ b/test/uploads/seed.ts
@@ -32,6 +32,7 @@ export const seed = async (payload: Payload) => {
       email: devUser.email,
       password: devUser.password,
     },
+    overrideAccess: true,
   })
 
   // Create image
@@ -42,9 +43,15 @@ export const seed = async (payload: Payload) => {
     collection: mediaSlug,
     data: {},
     file: imageFile,
+    overrideAccess: true,
   })
 
-  await payload.create({ collection: mediaWithoutDeleteAccessSlug, data: {}, file: imageFile })
+  await payload.create({
+    collection: mediaWithoutDeleteAccessSlug,
+    data: {},
+    file: imageFile,
+    overrideAccess: true,
+  })
 
   const { id: versionedImage } = await payload.create({
     collection: versionSlug,
@@ -53,6 +60,7 @@ export const seed = async (payload: Payload) => {
       title: 'upload',
     },
     file: imageFile,
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -61,6 +69,7 @@ export const seed = async (payload: Payload) => {
       image: uploadedImage,
       versionedImage,
     },
+    overrideAccess: true,
   })
 
   // Create animated type images
@@ -71,6 +80,7 @@ export const seed = async (payload: Payload) => {
     collection: animatedTypeMedia,
     data: {},
     file: animatedImageFile,
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -80,6 +90,7 @@ export const seed = async (payload: Payload) => {
       title: 'upload',
     },
     file: animatedImageFile,
+    overrideAccess: true,
   })
 
   const nonAnimatedImageFilePath = path.resolve(seedDir, './non-animated.webp')
@@ -89,6 +100,7 @@ export const seed = async (payload: Payload) => {
     collection: animatedTypeMedia,
     data: {},
     file: nonAnimatedImageFile,
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -98,6 +110,7 @@ export const seed = async (payload: Payload) => {
       title: 'upload',
     },
     file: nonAnimatedImageFile,
+    overrideAccess: true,
   })
 
   // Create audio
@@ -108,6 +121,7 @@ export const seed = async (payload: Payload) => {
     collection: mediaSlug,
     data: {},
     file: audioFile,
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -115,6 +129,7 @@ export const seed = async (payload: Payload) => {
     data: {
       audio: file.id,
     },
+    overrideAccess: true,
   })
 
   // Create admin thumbnail media
@@ -125,6 +140,7 @@ export const seed = async (payload: Payload) => {
       ...audioFile,
       name: 'audio-thumbnail.mp3', // Override to avoid conflicts
     } as File,
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -134,6 +150,7 @@ export const seed = async (payload: Payload) => {
       ...imageFile,
       name: `thumb-${imageFile?.name}`,
     } as File,
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -143,6 +160,7 @@ export const seed = async (payload: Payload) => {
       ...imageFile,
       name: `function-image-${imageFile?.name}`,
     } as File,
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -152,6 +170,7 @@ export const seed = async (payload: Payload) => {
       ...imageFile,
       name: `searchQueries-image-${imageFile?.name}`,
     } as File,
+    overrideAccess: true,
   })
 
   // Create media with and without relation preview
@@ -159,6 +178,7 @@ export const seed = async (payload: Payload) => {
     collection: 'media-with-relation-preview',
     data: {},
     file: imageFile,
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -168,12 +188,14 @@ export const seed = async (payload: Payload) => {
       ...imageFile,
       name: `withoutCacheTags-image-${imageFile?.name}`,
     } as File,
+    overrideAccess: true,
   })
 
   const { id: uploadedImageWithoutPreview } = await payload.create({
     collection: 'media-without-relation-preview',
     data: {},
     file: imageFile,
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -186,6 +208,7 @@ export const seed = async (payload: Payload) => {
       imageWithPreview2: uploadedImageWithPreview,
       imageWithPreview3: uploadedImageWithoutPreview,
     },
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -194,6 +217,7 @@ export const seed = async (payload: Payload) => {
       alt: 'alt-1',
     },
     file: imageFile,
+    overrideAccess: true,
   })
 
   for (let i = 0; i < 20; i++) {
@@ -209,6 +233,7 @@ export const seed = async (payload: Payload) => {
     await payload.create({
       collection: 'list-view-preview',
       data,
+      overrideAccess: true,
     })
   }
 
@@ -223,6 +248,7 @@ export const seed = async (payload: Payload) => {
     collection: mediaSlug,
     data: {},
     file: pdfFile,
+    overrideAccess: true,
   })
 
   const videoFilePath = path.resolve(seedDir, './christmas-mariachi-in-guadalajara.mp4')
@@ -232,6 +258,7 @@ export const seed = async (payload: Payload) => {
     collection: mediaSlug,
     data: {},
     file: videoFile,
+    overrideAccess: true,
   })
 
   // Seed media-with-fields with one of each supported file type, every field filled in and the
@@ -398,6 +425,7 @@ export const seed = async (payload: Payload) => {
       collection: mediaWithFieldsSlug,
       data,
       file: { ...file, name: `with-fields-${file?.name}` } as File,
+      overrideAccess: true,
     })
   }
 
@@ -408,6 +436,7 @@ export const seed = async (payload: Payload) => {
       ...imageFile,
       name: `single-preview-image-${imageFile?.name}`,
     } as File,
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -417,6 +446,7 @@ export const seed = async (payload: Payload) => {
       ...audioFile,
       name: `single-preview-audio-${audioFile?.name}`,
     } as File,
+    overrideAccess: true,
   })
 
   // Seed filePreview map collection — one image (no match), one PDF (exact), one audio (category
@@ -428,6 +458,7 @@ export const seed = async (payload: Payload) => {
       ...imageFile,
       name: `map-preview-image-${imageFile?.name}`,
     } as File,
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -437,6 +468,7 @@ export const seed = async (payload: Payload) => {
       ...pdfFile,
       name: `map-preview-pdf-${pdfFile?.name}`,
     } as File,
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -446,6 +478,7 @@ export const seed = async (payload: Payload) => {
       ...audioFile,
       name: `map-preview-audio-${audioFile?.name}`,
     } as File,
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -455,6 +488,7 @@ export const seed = async (payload: Payload) => {
       ...videoFile,
       name: `map-preview-video-${videoFile?.name}`,
     } as File,
+    overrideAccess: true,
   })
 
   // Seed file-preview collection — image and audio to exercise the switch-case component
@@ -465,6 +499,7 @@ export const seed = async (payload: Payload) => {
       ...imageFile,
       name: `file-preview-image-${imageFile?.name}`,
     } as File,
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -474,5 +509,6 @@ export const seed = async (payload: Payload) => {
       ...audioFile,
       name: `file-preview-audio-${audioFile?.name}`,
     } as File,
+    overrideAccess: true,
   })
 }

--- a/test/uuid-v7/int.spec.ts
+++ b/test/uuid-v7/int.spec.ts
@@ -21,6 +21,7 @@ test.suite({ config: './config.ts', db: (adapter) => adapter === 'postgres-uuidv
       const doc = await payload.create({
         collection: 'posts',
         data: { title: 'uuid v7 post' },
+        overrideAccess: true,
       })
 
       expect(typeof doc.id).toBe('string')
@@ -35,10 +36,12 @@ test.suite({ config: './config.ts', db: (adapter) => adapter === 'postgres-uuidv
       const first = await payload.create({
         collection: 'posts',
         data: { title: 'first' },
+        overrideAccess: true,
       })
       const second = await payload.create({
         collection: 'posts',
         data: { title: 'second' },
+        overrideAccess: true,
       })
 
       expect(second.id > first.id).toBe(true)
@@ -48,11 +51,13 @@ test.suite({ config: './config.ts', db: (adapter) => adapter === 'postgres-uuidv
       const created = await payload.create({
         collection: 'posts',
         data: { title: 'find me' },
+        overrideAccess: true,
       })
 
       const found = await payload.findByID({
         collection: 'posts',
         id: created.id,
+        overrideAccess: true,
       })
 
       expect(found.id).toBe(created.id)
@@ -63,6 +68,7 @@ test.suite({ config: './config.ts', db: (adapter) => adapter === 'postgres-uuidv
       const category = await payload.create({
         collection: 'categories',
         data: { name: 'Cat A' },
+        overrideAccess: true,
       })
       const article = await payload.create({
         collection: 'articles',
@@ -71,6 +77,7 @@ test.suite({ config: './config.ts', db: (adapter) => adapter === 'postgres-uuidv
           category: category.id,
         },
         depth: 1,
+        overrideAccess: true,
       })
 
       expect(article.category).toMatchObject({ id: category.id })
@@ -80,11 +87,13 @@ test.suite({ config: './config.ts', db: (adapter) => adapter === 'postgres-uuidv
       const created = await payload.create({
         collection: 'posts',
         data: { title: 'query by id' },
+        overrideAccess: true,
       })
 
       const res = await payload.find({
         collection: 'posts',
         where: { id: { equals: created.id } },
+        overrideAccess: true,
       })
 
       expect(res.docs).toHaveLength(1)

--- a/test/v4/baseConfig.ts
+++ b/test/v4/baseConfig.ts
@@ -207,6 +207,7 @@ export const seed: NonNullable<Config['onInit']> = async (payload) => {
       password: devUser.password,
       roles: ['admin'],
     },
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -216,6 +217,7 @@ export const seed: NonNullable<Config['onInit']> = async (payload) => {
       password: 'test',
       roles: ['user'],
     },
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -225,6 +227,7 @@ export const seed: NonNullable<Config['onInit']> = async (payload) => {
       password: devUser.password,
       roles: ['admin'],
     },
+    overrideAccess: true,
   })
 
   const authors = [
@@ -237,6 +240,7 @@ export const seed: NonNullable<Config['onInit']> = async (payload) => {
     await payload.create({
       collection: 'users',
       data: author,
+      overrideAccess: true,
     })
   }
 
@@ -257,16 +261,18 @@ export const seed: NonNullable<Config['onInit']> = async (payload) => {
     const created = await payload.create({
       collection: textFieldsSlug,
       data: post,
+      overrideAccess: true,
     })
     createdPosts.push(created)
   }
 
-  const richTextCount = await payload.count({ collection: richTextFieldsSlug })
+  const richTextCount = await payload.count({ collection: richTextFieldsSlug, overrideAccess: true })
   if (richTextCount.totalDocs === 0) {
     const uploadDoc = await payload.create({
       collection: uploadsSlug,
       data: { alt: 'Farming image' },
       file: imageFile,
+      overrideAccess: true,
     })
 
     const formattedUploadID =
@@ -276,6 +282,7 @@ export const seed: NonNullable<Config['onInit']> = async (payload) => {
       collection: 'users',
       limit: 1,
       where: { email: { equals: devUser.email } },
+      overrideAccess: true,
     })
     const userId = devUserDoc.docs[0]?.id
     const formattedUserID =
@@ -297,6 +304,7 @@ export const seed: NonNullable<Config['onInit']> = async (payload) => {
         title: 'Data harvest \u2013 how AI and sensors are revolutionizing farming',
         typography: getTypographyContent(formattedUserID),
       },
+      overrideAccess: true,
     })
   }
 
@@ -307,6 +315,7 @@ export const seed: NonNullable<Config['onInit']> = async (payload) => {
       authorRequired: devUserDoc.id,
       relatedPosts: createdPosts.slice(0, 3).map((p) => p.id) as string[],
     },
+    overrideAccess: true,
   })
   await payload.create({
     collection: relationshipFieldsSlug,
@@ -314,12 +323,14 @@ export const seed: NonNullable<Config['onInit']> = async (payload) => {
       authorRequired: devUserDoc.id,
       relatedPosts: createdPosts.slice(3, 6).map((p) => p.id) as string[],
     },
+    overrideAccess: true,
   })
 
   // Seed blocks collection
   await payload.create({
     collection: blocksFieldsSlug,
     data: blocksSeedData,
+    overrideAccess: true,
   })
 
   // Seed join fields collection
@@ -328,6 +339,7 @@ export const seed: NonNullable<Config['onInit']> = async (payload) => {
     data: {
       name: 'Example Category',
     },
+    overrideAccess: true,
   })
 
   // Create 15 posts to test join field pagination (defaultLimit: 3)
@@ -339,6 +351,7 @@ export const seed: NonNullable<Config['onInit']> = async (payload) => {
         category: joinCategory.id,
         title: `Post ${i}`,
       },
+      overrideAccess: true,
     })
   }
 
@@ -346,41 +359,49 @@ export const seed: NonNullable<Config['onInit']> = async (payload) => {
   const techTag = await payload.create({
     collection: tagsSlug,
     data: { name: 'Technology' },
+    overrideAccess: true,
   })
 
   const frontendTag = await payload.create({
     collection: tagsSlug,
     data: { name: 'Frontend', parent: techTag.id },
+    overrideAccess: true,
   })
 
   await payload.create({
     collection: tagsSlug,
     data: { name: 'React', parent: frontendTag.id },
+    overrideAccess: true,
   })
 
   await payload.create({
     collection: tagsSlug,
     data: { name: 'Vue', parent: frontendTag.id },
+    overrideAccess: true,
   })
 
   const backendTag = await payload.create({
     collection: tagsSlug,
     data: { name: 'Backend', parent: techTag.id },
+    overrideAccess: true,
   })
 
   await payload.create({
     collection: tagsSlug,
     data: { name: 'Node.js', parent: backendTag.id },
+    overrideAccess: true,
   })
 
   await payload.create({
     collection: tagsSlug,
     data: { name: 'Python', parent: backendTag.id },
+    overrideAccess: true,
   })
 
   await payload.create({
     collection: tagsSlug,
     data: { name: 'Design' },
+    overrideAccess: true,
   })
 
   // Add more root-level tags to test pagination (20+ total root tags)
@@ -409,6 +430,7 @@ export const seed: NonNullable<Config['onInit']> = async (payload) => {
     await payload.create({
       collection: tagsSlug,
       data: { name: tagName },
+      overrideAccess: true,
     })
   }
 
@@ -420,6 +442,7 @@ export const seed: NonNullable<Config['onInit']> = async (payload) => {
         description: `Description for tag item ${i}`,
         title: `Tag Item ${i}`,
       },
+      overrideAccess: true,
     })
   }
 
@@ -427,28 +450,33 @@ export const seed: NonNullable<Config['onInit']> = async (payload) => {
   const rootFolder = await payload.create({
     collection: foldersSlug,
     data: { name: 'Root Folder' },
+    overrideAccess: true,
   })
 
   await payload.create({
     collection: foldersSlug,
     data: { name: 'Subfolder A', parent: rootFolder.id },
+    overrideAccess: true,
   })
 
   await payload.create({
     collection: foldersSlug,
     data: { name: 'Subfolder B', parent: rootFolder.id },
+    overrideAccess: true,
   })
 
   // Seed nested child folders under a single parent to test nested LoadMoreRow pagination
   const nestedParentFolder = await payload.create({
     collection: foldersSlug,
     data: { name: 'Nested Parent Folder', parent: rootFolder.id },
+    overrideAccess: true,
   })
 
   for (let i = 1; i <= 10; i++) {
     await payload.create({
       collection: foldersSlug,
       data: { name: `Nested Child ${i}`, parent: nestedParentFolder.id },
+      overrideAccess: true,
     })
   }
 
@@ -456,12 +484,14 @@ export const seed: NonNullable<Config['onInit']> = async (payload) => {
   const branchFolder = await payload.create({
     collection: foldersSlug,
     data: { name: 'Branch Folder', parent: nestedParentFolder.id },
+    overrideAccess: true,
   })
 
   for (let i = 1; i <= 10; i++) {
     await payload.create({
       collection: foldersSlug,
       data: { name: `Leaf Child ${i}`, parent: branchFolder.id },
+      overrideAccess: true,
     })
   }
 
@@ -472,6 +502,7 @@ export const seed: NonNullable<Config['onInit']> = async (payload) => {
       data: {
         title: `Folder Item ${i}`,
       },
+      overrideAccess: true,
     })
   }
 
@@ -490,6 +521,7 @@ export const seed: NonNullable<Config['onInit']> = async (payload) => {
         status: statuses[i % statuses.length],
         title: `Document ${index}`,
       },
+      overrideAccess: true,
     })
   }
 
@@ -506,6 +538,7 @@ export const seed: NonNullable<Config['onInit']> = async (payload) => {
     await payload.create({
       collection: orderableSlug,
       data: item,
+      overrideAccess: true,
     })
   }
 
@@ -527,6 +560,7 @@ export const seed: NonNullable<Config['onInit']> = async (payload) => {
         status: { equals: 'published' },
       },
     },
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -540,6 +574,7 @@ export const seed: NonNullable<Config['onInit']> = async (payload) => {
         category: { equals: 'news' },
       },
     },
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -553,6 +588,7 @@ export const seed: NonNullable<Config['onInit']> = async (payload) => {
         status: { equals: 'draft' },
       },
     },
+    overrideAccess: true,
   })
 
   // Seed draft-versions collection with many versions for pagination testing
@@ -563,6 +599,7 @@ export const seed: NonNullable<Config['onInit']> = async (payload) => {
       title: 'Document With Many Versions',
     },
     draft: true,
+    overrideAccess: true,
   })
 
   for (let i = 0; i < 20; i++) {
@@ -573,6 +610,7 @@ export const seed: NonNullable<Config['onInit']> = async (payload) => {
         content: `Updated content version ${i + 2}`,
         title: `Document With Many Versions - v${i + 2}`,
       },
+      overrideAccess: true,
     })
   }
 
@@ -580,6 +618,7 @@ export const seed: NonNullable<Config['onInit']> = async (payload) => {
   const existingUpload = await payload.find({
     collection: uploadsSlug,
     limit: 1,
+    overrideAccess: true,
   })
   const heroUploadID = existingUpload.docs[0]?.id
 
@@ -694,6 +733,7 @@ export const seed: NonNullable<Config['onInit']> = async (payload) => {
       track: 'frontend',
       venueLocation: [-122.4194, 37.7749],
     },
+    overrideAccess: true,
   })
 
   const aiTalk = await payload.create({
@@ -736,6 +776,7 @@ export const seed: NonNullable<Config['onInit']> = async (payload) => {
       title: 'LLM Agents Without the Hype',
       track: 'ai-ml',
     },
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -760,6 +801,7 @@ export const seed: NonNullable<Config['onInit']> = async (payload) => {
       track: 'backend',
     },
     draft: true,
+    overrideAccess: true,
   })
 
   // Seed drawers collection: a couple of docs linked via the
@@ -865,6 +907,7 @@ export const seed: NonNullable<Config['onInit']> = async (payload) => {
         status: seed.status,
         title: seed.title,
       },
+      overrideAccess: true,
     })
     previousNestedChild = created.id
   }

--- a/test/v4/seed/categoriesSeedData.ts
+++ b/test/v4/seed/categoriesSeedData.ts
@@ -6,27 +6,33 @@ export async function seedHierarchy(payload: Payload) {
   const parent1 = await payload.create({
     collection: hierarchySlug,
     data: { name: 'Parent 1' },
+    overrideAccess: true,
   })
   const parent2 = await payload.create({
     collection: hierarchySlug,
     data: { name: 'Parent 2' },
+    overrideAccess: true,
   })
 
   await payload.create({
     collection: hierarchySlug,
     data: { name: 'Child 1a', parent: parent1.id },
+    overrideAccess: true,
   })
   await payload.create({
     collection: hierarchySlug,
     data: { name: 'Child 1b', parent: parent1.id },
+    overrideAccess: true,
   })
 
   await payload.create({
     collection: hierarchySlug,
     data: { name: 'Child 2a', parent: parent2.id },
+    overrideAccess: true,
   })
   await payload.create({
     collection: hierarchySlug,
     data: { name: 'Child 2b', parent: parent2.id },
+    overrideAccess: true,
   })
 }

--- a/test/v4/seed/versionsDiffData.ts
+++ b/test/v4/seed/versionsDiffData.ts
@@ -3,10 +3,10 @@ import type { Payload } from 'payload'
 import { tagsSlug, uploadsSlug, versionsDiffSlug } from '../slugs.js'
 
 export async function seedVersionsDiff(payload: Payload) {
-  const tagDocs = await payload.find({ collection: tagsSlug, limit: 3 })
+  const tagDocs = await payload.find({ collection: tagsSlug, limit: 3, overrideAccess: true })
   const tagIds = tagDocs.docs.map((d) => d.id)
 
-  const uploadDocs = await payload.find({ collection: uploadsSlug, limit: 2 })
+  const uploadDocs = await payload.find({ collection: uploadsSlug, limit: 2, overrideAccess: true })
   const uploadIds = uploadDocs.docs.map((d) => d.id)
 
   const versionsDiffDoc = await payload.create({
@@ -39,6 +39,7 @@ export async function seedVersionsDiff(payload: Payload) {
       upload: uploadIds[0],
       uploadMany: uploadIds.length > 1 ? [uploadIds[0]!, uploadIds[1]!] : [uploadIds[0]!],
     },
+    overrideAccess: true,
   })
 
   await payload.update({
@@ -75,5 +76,6 @@ export async function seedVersionsDiff(payload: Payload) {
       upload: uploadIds[1] || uploadIds[0],
       uploadMany: uploadIds.length > 1 ? [uploadIds[1]!] : [uploadIds[0]!],
     },
+    overrideAccess: true,
   })
 }

--- a/test/versions/e2e.spec.ts
+++ b/test/versions/e2e.spec.ts
@@ -163,6 +163,7 @@ describe('Versions', () => {
           description: 'This is published',
           title: 'Published Document',
         },
+        overrideAccess: true,
       })
 
       // Navigate to the document
@@ -364,6 +365,7 @@ describe('Versions', () => {
           _status: 'draft',
         },
         draft: false,
+        overrideAccess: true,
       })
 
       await page.goto(`${url.edit(publishedDoc.id)}/versions`)
@@ -401,6 +403,7 @@ describe('Versions', () => {
         data: {
           title: 'initial title',
         },
+        overrideAccess: true,
       })
 
       const global = new AdminUrlUtil(serverURL, draftWithMaxGlobalSlug)
@@ -454,6 +457,7 @@ describe('Versions', () => {
           description: 'post description',
           title: 'post title',
         },
+        overrideAccess: true,
       })
 
       await page.goto(postURL.edit(postID))
@@ -507,6 +511,7 @@ describe('Versions', () => {
           description: 'post description',
           title: 'post title',
         },
+        overrideAccess: true,
       })
 
       const { id: docID } = await payload.create({
@@ -516,6 +521,7 @@ describe('Versions', () => {
           relationship: postID,
           title: 'autosave title',
         },
+        overrideAccess: true,
       })
 
       await page.goto(autosaveURL.edit(docID))
@@ -561,6 +567,7 @@ describe('Versions', () => {
       const { totalDocs: initialDocsCount } = await payload.find({
         collection: autosaveCollectionSlug,
         draft: true,
+        overrideAccess: true,
       })
 
       await page.goto(autosaveURL.create)
@@ -571,6 +578,7 @@ describe('Versions', () => {
       const { totalDocs: updatedDocsCount } = await payload.find({
         collection: autosaveCollectionSlug,
         draft: true,
+        overrideAccess: true,
       })
 
       await expect(() => {
@@ -589,6 +597,7 @@ describe('Versions', () => {
       const { totalDocs: latestDocsCount } = await payload.find({
         collection: autosaveCollectionSlug,
         draft: true,
+        overrideAccess: true,
       })
 
       await expect(() => {
@@ -778,6 +787,7 @@ describe('Versions', () => {
           _status: 'draft',
           title: 'draft title',
         },
+        overrideAccess: true,
       })
 
       await page.goto(disablePublishURL.edit(String(draftDoc.id)))
@@ -816,6 +826,7 @@ describe('Versions', () => {
           _status: 'published',
           title: 'title',
         },
+        overrideAccess: true,
       })
       await page.goto(errorOnUnpublishURL.edit(String(publishedDoc.id)))
       await openDocControls(page)
@@ -833,6 +844,7 @@ describe('Versions', () => {
           _status: 'published',
           title: 'Test Custom Unpublish',
         },
+        overrideAccess: true,
       })
 
       const customUnpublishURL = new AdminUrlUtil(serverURL, draftWithCustomUnpublishSlug)
@@ -844,6 +856,7 @@ describe('Versions', () => {
       await payload.delete({
         id: publishedDoc.id,
         collection: draftWithCustomUnpublishSlug,
+        overrideAccess: true,
       })
     })
 
@@ -854,6 +867,7 @@ describe('Versions', () => {
           description: 'This collection has drafts disabled',
           title: 'No Drafts Doc',
         },
+        overrideAccess: true,
       })
 
       await page.goto(versionURL.edit(String(doc.id)))
@@ -864,6 +878,7 @@ describe('Versions', () => {
       await payload.delete({
         id: doc.id,
         collection: versionCollectionSlug,
+        overrideAccess: true,
       })
     })
 
@@ -875,6 +890,7 @@ describe('Versions', () => {
           description: 'description',
           title: 'unpublish version count test',
         },
+        overrideAccess: true,
       })
 
       await page.goto(url.edit(publishedDoc.id))
@@ -893,6 +909,7 @@ describe('Versions', () => {
       await payload.delete({
         id: publishedDoc.id,
         collection: draftCollectionSlug,
+        overrideAccess: true,
       })
     })
 
@@ -904,6 +921,7 @@ describe('Versions', () => {
           title: 'some title',
         },
         draft: true,
+        overrideAccess: true,
       })
 
       await page.goto(postURL.create)
@@ -929,6 +947,7 @@ describe('Versions', () => {
           title: 'some title',
         },
         draft: true,
+        overrideAccess: true,
       })
 
       await page.goto(url.edit(createdDoc.id))
@@ -975,6 +994,7 @@ describe('Versions', () => {
           title: 'initial title',
         },
         draft: true,
+        overrideAccess: true,
       })
 
       const collection = new AdminUrlUtil(serverURL, draftWithMaxCollectionSlug)
@@ -1154,6 +1174,7 @@ describe('Versions', () => {
           alt: 'Original image',
         },
         filePath: path.resolve(dirname, './image.jpg'),
+        overrideAccess: true,
       })
 
       await page.goto(uploadURL.edit(publishedDoc.id))
@@ -1176,6 +1197,7 @@ describe('Versions', () => {
       await expect(async () => {
         const { docs } = await payload.find({
           collection: draftWithUploadCollectionSlug,
+          overrideAccess: true,
           where: { id: { equals: publishedDoc.id } },
         })
         expect(docs[0]!._status).toStrictEqual('published')
@@ -1191,6 +1213,7 @@ describe('Versions', () => {
           alt: 'Original image',
         },
         filePath: path.resolve(dirname, './image.jpg'),
+        overrideAccess: true,
       })
 
       await page.goto(uploadURL.edit(publishedDoc.id))
@@ -1210,6 +1233,7 @@ describe('Versions', () => {
         const { docs: draftDocs } = await payload.find({
           collection: draftWithUploadCollectionSlug,
           draft: true,
+          overrideAccess: true,
           where: { id: { equals: publishedDoc.id } },
         })
         expect(draftDocs[0]!._status).toStrictEqual('draft')
@@ -1217,6 +1241,7 @@ describe('Versions', () => {
 
         const { docs: mainDocs } = await payload.find({
           collection: draftWithUploadCollectionSlug,
+          overrideAccess: true,
           where: { id: { equals: publishedDoc.id } },
         })
         expect(mainDocs[0]!.filename).toStrictEqual(publishedDoc.filename)
@@ -1231,6 +1256,7 @@ describe('Versions', () => {
           alt: 'Original image',
         },
         filePath: path.resolve(dirname, './image.jpg'),
+        overrideAccess: true,
       })
 
       await page.goto(uploadURL.edit(publishedDoc.id))
@@ -1252,12 +1278,14 @@ describe('Versions', () => {
         const { docs: draftDocs } = await payload.find({
           collection: draftWithUploadCollectionSlug,
           draft: true,
+          overrideAccess: true,
           where: { id: { equals: duplicatedDocID } },
         })
         expect(draftDocs[0]!._status).toStrictEqual('draft')
 
         const { docs: mainDocs } = await payload.find({
           collection: draftWithUploadCollectionSlug,
+          overrideAccess: true,
           where: { id: { equals: duplicatedDocID } },
         })
         expect(mainDocs[0]!._status).toStrictEqual('draft')
@@ -1297,6 +1325,7 @@ describe('Versions', () => {
         data: {
           title: 'initial title',
         },
+        overrideAccess: true,
       })
 
       const global = new AdminUrlUtil(serverURL, draftWithMaxGlobalSlug)
@@ -1387,6 +1416,7 @@ describe('Versions', () => {
       await payload.updateGlobal({
         slug: simpleDraftGlobalSlug,
         data: { _status: 'published', title: 'published global' },
+        overrideAccess: true,
       })
 
       const globalURL = new AdminUrlUtil(serverURL, simpleDraftGlobalSlug)
@@ -1400,6 +1430,7 @@ describe('Versions', () => {
       await payload.updateGlobal({
         slug: simpleDraftGlobalSlug,
         data: { _status: 'published', title: 'published global' },
+        overrideAccess: true,
       })
 
       const globalURL = new AdminUrlUtil(serverURL, simpleDraftGlobalSlug)
@@ -1418,6 +1449,7 @@ describe('Versions', () => {
       await payload.updateGlobal({
         slug: simpleDraftGlobalSlug,
         data: { _status: 'published', title: 'unpublish version count test' },
+        overrideAccess: true,
       })
 
       const globalURL = new AdminUrlUtil(serverURL, simpleDraftGlobalSlug)
@@ -1442,6 +1474,7 @@ describe('Versions', () => {
           _status: 'published',
           title: 'published global',
         },
+        overrideAccess: true,
       })
 
       const url = new AdminUrlUtil(serverURL, disablePublishGlobalSlug)
@@ -1457,12 +1490,14 @@ describe('Versions', () => {
         data: {
           title: 'initial title',
         },
+        overrideAccess: true,
       })
       await payload.updateGlobal({
         slug: draftGlobalSlug,
         data: {
           title: 'initial title 2',
         },
+        overrideAccess: true,
       })
 
       const url = new AdminUrlUtil(serverURL, draftGlobalSlug)
@@ -1624,6 +1659,7 @@ describe('Versions', () => {
           description: 'new description',
           title: 'new post',
         },
+        overrideAccess: true,
       })
 
       await localPage.goto(
@@ -1662,6 +1698,7 @@ describe('Versions', () => {
         docs: [createdJob],
       } = await payload.find({
         collection: 'payload-jobs',
+        overrideAccess: true,
         where: {
           'input.doc.value': {
             equals: String(post.id),
@@ -1766,6 +1803,7 @@ describe('Versions', () => {
       const data = await payload.find({
         collection: localizedCollectionSlug,
         locale: '*',
+        overrideAccess: true,
         where: {
           id: { equals: id },
         },
@@ -1807,6 +1845,7 @@ describe('Versions', () => {
         },
         draft: true,
         locale: 'en',
+        overrideAccess: true,
       })
 
       // Step 3: Publish specific locale (English) via API
@@ -1825,6 +1864,7 @@ describe('Versions', () => {
         },
         draft: false,
         locale: 'en',
+        overrideAccess: true,
       })
 
       // Step 4: Verify blocks survived with metadata intact
@@ -1835,6 +1875,7 @@ describe('Versions', () => {
       // Step 5: Verify via find (reload from DB)
       const data = await payload.find({
         collection: localizedCollectionSlug,
+        overrideAccess: true,
         where: {
           id: { equals: id },
         },
@@ -2166,6 +2207,7 @@ describe('Versions', () => {
           description: 'some description',
           title: 'This is a test',
         },
+        overrideAccess: true,
       })
 
       const url = new AdminUrlUtil(serverURL, postsCollectionSlug)
@@ -2267,6 +2309,7 @@ describe('Versions', () => {
           title: 'new post',
         },
         depth: 0,
+        overrideAccess: true,
       })
 
       postID = newPost.id
@@ -2287,12 +2330,14 @@ describe('Versions', () => {
         },
         depth: 0,
         draft: true,
+        overrideAccess: true,
       })
 
       const versions = await payload.findVersions({
         collection: draftCollectionSlug,
         depth: 0,
         limit: 2,
+        overrideAccess: true,
         where: {
           parent: { equals: postID },
         },
@@ -2306,6 +2351,7 @@ describe('Versions', () => {
           collection: diffCollectionSlug,
           depth: 0,
           limit: 1,
+          overrideAccess: true,
         })
       ).docs[0] as Diff
 
@@ -2316,6 +2362,7 @@ describe('Versions', () => {
           collection: diffCollectionSlug,
           depth: 0,
           limit: 1,
+          overrideAccess: true,
           where: {
             parent: { equals: diffID },
           },
@@ -2525,6 +2572,7 @@ describe('Versions', () => {
             return block
           }),
         },
+        overrideAccess: true,
       })
 
       const latestVersionDiff = (
@@ -2535,6 +2583,7 @@ describe('Versions', () => {
           where: {
             parent: { equals: diffID },
           },
+          overrideAccess: true,
         })
       ).docs[0] as Diff
 
@@ -2727,6 +2776,7 @@ describe('Versions', () => {
         collection: 'draft-posts',
         depth: 0,
         limit: 3,
+        overrideAccess: true,
         sort: 'createdAt',
       })
 
@@ -2861,6 +2911,7 @@ describe('Versions', () => {
         collection: 'media',
         depth: 0,
         limit: 2,
+        overrideAccess: true,
         sort: 'createdAt',
       })
 
@@ -2903,6 +2954,7 @@ describe('Versions', () => {
     test('correctly renders diff for relationship fields with deleted relation', async () => {
       await payload.delete({
         collection: 'draft-posts',
+        overrideAccess: true,
       })
 
       await navigateToDiffVersionView()
@@ -2923,6 +2975,7 @@ describe('Versions', () => {
     test('correctly renders diff for upload fields with deleted upload', async () => {
       await payload.delete({
         collection: 'media',
+        overrideAccess: true,
       })
 
       await navigateToDiffVersionView()
@@ -2952,6 +3005,7 @@ describe('Versions', () => {
             }),
           ],
         },
+        overrideAccess: true,
       })
 
       const latestVersionDiff = (
@@ -2959,6 +3013,7 @@ describe('Versions', () => {
           collection: diffCollectionSlug,
           depth: 0,
           limit: 1,
+          overrideAccess: true,
           where: {
             parent: { equals: diffID },
           },
@@ -3004,6 +3059,7 @@ describe('Versions', () => {
         data: {
           array: newArray,
         },
+        overrideAccess: true,
       })
 
       await payload.update({
@@ -3020,6 +3076,7 @@ describe('Versions', () => {
             return arrayItem
           }),
         },
+        overrideAccess: true,
       })
 
       const latestVersionDiff = (
@@ -3027,6 +3084,7 @@ describe('Versions', () => {
           collection: diffCollectionSlug,
           depth: 0,
           limit: 1,
+          overrideAccess: true,
           where: {
             parent: { equals: diffID },
           },
@@ -3053,6 +3111,7 @@ describe('Versions', () => {
         data: {
           text: 'Test text document',
         },
+        overrideAccess: true,
       })
 
       await payload.update({
@@ -3080,6 +3139,7 @@ describe('Versions', () => {
             },
           ],
         },
+        overrideAccess: true,
       })
 
       // Swap the order of the blocks
@@ -3108,6 +3168,7 @@ describe('Versions', () => {
             },
           ],
         },
+        overrideAccess: true,
       })
 
       const latestVersionDiff = (
@@ -3115,6 +3176,7 @@ describe('Versions', () => {
           collection: diffCollectionSlug,
           depth: 0,
           limit: 1,
+          overrideAccess: true,
           where: {
             parent: { equals: diffID },
           },
@@ -3136,6 +3198,7 @@ describe('Versions', () => {
           _status: 'published',
           text: '<b>bold</b> & "quotes"',
         },
+        overrideAccess: true,
       })
 
       // Update to create a version
@@ -3146,6 +3209,7 @@ describe('Versions', () => {
           _status: 'published',
           text: '<script>alert(1)</script>',
         },
+        overrideAccess: true,
       })
 
       const versionDiff = (
@@ -3153,6 +3217,7 @@ describe('Versions', () => {
           collection: diffCollectionSlug,
           depth: 0,
           limit: 1,
+          overrideAccess: true,
           where: {
             parent: { equals: doc.id },
           },
@@ -3175,7 +3240,7 @@ describe('Versions', () => {
       await expect(text.locator('.html-diff__diff-new')).toHaveText('<script>alert(1)</script>')
 
       // Cleanup
-      await payload.delete({ id: doc.id, collection: diffCollectionSlug })
+      await payload.delete({ id: doc.id, collection: diffCollectionSlug, overrideAccess: true })
     })
 
     test('correctly renders JSON fields containing HTML special characters', async () => {
@@ -3186,6 +3251,7 @@ describe('Versions', () => {
           _status: 'published',
           json: { html: '<div class="test">&amp;</div>' },
         },
+        overrideAccess: true,
       })
 
       // Update to create a version
@@ -3196,6 +3262,7 @@ describe('Versions', () => {
           _status: 'published',
           json: { html: '<span onclick="alert(1)">click</span>' },
         },
+        overrideAccess: true,
       })
 
       const versionDiff = (
@@ -3203,6 +3270,7 @@ describe('Versions', () => {
           collection: diffCollectionSlug,
           depth: 0,
           limit: 1,
+          overrideAccess: true,
           where: {
             parent: { equals: doc.id },
           },
@@ -3227,7 +3295,7 @@ describe('Versions', () => {
       )
 
       // Cleanup
-      await payload.delete({ id: doc.id, collection: diffCollectionSlug })
+      await payload.delete({ id: doc.id, collection: diffCollectionSlug, overrideAccess: true })
     })
   })
 })

--- a/test/versions/int.spec.ts
+++ b/test/versions/int.spec.ts
@@ -67,6 +67,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
     await payload.delete({
       collection: 'payload-jobs',
       where: {},
+      overrideAccess: true,
     })
   })
 
@@ -82,6 +83,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             title: 'i have a title',
           },
           draft: true,
+          overrideAccess: true,
         })
 
         expect(draft.id).toBeDefined()
@@ -97,6 +99,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             description: '345j23o4ifj34jf54g',
             title: 'Here is an autosave post in EN',
           },
+          overrideAccess: true,
         })
 
         // Update to create a version
@@ -106,6 +109,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           data: {
             title: updatedTitle,
           },
+          overrideAccess: true,
         })
 
         // Get versions
@@ -116,11 +120,13 @@ test.suite({ config: './config.ts' })('Versions', () => {
               equals: autosavePost.id,
             },
           },
+          overrideAccess: true,
         })
 
         const updatedPost = await payload.findByID({
           id: autosavePost.id,
           collection: autosaveCollectionSlug,
+          overrideAccess: true,
         })
         expect(updatedPost.title).toBe(updatedTitle)
         expect(updatedPost._status).toStrictEqual('draft')
@@ -136,6 +142,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             description: 'description 1',
             title: 'unique unchanging title',
           },
+          overrideAccess: true,
         })
 
         await payload.update({
@@ -144,6 +151,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           data: {
             description: 'description 2',
           },
+          overrideAccess: true,
         })
 
         const finalDescription = 'final description'
@@ -154,6 +162,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           data: {
             description: finalDescription,
           },
+          overrideAccess: true,
         })
 
         expect(secondUpdate.description).toBe(finalDescription)
@@ -167,6 +176,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             description: 'test description',
             title: 'initial title',
           },
+          overrideAccess: true,
         })
 
         await payload.update({
@@ -175,6 +185,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           data: {
             title: 'updated title',
           },
+          overrideAccess: true,
         })
 
         // Get the version ID
@@ -185,6 +196,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
               equals: autosavePost.id,
             },
           },
+          overrideAccess: true,
         })
 
         const versionID = versions.docs[0].id
@@ -193,6 +205,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
         const version = await payload.findVersionByID({
           id: versionID,
           collection: autosaveCollectionSlug,
+          overrideAccess: true,
         })
 
         expect(version.id).toStrictEqual(versionID)
@@ -209,6 +222,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             description: 'test description',
             title: 'initial title',
           },
+          overrideAccess: true,
         })
 
         await payload.update({
@@ -217,6 +231,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           data: {
             title: englishTitle,
           },
+          overrideAccess: true,
         })
 
         const updatedPostES = await payload.update({
@@ -226,6 +241,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             title: spanishTitle,
           },
           locale: 'es',
+          overrideAccess: true,
         })
 
         expect(updatedPostES.title).toBe(spanishTitle)
@@ -238,6 +254,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           data: {
             title: newEnglishTitle,
           },
+          overrideAccess: true,
         })
 
         const versions = await payload.findVersions({
@@ -248,6 +265,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
               equals: autosavePost.id,
             },
           },
+          overrideAccess: true,
         })
 
         expect(versions.docs[0].version.title.en).toStrictEqual(newEnglishTitle)
@@ -262,6 +280,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             description: 'Description',
             title: 'Some Title',
           },
+          overrideAccess: true,
         })
 
         await payload.create({
@@ -271,6 +290,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             relation: draftPost.id,
             title: 'With Relation',
           },
+          overrideAccess: true,
         })
 
         const query = {
@@ -294,6 +314,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
         const doc = await payload.create({
           collection: autosaveCollectionSlug,
           data: { description: 'descr', title: 'title' },
+          overrideAccess: true,
         })
 
         await wait(10)
@@ -302,6 +323,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           id: doc.id,
           collection: autosaveCollectionSlug,
           data: {},
+          overrideAccess: true,
         })
 
         expect(upd.createdAt).toBe(doc.createdAt)
@@ -322,6 +344,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
               },
             ],
           },
+          overrideAccess: true,
         })
 
         // Version itself should have new createdAt
@@ -333,6 +356,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           id: doc.id,
           collection: autosaveCollectionSlug,
           draft: false,
+          overrideAccess: true,
         })
 
         // createdAt from non-versions should be the same as version_createdAt in versions
@@ -344,7 +368,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
       test('should allow to create with a localized relationships inside a localized array and a block', async ({
         payload,
       }) => {
-        const post = await payload.create({ collection: 'posts', data: {} })
+        const post = await payload.create({ collection: 'posts', data: {}, overrideAccess: true })
         const res = await payload.create({
           collection: 'localized-posts',
           data: {
@@ -361,6 +385,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           },
           depth: 0,
           draft: true,
+          overrideAccess: true,
         })
         expect(res.blocks[0]?.array[0]?.relationship).toEqual(post.id)
         const {
@@ -369,6 +394,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           collection: 'localized-posts',
           depth: 0,
           where: { parent: { equals: res.id } },
+          overrideAccess: true,
         })
         expect(resFromVersions?.version.blocks[0]?.array[0]?.relationship).toEqual(post.id)
       })
@@ -378,6 +404,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           collection: 'autosave-posts',
           data: { _status: 'draft', description: 'description', title: 'post' },
           draft: true,
+          overrideAccess: true,
         })
 
         await payload.update({
@@ -386,6 +413,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           collection: 'autosave-posts',
           data: { title: 'autosave' },
           draft: true,
+          overrideAccess: true,
         })
 
         const getVersionsCount = async () => {
@@ -394,6 +422,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             where: {
               parent: { equals: post.id },
             },
+            overrideAccess: true,
           })
 
           return versionsCount
@@ -408,6 +437,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           collection: 'autosave-posts',
           data: { title: 'post-updated-1' },
           draft: true,
+          overrideAccess: true,
         })
 
         expect(await getVersionsCount()).toBe(2)
@@ -419,6 +449,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           data: { title: 'post-updated-2' },
           draft: true,
           where: { id: { equals: post.id } },
+          overrideAccess: true,
         })
         expect(await getVersionsCount()).toBe(2)
       })
@@ -432,6 +463,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
         const published = await payload.create({
           collection: autosaveCollectionSlug,
           data: { _status: 'published', description: 'original', title: 'Published Post' },
+          overrideAccess: true,
         })
 
         // Autosave a change on the published document
@@ -441,6 +473,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           collection: autosaveCollectionSlug,
           data: { title: 'Autosaved Title' },
           draft: true,
+          overrideAccess: true,
         })
 
         // Simulate page reload: read the latest draft version (what getLatestCollectionVersion does)
@@ -451,6 +484,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           where: {
             and: [{ parent: { equals: published.id } }, { latest: { equals: true } }],
           },
+          overrideAccess: true,
         })
 
         expect(latestVersions).toHaveLength(1)
@@ -466,6 +500,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
         const published = await payload.create({
           collection: autosaveCollectionSlug,
           data: { _status: 'published', description: 'desc', title: 'Original' },
+          overrideAccess: true,
         })
 
         // First autosave creates a draft version
@@ -475,11 +510,13 @@ test.suite({ config: './config.ts' })('Versions', () => {
           collection: autosaveCollectionSlug,
           data: { title: 'Change 1' },
           draft: true,
+          overrideAccess: true,
         })
 
         const countAfterFirst = await payload.countVersions({
           collection: autosaveCollectionSlug,
           where: { parent: { equals: published.id } },
+          overrideAccess: true,
         })
 
         // Second autosave should update the existing draft, NOT create a new one
@@ -489,11 +526,13 @@ test.suite({ config: './config.ts' })('Versions', () => {
           collection: autosaveCollectionSlug,
           data: { title: 'Change 2' },
           draft: true,
+          overrideAccess: true,
         })
 
         const countAfterSecond = await payload.countVersions({
           collection: autosaveCollectionSlug,
           where: { parent: { equals: published.id } },
+          overrideAccess: true,
         })
 
         expect(countAfterSecond.totalDocs).toBe(countAfterFirst.totalDocs)
@@ -505,11 +544,13 @@ test.suite({ config: './config.ts' })('Versions', () => {
           collection: autosaveCollectionSlug,
           data: { title: 'Change 3' },
           draft: true,
+          overrideAccess: true,
         })
 
         const countAfterThird = await payload.countVersions({
           collection: autosaveCollectionSlug,
           where: { parent: { equals: published.id } },
+          overrideAccess: true,
         })
 
         expect(countAfterThird.totalDocs).toBe(countAfterFirst.totalDocs)
@@ -520,6 +561,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           limit: 1,
           sort: '-updatedAt',
           where: { parent: { equals: published.id } },
+          overrideAccess: true,
         })
 
         expect(docs[0].version.title).toBe('Change 3')
@@ -533,12 +575,14 @@ test.suite({ config: './config.ts' })('Versions', () => {
           collection,
           data: { description: 'description' },
           draft: true,
+          overrideAccess: true,
         })
 
         const docWithLocales = await payload.findByID({
           collection,
           id: post.id,
           locale: 'all',
+          overrideAccess: true,
         })
 
         const result = await saveVersion({
@@ -564,6 +608,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             _status: 'published',
           },
           draft: false,
+          overrideAccess: true,
         })
 
         const duplicatedDoc = await payload.create({
@@ -573,12 +618,13 @@ test.suite({ config: './config.ts' })('Versions', () => {
             _status: 'draft',
           },
           draft: true,
+          overrideAccess: true,
         })
 
         expect(duplicatedDoc._status).toBe('draft')
 
-        await payload.delete({ collection: draftCollectionSlug, id: originalDoc.id })
-        await payload.delete({ collection: draftCollectionSlug, id: duplicatedDoc.id })
+        await payload.delete({ collection: draftCollectionSlug, id: originalDoc.id, overrideAccess: true })
+        await payload.delete({ collection: draftCollectionSlug, id: duplicatedDoc.id, overrideAccess: true })
       })
 
       test('should duplicate a draft document with empty required fields via local API', async ({
@@ -591,6 +637,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             _status: 'draft',
           },
           draft: true,
+          overrideAccess: true,
         })
 
         // description is required but missing — duplicate should still succeed as a draft
@@ -598,14 +645,15 @@ test.suite({ config: './config.ts' })('Versions', () => {
           id: originalDoc.id,
           collection: draftCollectionSlug,
           draft: true,
+          overrideAccess: true,
         })
 
         expect(duplicatedDoc._status).toBe('draft')
         expect(duplicatedDoc.id).not.toEqual(originalDoc.id)
         expect(duplicatedDoc.title).toContain('Draft with partial data')
 
-        await payload.delete({ collection: draftCollectionSlug, id: originalDoc.id })
-        await payload.delete({ collection: draftCollectionSlug, id: duplicatedDoc.id })
+        await payload.delete({ collection: draftCollectionSlug, id: originalDoc.id, overrideAccess: true })
+        await payload.delete({ collection: draftCollectionSlug, id: duplicatedDoc.id, overrideAccess: true })
       })
 
       test('should duplicate a draft document with empty required fields via REST API without explicit draft param', async ({
@@ -619,6 +667,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             _status: 'draft',
           },
           draft: true,
+          overrideAccess: true,
         })
 
         // Mimics the admin UI: POST to /:collection/:id/duplicate
@@ -636,8 +685,8 @@ test.suite({ config: './config.ts' })('Versions', () => {
         expect(doc._status).toBe('draft')
         expect(doc.id).not.toEqual(originalDoc.id)
 
-        await payload.delete({ collection: draftCollectionSlug, id: originalDoc.id })
-        await payload.delete({ collection: draftCollectionSlug, id: doc.id })
+        await payload.delete({ collection: draftCollectionSlug, id: originalDoc.id, overrideAccess: true })
+        await payload.delete({ collection: draftCollectionSlug, id: doc.id, overrideAccess: true })
       })
     })
 
@@ -646,11 +695,13 @@ test.suite({ config: './config.ts' })('Versions', () => {
         const versions = await payload.findVersions({
           collection: draftCollectionSlug,
           limit: 5,
+          overrideAccess: true,
         })
         const versionsPage2 = await payload.findVersions({
           collection: draftCollectionSlug,
           limit: 5,
           page: 2,
+          overrideAccess: true,
         })
 
         expect(versions.docs).toHaveLength(5)
@@ -666,12 +717,14 @@ test.suite({ config: './config.ts' })('Versions', () => {
           collection: draftCollectionSlug,
           draft: true,
           sort: 'title',
+          overrideAccess: true,
         })
 
         const draftsDescending = await payload.find({
           collection: draftCollectionSlug,
           draft: true,
           sort: '-title',
+          overrideAccess: true,
         })
 
         expect(draftsAscending).toBeDefined()
@@ -687,6 +740,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           draft: true,
           limit: 100,
           sort: 'createdAt',
+          overrideAccess: true,
         })
 
         const draftsDescending = await payload.findVersions({
@@ -694,6 +748,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           draft: true,
           limit: 100,
           sort: '-createdAt',
+          overrideAccess: true,
         })
 
         expect(draftsAscending).toBeDefined()
@@ -707,15 +762,17 @@ test.suite({ config: './config.ts' })('Versions', () => {
         const doc = await payload.create({
           collection: draftCollectionSlug,
           data: { description: 'a', title: 'test-doc' },
+          overrideAccess: true,
         })
 
         for (let i = 0; i < 100; i++) {
-          await payload.update({ collection: draftCollectionSlug, id: doc.id, data: {} })
+          await payload.update({ collection: draftCollectionSlug, id: doc.id, data: {}, overrideAccess: true })
         }
         const res = await payload.findVersions({
           collection: draftCollectionSlug,
           limit: 0,
           where: { parent: { equals: doc.id } },
+          overrideAccess: true,
         })
         expect(res.docs).toHaveLength(101)
       })
@@ -736,6 +793,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             description: 'description 1',
             title: 'first post',
           },
+          overrideAccess: true,
         })
 
         const updatedPost = await payload.update({
@@ -744,6 +802,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           data: {
             title: 'This should be the latest version',
           },
+          overrideAccess: true,
         })
 
         const versions = await payload.findVersions({
@@ -751,6 +810,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           where: {
             parent: { equals: somePost.id },
           },
+          overrideAccess: true,
         })
 
         expect(versions.docs[0]!.version.title).toBe(updatedPost.title)
@@ -766,6 +826,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             title: 'version title',
           },
           draft: true,
+          overrideAccess: true,
         })
 
         let updatedPost = await payload.update({
@@ -782,6 +843,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             title: title2,
           },
           draft: true,
+          overrideAccess: true,
         })
 
         updatedPost = await payload.update({
@@ -800,6 +862,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             title: title2,
           },
           draft: true,
+          overrideAccess: true,
         })
 
         expect(updatedPost.title).toBe(title2)
@@ -811,6 +874,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           id: versionedPost.id,
           collection: draftCollectionSlug,
           draft: true,
+          overrideAccess: true,
         })
         expect(draftFromUpdatedPost.title).toBe(title2)
         expect(draftFromUpdatedPost.blocksField).toHaveLength(1)
@@ -823,6 +887,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
               equals: versionedPost.id,
             },
           },
+          overrideAccess: true,
         })
 
         const versionToRestore = versions.docs[versions.docs.length - 1]
@@ -830,6 +895,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
         const restoredVersion = await payload.restoreVersion({
           id: versionToRestore!.id,
           collection: draftCollectionSlug,
+          overrideAccess: true,
         })
 
         expect({ ...restoredVersion }).toMatchObject({
@@ -841,6 +907,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           id: versionedPost.id,
           collection: draftCollectionSlug,
           draft: true,
+          overrideAccess: true,
         })
 
         expect(latestDraft).toMatchObject({
@@ -860,6 +927,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           collection: draftCollectionSlug,
           data: { description: 'target', title: 'filter-options target' },
           draft: true,
+          overrideAccess: true,
         })
 
         const doc = await payload.create({
@@ -870,6 +938,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             title: 'filter-options doc',
           },
           draft: true,
+          overrideAccess: true,
         })
 
         await payload.update({
@@ -880,11 +949,13 @@ test.suite({ config: './config.ts' })('Versions', () => {
             title: 'filter-options doc updated',
           },
           draft: true,
+          overrideAccess: true,
         })
 
         const versions = await payload.findVersions({
           collection: draftCollectionSlug,
           where: { parent: { equals: doc.id } },
+          overrideAccess: true,
         })
 
         const versionToRestore = versions.docs[versions.docs.length - 1]
@@ -904,11 +975,12 @@ test.suite({ config: './config.ts' })('Versions', () => {
           collection: draftCollectionSlug,
           depth: 0,
           draft: true,
+          overrideAccess: true,
         })
         expect(restored.relationWithFilterOptions).toStrictEqual([target.id])
 
-        await payload.delete({ id: doc.id, collection: draftCollectionSlug })
-        await payload.delete({ id: target.id, collection: draftCollectionSlug })
+        await payload.delete({ id: doc.id, collection: draftCollectionSlug, overrideAccess: true })
+        await payload.delete({ id: target.id, collection: draftCollectionSlug, overrideAccess: true })
       })
 
       test('should not copy current document fields into restored version', async ({ payload }) => {
@@ -926,6 +998,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             title: 'leak test',
           },
           draft: true,
+          overrideAccess: true,
         })
 
         const blockId = doc.blocksField?.[0]!.id
@@ -949,12 +1022,14 @@ test.suite({ config: './config.ts' })('Versions', () => {
             title: 'leak test',
           },
           draft: true,
+          overrideAccess: true,
         })
 
         // Find versions and restore the original (oldest) version
         const versions = await payload.findVersions({
           collection: draftCollectionSlug,
           where: { parent: { equals: doc.id } },
+          overrideAccess: true,
         })
 
         const originalVersion = versions.docs[versions.docs.length - 1]
@@ -962,12 +1037,14 @@ test.suite({ config: './config.ts' })('Versions', () => {
         await payload.restoreVersion({
           id: originalVersion!.id,
           collection: draftCollectionSlug,
+          overrideAccess: true,
         })
 
         const restored = await payload.findByID({
           id: doc.id,
           collection: draftCollectionSlug,
           draft: true,
+          overrideAccess: true,
         })
 
         // Top-level fields should NOT have leaked from the updated version
@@ -989,6 +1066,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           description: 'description',
           title: 'v1',
         },
+        overrideAccess: true,
       })
 
       // update the post
@@ -1000,6 +1078,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           title: 'v2',
         },
         draft: true,
+        overrideAccess: true,
       })
 
       // get the version id of the original draft
@@ -1010,6 +1089,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             equals: originalPost.id,
           },
         },
+        overrideAccess: true,
       })
 
       // restore the version
@@ -1017,6 +1097,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
       const restoredVersion = await payload.restoreVersion({
         id: versionToRestore!.id,
         collection: draftCollectionSlug,
+        overrideAccess: true,
       })
 
       // get the latest draft
@@ -1024,6 +1105,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
         id: originalPost.id,
         collection: draftCollectionSlug,
         draft: true,
+        overrideAccess: true,
       })
 
       // assert it has the original post content
@@ -1041,6 +1123,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           description: 'description v1',
           title: 'title v1 en',
         },
+        overrideAccess: true,
       })
 
       await payload.update({
@@ -1052,6 +1135,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           title: 'title v2 en',
         },
         draft: true,
+        overrideAccess: true,
       })
 
       const versions = await payload.findVersions({
@@ -1061,6 +1145,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             equals: originalPost.id,
           },
         },
+        overrideAccess: true,
       })
 
       const oldestVersion = versions.docs[versions.docs.length - 1]
@@ -1070,6 +1155,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
         collection: draftCollectionSlug,
         fallbackLocale: false,
         locale: 'de',
+        overrideAccess: true,
       })
 
       expect(restoredVersion.id).toStrictEqual(originalPost.id)
@@ -1079,13 +1165,15 @@ test.suite({ config: './config.ts' })('Versions', () => {
       const post = await payload.create({
         collection: draftCollectionSlug,
         data: { description: 'a', title: 'title' },
+        overrideAccess: true,
       })
       for (let i = 0; i < 100; i++) {
-        await payload.update({ id: post.id, collection: draftCollectionSlug, data: {} })
+        await payload.update({ id: post.id, collection: draftCollectionSlug, data: {}, overrideAccess: true })
       }
       const res = await payload.findVersions({
         collection: draftCollectionSlug,
         where: { parent: { equals: post.id } },
+        overrideAccess: true,
       })
       expect(res.totalDocs).toBe(101)
       expect(res.docs).toHaveLength(10)
@@ -1093,6 +1181,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
         collection: draftCollectionSlug,
         pagination: false,
         where: { parent: { equals: post.id } },
+        overrideAccess: true,
       })
 
       expect(resPaginationFalse.docs).toHaveLength(101)
@@ -1103,6 +1192,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
         limit: 0,
         pagination: false,
         where: { parent: { equals: post.id } },
+        overrideAccess: true,
       })
       expect(resPaginationFalseLimit0.docs).toHaveLength(101)
       expect(resPaginationFalseLimit0.totalDocs).toBe(101)
@@ -1126,6 +1216,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             description: 'kjnjyhbbdsfseankuhsjsfghb',
             title: originalTitle,
           },
+          overrideAccess: true,
         })
 
         const patchedTitle = 'Here is a draft post with a patched title'
@@ -1139,6 +1230,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           },
           draft: true,
           locale: 'en',
+          overrideAccess: true,
         })
 
         const spanishTitle = 'es title'
@@ -1153,11 +1245,13 @@ test.suite({ config: './config.ts' })('Versions', () => {
           },
           draft: true,
           locale: 'es',
+          overrideAccess: true,
         })
 
         const publishedPost = await payload.findByID({
           id: originalPublishedPost.id,
           collection: autosaveCollectionSlug,
+          overrideAccess: true,
         })
 
         const draftPost = await payload.findByID({
@@ -1165,6 +1259,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           collection: autosaveCollectionSlug,
           draft: true,
           locale: 'all',
+          overrideAccess: true,
         })
 
         expect(publishedPost.title).toBe(originalTitle)
@@ -1180,6 +1275,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             title: 'title',
           },
           draft: true,
+          overrideAccess: true,
         })
 
         await wait(10)
@@ -1191,6 +1287,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             title: 'updated title',
           },
           draft: true,
+          overrideAccess: true,
         })
 
         const createdUpdatedAt = new Date(created.updatedAt)
@@ -1209,6 +1306,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             title: 'title',
           },
           draft: true,
+          overrideAccess: true,
         })
 
         await wait(10)
@@ -1221,6 +1319,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             title: 'updated title',
           },
           draft: true,
+          overrideAccess: true,
         })
 
         const createdUpdatedAt = new Date(created.updatedAt)
@@ -1241,6 +1340,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             title: 'title 1',
           },
           draft: false,
+          overrideAccess: true,
         })
         await payload.update({
           id: doc.id,
@@ -1251,6 +1351,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             title: 'title 2',
           },
           draft: true,
+          overrideAccess: true,
         })
 
         const doc2 = await payload.create({
@@ -1261,6 +1362,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             title: 'title 1-2',
           },
           draft: false,
+          overrideAccess: true,
         })
 
         await payload.update({
@@ -1272,6 +1374,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             title: 'title 2-2',
           },
           draft: true,
+          overrideAccess: true,
         })
         await payload.update({
           id: doc2.id,
@@ -1282,6 +1385,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             title: 'title 3-2',
           },
           draft: true,
+          overrideAccess: true,
         })
 
         const lastDocVersion = await payload.findVersions({
@@ -1292,6 +1396,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
               equals: doc.id,
             },
           },
+          overrideAccess: true,
         })
         expect(lastDocVersion.docs[0]?.version.tag).toEqual(firstDocTag)
 
@@ -1307,6 +1412,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
         const doc = await payload.create({
           collection: nestedArraySelectCollectionSlug,
           data: {},
+          overrideAccess: true,
         })
 
         const updated = await payload.update({
@@ -1316,6 +1422,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             outer: [{ inner: [{ days: ['monday'] }] }],
           },
           draft: true,
+          overrideAccess: true,
         })
 
         expect(updated.outer?.[0]?.inner?.[0]?.days).toEqual(['monday'])
@@ -1334,6 +1441,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             description: 'desc',
           },
           draft: true,
+          overrideAccess: true,
         })
 
         await expect(
@@ -1342,6 +1450,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             collection: draftCollectionSlug,
             data: { _status: 'published' },
             draft: true,
+            overrideAccess: true,
           }),
         ).rejects.toThrow(ValidationError)
 
@@ -1353,6 +1462,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           where: {
             id: { equals: doc.id },
           },
+          overrideAccess: true,
         })
 
         expect(updateManyResult.docs).toHaveLength(0)
@@ -1367,6 +1477,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           collection: autosaveCollectionSlug,
           data: { _status: 'draft', description: 'some-description', title: 'my-title' },
           draft: true,
+          overrideAccess: true,
         })
 
         // Autosave the same draft, calls db.updateVersion
@@ -1378,6 +1489,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             title: 'new-title',
           },
           draft: true,
+          overrideAccess: true,
         })
 
         const versionsCount = await payload.countVersions({
@@ -1387,6 +1499,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
               equals: id,
             },
           },
+          overrideAccess: true,
         })
 
         // This should not create a new version
@@ -1398,6 +1511,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             title: 'new-title-2',
           },
           draft: true,
+          overrideAccess: true,
         })
 
         const versionsCountAfter = await payload.countVersions({
@@ -1407,6 +1521,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
               equals: id,
             },
           },
+          overrideAccess: true,
         })
 
         expect(versionsCount.totalDocs).toBe(versionsCountAfter.totalDocs)
@@ -1439,6 +1554,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             description: 'description to bulk update',
             title: 'initial value',
           },
+          overrideAccess: true,
         })
 
         await payload.update({
@@ -1448,6 +1564,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             title: 'updated title',
           },
           draft: true,
+          overrideAccess: true,
         })
 
         // bulk publish
@@ -1463,6 +1580,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
               in: [doc.id],
             },
           },
+          overrideAccess: true,
         })
 
         const updatedDoc = updated.docs?.[0]
@@ -1473,6 +1591,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           where: {
             id: { equals: doc.id },
           },
+          overrideAccess: true,
         })
 
         const findDoc = findResult.docs?.[0]
@@ -1493,6 +1612,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             description: 'description',
             title: 'title to delete',
           },
+          overrideAccess: true,
         })
 
         const drafts = await payload.db.queryDrafts({
@@ -1509,6 +1629,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           where: {
             id: { equals: postToDelete.id },
           },
+          overrideAccess: true,
         })
 
         const result = await payload.db.queryDrafts({
@@ -1547,6 +1668,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             title: 'A',
           },
           draft: true,
+          overrideAccess: true,
         })
 
         await payload.update({
@@ -1558,6 +1680,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             title: 'B',
           },
           draft: true,
+          overrideAccess: true,
         })
 
         await payload.update({
@@ -1569,12 +1692,14 @@ test.suite({ config: './config.ts' })('Versions', () => {
             title: 'C',
           },
           draft: true,
+          overrideAccess: true,
         })
 
         const mostRecentDraft = await payload.findByID({
           id: originalDraft.id,
           collection: draftCollectionSlug,
           draft: true,
+          overrideAccess: true,
         })
 
         expect(mostRecentDraft.title).toStrictEqual('C')
@@ -1586,6 +1711,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
               equals: originalDraft.id,
             },
           },
+          overrideAccess: true,
         })
 
         expect(versions.docs).toHaveLength(3)
@@ -1610,11 +1736,13 @@ test.suite({ config: './config.ts' })('Versions', () => {
             description: 'test',
             title: 'unpublish test',
           },
+          overrideAccess: true,
         })
 
         const initialVersions = await payload.findVersions({
           collection: draftCollectionSlug,
           where: { parent: { equals: doc.id } },
+          overrideAccess: true,
         })
 
         expect(initialVersions.docs).toHaveLength(1)
@@ -1625,6 +1753,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           collection: draftCollectionSlug,
           data: { _status: 'draft' },
           unpublishAllLocales: true,
+          overrideAccess: true,
         })
 
         expect(unpublished._status).toBe('draft')
@@ -1632,6 +1761,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
         const afterVersions = await payload.findVersions({
           collection: draftCollectionSlug,
           where: { parent: { equals: doc.id } },
+          overrideAccess: true,
         })
 
         expect(afterVersions.docs).toHaveLength(1)
@@ -1642,10 +1772,12 @@ test.suite({ config: './config.ts' })('Versions', () => {
         await payload.updateGlobal({
           slug: draftGlobalSlug,
           data: { _status: 'published', title: 'unpublish global test' },
+          overrideAccess: true,
         })
 
         const initialVersions = await payload.findGlobalVersions({
           slug: draftGlobalSlug,
+          overrideAccess: true,
         })
 
         const initialCount = initialVersions.docs.length
@@ -1654,10 +1786,12 @@ test.suite({ config: './config.ts' })('Versions', () => {
           slug: draftGlobalSlug,
           data: { _status: 'draft' },
           unpublishAllLocales: true,
+          overrideAccess: true,
         })
 
         const afterVersions = await payload.findGlobalVersions({
           slug: draftGlobalSlug,
+          overrideAccess: true,
         })
 
         expect(afterVersions.docs).toHaveLength(initialCount)
@@ -1674,6 +1808,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             description: 'test',
             title: 'main table unpublish test',
           },
+          overrideAccess: true,
         })
 
         await payload.update({
@@ -1681,12 +1816,14 @@ test.suite({ config: './config.ts' })('Versions', () => {
           collection: draftCollectionSlug,
           data: { _status: 'draft' },
           unpublishAllLocales: true,
+          overrideAccess: true,
         })
 
         const found = await payload.findByID({
           id: doc.id,
           collection: draftCollectionSlug,
           draft: false,
+          overrideAccess: true,
         })
 
         expect(found._status).toBe('draft')
@@ -1703,6 +1840,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             title: 'unpublish localized test',
           },
           locale: 'en',
+          overrideAccess: true,
         })
 
         const unpublished = await payload.update({
@@ -1711,11 +1849,12 @@ test.suite({ config: './config.ts' })('Versions', () => {
           data: { _status: 'draft' },
           locale: 'es',
           unpublishAllLocales: true,
+          overrideAccess: true,
         })
 
         expect(unpublished._status).toBe('draft')
 
-        await payload.delete({ collection: draftCollectionSlug, id: doc.id })
+        await payload.delete({ collection: draftCollectionSlug, id: doc.id, overrideAccess: true })
       })
 
       test('should unpublish a global with localized required fields from a non-default locale', async ({
@@ -1725,6 +1864,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           slug: draftGlobalSlug,
           data: { _status: 'published', title: 'unpublish global localized test' },
           locale: 'en',
+          overrideAccess: true,
         })
 
         const unpublished = await payload.updateGlobal({
@@ -1733,6 +1873,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           fallbackLocale: false,
           locale: 'es',
           unpublishAllLocales: true,
+          overrideAccess: true,
         })
 
         expect(unpublished._status).toBe('draft')
@@ -1759,6 +1900,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             // description is required but omitted - should work with draft: true
           },
           draft: true,
+          overrideAccess: true,
         })
 
         expect(draft.title).toBe('Draft without description')
@@ -1777,6 +1919,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
               title: 'Published without description',
             },
             draft: false,
+            overrideAccess: true,
           }),
         ).rejects.toThrow(ValidationError)
       })
@@ -1792,6 +1935,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             data: {
               title: 'Post without description',
             },
+            overrideAccess: true,
           }),
         ).rejects.toThrow(ValidationError)
       })
@@ -1804,6 +1948,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             // Both title and description are required but omitted
           },
           draft: true,
+          overrideAccess: true,
         })
 
         expect(draft._status).toBe('draft')
@@ -1824,6 +1969,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             description: 'A',
             title: 'A',
           },
+          overrideAccess: true,
         })
         // v2
         await payload.update({
@@ -1833,6 +1979,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             description: 'B',
             title: 'B',
           },
+          overrideAccess: true,
         })
         // v3
         await payload.update({
@@ -1842,6 +1989,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             description: 'C',
             title: 'C',
           },
+          overrideAccess: true,
         })
 
         // doc2 - v1
@@ -1851,6 +1999,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             description: 'D',
             title: 'D',
           },
+          overrideAccess: true,
         })
         // v2
         await payload.update({
@@ -1860,6 +2009,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             description: 'E',
             title: 'E',
           },
+          overrideAccess: true,
         })
         // v3
         await payload.update({
@@ -1869,6 +2019,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             description: 'F',
             title: 'F',
           },
+          overrideAccess: true,
         })
 
         const doc1Versions = await payload.findVersions({
@@ -1879,6 +2030,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
               equals: doc1.id,
             },
           },
+          overrideAccess: true,
         })
 
         const doc2Versions = await payload.findVersions({
@@ -1889,6 +2041,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
               equals: doc2.id,
             },
           },
+          overrideAccess: true,
         })
 
         // correctly retains 2 documents in the versions collection
@@ -1903,6 +2056,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
 
         const docs = await payload.find({
           collection: versionCollectionSlug,
+          overrideAccess: true,
         })
 
         // correctly retains 2 documents in the actual collection
@@ -1923,6 +2077,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             description: 'A',
             title: 'A',
           },
+          overrideAccess: true,
         })
 
         const writeAmount = 100
@@ -1937,6 +2092,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
                   collection: draftCollectionSlug,
                   data: {},
                   draft: true,
+                  overrideAccess: true,
                 })
                 .then(resolve)
                 .catch(resolve)
@@ -1962,6 +2118,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
               },
             ],
           },
+          overrideAccess: true,
         })
 
         expect(docs[0]).toBeDefined()
@@ -1979,6 +2136,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           collection: autosaveCollectionSlug,
           data: { title: 'original', _status: 'draft' },
           draft: true,
+          overrideAccess: true,
         })
 
         // Establish an existing autosave version so updateLatestVersion has something to update
@@ -1988,6 +2146,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           collection: autosaveCollectionSlug,
           data: { title: 'first autosave' },
           draft: true,
+          overrideAccess: true,
         })
 
         const spy = vi
@@ -2001,6 +2160,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           collection: autosaveCollectionSlug,
           data: { title: 'second autosave' },
           draft: true,
+          overrideAccess: true,
         })
 
         spy.mockRestore()
@@ -2011,6 +2171,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
         const { totalDocs } = await payload.countVersions({
           collection: autosaveCollectionSlug,
           where: { parent: { equals: doc.id } },
+          overrideAccess: true,
         })
 
         // create → 1 version, first autosave updates in place → still 1 version on autosave collection (it creates a new autosave),
@@ -2028,6 +2189,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           collection: autosaveCollectionSlug,
           data: { title: 'original', _status: 'draft' },
           draft: true,
+          overrideAccess: true,
         })
 
         const updateVersionSpy = vi
@@ -2044,6 +2206,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             collection: autosaveCollectionSlug,
             data: { title: 'will fail' },
             draft: true,
+            overrideAccess: true,
           }),
         ).rejects.toThrow('database connection lost')
 
@@ -2091,6 +2254,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           alt: 'Original image',
         },
         file: imageFile,
+        overrideAccess: true,
       })
 
       uploadedFilenames.push(publishedDoc.filename)
@@ -2109,17 +2273,20 @@ test.suite({ config: './config.ts' })('Versions', () => {
         },
         draft: true,
         file: draftImageFile,
+        overrideAccess: true,
       })
 
       const mainDoc = await payload.findByID({
         id: publishedDoc.id,
         collection: draftWithUploadCollectionSlug,
+        overrideAccess: true,
       })
 
       const draftDoc = await payload.findByID({
         id: publishedDoc.id,
         collection: draftWithUploadCollectionSlug,
         draft: true,
+        overrideAccess: true,
       })
 
       uploadedFilenames.push(draftDoc.filename)
@@ -2147,6 +2314,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           alt: 'Published image',
         },
         file: imageFile,
+        overrideAccess: true,
       })
 
       uploadedFilenames.push(publishedDoc.filename)
@@ -2168,12 +2336,14 @@ test.suite({ config: './config.ts' })('Versions', () => {
         },
         draft: true,
         file: draftImageFile,
+        overrideAccess: true,
       })
 
       const draftDoc = await payload.findByID({
         id: publishedDoc.id,
         collection: draftWithUploadCollectionSlug,
         draft: true,
+        overrideAccess: true,
       })
 
       uploadedFilenames.push(draftDoc.filename)
@@ -2195,6 +2365,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           alt: 'Original',
         },
         file: imageFile,
+        overrideAccess: true,
       })
 
       uploadedFilenames.push(publishedDoc.filename)
@@ -2212,12 +2383,14 @@ test.suite({ config: './config.ts' })('Versions', () => {
         },
         draft: true,
         file: draftImageFile,
+        overrideAccess: true,
       })
 
       const draftDoc = await payload.findByID({
         id: publishedDoc.id,
         collection: draftWithUploadCollectionSlug,
         draft: true,
+        overrideAccess: true,
       })
 
       uploadedFilenames.push(draftDoc.filename)
@@ -2231,11 +2404,13 @@ test.suite({ config: './config.ts' })('Versions', () => {
         where: {
           id: { equals: publishedDoc.id },
         },
+        overrideAccess: true,
       })
 
       const republishedDoc = await payload.findByID({
         id: publishedDoc.id,
         collection: draftWithUploadCollectionSlug,
+        overrideAccess: true,
       })
 
       expect(republishedDoc._status).toBe('published')
@@ -2257,6 +2432,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           alt: 'Original published',
         },
         file: imageFile,
+        overrideAccess: true,
       })
 
       uploadedFilenames.push(publishedDoc.filename)
@@ -2269,6 +2445,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
         },
         draft: true,
         duplicateFromID: publishedDoc.id,
+        overrideAccess: true,
       })
 
       uploadedFilenames.push(duplicatedDoc.filename)
@@ -2300,6 +2477,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           alt: 'Original image',
         },
         file: imageFile,
+        overrideAccess: true,
       })
 
       expect(publishedDoc._status).toBe('published')
@@ -2317,17 +2495,20 @@ test.suite({ config: './config.ts' })('Versions', () => {
         },
         draft: true,
         file: draftImageFile,
+        overrideAccess: true,
       })
 
       const mainDoc = await payload.findByID({
         id: publishedDoc.id,
         collection: draftWithUploadCloudStorageCollectionSlug,
+        overrideAccess: true,
       })
 
       const draftDoc = await payload.findByID({
         id: publishedDoc.id,
         collection: draftWithUploadCloudStorageCollectionSlug,
         draft: true,
+        overrideAccess: true,
       })
 
       expect(mainDoc._status).toBe('published')
@@ -2353,6 +2534,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           alt: 'Original image',
         },
         file: imageFile,
+        overrideAccess: true,
       })
 
       const draftImageFile = await getFileByPath(path.resolve(dirname, './image.png'))
@@ -2368,6 +2550,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
         },
         draft: true,
         file: draftImageFile,
+        overrideAccess: true,
       })
 
       expect(cloudStorageDeletedFilenames).not.toContain(publishedDoc.filename)
@@ -2385,6 +2568,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           alt: 'Original',
         },
         file: imageFile,
+        overrideAccess: true,
       })
 
       const draftImageFile = await getFileByPath(path.resolve(dirname, './image.png'))
@@ -2400,12 +2584,14 @@ test.suite({ config: './config.ts' })('Versions', () => {
         },
         draft: true,
         file: draftImageFile,
+        overrideAccess: true,
       })
 
       const draftDoc = await payload.findByID({
         id: publishedDoc.id,
         collection: draftWithUploadCloudStorageCollectionSlug,
         draft: true,
+        overrideAccess: true,
       })
 
       const republishedDoc = await payload.update({
@@ -2415,6 +2601,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           _status: 'published',
         },
         draft: true,
+        overrideAccess: true,
       })
 
       expect(republishedDoc._status).toBe('published')
@@ -2436,6 +2623,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           alt: 'Original',
         },
         file: imageFile,
+        overrideAccess: true,
       })
 
       const newFile = await getFileByPath(path.resolve(dirname, './image.png'))
@@ -2450,11 +2638,13 @@ test.suite({ config: './config.ts' })('Versions', () => {
           alt: 'Replaced',
         },
         file: newFile,
+        overrideAccess: true,
       })
 
       const mainDoc = await payload.findByID({
         id: publishedDoc.id,
         collection: draftWithUploadCloudStorageCollectionSlug,
+        overrideAccess: true,
       })
 
       expect(mainDoc._status).toBe('published')
@@ -2480,6 +2670,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           radio: 'test',
           title: args?.title || originalTitle,
         },
+        overrideAccess: true,
       })
 
       // This will be created in the `_draft-posts_versions` collection
@@ -2490,6 +2681,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           title: updatedTitle1,
         },
         draft: true,
+        overrideAccess: true,
       })
 
       // This will be created in the `_draft-posts_versions` collection
@@ -2501,6 +2693,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           title: updatedTitle2,
         },
         draft: true,
+        overrideAccess: true,
       })
     }
 
@@ -2528,6 +2721,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             equals: originalTitle,
           },
         },
+        overrideAccess: true,
       })
 
       expect(findResults.docs[0].title).toStrictEqual(originalTitle)
@@ -2540,6 +2734,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           description: 'Description',
           title: 'Title',
         },
+        overrideAccess: true,
       })
 
       const createVersions = async (int: number = 1) => {
@@ -2550,6 +2745,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             data: {
               title: `Title ${i}`,
             },
+            overrideAccess: true,
           })
         }
       }
@@ -2563,6 +2759,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             equals: id,
           },
         },
+        overrideAccess: true,
       })
 
       expect(findResults.totalDocs).toBe(11)
@@ -2584,6 +2781,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             equals: updatedTitle1,
           },
         },
+        overrideAccess: true,
       })
 
       expect(draftFindResults.docs).toHaveLength(0)
@@ -2600,6 +2798,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             equals: updatedTitle2,
           },
         },
+        overrideAccess: true,
       })
 
       expect(draftFindResults.docs[0].title).toStrictEqual(updatedTitle2)
@@ -2637,6 +2836,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
       const publishedFindResults = await payload.find({
         collection: draftCollectionSlug,
         where: query,
+        overrideAccess: true,
       })
 
       expect(publishedFindResults.docs).toHaveLength(1)
@@ -2646,6 +2846,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
         collection: draftCollectionSlug,
         draft: true,
         where: query,
+        overrideAccess: true,
       })
 
       expect(draftFindResults.docs).toHaveLength(1)
@@ -2663,6 +2864,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             equals: originalTitle,
           },
         },
+        overrideAccess: true,
       })
 
       expect(draftFindResults.docs).toHaveLength(0)
@@ -2673,6 +2875,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
       const allDocs = await payload.find({
         collection: draftCollectionSlug,
         draft: true,
+        overrideAccess: true,
       })
 
       expect(allDocs.docs).toHaveLength(2)
@@ -2685,6 +2888,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             equals: firstDraft.id,
           },
         },
+        overrideAccess: true,
       })
 
       expect(byID.docs).toHaveLength(1)
@@ -2702,6 +2906,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             like: 'title',
           },
         },
+        overrideAccess: true,
       })
 
       expect(allDocs.docs).toHaveLength(2)
@@ -2723,6 +2928,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             },
           ],
         },
+        overrideAccess: true,
       })
 
       expect(results.docs).toHaveLength(1)
@@ -3076,6 +3282,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           description: 'test description',
           title: 'initial title',
         },
+        overrideAccess: true,
       })
 
       await payload.update({
@@ -3084,6 +3291,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
         data: {
           title: 'updated title',
         },
+        overrideAccess: true,
       })
 
       const response = await restClient.GET(`/${autosaveCollectionSlug}/versions`)
@@ -3111,6 +3319,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             description: 'Test Description',
             title,
           },
+          overrideAccess: true,
         })
       }
 
@@ -3125,6 +3334,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           id,
           collection: draftCollectionSlug,
           data,
+          overrideAccess: true,
         })
       }
 
@@ -3186,6 +3396,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
         data: {
           title: 'Test Global',
         },
+        overrideAccess: true,
       })
 
       await payload.updateGlobal({
@@ -3193,10 +3404,12 @@ test.suite({ config: './config.ts' })('Versions', () => {
         data: {
           title: title2,
         },
+        overrideAccess: true,
       })
 
       const versions = await payload.findGlobalVersions({
         slug: autoSaveGlobalSlug,
+        overrideAccess: true,
       })
 
       globalVersionID = versions.docs[0]!.id
@@ -3206,6 +3419,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
         const title2 = 'Here is an updated global title in EN'
         const updatedGlobal = await payload.findGlobal({
           slug: autoSaveGlobalSlug,
+          overrideAccess: true,
         })
         expect(updatedGlobal.title).toBe(title2)
         expect(updatedGlobal._status).toStrictEqual('draft')
@@ -3220,6 +3434,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             title: 'Draft',
           },
           draft: true,
+          overrideAccess: true,
         })
         expect(draftVersion.title).toStrictEqual('Draft')
         expect(draftVersion._status).toStrictEqual('draft')
@@ -3231,6 +3446,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             title: 'Published',
           },
           draft: false,
+          overrideAccess: true,
         })
         expect(publishedVersion.title).toStrictEqual('Published')
         expect(publishedVersion._status).toStrictEqual('published')
@@ -3243,6 +3459,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           slug: autoSaveGlobalSlug,
           data: { title: 'asd' },
           publishAllLocales: true,
+          overrideAccess: true,
         })
 
         await wait(10)
@@ -3251,6 +3468,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           slug: autoSaveGlobalSlug,
           data: { title: 'asd2' },
           publishAllLocales: true,
+          overrideAccess: true,
         })
 
         expect(upd.createdAt).toBe(doc.createdAt)
@@ -3264,6 +3482,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
               equals: true,
             },
           },
+          overrideAccess: true,
         })
 
         // Version itself should have new createdAt
@@ -3274,6 +3493,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
         const fromNonVersionsTable = await payload.findGlobal({
           slug: autoSaveGlobalSlug,
           draft: false,
+          overrideAccess: true,
         })
 
         // createdAt from non-versions should be the same as version_createdAt in versions
@@ -3290,33 +3510,37 @@ test.suite({ config: './config.ts' })('Versions', () => {
             slug: 'max-versions',
             limit: 1,
             sort: '-createdAt',
+            overrideAccess: true,
           })
           .then((r) => r.docs[0])
 
-      await payload.updateGlobal({ slug: 'max-versions', data: { title: '1' } })
+      await payload.updateGlobal({ slug: 'max-versions', data: { title: '1' }, overrideAccess: true })
       const version_1 = await getLatestVersion()
-      await payload.updateGlobal({ slug: 'max-versions', data: { title: '2' } })
-      await payload.updateGlobal({ slug: 'max-versions', data: { title: '3' } })
+      await payload.updateGlobal({ slug: 'max-versions', data: { title: '2' }, overrideAccess: true })
+      await payload.updateGlobal({ slug: 'max-versions', data: { title: '3' }, overrideAccess: true })
       const version_1_deleted = await payload.findGlobalVersionByID({
         id: version_1?.id as string,
         slug: 'max-versions',
         disableErrors: true,
+        overrideAccess: true,
       })
       expect(version_1_deleted).toBeFalsy()
     })
 
     test('findGlobalVersions - pagination should work correctly', async ({ payload }) => {
       for (let i = 0; i < 100; i++) {
-        await payload.updateGlobal({ slug: 'draft-unlimited-global', data: { title: 'title' } })
+        await payload.updateGlobal({ slug: 'draft-unlimited-global', data: { title: 'title' }, overrideAccess: true })
       }
       const res = await payload.findGlobalVersions({
         slug: 'draft-unlimited-global',
+        overrideAccess: true,
       })
       expect(res.totalDocs).toBe(100)
       expect(res.docs).toHaveLength(10)
       const resPaginationFalse = await payload.findGlobalVersions({
         slug: 'draft-unlimited-global',
         pagination: false,
+        overrideAccess: true,
       })
       expect(resPaginationFalse.docs).toHaveLength(100)
       expect(resPaginationFalse.totalDocs).toBe(100)
@@ -3325,6 +3549,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
         slug: 'draft-unlimited-global',
         limit: 0,
         pagination: false,
+        overrideAccess: true,
       })
       expect(resPaginationFalseLimit0.docs).toHaveLength(100)
       expect(resPaginationFalseLimit0.totalDocs).toBe(100)
@@ -3335,6 +3560,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
         const version = await payload.findGlobalVersionByID({
           id: globalVersionID,
           slug: autoSaveGlobalSlug,
+          overrideAccess: true,
         })
 
         expect(version.id).toStrictEqual(globalVersionID)
@@ -3343,12 +3569,13 @@ test.suite({ config: './config.ts' })('Versions', () => {
       test('should findGlobalVersions with limit: 0', async ({ payload }) => {
         await payload.db.deleteVersions({ globalSlug: draftUnlimitedGlobalSlug, where: {} })
         for (let i = 0; i < 100; i++) {
-          await payload.updateGlobal({ slug: draftUnlimitedGlobalSlug, data: { title: 'global' } })
+          await payload.updateGlobal({ slug: draftUnlimitedGlobalSlug, data: { title: 'global' }, overrideAccess: true })
         }
 
         const res = await payload.findGlobalVersions({
           slug: draftUnlimitedGlobalSlug,
           limit: 0,
+          overrideAccess: true,
         })
 
         expect(res.docs).toHaveLength(100)
@@ -3365,6 +3592,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           data: {
             title: englishTitle,
           },
+          overrideAccess: true,
         })
 
         const updatedGlobalES = await payload.updateGlobal({
@@ -3373,6 +3601,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             title: spanishTitle,
           },
           locale: 'es',
+          overrideAccess: true,
         })
 
         expect(updatedGlobalES.title).toBe(spanishTitle)
@@ -3384,11 +3613,13 @@ test.suite({ config: './config.ts' })('Versions', () => {
           data: {
             title: newEnglishTitle,
           },
+          overrideAccess: true,
         })
 
         const versions = await payload.findGlobalVersions({
           slug: autoSaveGlobalSlug,
           locale: 'all',
+          overrideAccess: true,
         })
 
         expect(versions.docs[0].version.title.en).toStrictEqual(newEnglishTitle)
@@ -3404,6 +3635,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             title: 'title',
           },
           draft: true,
+          overrideAccess: true,
         })
 
         await wait(10)
@@ -3414,6 +3646,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             title: 'updated title',
           },
           draft: true,
+          overrideAccess: true,
         })
 
         const createdUpdatedAt = new Date(created.updatedAt)
@@ -3431,6 +3664,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             title: 'title',
           },
           draft: true,
+          overrideAccess: true,
         })
 
         await wait(10)
@@ -3442,6 +3676,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           },
           draft: true,
           autosave: true,
+          overrideAccess: true,
         })
 
         const createdUpdatedAt = new Date(created.updatedAt)
@@ -3461,6 +3696,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             title: title2,
           },
           publishAllLocales: true,
+          overrideAccess: true,
         })
 
         expect(updatedGlobal.title).toBe(title2)
@@ -3469,16 +3705,19 @@ test.suite({ config: './config.ts' })('Versions', () => {
         const foundUpdatedGlobal = await payload.findGlobal({
           slug: autoSaveGlobalSlug,
           draft: true,
+          overrideAccess: true,
         })
         expect(foundUpdatedGlobal.title).toBe(title2)
 
         const versions = await payload.findGlobalVersions({
           slug: autoSaveGlobalSlug,
+          overrideAccess: true,
         })
 
         const restore = await payload.restoreGlobalVersion({
           id: versions.docs[1]!.id,
           slug: autoSaveGlobalSlug,
+          overrideAccess: true,
         })
 
         expect(restore.version.title).toBeDefined()
@@ -3486,6 +3725,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
         const restoredGlobal = await payload.findGlobal({
           slug: autoSaveGlobalSlug,
           draft: true,
+          overrideAccess: true,
         })
 
         expect(restoredGlobal.title).toBe(restore.version.title.en)
@@ -3504,11 +3744,13 @@ test.suite({ config: './config.ts' })('Versions', () => {
             title: originalTitle,
           },
           publishAllLocales: true,
+          overrideAccess: true,
         })
 
         const publishedGlobal = await payload.findGlobal({
           slug: autoSaveGlobalSlug,
           draft: true,
+          overrideAccess: true,
         })
 
         const updatedTitle2 = 'Here is a draft global with a patched title'
@@ -3521,6 +3763,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           },
           draft: true,
           locale: 'en',
+          overrideAccess: true,
         })
 
         await payload.updateGlobal({
@@ -3531,12 +3774,14 @@ test.suite({ config: './config.ts' })('Versions', () => {
           },
           draft: true,
           locale: 'es',
+          overrideAccess: true,
         })
 
         const updatedGlobal = await payload.findGlobal({
           slug: autoSaveGlobalSlug,
           draft: true,
           locale: 'all',
+          overrideAccess: true,
         })
 
         expect(publishedGlobal.title).toBe(originalTitle)
@@ -3554,6 +3799,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             title: originalTitle,
           },
           draft: true,
+          overrideAccess: true,
         })
 
         const updatedTitle2 = 'Now try to publish'
@@ -3564,6 +3810,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             _status: 'published',
             title: updatedTitle2,
           },
+          overrideAccess: true,
         })
 
         expect(result.title).toBe(updatedTitle2)
@@ -3710,6 +3957,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           title: 'my doc to publish in the future',
         },
         draft: true,
+        overrideAccess: true,
       })
 
       expect(draft._status).toStrictEqual('draft')
@@ -3735,6 +3983,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
         id: draft.id,
         collection: draftCollectionSlug,
         draft: false,
+        overrideAccess: true,
       })
 
       expect(retrieved._status).toStrictEqual('published')
@@ -3754,6 +4003,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           title: 'my doc to publish in the future',
         },
         draft: true,
+        overrideAccess: true,
       })
 
       expect(draft._status).toStrictEqual('draft')
@@ -3781,6 +4031,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
       const retrieved = await payload.findByID({
         id: draft.id,
         collection: draftCollectionSlug,
+        overrideAccess: true,
       })
 
       expect(retrieved._status).toStrictEqual('draft')
@@ -3799,6 +4050,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           description: 'hello',
           title: 'my doc to publish in the future',
         },
+        overrideAccess: true,
       })
 
       expect(published._status).toStrictEqual('published')
@@ -3824,6 +4076,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
       const retrieved = await payload.findByID({
         id: published.id,
         collection: draftCollectionSlug,
+        overrideAccess: true,
       })
 
       expect(retrieved._status).toStrictEqual('draft')
@@ -3842,6 +4095,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           title: 'my doc to publish in the future',
         },
         draft: true,
+        overrideAccess: true,
       })
 
       expect(draft._status).toStrictEqual('draft')
@@ -3865,6 +4119,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
         where: {
           id: { equals: draft.id },
         },
+        overrideAccess: true,
       })
 
       const { docs } = await payload.find({
@@ -3874,6 +4129,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             equals: draft.id,
           },
         },
+        overrideAccess: true,
       })
 
       expect(docs[0]).toBeUndefined()
@@ -3892,6 +4148,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           title: 'my doc to publish in the future',
         },
         draft: true,
+        overrideAccess: true,
       })
 
       expect(draft._status).toStrictEqual('draft')
@@ -3913,6 +4170,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
       await payload.delete({
         id: draft.id,
         collection: draftCollectionSlug,
+        overrideAccess: true,
       })
 
       const { docs } = await payload.find({
@@ -3922,6 +4180,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             equals: draft.id,
           },
         },
+        overrideAccess: true,
       })
 
       expect(docs[0]).toBeUndefined()
@@ -3940,6 +4199,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           title: 'i will publish',
         },
         draft: true,
+        overrideAccess: true,
       })
 
       expect(draft._status).toStrictEqual('draft')
@@ -3960,6 +4220,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
 
       const retrieved = await payload.findGlobal({
         slug: draftGlobalSlug,
+        overrideAccess: true,
       })
 
       expect(retrieved._status).toStrictEqual('published')
@@ -3973,6 +4234,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           _status: 'published',
           title: 'i will be a draft',
         },
+        overrideAccess: true,
       })
 
       expect(draft._status).toStrictEqual('published')
@@ -3994,6 +4256,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
 
       const retrieved = await payload.findGlobal({
         slug: draftGlobalSlug,
+        overrideAccess: true,
       })
 
       expect(retrieved._status).toStrictEqual('draft')
@@ -4009,6 +4272,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           title: 'draft only',
         },
         draft: true,
+        overrideAccess: true,
       })
 
       expect(draft._status).toStrictEqual('draft')
@@ -4042,6 +4306,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             description: 'hello',
             title: 'my doc',
           },
+          overrideAccess: true,
         })
       })
 
@@ -4079,6 +4344,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
                 equals: draftDoc.id,
               },
             },
+            overrideAccess: true,
           })
         ).docs
         expect(event).toBeDefined()
@@ -4128,6 +4394,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             restrictedToUpdate: true,
           },
           id: draftDoc.id,
+          overrideAccess: true,
         })
 
         await expect(
@@ -4166,6 +4433,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
                 equals: draftDoc.id,
               },
             },
+            overrideAccess: true,
           })
         ).docs
 
@@ -4185,6 +4453,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
                 equals: String(draftDoc.id),
               },
             },
+            overrideAccess: true,
           })
         ).docs
 
@@ -4215,6 +4484,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
         const result = await payload.findByID({
           collection: 'payload-jobs',
           id: unrelatedJob.id,
+          overrideAccess: true,
         })
 
         expect(result.id).toBe(unrelatedJob.id)
@@ -4245,6 +4515,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           },
           draft: true,
           locale: 'es',
+          overrideAccess: true,
         })
 
         // save english draft
@@ -4257,6 +4528,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           },
           draft: true,
           locale: 'en',
+          overrideAccess: true,
         })
 
         // save german draft
@@ -4268,6 +4540,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           },
           draft: true,
           locale: 'de',
+          overrideAccess: true,
         })
 
         // publish only english
@@ -4280,12 +4553,14 @@ test.suite({ config: './config.ts' })('Versions', () => {
           },
           draft: false,
           locale: 'en',
+          overrideAccess: true,
         })
 
         const docWithoutSpanishDraft = await payload.findByID({
           id: draft1.id,
           collection: localizedCollectionSlug,
           locale: 'all',
+          overrideAccess: true,
         })
 
         // We're getting the published version,
@@ -4301,6 +4576,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           collection: localizedCollectionSlug,
           draft: true,
           locale: 'all',
+          overrideAccess: true,
         })
 
         // After updating English via specific locale,
@@ -4318,12 +4594,14 @@ test.suite({ config: './config.ts' })('Versions', () => {
           },
           draft: false,
           locale: 'en',
+          overrideAccess: true,
         })
 
         const docWithoutSpanishDraft2 = await payload.findByID({
           id: draft1.id,
           collection: localizedCollectionSlug,
           locale: 'all',
+          overrideAccess: true,
         })
 
         // On the second consecutive publish of a specific locale,
@@ -4343,6 +4621,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           },
           draft: true,
           locale: 'de',
+          overrideAccess: true,
         })
 
         const docWithGermanDraft = await payload.findByID({
@@ -4350,6 +4629,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           collection: localizedCollectionSlug,
           draft: true,
           locale: 'all',
+          overrideAccess: true,
         })
 
         // Make sure we retain the Spanish draft,
@@ -4369,6 +4649,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           },
           draft: false,
           locale: 'de',
+          overrideAccess: true,
         })
 
         await payload.update({
@@ -4380,12 +4661,14 @@ test.suite({ config: './config.ts' })('Versions', () => {
           },
           draft: false,
           locale: 'en',
+          overrideAccess: true,
         })
 
         const finalPublishedNoES = await payload.findByID({
           id: draft1.id,
           collection: localizedCollectionSlug,
           locale: 'all',
+          overrideAccess: true,
         })
 
         expect(finalPublishedNoES.text.de).toStrictEqual('German published 1')
@@ -4398,6 +4681,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           collection: localizedCollectionSlug,
           draft: true,
           locale: 'all',
+          overrideAccess: true,
         })
 
         expect(finalDraft.text.de).toStrictEqual('German published 1')
@@ -4410,6 +4694,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           data: {
             _status: 'published',
           },
+          overrideAccess: true,
         })
 
         const finalPublished = await payload.findByID({
@@ -4417,6 +4702,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           collection: localizedCollectionSlug,
           draft: true,
           locale: 'all',
+          overrideAccess: true,
         })
 
         expect(finalPublished.text.de).toStrictEqual('German published 1')
@@ -4432,6 +4718,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           },
           draft: true,
           locale: 'es',
+          overrideAccess: true,
         })
 
         await payload.update({
@@ -4442,12 +4729,14 @@ test.suite({ config: './config.ts' })('Versions', () => {
             text: 'English publish',
           },
           draft: false,
+          overrideAccess: true,
         })
 
         const publishedOnlyEN = await payload.findByID({
           id: draft.id,
           collection: localizedCollectionSlug,
           locale: 'all',
+          overrideAccess: true,
         })
 
         expect(publishedOnlyEN.text.es ?? null).toBeNull()
@@ -4464,6 +4753,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           },
           draft: true,
           locale: 'es',
+          overrideAccess: true,
         })
 
         await payload.update({
@@ -4474,12 +4764,14 @@ test.suite({ config: './config.ts' })('Versions', () => {
             text: 'English publish',
           },
           draft: false,
+          overrideAccess: true,
         })
 
         const publishedOnlyEN = await payload.findByID({
           id: draft.id,
           collection: localizedCollectionSlug,
           locale: 'all',
+          overrideAccess: true,
         })
 
         expect(publishedOnlyEN.text.es ?? null).toBeNull()
@@ -4493,12 +4785,14 @@ test.suite({ config: './config.ts' })('Versions', () => {
           },
           draft: false,
           publishAllLocales: true,
+          overrideAccess: true,
         })
 
         const publishedAll = await payload.findByID({
           id: published2.id,
           collection: localizedCollectionSlug,
           locale: 'all',
+          overrideAccess: true,
         })
 
         expect(publishedAll.text.es).toStrictEqual('Spanish draft')
@@ -4513,6 +4807,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           },
           draft: true,
           locale: 'es',
+          overrideAccess: true,
         })
 
         const published = await payload.update({
@@ -4524,12 +4819,14 @@ test.suite({ config: './config.ts' })('Versions', () => {
           },
           draft: false,
           locale: 'de',
+          overrideAccess: true,
         })
 
         const publishedOnlyDE = await payload.findByID({
           id: published.id,
           collection: localizedCollectionSlug,
           locale: 'all',
+          overrideAccess: true,
         })
 
         expect(publishedOnlyDE.text.es ?? null).toBeNull()
@@ -4545,6 +4842,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           },
           draft: true,
           locale: 'es',
+          overrideAccess: true,
         })
 
         const published = await payload.update({
@@ -4555,12 +4853,14 @@ test.suite({ config: './config.ts' })('Versions', () => {
             text: 'English publish',
           },
           draft: false,
+          overrideAccess: true,
         })
 
         const publishedOnlyEN = await payload.findByID({
           id: published.id,
           collection: localizedCollectionSlug,
           locale: 'all',
+          overrideAccess: true,
         })
 
         expect(publishedOnlyEN.text.es ?? null).toBeNull()
@@ -4569,6 +4869,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
         const allVersions = await payload.findVersions({
           collection: localizedCollectionSlug,
           locale: 'all',
+          overrideAccess: true,
         })
 
         const versions = allVersions.docs.filter((version) => version.parent === published.id)
@@ -4589,6 +4890,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           },
           draft: true,
           locale: 'en',
+          overrideAccess: true,
         })
 
         // Step 2: Update with blocks
@@ -4606,6 +4908,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           },
           draft: true,
           locale: 'en',
+          overrideAccess: true,
         })
 
         // Step 3: Publish only English locale
@@ -4624,6 +4927,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           },
           draft: false,
           locale: 'en',
+          overrideAccess: true,
         })
 
         // Blocks should be preserved with blockType intact
@@ -4635,6 +4939,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
         const found = await payload.findByID({
           id: draft.id,
           collection: localizedCollectionSlug,
+          overrideAccess: true,
         })
 
         expect(found.blocks).toHaveLength(1)
@@ -4662,6 +4967,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             title: 'German published',
           },
           locale: 'de',
+          overrideAccess: true,
         })
 
         // save spanish draft
@@ -4673,6 +4979,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           },
           draft: true,
           locale: 'es',
+          overrideAccess: true,
         })
 
         // publish only english
@@ -4683,11 +4990,13 @@ test.suite({ config: './config.ts' })('Versions', () => {
             title: 'Eng published',
           },
           locale: 'en',
+          overrideAccess: true,
         })
 
         const globalData = await payload.findGlobal({
           slug: global,
           locale: 'all',
+          overrideAccess: true,
         })
 
         // Expect only previously published data to be present
@@ -4705,6 +5014,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           },
           draft: true,
           locale: 'es',
+          overrideAccess: true,
         })
 
         // publish only english
@@ -4716,11 +5026,13 @@ test.suite({ config: './config.ts' })('Versions', () => {
           },
           draft: false,
           locale: 'en',
+          overrideAccess: true,
         })
 
         const globalData = await payload.findGlobal({
           slug: global,
           locale: 'all',
+          overrideAccess: true,
         })
 
         // Expect no draft data to be present
@@ -4740,6 +5052,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           },
           draft: true,
           locale: 'es',
+          overrideAccess: true,
         })
 
         // publish only english
@@ -4750,11 +5063,13 @@ test.suite({ config: './config.ts' })('Versions', () => {
             title: 'Eng published',
           },
           locale: 'en',
+          overrideAccess: true,
         })
 
         const publishedOnlyEN = await payload.findGlobal({
           slug: global,
           locale: 'all',
+          overrideAccess: true,
         })
 
         expect(publishedOnlyEN.title.es).toBeUndefined()
@@ -4766,11 +5081,13 @@ test.suite({ config: './config.ts' })('Versions', () => {
             _status: 'published',
           },
           publishAllLocales: true,
+          overrideAccess: true,
         })
 
         const publishedAll = await payload.findGlobal({
           slug: global,
           locale: 'all',
+          overrideAccess: true,
         })
 
         expect(publishedAll.title.es).toStrictEqual('Spanish draft')
@@ -4787,6 +5104,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           },
           draft: true,
           locale: 'es',
+          overrideAccess: true,
         })
 
         // publish only german
@@ -4797,11 +5115,13 @@ test.suite({ config: './config.ts' })('Versions', () => {
             title: 'German published',
           },
           locale: 'de',
+          overrideAccess: true,
         })
 
         const globalData = await payload.findGlobal({
           slug: global,
           locale: 'all',
+          overrideAccess: true,
         })
 
         // Expect only published data to be present
@@ -4819,6 +5139,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
           },
           draft: true,
           locale: 'es',
+          overrideAccess: true,
         })
 
         // publish only english
@@ -4829,6 +5150,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
             title: 'New eng',
           },
           draft: false,
+          overrideAccess: true,
         })
 
         const allVersions = await payload.findGlobalVersions({
@@ -4839,6 +5161,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
               equals: 'published',
             },
           },
+          overrideAccess: true,
         })
 
         const versions = allVersions.docs

--- a/test/versions/seed.ts
+++ b/test/versions/seed.ts
@@ -37,12 +37,14 @@ export async function seed(_payload: Payload, parallel: boolean = false) {
     collection: mediaCollectionSlug,
     data: {},
     file: imageFile,
+    overrideAccess: true,
   })
 
   const { id: uploadedImageMedia2 } = await _payload.create({
     collection: media2CollectionSlug,
     data: {},
     file: imageFile,
+    overrideAccess: true,
   })
 
   const imageFilePath2 = path.resolve(seedDir, './image.png')
@@ -52,12 +54,14 @@ export async function seed(_payload: Payload, parallel: boolean = false) {
     collection: mediaCollectionSlug,
     data: {},
     file: imageFile2,
+    overrideAccess: true,
   })
 
   const { id: uploadedImage2Media2 } = await _payload.create({
     collection: media2CollectionSlug,
     data: {},
     file: imageFile2,
+    overrideAccess: true,
   })
 
   const { id: devUserID } = await _payload.create({
@@ -147,6 +151,7 @@ export async function seed(_payload: Payload, parallel: boolean = false) {
     data: {
       title: 'Initial seeded title',
     },
+    overrideAccess: true,
   })
 
   const { id: doc1ID } = await _payload.create({
@@ -154,6 +159,7 @@ export async function seed(_payload: Payload, parallel: boolean = false) {
     data: {
       text: 'Document 1',
     },
+    overrideAccess: true,
   })
 
   const { id: doc2ID } = await _payload.create({
@@ -161,6 +167,7 @@ export async function seed(_payload: Payload, parallel: boolean = false) {
     data: {
       text: 'Document 2',
     },
+    overrideAccess: true,
   })
 
   const diffDocDraft = await _payload.create({
@@ -171,6 +178,7 @@ export async function seed(_payload: Payload, parallel: boolean = false) {
       text: 'Draft 1',
     },
     depth: 0,
+    overrideAccess: true,
   })
 
   await _payload.update({
@@ -182,6 +190,7 @@ export async function seed(_payload: Payload, parallel: boolean = false) {
     },
     depth: 0,
     id: diffDocDraft.id,
+    overrideAccess: true,
   })
 
   await _payload.update({
@@ -193,6 +202,7 @@ export async function seed(_payload: Payload, parallel: boolean = false) {
     },
     depth: 0,
     id: diffDocDraft.id,
+    overrideAccess: true,
   })
   await _payload.update({
     collection: diffCollectionSlug,
@@ -203,6 +213,7 @@ export async function seed(_payload: Payload, parallel: boolean = false) {
     },
     depth: 0,
     id: diffDocDraft.id,
+    overrideAccess: true,
   })
 
   const diffDoc = await _payload.update({
@@ -312,6 +323,7 @@ export async function seed(_payload: Payload, parallel: boolean = false) {
       uploadHasMany: [uploadedImage],
     },
     depth: 0,
+    overrideAccess: true,
   })
 
   const pointGeoJSON: any = {
@@ -335,6 +347,7 @@ export async function seed(_payload: Payload, parallel: boolean = false) {
     depth: 0,
     limit: 50,
     sort: '-createdAt',
+    overrideAccess: true,
   })
 
   let i = 0
@@ -464,5 +477,6 @@ export async function seed(_payload: Payload, parallel: boolean = false) {
       zeroDepthRelationship: devUserID,
     },
     depth: 0,
+    overrideAccess: true,
   })
 }


### PR DESCRIPTION
Adds an explicit `overrideAccess: true` to every Local API call in `test/` that previously relied on the default.

This is preparation for flipping the Local API default to `false`, which lands later in this stack. It is split out so that the breaking change itself stays small enough to read (still big, sorry)

## This changes no behaviour

The Local API currently defaults `overrideAccess` to `true`. All 21 local operations
destructure `overrideAccess = true`. Writing the value explicitly produces exactly what
the default already produced, so every one of these tests asserts the same thing it did
before.

## A note on verification
`tsconfig.base.json` excludes `**/*.spec.ts`, so a typecheck cannot see most of this directory and `test/` carries thousands of pre-existing type errors regardless. Relying on all tests to pass to confirm correct changes.