### PR TITLE
chore: make overrideAccess explicit in templates

### DIFF
--- a/templates/_template/tests/helpers/seedUser.ts
+++ b/templates/_template/tests/helpers/seedUser.ts
@@ -20,12 +20,14 @@ export async function seedTestUser(): Promise<void> {
         equals: testUser.email,
       },
     },
+    overrideAccess: true,
   })
 
   // Create fresh test user
   await payload.create({
     collection: 'users',
     data: testUser,
+    overrideAccess: true,
   })
 }
 
@@ -42,5 +44,6 @@ export async function cleanupTestUser(): Promise<void> {
         equals: testUser.email,
       },
     },
+    overrideAccess: true,
   })
 }

--- a/templates/_template/tests/int/api.int.spec.ts
+++ b/templates/_template/tests/int/api.int.spec.ts
@@ -14,6 +14,7 @@ describe('API', () => {
   it('fetches users', async () => {
     const users = await payload.find({
       collection: 'users',
+      overrideAccess: true,
     })
     expect(users).toBeDefined()
   })

--- a/templates/blank-tanstack/tests/helpers/seedUser.ts
+++ b/templates/blank-tanstack/tests/helpers/seedUser.ts
@@ -20,12 +20,14 @@ export async function seedTestUser(): Promise<void> {
         equals: testUser.email,
       },
     },
+    overrideAccess: true,
   })
 
   // Create fresh test user
   await payload.create({
     collection: 'users',
     data: testUser,
+    overrideAccess: true,
   })
 }
 
@@ -42,5 +44,6 @@ export async function cleanupTestUser(): Promise<void> {
         equals: testUser.email,
       },
     },
+    overrideAccess: true,
   })
 }

--- a/templates/blank-tanstack/tests/int/api.int.spec.ts
+++ b/templates/blank-tanstack/tests/int/api.int.spec.ts
@@ -14,6 +14,7 @@ describe('API', () => {
   it('fetches users', async () => {
     const users = await payload.find({
       collection: 'users',
+      overrideAccess: true,
     })
     expect(users).toBeDefined()
   })

--- a/templates/blank/tests/helpers/seedUser.ts
+++ b/templates/blank/tests/helpers/seedUser.ts
@@ -20,12 +20,14 @@ export async function seedTestUser(): Promise<void> {
         equals: testUser.email,
       },
     },
+    overrideAccess: true,
   })
 
   // Create fresh test user
   await payload.create({
     collection: 'users',
     data: testUser,
+    overrideAccess: true,
   })
 }
 
@@ -42,5 +44,6 @@ export async function cleanupTestUser(): Promise<void> {
         equals: testUser.email,
       },
     },
+    overrideAccess: true,
   })
 }

