### PR TITLE
chore: make overrideAccess explicit in plugins

### DIFF
--- a/packages/plugin-cloud-storage/src/hooks/afterChange.ts
+++ b/packages/plugin-cloud-storage/src/hooks/afterChange.ts
@@ -67,6 +67,7 @@ export const getAfterChangeHook =
               data: uploadMetadata,
               depth: 0,
               draft: isDraftSave,
+              overrideAccess: true,
               req,
             })
           } finally {

--- a/packages/plugin-cloud-storage/src/utilities/getFilePrefix.ts
+++ b/packages/plugin-cloud-storage/src/utilities/getFilePrefix.ts
@@ -47,6 +47,7 @@ export async function getFilePrefix({
     depth: 0,
     draft: true,
     limit: 1,
+    overrideAccess: true,
     pagination: false,
     where: {
       or: [

--- a/packages/plugin-ecommerce/src/collections/carts/beforeChange.ts
+++ b/packages/plugin-ecommerce/src/collections/carts/beforeChange.ts
@@ -37,6 +37,7 @@ export const beforeChangeCart: (args: Props) => CollectionBeforeChangeHook =
             id,
             collection: variantsSlug,
             depth: 0,
+            overrideAccess: true,
             select: {
               [priceField]: true,
             },
@@ -50,6 +51,7 @@ export const beforeChangeCart: (args: Props) => CollectionBeforeChangeHook =
             id,
             collection: productsSlug,
             depth: 0,
+            overrideAccess: true,
             select: {
               [priceField]: true,
             },

--- a/packages/plugin-ecommerce/src/collections/variants/createVariantsCollection/hooks/beforeChange.ts
+++ b/packages/plugin-ecommerce/src/collections/variants/createVariantsCollection/hooks/beforeChange.ts
@@ -15,6 +15,7 @@ export const variantsCollectionBeforeChange: (args: Props) => CollectionBeforeCh
         id: productID,
         collection: productsSlug,
         depth: 0,
+        overrideAccess: true,
         select: {
           title: true,
           variantTypes: true,
@@ -30,6 +31,7 @@ export const variantsCollectionBeforeChange: (args: Props) => CollectionBeforeCh
           id: option,
           collection: variantOptionsSlug,
           depth: 0,
+          overrideAccess: true,
           select: {
             label: true,
           },

--- a/packages/plugin-ecommerce/src/collections/variants/createVariantsCollection/hooks/validateOptions.ts
+++ b/packages/plugin-ecommerce/src/collections/variants/createVariantsCollection/hooks/validateOptions.ts
@@ -38,6 +38,7 @@ export const validateOptions: (props?: Props) => Validate =
           },
         },
       },
+      overrideAccess: true,
       select: {
         variants: true,
         variantTypes: true,

--- a/packages/plugin-ecommerce/src/endpoints/confirmOrder.ts
+++ b/packages/plugin-ecommerce/src/endpoints/confirmOrder.ts
@@ -178,6 +178,7 @@ export const confirmOrderHandler: ConfirmOrderHandler =
           id: paymentResponse.transactionID,
           collection: transactionsSlug,
           depth: 0,
+          overrideAccess: true,
           select: {
             id: true,
             items: true,

--- a/packages/plugin-ecommerce/src/endpoints/initiatePayment.ts
+++ b/packages/plugin-ecommerce/src/endpoints/initiatePayment.ts
@@ -206,6 +206,7 @@ export const initiatePaymentHandler: InitiatePayment =
           id,
           collection: productsSlug,
           depth: 0,
+          overrideAccess: true,
           select: {
             inventory: true,
             [priceField]: true,
@@ -258,6 +259,7 @@ export const initiatePaymentHandler: InitiatePayment =
             id,
             collection: variantsSlug,
             depth: 0,
+            overrideAccess: true,
             select: {
               inventory: true,
               [priceField]: true,

--- a/packages/plugin-ecommerce/src/payments/adapters/stripe/confirmOrder.ts
+++ b/packages/plugin-ecommerce/src/payments/adapters/stripe/confirmOrder.ts
@@ -60,6 +60,7 @@ export const confirmOrder: (props: Props) => NonNullable<PaymentAdapter>['confir
       // Find our existing transaction by the payment intent ID
       const transactionsResults = await payload.find({
         collection: transactionsSlug,
+        overrideAccess: true,
         req,
         where: {
           'stripe.paymentIntentID': {
@@ -108,6 +109,7 @@ export const confirmOrder: (props: Props) => NonNullable<PaymentAdapter>['confir
           status: 'processing',
           transactions: [transaction.id],
         },
+        overrideAccess: true,
         req,
       })
 
@@ -119,6 +121,7 @@ export const confirmOrder: (props: Props) => NonNullable<PaymentAdapter>['confir
         data: {
           purchasedAt: timestamp,
         },
+        overrideAccess: true,
         req,
       })
 
@@ -129,6 +132,7 @@ export const confirmOrder: (props: Props) => NonNullable<PaymentAdapter>['confir
           order: order.id,
           status: 'succeeded',
         },
+        overrideAccess: true,
         req,
       })
 

--- a/packages/plugin-ecommerce/src/payments/adapters/stripe/initiatePayment.ts
+++ b/packages/plugin-ecommerce/src/payments/adapters/stripe/initiatePayment.ts
@@ -119,6 +119,7 @@ export const initiatePayment: (props: Props) => NonNullable<PaymentAdapter>['ini
             paymentIntentID: paymentIntent.id,
           },
         },
+        overrideAccess: true,
         req,
       })
 

--- a/packages/plugin-ecommerce/src/ui/VariantOptionsSelector/index.tsx
+++ b/packages/plugin-ecommerce/src/ui/VariantOptionsSelector/index.tsx
@@ -21,6 +21,7 @@ export const VariantOptionsSelector: React.FC<Props> = async (props) => {
     collection: productsSlug,
     depth: 0,
     draft: true,
+    overrideAccess: true,
     select: {
       variants: true,
       variantTypes: true,
@@ -49,6 +50,7 @@ export const VariantOptionsSelector: React.FC<Props> = async (props) => {
             sort: 'value',
           },
         },
+        overrideAccess: true,
       })
 
       if (variantType) {

--- a/packages/plugin-form-builder/src/collections/FormSubmissions/hooks/handleUploads.ts
+++ b/packages/plugin-form-builder/src/collections/FormSubmissions/hooks/handleUploads.ts
@@ -60,6 +60,7 @@ export const handleUploads = async (
     form = await payload.findByID({
       id: formID,
       collection: formSlug,
+      overrideAccess: true,
       req,
     })
   } catch {
@@ -170,6 +171,7 @@ export const handleUploads = async (
               mimetype: requestFile.mimetype,
               size: requestFile.size,
             },
+            overrideAccess: true,
             req,
           })
 
@@ -226,6 +228,7 @@ export const handleUploads = async (
           fileDoc = (await payload.findByID({
             id: fileId,
             collection: uploadCollection,
+            overrideAccess: true,
             req,
           })) as FileData & TypeWithID
         } catch {
@@ -294,7 +297,7 @@ export const handleUploads = async (
     // Best-effort cleanup of any docs created before the error was detected
     for (const doc of createdDocs) {
       try {
-        await payload.delete({ id: doc.id, collection: doc.collection, req })
+        await payload.delete({ id: doc.id, collection: doc.collection, overrideAccess: true, req })
       } catch {
         // best-effort — don't mask the original validation error
       }

--- a/packages/plugin-form-builder/src/collections/FormSubmissions/hooks/sendEmail.ts
+++ b/packages/plugin-form-builder/src/collections/FormSubmissions/hooks/sendEmail.ts
@@ -27,6 +27,7 @@ export const sendEmail = async (
         id: formID,
         collection: formOverrides?.slug || 'forms',
         locale,
+        overrideAccess: true,
         req,
       })
 

--- a/packages/plugin-form-builder/src/collections/FormSubmissions/index.ts
+++ b/packages/plugin-form-builder/src/collections/FormSubmissions/index.ts
@@ -37,6 +37,7 @@ export const generateSubmissionCollection = (
             _existingForm = await payload.findByID({
               id: value,
               collection: formSlug,
+              overrideAccess: true,
               req,
             })
 

--- a/packages/plugin-import-export/src/import/createImport.ts
+++ b/packages/plugin-import-export/src/import/createImport.ts
@@ -72,6 +72,7 @@ export const createImport = async ({
     user = (await req.payload.findByID({
       id: userID,
       collection: userCollection,
+      overrideAccess: true,
       req,
     })) as User
   }

--- a/packages/plugin-import-export/src/import/getCreateImportCollectionTask.ts
+++ b/packages/plugin-import-export/src/import/getCreateImportCollectionTask.ts
@@ -40,6 +40,7 @@ export const getCreateCollectionImportTask = (
       const importDoc = await req.payload.findByID({
         id: importId,
         collection: importCollection,
+        overrideAccess: true,
       })
 
       if (!importDoc) {
@@ -121,6 +122,7 @@ export const getCreateCollectionImportTask = (
             updated: result.updated,
           },
         },
+        overrideAccess: true,
       })
 
       return {

--- a/packages/plugin-multi-tenant/src/hooks/afterTenantDelete.ts
+++ b/packages/plugin-multi-tenant/src/hooks/afterTenantDelete.ts
@@ -88,6 +88,7 @@ export const afterTenantDelete =
       cleanupPromises.push(
         req.payload.delete({
           collection: slug,
+          overrideAccess: true,
           req,
           where: {
             [tenantFieldName]: {
@@ -103,6 +104,7 @@ export const afterTenantDelete =
         collection: usersSlug,
         depth: 0,
         limit: 0,
+        overrideAccess: true,
         req,
         where: {
           [`${usersTenantsArrayFieldName}.${usersTenantsArrayTenantFieldName}`]: {
@@ -128,6 +130,7 @@ export const afterTenantDelete =
                 }
               }),
             },
+            overrideAccess: true,
             req,
           }),
         )

--- a/packages/plugin-multi-tenant/src/utilities/getGlobalViewRedirect.ts
+++ b/packages/plugin-multi-tenant/src/utilities/getGlobalViewRedirect.ts
@@ -75,6 +75,7 @@ export async function getGlobalViewRedirect({
         collection: collectionSlug,
         depth: 0,
         limit: 1,
+        overrideAccess: true,
         pagination: false,
         select: {
           id: true,
@@ -171,6 +172,7 @@ async function generateCreateRedirect({
         },
         depth: 0,
         draft: true,
+        overrideAccess: true,
         select: {
           id: true,
         },

--- a/packages/plugin-nested-docs/src/hooks/resaveChildren.ts
+++ b/packages/plugin-nested-docs/src/hooks/resaveChildren.ts
@@ -22,6 +22,7 @@ export const resaveChildren =
       draft: true,
       limit: 0,
       locale: req.locale,
+      overrideAccess: true,
       req,
       where: {
         [parentSlug]: {
@@ -38,6 +39,7 @@ export const resaveChildren =
       draft: false,
       limit: 0,
       locale: req.locale,
+      overrideAccess: true,
       req,
       where: {
         [parentSlug]: {
@@ -82,6 +84,7 @@ export const resaveChildren =
             depth: 0,
             draft: isDraft,
             locale: req.locale,
+            overrideAccess: true,
             req,
           })
         }

--- a/packages/plugin-nested-docs/src/hooks/resaveSelfAfterCreate.ts
+++ b/packages/plugin-nested-docs/src/hooks/resaveSelfAfterCreate.ts
@@ -30,6 +30,7 @@ export const resaveSelfAfterCreate =
         depth: 0,
         draft: collection?.versions?.drafts && doc._status !== 'published',
         locale,
+        overrideAccess: true,
         req,
       })
     } catch (err: unknown) {

--- a/packages/plugin-nested-docs/src/utilities/getParents.ts
+++ b/packages/plugin-nested-docs/src/utilities/getParents.ts
@@ -21,6 +21,7 @@ export const getParents = async (
         collection: collection.slug,
         depth: 0,
         disableErrors: true,
+        overrideAccess: true,
         req,
       })
     }

--- a/packages/plugin-search/src/Search/hooks/deleteFromSearch.ts
+++ b/packages/plugin-search/src/Search/hooks/deleteFromSearch.ts
@@ -9,6 +9,7 @@ export const deleteFromSearch: DeleteFromSearch =
       await payload.delete({
         collection: searchSlug,
         depth: 0,
+        overrideAccess: true,
         req,
         where: {
           'doc.relationTo': {

--- a/packages/plugin-search/src/utilities/syncDocAsSearchIndex.ts
+++ b/packages/plugin-search/src/utilities/syncDocAsSearchIndex.ts
@@ -73,6 +73,7 @@ export const syncDocAsSearchIndex = async ({
         id,
         collection,
         locale: syncLocale,
+        overrideAccess: true,
         req,
         // Include trashed documents when the document being synced is trashed
         trash: isTrashDocument,
@@ -117,6 +118,7 @@ export const syncDocAsSearchIndex = async ({
         },
         depth: 0,
         locale: syncLocale,
+        overrideAccess: true,
         req,
       })
     }
@@ -128,6 +130,7 @@ export const syncDocAsSearchIndex = async ({
           collection: searchSlug,
           depth: 0,
           locale: syncLocale,
+          overrideAccess: true,
           req,
           where: {
             'doc.relationTo': {
@@ -154,6 +157,7 @@ export const syncDocAsSearchIndex = async ({
             await payload.delete({
               collection: searchSlug,
               depth: 0,
+              overrideAccess: true,
               req,
               where: { id: { in: duplicativeDocIDs } },
             })
@@ -177,6 +181,7 @@ export const syncDocAsSearchIndex = async ({
                 id: searchDocID,
                 collection: searchSlug,
                 depth: 0,
+                overrideAccess: true,
                 req,
               })
             } catch (err: unknown) {
@@ -198,6 +203,7 @@ export const syncDocAsSearchIndex = async ({
                   },
                   depth: 0,
                   locale: syncLocale,
+                  overrideAccess: true,
                   req,
                 })
               } catch (err: unknown) {
@@ -216,6 +222,7 @@ export const syncDocAsSearchIndex = async ({
                 draft: false,
                 limit: 1,
                 locale: syncLocale,
+                overrideAccess: true,
                 pagination: false,
                 req,
                 where: {
@@ -241,6 +248,7 @@ export const syncDocAsSearchIndex = async ({
                     id: searchDocID,
                     collection: searchSlug,
                     depth: 0,
+                    overrideAccess: true,
                     req,
                   })
                 } catch (err: unknown) {
@@ -259,6 +267,7 @@ export const syncDocAsSearchIndex = async ({
               },
               depth: 0,
               locale: syncLocale,
+              overrideAccess: true,
               req,
             })
           } catch (err: unknown) {

--- a/packages/plugin-stripe/src/webhooks/handleCreatedOrUpdated.ts
+++ b/packages/plugin-stripe/src/webhooks/handleCreatedOrUpdated.ts
@@ -55,6 +55,7 @@ export const handleCreatedOrUpdated: HandleCreatedOrUpdated = async (args) => {
     const payloadQuery = await payload.find({
       collection: collectionSlug,
       limit: 1,
+      overrideAccess: true,
       pagination: false,
       where: {
         stripeID: {
@@ -98,6 +99,7 @@ export const handleCreatedOrUpdated: HandleCreatedOrUpdated = async (args) => {
             const authQuery = await payload.find({
               collection: collectionSlug,
               limit: 1,
+              overrideAccess: true,
               pagination: false,
               where: {
                 email: {
@@ -121,6 +123,7 @@ export const handleCreatedOrUpdated: HandleCreatedOrUpdated = async (args) => {
                   id: authDoc.id,
                   collection: collectionSlug,
                   data: syncedData,
+                  overrideAccess: true,
                 })
 
                 if (logs) {
@@ -171,6 +174,7 @@ export const handleCreatedOrUpdated: HandleCreatedOrUpdated = async (args) => {
               passwordConfirm: password,
             },
             disableVerificationEmail: isAuthCollection ? true : undefined,
+            overrideAccess: true,
           })
 
           if (logs) {
@@ -197,6 +201,7 @@ export const handleCreatedOrUpdated: HandleCreatedOrUpdated = async (args) => {
           id: foundDoc.id,
           collection: collectionSlug,
           data: syncedData,
+          overrideAccess: true,
         })
 
         if (logs) {

--- a/packages/plugin-stripe/src/webhooks/handleDeleted.ts
+++ b/packages/plugin-stripe/src/webhooks/handleDeleted.ts
@@ -41,6 +41,7 @@ export const handleDeleted: HandleDeleted = async (args) => {
       const payloadQuery = await payload.find({
         collection: collectionSlug,
         limit: 1,
+        overrideAccess: true,
         pagination: false,
         where: {
           stripeID: {
@@ -69,6 +70,7 @@ export const handleDeleted: HandleDeleted = async (args) => {
           payload.delete({
             id: foundDoc.id,
             collection: collectionSlug,
+            overrideAccess: true,
           })
 
           // NOTE: the `afterDelete` hook will trigger, which will attempt to delete the document from Stripe and safely error out


### PR DESCRIPTION
Adds an explicit `overrideAccess: true` to every Local API call in the plugin packages
that previously relied on the default.

This is preparation for flipping the Local API default to `false`, which lands later
in this stack. It is split out so that the breaking change itself stays small enough
to read.

## This changes no behaviour

The Local API currently defaults `overrideAccess` to `true`. Writing the value
explicitly produces exactly what the default already produced.

| Plugin | Files |
| --- | --- |
| `plugin-ecommerce` | 8 |
| `plugin-form-builder` | 3 |
| `plugin-nested-docs` | 3 |
| `plugin-cloud-storage` | 2 |
| `plugin-import-export` | 2 |
| `plugin-multi-tenant` | 2 |
| `plugin-search` | 2 |
| `plugin-stripe` | 2 |
| `plugin-mcp` | 1 |

`plugin-redirects`, `plugin-sentry`, and `plugin-seo` have no Local API calls that
omit the property, so they are untouched. The storage adapters, email adapters, and
`translations` are likewise void.