### PR TITLE
fix: type date validation values as strings

### DIFF
--- a/packages/payload/src/fields/validations.ts
+++ b/packages/payload/src/fields/validations.ts
@@ -405,13 +405,13 @@ export const checkbox: CheckboxFieldValidation = (value, { req: { t }, required 
   return true
 }
 
-export type DateFieldValidation = Validate<Date, unknown, unknown, DateField>
+export type DateFieldValidation = Validate<string, unknown, unknown, DateField>
 
 export const date: DateFieldValidation = (
   value,
   { name, req: { t }, required, siblingData, timezone },
 ) => {
-  const validDate = value && !isNaN(Date.parse(value.toString()))
+  const validDate = value && !isNaN(Date.parse(value))
 
   // We need to also check for the timezone data based on this field's config
   // We cannot do this inside the timezone field validation as it's visually hidden

--- a/test/types/types.spec.ts
+++ b/test/types/types.spec.ts
@@ -5,6 +5,7 @@ import type {
   BulkOperationResult,
   CollectionSlug,
   CustomDocumentViewConfig,
+  DateFieldValidation,
   DefaultDocumentViewConfig,
   GeneratedTypes,
   Job,
@@ -82,6 +83,10 @@ import type {
 } from './payload-types.js'
 
 describe('Types testing', () => {
+  test('should type date validation values as serialized strings', () => {
+    expect<Parameters<DateFieldValidation>[0]>().type.toBe<null | string | undefined>()
+  })
+
   test('should fall back when generated types do not include jobs', () => {
     expect<Job['id']>().type.toBe<number | string>()
     expect<Job['processingToken']>().type.toBe<null | string | undefined>()


### PR DESCRIPTION
### What?

Corrects the DateFieldValidation input type from Date to the serialized string value passed to date validators. Also removes the unnecessary string conversion before parsing and adds a type-level regression test.

### Why?

Payload date fields are represented as strings in generated types and are passed to validation as strings at runtime. Typing validator values as Date makes custom date validators inconsistent with their actual input.

### How?

- Changes the DateFieldValidation value generic to string
- Parses the string value directly
- Asserts the public validation input type with TSTyche

Fixes #10605