--- a/templates/blank/tests/int/api.int.spec.ts
+++ b/templates/blank/tests/int/api.int.spec.ts
@@ -14,6 +14,7 @@ describe('API', () => {
   it('fetches users', async () => {
     const users = await payload.find({
       collection: 'users',
+      overrideAccess: true,
     })
     expect(users).toBeDefined()
   })

--- a/templates/ecommerce/src/blocks/ArchiveBlock/Component.tsx
+++ b/templates/ecommerce/src/blocks/ArchiveBlock/Component.tsx
@@ -31,6 +31,7 @@ export const ArchiveBlock: React.FC<
       collection: 'products',
       depth: 1,
       limit,
+      overrideAccess: true,
       ...(flattenedCategories && flattenedCategories.length > 0
         ? {
             where: {

--- a/templates/ecommerce/src/blocks/Carousel/Component.tsx
+++ b/templates/ecommerce/src/blocks/Carousel/Component.tsx
@@ -29,6 +29,7 @@ export const CarouselBlock: React.FC<
       collection: 'products',
       depth: 1,
       limit: limit || undefined,
+      overrideAccess: true,
       ...(flattenedCategories && flattenedCategories.length > 0
         ? {
             where: {

--- a/templates/ecommerce/src/collections/Users/hooks/ensureFirstUserIsAdmin.ts
+++ b/templates/ecommerce/src/collections/Users/hooks/ensureFirstUserIsAdmin.ts
@@ -9,7 +9,12 @@ import type { User } from '@/payload-types'
 // it ensures that only admins can create and update the `roles` field
 export const ensureFirstUserIsAdmin: FieldHook<User> = async ({ operation, req, value }) => {
   if (operation === 'create') {
-    const users = await req.payload.find({ collection: 'users', depth: 0, limit: 0 })
+    const users = await req.payload.find({
+      collection: 'users',
+      depth: 0,
+      limit: 0,
+      overrideAccess: true,
+    })
     if (users.totalDocs === 0) {
       // if `admin` not in array of values, add it
       if (!(value || []).includes('admin')) {

--- a/templates/ecommerce/src/components/CategoryTabs/index.tsx
+++ b/templates/ecommerce/src/components/CategoryTabs/index.tsx
@@ -14,6 +14,7 @@ async function List() {
       title: true,
       slug: true,
     },
+    overrideAccess: true,
   })
 
   const categories = categoriesData.docs?.map((category) => {

--- a/templates/ecommerce/src/components/forms/FindOrderForm/sendOrderAccessEmail.ts
+++ b/templates/ecommerce/src/components/forms/FindOrderForm/sendOrderAccessEmail.ts
@@ -28,6 +28,7 @@ export async function sendOrderAccessEmail({
       },
       limit: 1,
       depth: 0,
+      overrideAccess: true,
     })
 
     const order = orders[0]

--- a/templates/ecommerce/src/components/layout/search/Categories.tsx
+++ b/templates/ecommerce/src/components/layout/search/Categories.tsx
@@ -12,6 +12,7 @@ async function CategoryList() {
   const categories = await payload.find({
     collection: 'categories',
     sort: 'title',
+    overrideAccess: true,
   })
 
   return (

--- a/templates/ecommerce/src/endpoints/seed/index.ts
+++ b/templates/ecommerce/src/endpoints/seed/index.ts
@@ -99,6 +99,7 @@ export const seed = async ({
         context: {
           disableRevalidate: true,
         },
+        overrideAccess: true,
       }),
     ),
   )
@@ -120,6 +121,7 @@ export const seed = async ({
         equals: 'customer@example.com',
       },
     },
+    overrideAccess: true,
   })
 
   payload.logger.info(`— Seeding media...`)
@@ -158,26 +160,31 @@ export const seed = async ({
         password: 'password',
         roles: ['customer'],
       },
+      overrideAccess: true,
     }),
     payload.create({
       collection: 'media',
       data: imageHatData,
       file: imageHatBuffer,
+      overrideAccess: true,
     }),
     payload.create({
       collection: 'media',
       data: imageTshirtBlackData,
       file: imageTshirtBlackBuffer,
+      overrideAccess: true,
     }),
     payload.create({
       collection: 'media',
       data: imageTshirtWhiteData,
       file: imageTshirtWhiteBuffer,
+      overrideAccess: true,
     }),
     payload.create({
       collection: 'media',
       data: imageHero1Data,
       file: heroBuffer,
+      overrideAccess: true,
     }),
     ...categories.map((category) =>
       payload.create({
@@ -186,6 +193,7 @@ export const seed = async ({
           title: category,
           slug: category,
         },
+        overrideAccess: true,
       }),
     ),
   ])
@@ -198,6 +206,7 @@ export const seed = async ({
       name: 'size',
       label: 'Size',
     },
+    overrideAccess: true,
   })
 
   const sizeVariantOptionsResults: VariantOption[] = []
@@ -209,6 +218,7 @@ export const seed = async ({
         ...option,
         variantType: sizeVariantType.id,
       },
+      overrideAccess: true,
     })
     sizeVariantOptionsResults.push(result)
   }
@@ -221,6 +231,7 @@ export const seed = async ({
       name: 'color',
       label: 'Color',
     },
+    overrideAccess: true,
   })
 
   const [black, white] = await Promise.all(
@@ -231,6 +242,7 @@ export const seed = async ({
           ...option,
           variantType: colorVariantType.id,
         },
+        overrideAccess: true,
       })
     }),
   )
@@ -247,6 +259,7 @@ export const seed = async ({
       categories: [hatsCategory],
       relatedProducts: [],
     }),
+    overrideAccess: true,
   })
 
   const productTshirt = await payload.create({
@@ -263,6 +276,7 @@ export const seed = async ({
       categories: [tshirtsCategory],
       relatedProducts: [productHat],
     }),
+    overrideAccess: true,
   })
 
   let hoodieID: number | string = productTshirt.id
@@ -285,6 +299,7 @@ export const seed = async ({
           product: productTshirt,
           variantOptions: [variantOption, white],
         }),
+        overrideAccess: true,
       }),
     ),
   )
@@ -299,6 +314,7 @@ export const seed = async ({
           variantOptions: [variantOption, black],
           ...(variantOption.value === 'medium' ? { inventory: 0 } : {}),
         }),
+        overrideAccess: true,
       }),
     ),
   )
@@ -309,6 +325,7 @@ export const seed = async ({
     collection: 'forms',
     depth: 0,
     data: contactFormData(),
+    overrideAccess: true,
   })
 
   payload.logger.info(`— Seeding pages...`)
@@ -321,6 +338,7 @@ export const seed = async ({
         contentImage: imageHero,
         metaImage: imageHat,
       }),
+      overrideAccess: true,
     }),
     payload.create({
       collection: 'pages',
@@ -328,6 +346,7 @@ export const seed = async ({
       data: contactPageData({
         contactForm: contactForm,
       }),
+      overrideAccess: true,
     }),
   ])
 
@@ -340,6 +359,7 @@ export const seed = async ({
       customer: customer.id,
       ...(baseAddressUSData as Address),
     },
+    overrideAccess: true,
   })
 
   const customerUKAddress = await payload.create({
@@ -349,6 +369,7 @@ export const seed = async ({
       customer: customer.id,
       ...(baseAddressUKData as Address),
     },
+    overrideAccess: true,
   })
 
   payload.logger.info(`— Seeding transactions...`)
@@ -366,6 +387,7 @@ export const seed = async ({
       status: 'pending',
       billingAddress: baseAddressUSData,
     },
+    overrideAccess: true,
   })
 
   const succeededTransaction = await payload.create({
@@ -381,6 +403,7 @@ export const seed = async ({
       status: 'succeeded',
       billingAddress: baseAddressUSData,
     },
+    overrideAccess: true,
   })
 
   let succeededTransactionID: number | string = succeededTransaction.id
@@ -405,6 +428,7 @@ export const seed = async ({
         },
       ],
     },
+    overrideAccess: true,
   })
 
   const oldTimestamp = new Date('2023-01-01T00:00:00Z').toISOString()
@@ -422,6 +446,7 @@ export const seed = async ({
         },
       ],
     },
+    overrideAccess: true,
   })
 
   // Cart is purchased because it has a purchasedAt date
@@ -445,6 +470,7 @@ export const seed = async ({
         },
       ],
     },
+    overrideAccess: true,
   })
 
   let completedCartID: number | string = completedCart.id
@@ -477,6 +503,7 @@ export const seed = async ({
       status: 'completed',
       transactions: [succeededTransaction.id],
     },
+    overrideAccess: true,
   })
 
   const orderInProcessing = await payload.create({
@@ -501,6 +528,7 @@ export const seed = async ({
       status: 'processing',
       transactions: [succeededTransaction.id],
     },
+    overrideAccess: true,
   })
 
   payload.logger.info(`— Seeding globals...`)
@@ -533,6 +561,7 @@ export const seed = async ({
           },
         ],
       },
+      overrideAccess: true,
     }),
     payload.updateGlobal({
       slug: 'footer',
@@ -570,6 +599,7 @@ export const seed = async ({
           },
         ],
       },
+      overrideAccess: true,
     }),
   ])
 

--- a/templates/ecommerce/src/utilities/getDocument.ts
+++ b/templates/ecommerce/src/utilities/getDocument.ts
@@ -17,6 +17,7 @@ async function getDocument(collection: Collection, slug: string, depth = 0) {
         equals: slug,
       },
     },
+    overrideAccess: true,
   })
 
   return page.docs[0]

--- a/templates/ecommerce/src/utilities/getGlobals.ts
+++ b/templates/ecommerce/src/utilities/getGlobals.ts
@@ -12,6 +12,7 @@ async function getGlobal<T extends Global>(slug: T, depth = 0) {
   const global = await payload.findGlobal({
     slug,
     depth,
+    overrideAccess: true,
   })
 
   return global

--- a/templates/ecommerce/tests/helpers/seedUser.ts
+++ b/templates/ecommerce/tests/helpers/seedUser.ts
@@ -20,12 +20,14 @@ export async function seedTestUser(): Promise<void> {
         equals: testUser.email,
       },
     },
+    overrideAccess: true,
   })
 
   // Create fresh test user
   await payload.create({
     collection: 'users',
     data: testUser,
+    overrideAccess: true,
   })
 }
 
@@ -42,5 +44,6 @@ export async function cleanupTestUser(): Promise<void> {
         equals: testUser.email,
       },
     },
+    overrideAccess: true,
   })
 }

--- a/templates/ecommerce/tests/int/api.int.spec.ts
+++ b/templates/ecommerce/tests/int/api.int.spec.ts
@@ -14,6 +14,7 @@ describe('API', () => {
   it('fetches users', async () => {
     const users = await payload.find({
       collection: 'users',
+      overrideAccess: true,
     })
     expect(users).toBeDefined()
   })

--- a/templates/plugin/dev/int.spec.ts
+++ b/templates/plugin/dev/int.spec.ts
@@ -38,6 +38,7 @@ describe('Plugin integration tests', () => {
       data: {
         addedByPlugin: 'added by plugin',
       },
+      overrideAccess: true,
     })
     expect(post.addedByPlugin).toBe('added by plugin')
   })
@@ -45,7 +46,7 @@ describe('Plugin integration tests', () => {
   test('plugin creates and seeds plugin-collection', async () => {
     expect(payload.collections['plugin-collection']).toBeDefined()
 
-    const { docs } = await payload.find({ collection: 'plugin-collection' })
+    const { docs } = await payload.find({ collection: 'plugin-collection', overrideAccess: true })
 
     expect(docs).toHaveLength(1)
   })

--- a/templates/plugin/dev/seed.ts
+++ b/templates/plugin/dev/seed.ts
@@ -10,12 +10,14 @@ export const seed = async (payload: Payload) => {
         equals: devUser.email,
       },
     },
+    overrideAccess: true,
   })
 
   if (!totalDocs) {
     await payload.create({
       collection: 'users',
       data: devUser,
+      overrideAccess: true,
     })
   }
 }

--- a/templates/plugin/src/components/BeforeDashboardServer.tsx
+++ b/templates/plugin/src/components/BeforeDashboardServer.tsx
@@ -5,7 +5,7 @@ import styles from './BeforeDashboardServer.module.css'
 export const BeforeDashboardServer = async (props: ServerComponentProps) => {
   const { payload } = props
 
-  const { docs } = await payload.find({ collection: 'plugin-collection' })
+  const { docs } = await payload.find({ collection: 'plugin-collection', overrideAccess: true })
 
   return (
     <div className={styles.wrapper}>

--- a/templates/plugin/src/index.ts
+++ b/templates/plugin/src/index.ts
@@ -97,6 +97,7 @@ export const myPlugin =
             equals: 'seeded-by-plugin',
           },
         },
+        overrideAccess: true,
       })
 
       if (totalDocs === 0) {
@@ -105,6 +106,7 @@ export const myPlugin =
           data: {
             id: 'seeded-by-plugin',
           },
+          overrideAccess: true,
         })
       }
     }

--- a/templates/website/src/app/(frontend)/search/page.tsx
+++ b/templates/website/src/app/(frontend)/search/page.tsx
@@ -28,6 +28,7 @@ export default async function Page({ searchParams: searchParamsPromise }: Args) 
       meta: true,
     },
     // pagination: false reduces overhead if you don't need totalDocs
+    overrideAccess: true,
     pagination: false,
     ...(query
       ? {

--- a/templates/website/src/blocks/ArchiveBlock/Component.tsx
+++ b/templates/website/src/blocks/ArchiveBlock/Component.tsx
@@ -30,6 +30,7 @@ export const ArchiveBlock: React.FC<
       collection: 'posts',
       depth: 1,
       limit,
+      overrideAccess: true,
       ...(flattenedCategories && flattenedCategories.length > 0
         ? {
             where: {

--- a/templates/website/src/collections/Posts/hooks/populateAuthors.ts
+++ b/templates/website/src/collections/Posts/hooks/populateAuthors.ts
@@ -15,6 +15,7 @@ export const populateAuthors: CollectionAfterReadHook = async ({ doc, req, req: 
           id: typeof author === 'object' ? author?.id : author,
           collection: 'users',
           depth: 0,
+          overrideAccess: true,
         })
 
         if (authorDoc) {

--- a/templates/website/src/endpoints/seed/index.ts
+++ b/templates/website/src/endpoints/seed/index.ts
@@ -55,6 +55,7 @@ export const seed = async ({
         context: {
           disableRevalidate: true,
         },
+        overrideAccess: true,
       }),
     ),
   )
@@ -79,6 +80,7 @@ export const seed = async ({
         equals: 'demo-author@example.com',
       },
     },
+    overrideAccess: true,
   })
 
   payload.logger.info(`— Seeding media...`)
@@ -106,26 +108,31 @@ export const seed = async ({
         email: 'demo-author@example.com',
         password: 'password',
       },
+      overrideAccess: true,
     }),
     payload.create({
       collection: 'media',
       data: image1,
       file: image1Buffer,
+      overrideAccess: true,
     }),
     payload.create({
       collection: 'media',
       data: image2,
       file: image2Buffer,
+      overrideAccess: true,
     }),
     payload.create({
       collection: 'media',
       data: image2,
       file: image3Buffer,
+      overrideAccess: true,
     }),
     payload.create({
       collection: 'media',
       data: imageHero1,
       file: hero1Buffer,
+      overrideAccess: true,
     }),
     categories.map((category) =>
       payload.create({
@@ -134,6 +141,7 @@ export const seed = async ({
           title: category,
           slug: category,
         },
+        overrideAccess: true,
       }),
     ),
   ])
@@ -149,6 +157,7 @@ export const seed = async ({
       disableRevalidate: true,
     },
     data: post1({ heroImage: image1Doc, blockImage: image2Doc, author: demoAuthor }),
+    overrideAccess: true,
   })
 
   const post2Doc = await payload.create({
@@ -158,6 +167,7 @@ export const seed = async ({
       disableRevalidate: true,
     },
     data: post2({ heroImage: image2Doc, blockImage: image3Doc, author: demoAuthor }),
+    overrideAccess: true,
   })
 
   const post3Doc = await payload.create({
@@ -167,6 +177,7 @@ export const seed = async ({
       disableRevalidate: true,
     },
     data: post3({ heroImage: image3Doc, blockImage: image1Doc, author: demoAuthor }),
+    overrideAccess: true,
   })
 
   // update each post with related posts
@@ -176,6 +187,7 @@ export const seed = async ({
     data: {
       relatedPosts: [post2Doc.id, post3Doc.id],
     },
+    overrideAccess: true,
   })
   await payload.update({
     id: post2Doc.id,
@@ -183,6 +195,7 @@ export const seed = async ({
     data: {
       relatedPosts: [post1Doc.id, post3Doc.id],
     },
+    overrideAccess: true,
   })
   await payload.update({
     id: post3Doc.id,
@@ -190,6 +203,7 @@ export const seed = async ({
     data: {
       relatedPosts: [post1Doc.id, post2Doc.id],
     },
+    overrideAccess: true,
   })
 
   payload.logger.info(`— Seeding contact form...`)
@@ -198,6 +212,7 @@ export const seed = async ({
     collection: 'forms',
     depth: 0,
     data: contactFormData,
+    overrideAccess: true,
   })
 
   payload.logger.info(`— Seeding pages...`)
@@ -207,11 +222,13 @@ export const seed = async ({
       collection: 'pages',
       depth: 0,
       data: home({ heroImage: imageHomeDoc, metaImage: image2Doc }),
+      overrideAccess: true,
     }),
     payload.create({
       collection: 'pages',
       depth: 0,
       data: contactPageData({ contactForm: contactForm }),
+      overrideAccess: true,
     }),
   ])
 
@@ -241,6 +258,7 @@ export const seed = async ({
           },
         ],
       },
+      overrideAccess: true,
     }),
     payload.updateGlobal({
       slug: 'footer',
@@ -271,6 +289,7 @@ export const seed = async ({
           },
         ],
       },
+      overrideAccess: true,
     }),
   ])
 

--- a/templates/website/src/search/beforeSync.ts
+++ b/templates/website/src/search/beforeSync.ts
@@ -38,6 +38,7 @@ export const beforeSyncWithSearch: BeforeSync = async ({ req, originalDoc, searc
         depth: 0,
         select: { title: true },
         req,
+        overrideAccess: true,
       })
 
       if (doc !== null) {

--- a/templates/website/src/utilities/getDocument.ts
+++ b/templates/website/src/utilities/getDocument.ts
@@ -17,6 +17,7 @@ async function getDocument(collection: Collection, slug: string, depth = 0) {
         equals: slug,
       },
     },
+    overrideAccess: true,
   })
 
   return page.docs[0]

--- a/templates/website/src/utilities/getGlobals.ts
+++ b/templates/website/src/utilities/getGlobals.ts
@@ -12,6 +12,7 @@ async function getGlobal<T extends Global>(slug: T, depth = 0): Promise<DataFrom
   const global = await payload.findGlobal({
     slug,
     depth,
+    overrideAccess: true,
   })
 
   return global

--- a/templates/website/src/utilities/getRedirects.ts
+++ b/templates/website/src/utilities/getRedirects.ts
@@ -10,6 +10,7 @@ export async function getRedirects(depth = 1) {
     depth,
     limit: 0,
     pagination: false,
+    overrideAccess: true,
   })
 
   return redirects

--- a/templates/website/tests/helpers/seedRelatedPosts.ts
+++ b/templates/website/tests/helpers/seedRelatedPosts.ts
@@ -38,6 +38,7 @@ export async function seedRelatedPosts(): Promise<void> {
       slug: relatedPostsFixture.categorySlug,
       title: relatedPostsFixture.categoryTitle,
     },
+    overrideAccess: true,
     ...disableRevalidate,
   })
 
@@ -45,6 +46,7 @@ export async function seedRelatedPosts(): Promise<void> {
     collection: 'media',
     data: { alt: relatedPostsFixture.imageAlt },
     filePath: path.resolve(dirname, '../../src/endpoints/seed/image-post1.webp'),
+    overrideAccess: true,
     ...disableRevalidate,
   })
 
@@ -58,6 +60,7 @@ export async function seedRelatedPosts(): Promise<void> {
       slug: relatedPostsFixture.relatedPostSlug,
       title: relatedPostsFixture.relatedPostTitle,
     },
+    overrideAccess: true,
     ...disableRevalidate,
   })
 
@@ -70,6 +73,7 @@ export async function seedRelatedPosts(): Promise<void> {
       slug: relatedPostsFixture.postSlug,
       title: relatedPostsFixture.postTitle,
     },
+    overrideAccess: true,
     ...disableRevalidate,
   })
 }
@@ -88,6 +92,7 @@ async function deleteFixture({ payload }: { payload: Payload }): Promise<void> {
         in: [relatedPostsFixture.postSlug, relatedPostsFixture.relatedPostSlug],
       },
     },
+    overrideAccess: true,
     ...disableRevalidate,
   })
 
@@ -96,6 +101,7 @@ async function deleteFixture({ payload }: { payload: Payload }): Promise<void> {
     where: {
       slug: { equals: relatedPostsFixture.categorySlug },
     },
+    overrideAccess: true,
     ...disableRevalidate,
   })
 
@@ -104,6 +110,7 @@ async function deleteFixture({ payload }: { payload: Payload }): Promise<void> {
     where: {
       alt: { equals: relatedPostsFixture.imageAlt },
     },
+    overrideAccess: true,
     ...disableRevalidate,
   })
 }

--- a/templates/website/tests/helpers/seedUser.ts
+++ b/templates/website/tests/helpers/seedUser.ts
@@ -20,12 +20,14 @@ export async function seedTestUser(): Promise<void> {
         equals: testUser.email,
       },
     },
+    overrideAccess: true,
   })
 
   // Create fresh test user
   await payload.create({
     collection: 'users',
     data: testUser,
+    overrideAccess: true,
   })
 }
 
@@ -42,5 +44,6 @@ export async function cleanupTestUser(): Promise<void> {
         equals: testUser.email,
       },
     },
+    overrideAccess: true,
   })
 }

--- a/templates/website/tests/int/api.int.spec.ts
+++ b/templates/website/tests/int/api.int.spec.ts
@@ -14,6 +14,7 @@ describe('API', () => {
   it('fetches users', async () => {
     const users = await payload.find({
       collection: 'users',
+      overrideAccess: true,
     })
     expect(users).toBeDefined()
   })

--- a/templates/with-cloudflare-d1/tests/helpers/seedUser.ts
+++ b/templates/with-cloudflare-d1/tests/helpers/seedUser.ts
@@ -20,12 +20,14 @@ export async function seedTestUser(): Promise<void> {
         equals: testUser.email,
       },
     },
+    overrideAccess: true,
   })
 
   // Create fresh test user
   await payload.create({
     collection: 'users',
     data: testUser,
+    overrideAccess: true,
   })
 }
 
@@ -42,5 +44,6 @@ export async function cleanupTestUser(): Promise<void> {
         equals: testUser.email,
       },
     },
+    overrideAccess: true,
   })
 }

--- a/templates/with-cloudflare-d1/tests/int/api.int.spec.ts
+++ b/templates/with-cloudflare-d1/tests/int/api.int.spec.ts
@@ -14,6 +14,7 @@ describe('API', () => {
   it('fetches users', async () => {
     const users = await payload.find({
       collection: 'users',
+      overrideAccess: true,
     })
     expect(users).toBeDefined()
   })

--- a/templates/with-postgres/tests/helpers/seedUser.ts
+++ b/templates/with-postgres/tests/helpers/seedUser.ts
@@ -20,12 +20,14 @@ export async function seedTestUser(): Promise<void> {
         equals: testUser.email,
       },
     },
+    overrideAccess: true,
   })
 
   // Create fresh test user
   await payload.create({
     collection: 'users',
     data: testUser,
+    overrideAccess: true,
   })
 }
 
@@ -42,5 +44,6 @@ export async function cleanupTestUser(): Promise<void> {
         equals: testUser.email,
       },
     },
+    overrideAccess: true,
   })
 }

--- a/templates/with-postgres/tests/int/api.int.spec.ts
+++ b/templates/with-postgres/tests/int/api.int.spec.ts
@@ -14,6 +14,7 @@ describe('API', () => {
   it('fetches users', async () => {
     const users = await payload.find({
       collection: 'users',
+      overrideAccess: true,
     })
     expect(users).toBeDefined()
   })

--- a/templates/with-vercel-mongodb/tests/helpers/seedUser.ts
+++ b/templates/with-vercel-mongodb/tests/helpers/seedUser.ts
@@ -20,12 +20,14 @@ export async function seedTestUser(): Promise<void> {
         equals: testUser.email,
       },
     },
+    overrideAccess: true,
   })
 
   // Create fresh test user
   await payload.create({
     collection: 'users',
     data: testUser,
+    overrideAccess: true,
   })
 }
 
@@ -42,5 +44,6 @@ export async function cleanupTestUser(): Promise<void> {
         equals: testUser.email,
       },
     },
+    overrideAccess: true,
   })
 }

--- a/templates/with-vercel-mongodb/tests/int/api.int.spec.ts
+++ b/templates/with-vercel-mongodb/tests/int/api.int.spec.ts
@@ -14,6 +14,7 @@ describe('API', () => {
   it('fetches users', async () => {
     const users = await payload.find({
       collection: 'users',
+      overrideAccess: true,
     })
     expect(users).toBeDefined()
   })

--- a/templates/with-vercel-postgres/tests/helpers/seedUser.ts
+++ b/templates/with-vercel-postgres/tests/helpers/seedUser.ts
@@ -20,12 +20,14 @@ export async function seedTestUser(): Promise<void> {
         equals: testUser.email,
       },
     },
+    overrideAccess: true,
   })
 
   // Create fresh test user
   await payload.create({
     collection: 'users',
     data: testUser,
+    overrideAccess: true,
   })
 }
 
@@ -42,5 +44,6 @@ export async function cleanupTestUser(): Promise<void> {
         equals: testUser.email,
       },
     },
+    overrideAccess: true,
   })
 }

--- a/templates/with-vercel-postgres/tests/int/api.int.spec.ts
+++ b/templates/with-vercel-postgres/tests/int/api.int.spec.ts
@@ -14,6 +14,7 @@ describe('API', () => {
   it('fetches users', async () => {
     const users = await payload.find({
       collection: 'users',
+      overrideAccess: true,
     })
     expect(users).toBeDefined()
   })

--- a/templates/with-vercel-website/src/app/(frontend)/search/page.tsx
+++ b/templates/with-vercel-website/src/app/(frontend)/search/page.tsx
@@ -28,6 +28,7 @@ export default async function Page({ searchParams: searchParamsPromise }: Args) 
       meta: true,
     },
     // pagination: false reduces overhead if you don't need totalDocs
+    overrideAccess: true,
     pagination: false,
     ...(query
       ? {

--- a/templates/with-vercel-website/src/blocks/ArchiveBlock/Component.tsx
+++ b/templates/with-vercel-website/src/blocks/ArchiveBlock/Component.tsx
@@ -30,6 +30,7 @@ export const ArchiveBlock: React.FC<
       collection: 'posts',
       depth: 1,
       limit,
+      overrideAccess: true,
       ...(flattenedCategories && flattenedCategories.length > 0
         ? {
             where: {

--- a/templates/with-vercel-website/src/collections/Posts/hooks/populateAuthors.ts
+++ b/templates/with-vercel-website/src/collections/Posts/hooks/populateAuthors.ts
@@ -15,6 +15,7 @@ export const populateAuthors: CollectionAfterReadHook = async ({ doc, req, req: 
           id: typeof author === 'object' ? author?.id : author,
           collection: 'users',
           depth: 0,
+          overrideAccess: true,
         })
 
         if (authorDoc) {

--- a/templates/with-vercel-website/src/endpoints/seed/index.ts
+++ b/templates/with-vercel-website/src/endpoints/seed/index.ts
@@ -55,6 +55,7 @@ export const seed = async ({
         context: {
           disableRevalidate: true,
         },
+        overrideAccess: true,
       }),
     ),
   )
@@ -79,6 +80,7 @@ export const seed = async ({
         equals: 'demo-author@example.com',
       },
     },
+    overrideAccess: true,
   })
 
   payload.logger.info(`— Seeding media...`)
@@ -106,26 +108,31 @@ export const seed = async ({
         email: 'demo-author@example.com',
         password: 'password',
       },
+      overrideAccess: true,
     }),
     payload.create({
       collection: 'media',
       data: image1,
       file: image1Buffer,
+      overrideAccess: true,
     }),
     payload.create({
       collection: 'media',
       data: image2,
       file: image2Buffer,
+      overrideAccess: true,
     }),
     payload.create({
       collection: 'media',
       data: image2,
       file: image3Buffer,
+      overrideAccess: true,
     }),
     payload.create({
       collection: 'media',
       data: imageHero1,
       file: hero1Buffer,
+      overrideAccess: true,
     }),
     categories.map((category) =>
       payload.create({
@@ -134,6 +141,7 @@ export const seed = async ({
           title: category,
           slug: category,
         },
+        overrideAccess: true,
       }),
     ),
   ])
@@ -149,6 +157,7 @@ export const seed = async ({
       disableRevalidate: true,
     },
     data: post1({ heroImage: image1Doc, blockImage: image2Doc, author: demoAuthor }),
+    overrideAccess: true,
   })
 
   const post2Doc = await payload.create({
@@ -158,6 +167,7 @@ export const seed = async ({
       disableRevalidate: true,
     },
     data: post2({ heroImage: image2Doc, blockImage: image3Doc, author: demoAuthor }),
+    overrideAccess: true,
   })
 
   const post3Doc = await payload.create({
@@ -167,6 +177,7 @@ export const seed = async ({
       disableRevalidate: true,
     },
     data: post3({ heroImage: image3Doc, blockImage: image1Doc, author: demoAuthor }),
+    overrideAccess: true,
   })
 
   // update each post with related posts
@@ -176,6 +187,7 @@ export const seed = async ({
     data: {
       relatedPosts: [post2Doc.id, post3Doc.id],
     },
+    overrideAccess: true,
   })
   await payload.update({
     id: post2Doc.id,
@@ -183,6 +195,7 @@ export const seed = async ({
     data: {
       relatedPosts: [post1Doc.id, post3Doc.id],
     },
+    overrideAccess: true,
   })
   await payload.update({
     id: post3Doc.id,
@@ -190,6 +203,7 @@ export const seed = async ({
     data: {
       relatedPosts: [post1Doc.id, post2Doc.id],
     },
+    overrideAccess: true,
   })
 
   payload.logger.info(`— Seeding contact form...`)
@@ -198,6 +212,7 @@ export const seed = async ({
     collection: 'forms',
     depth: 0,
     data: contactFormData,
+    overrideAccess: true,
   })
 
   payload.logger.info(`— Seeding pages...`)
@@ -207,11 +222,13 @@ export const seed = async ({
       collection: 'pages',
       depth: 0,
       data: home({ heroImage: imageHomeDoc, metaImage: image2Doc }),
+      overrideAccess: true,
     }),
     payload.create({
       collection: 'pages',
       depth: 0,
       data: contactPageData({ contactForm: contactForm }),
+      overrideAccess: true,
     }),
   ])
 
@@ -241,6 +258,7 @@ export const seed = async ({
           },
         ],
       },
+      overrideAccess: true,
     }),
     payload.updateGlobal({
       slug: 'footer',
@@ -271,6 +289,7 @@ export const seed = async ({
           },
         ],
       },
+      overrideAccess: true,
     }),
   ])
 

--- a/templates/with-vercel-website/src/search/beforeSync.ts
+++ b/templates/with-vercel-website/src/search/beforeSync.ts
@@ -38,6 +38,7 @@ export const beforeSyncWithSearch: BeforeSync = async ({ req, originalDoc, searc
         depth: 0,
         select: { title: true },
         req,
+        overrideAccess: true,
       })
 
       if (doc !== null) {

--- a/templates/with-vercel-website/src/utilities/getDocument.ts
+++ b/templates/with-vercel-website/src/utilities/getDocument.ts
@@ -17,6 +17,7 @@ async function getDocument(collection: Collection, slug: string, depth = 0) {
         equals: slug,
       },
     },
+    overrideAccess: true,
   })
 
   return page.docs[0]

--- a/templates/with-vercel-website/src/utilities/getGlobals.ts
+++ b/templates/with-vercel-website/src/utilities/getGlobals.ts
@@ -12,6 +12,7 @@ async function getGlobal<T extends Global>(slug: T, depth = 0): Promise<DataFrom
   const global = await payload.findGlobal({
     slug,
     depth,
+    overrideAccess: true,
   })
 
   return global

--- a/templates/with-vercel-website/src/utilities/getRedirects.ts
+++ b/templates/with-vercel-website/src/utilities/getRedirects.ts
@@ -10,6 +10,7 @@ export async function getRedirects(depth = 1) {
     depth,
     limit: 0,
     pagination: false,
+    overrideAccess: true,
   })
 
   return redirects

--- a/templates/with-vercel-website/tests/helpers/seedUser.ts
+++ b/templates/with-vercel-website/tests/helpers/seedUser.ts
@@ -20,12 +20,14 @@ export async function seedTestUser(): Promise<void> {
         equals: testUser.email,
       },
     },
+    overrideAccess: true,
   })
 
   // Create fresh test user
   await payload.create({
     collection: 'users',
     data: testUser,
+    overrideAccess: true,
   })
 }
 
@@ -42,5 +44,6 @@ export async function cleanupTestUser(): Promise<void> {
         equals: testUser.email,
       },
     },
+    overrideAccess: true,
   })
 }

--- a/templates/with-vercel-website/tests/int/api.int.spec.ts
+++ b/templates/with-vercel-website/tests/int/api.int.spec.ts
@@ -14,6 +14,7 @@ describe('API', () => {
   it('fetches users', async () => {
     const users = await payload.find({
       collection: 'users',
+      overrideAccess: true,
     })
     expect(users).toBeDefined()
   })


### PR DESCRIPTION
Adds an explicit `overrideAccess: true` to every Local API call in `templates/` that
previously relied on the default.

This is preparation for flipping the Local API default to `false`, which lands later
in this stack. It is split out so that the breaking change itself stays small enough
to read.

## This changes no behaviour

The Local API currently defaults `overrideAccess` to `true`. Writing the value explicitly
produces exactly what the default already produced.

An earlier plan for this PR was to hand-pick values, mostly `false`, so the templates would
demonstrate access-respecting queries. That was dropped. It would have made this the only
behaviour-changing PR in the middle of the stack, and 118 hand-chosen access-control
decisions is the least reviewable diff we could produce. Converting templates to
`overrideAccess: false` plus `user` is worth doing as its own PR, where it gets reviewed
as an access-control change rather than as a mechanical sweep.

| Template | Files |
| --- | --- |
| `website` | 11 |
| `ecommerce` | 11 |
| `with-vercel-website` | 10 |
| `plugin` | 4 |
| `blank`, `blank-tanstack`, `_template`, `with-postgres`, `with-vercel-postgres`, `with-vercel-mongodb`, `with-cloudflare-d1` | 2 each |