### PR TITLE
chore: make overrideAccess explicit in examples

### DIFF
--- a/examples/astro/payload/src/payload.config.ts
+++ b/examples/astro/payload/src/payload.config.ts
@@ -39,10 +39,13 @@ export default buildConfig({
     outputFile: path.resolve(dirname, 'payload-types.ts'),
   },
   async onInit(payload) {
-    const { totalDocs: postsCount } = await payload.count({ collection: 'posts' })
+    const { totalDocs: postsCount } = await payload.count({
+      collection: 'posts',
+      overrideAccess: true,
+    })
 
     if (!postsCount) {
-      await payload.create({ collection: 'posts', data: { title: 'Post 1' } })
+      await payload.create({ collection: 'posts', data: { title: 'Post 1' }, overrideAccess: true })
     }
   },
   db: mongooseAdapter({

--- a/examples/astro/website/src/actions/index.ts
+++ b/examples/astro/website/src/actions/index.ts
@@ -11,7 +11,7 @@ export const server = {
     accept: 'json',
     handler: async (input) => {
       const payload = await getPayload({ config })
-      return payload.create({ collection: 'posts', data: input })
+      return payload.create({ collection: 'posts', data: input, overrideAccess: true })
     },
   }),
   deletePost: defineAction({
@@ -21,7 +21,7 @@ export const server = {
     accept: 'json',
     handler: async (input) => {
       const payload = await getPayload({ config })
-      return payload.delete({ collection: 'posts', id: input.id })
+      return payload.delete({ collection: 'posts', id: input.id, overrideAccess: true })
     },
   }),
 }

--- a/examples/auth/src/collections/hooks/loginAfterCreate.ts
+++ b/examples/auth/src/collections/hooks/loginAfterCreate.ts
@@ -15,6 +15,7 @@ export const loginAfterCreate: AfterChangeHook = async ({
         data: { email, password },
         req,
         res,
+        overrideAccess: true,
       })
 
       return {

--- a/examples/auth/src/migrations/seed.ts
+++ b/examples/auth/src/migrations/seed.ts
@@ -8,5 +8,6 @@ export async function up({ payload }: MigrateUpArgs): Promise<void> {
       password: 'demo',
       roles: ['admin'],
     },
+    overrideAccess: true,
   })
 }

--- a/examples/custom-components/src/migrations/seed.ts
+++ b/examples/custom-components/src/migrations/seed.ts
@@ -7,6 +7,7 @@ export async function up({ payload }: MigrateUpArgs): Promise<void> {
       email: 'demo@payloadcms.com',
       password: 'demo',
     },
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -14,5 +15,6 @@ export async function up({ payload }: MigrateUpArgs): Promise<void> {
     data: {
       title: 'Custom Fields',
     },
+    overrideAccess: true,
   })
 }

--- a/examples/draft-preview/src/components/Header/index.tsx
+++ b/examples/draft-preview/src/components/Header/index.tsx
@@ -16,6 +16,7 @@ export async function Header() {
   const header: MainMenu = await payload.findGlobal({
     slug: 'main-menu',
     depth: 1,
+    overrideAccess: true,
   })
 
   const navItems = header?.navItems || []

--- a/examples/draft-preview/src/migrations/seed.ts
+++ b/examples/draft-preview/src/migrations/seed.ts
@@ -11,6 +11,7 @@ export async function up({ payload }: MigrateUpArgs): Promise<void> {
       email: 'demo@payloadcms.com',
       password: 'demo',
     },
+    overrideAccess: true,
   })
 
   const { id: examplePageID } = await payload.create({
@@ -19,6 +20,7 @@ export async function up({ payload }: MigrateUpArgs): Promise<void> {
       skipRevalidate: true,
     },
     data: examplePage as any, // eslint-disable-line
+    overrideAccess: true,
   })
 
   await payload.update({
@@ -29,6 +31,7 @@ export async function up({ payload }: MigrateUpArgs): Promise<void> {
     },
     data: examplePageDraft as any, // eslint-disable-line
     draft: true,
+    overrideAccess: true,
   })
 
   const homepageJSON = JSON.parse(JSON.stringify(home).replace('{{DRAFT_PAGE_ID}}', examplePageID))
@@ -39,6 +42,7 @@ export async function up({ payload }: MigrateUpArgs): Promise<void> {
       skipRevalidate: true,
     },
     data: homepageJSON,
+    overrideAccess: true,
   })
 
   await payload.updateGlobal({
@@ -80,5 +84,6 @@ export async function up({ payload }: MigrateUpArgs): Promise<void> {
         },
       ],
     },
+    overrideAccess: true,
   })
 }

--- a/examples/form-builder/src/migrations/seed.ts
+++ b/examples/form-builder/src/migrations/seed.ts
@@ -17,6 +17,7 @@ export async function up({ payload }: MigrateUpArgs): Promise<void> {
       email: 'demo@payloadcms.com',
       password: 'demo',
     },
+    overrideAccess: true,
   })
 
   const basicFormJSON = JSON.parse(JSON.stringify(basicForm))
@@ -24,6 +25,7 @@ export async function up({ payload }: MigrateUpArgs): Promise<void> {
   const { id: basicFormID } = await payload.create({
     collection: 'forms',
     data: basicFormJSON,
+    overrideAccess: true,
   })
 
   const contactFormJSON = JSON.parse(JSON.stringify(contactForm))
@@ -31,6 +33,7 @@ export async function up({ payload }: MigrateUpArgs): Promise<void> {
   const { id: contactFormID } = await payload.create({
     collection: 'forms',
     data: contactFormJSON,
+    overrideAccess: true,
   })
 
   const advancedFormJSON = JSON.parse(JSON.stringify(advancedForm))
@@ -38,6 +41,7 @@ export async function up({ payload }: MigrateUpArgs): Promise<void> {
   const { id: advancedFormID } = await payload.create({
     collection: 'forms',
     data: advancedFormJSON,
+    overrideAccess: true,
   })
 
   const signUpFormJSON = JSON.parse(JSON.stringify(signUpForm))
@@ -45,6 +49,7 @@ export async function up({ payload }: MigrateUpArgs): Promise<void> {
   const { id: signUpFormID } = await payload.create({
     collection: 'forms',
     data: signUpFormJSON,
+    overrideAccess: true,
   })
 
   const homePageJSON = JSON.parse(
@@ -66,21 +71,25 @@ export async function up({ payload }: MigrateUpArgs): Promise<void> {
   await payload.create({
     collection: 'pages',
     data: homePageJSON,
+    overrideAccess: true,
   })
 
   const { id: contactPageID } = await payload.create({
     collection: 'pages',
     data: contactPageJSON,
+    overrideAccess: true,
   })
 
   const { id: advancedPageID } = await payload.create({
     collection: 'pages',
     data: advancedPageJSON,
+    overrideAccess: true,
   })
 
   const { id: signupPageID } = await payload.create({
     collection: 'pages',
     data: signupPageJSON,
+    overrideAccess: true,
   })
 
   await payload.updateGlobal({
@@ -119,5 +128,6 @@ export async function up({ payload }: MigrateUpArgs): Promise<void> {
         },
       ],
     },
+    overrideAccess: true,
   })
 }

--- a/examples/form-builder/src/utilities/getGlobals.ts
+++ b/examples/form-builder/src/utilities/getGlobals.ts
@@ -13,6 +13,7 @@ async function getGlobal<T extends Global>(slug: T, depth = 0): Promise<DataFrom
   const global = await payload.findGlobal({
     slug,
     depth,
+    overrideAccess: true,
   })
 
   return global

--- a/examples/live-preview/src/app/(app)/[slug]/page.tsx
+++ b/examples/live-preview/src/app/(app)/[slug]/page.tsx
@@ -30,6 +30,7 @@ export default async function Page({ params: paramsPromise }: PageParams) {
         equals: slug,
       },
     },
+    overrideAccess: true,
   })
 
   const data = pageRes?.docs?.[0] as null | PageType
@@ -58,6 +59,7 @@ export async function generateStaticParams() {
     depth: 0,
     draft: true,
     limit: 100,
+    overrideAccess: true,
   })
 
   const pages = pagesRes?.docs

--- a/examples/live-preview/src/app/(app)/_components/Header/index.tsx
+++ b/examples/live-preview/src/app/(app)/_components/Header/index.tsx
@@ -14,6 +14,7 @@ export const Header = async () => {
   const mainMenu = await payload.findGlobal({
     slug: 'main-menu',
     depth: 1,
+    overrideAccess: true,
   })
 
   const { navItems } = mainMenu

--- a/examples/live-preview/src/migrations/seed.ts
+++ b/examples/live-preview/src/migrations/seed.ts
@@ -92,11 +92,13 @@ export async function up({ payload }: MigrateUpArgs): Promise<void> {
       email: 'demo@payloadcms.com',
       password: 'demo',
     },
+    overrideAccess: true,
   })
 
   const { id: examplePageID } = await payload.create({
     collection: 'pages',
     data: examplePage as any, // eslint-disable-line
+    overrideAccess: true,
   })
 
   const { id: ogHomePageID } = await payload.create({
@@ -105,12 +107,14 @@ export async function up({ payload }: MigrateUpArgs): Promise<void> {
       title: 'Home',
       richText: [],
     },
+    overrideAccess: true,
   })
 
   const { id: homePageID } = await payload.update({
     id: ogHomePageID,
     collection: 'pages',
     data: home(ogHomePageID),
+    overrideAccess: true,
   })
 
   await payload.updateGlobal({
@@ -149,5 +153,6 @@ export async function up({ payload }: MigrateUpArgs): Promise<void> {
         },
       ],
     },
+    overrideAccess: true,
   })
 }

--- a/examples/localization/src/app/(frontend)/[locale]/search/page.tsx
+++ b/examples/localization/src/app/(frontend)/[locale]/search/page.tsx
@@ -32,6 +32,7 @@ export default async function Page({
     depth: 1,
     limit: 12,
     locale,
+    overrideAccess: true,
     ...(query
       ? {
           where: {

--- a/examples/localization/src/app/(frontend)/next/preview/route.ts
+++ b/examples/localization/src/app/(frontend)/next/preview/route.ts
@@ -75,6 +75,7 @@ export async function GET(
             equals: slug,
           },
         },
+        overrideAccess: true,
       })
 
       if (!docs.docs.length) {

--- a/examples/localization/src/blocks/ArchiveBlock/Component.tsx
+++ b/examples/localization/src/blocks/ArchiveBlock/Component.tsx
@@ -41,6 +41,7 @@ export const ArchiveBlock: React.FC<
       depth: 1,
       locale,
       limit,
+      overrideAccess: true,
       ...(flattenedCategories && flattenedCategories.length > 0
         ? {
             where: {

--- a/examples/localization/src/collections/Posts/hooks/populateAuthors.ts
+++ b/examples/localization/src/collections/Posts/hooks/populateAuthors.ts
@@ -15,6 +15,7 @@ export const populateAuthors: CollectionAfterReadHook = async ({ doc, req, req: 
         collection: 'users',
         depth: 0,
         req,
+        overrideAccess: true,
       })
 
       authorDocs.push(authorDoc)

--- a/examples/localization/src/endpoints/seed/index.ts
+++ b/examples/localization/src/endpoints/seed/index.ts
@@ -63,6 +63,7 @@ export const seed = async ({
         navItems: [],
       },
       req,
+      overrideAccess: true,
     })
   }
 
@@ -75,6 +76,7 @@ export const seed = async ({
         },
       },
       req,
+      overrideAccess: true,
     })
   }
 
@@ -82,6 +84,7 @@ export const seed = async ({
     collection: 'pages',
     where: {},
     req,
+    overrideAccess: true,
   })
   // #endregion
 
@@ -96,6 +99,7 @@ export const seed = async ({
       },
     },
     req,
+    overrideAccess: true,
   })
 
   const demoAuthor = await payload.create({
@@ -106,6 +110,7 @@ export const seed = async ({
       password: 'password',
     },
     req,
+    overrideAccess: true,
   })
 
   let demoAuthorID: number | string = demoAuthor.id
@@ -119,6 +124,7 @@ export const seed = async ({
     locale: 'en',
     filePath: path.resolve(dirname, 'image-post1.webp'),
     req,
+    overrideAccess: true,
   })
   await payload.update({
     collection: 'media',
@@ -127,6 +133,7 @@ export const seed = async ({
     locale: 'es',
     filePath: path.resolve(dirname, 'image-post1.webp'),
     req,
+    overrideAccess: true,
   })
 
   const image2Doc = await payload.create({
@@ -135,6 +142,7 @@ export const seed = async ({
     data: image2('en'),
     filePath: path.resolve(dirname, 'image-post2.webp'),
     req,
+    overrideAccess: true,
   })
   await payload.update({
     collection: 'media',
@@ -143,6 +151,7 @@ export const seed = async ({
     locale: 'es',
     filePath: path.resolve(dirname, 'image-post2.webp'),
     req,
+    overrideAccess: true,
   })
 
   const image3Doc = await payload.create({
@@ -151,6 +160,7 @@ export const seed = async ({
     data: image2('en'),
     filePath: path.resolve(dirname, 'image-post3.webp'),
     req,
+    overrideAccess: true,
   })
   await payload.update({
     collection: 'media',
@@ -159,6 +169,7 @@ export const seed = async ({
     locale: 'es',
     filePath: path.resolve(dirname, 'image-post3.webp'),
     req,
+    overrideAccess: true,
   })
 
   const imageHomeDoc = await payload.create({
@@ -167,6 +178,7 @@ export const seed = async ({
     data: image2('en'),
     filePath: path.resolve(dirname, 'image-hero1.webp'),
     req,
+    overrideAccess: true,
   })
   await payload.update({
     collection: 'media',
@@ -175,6 +187,7 @@ export const seed = async ({
     locale: 'es',
     filePath: path.resolve(dirname, 'image-hero1.webp'),
     req,
+    overrideAccess: true,
   })
 
   let image1ID: number | string = image1Doc.id
@@ -200,6 +213,7 @@ export const seed = async ({
       title: 'Technology',
     },
     req,
+    overrideAccess: true,
   })
   await payload.update({
     collection: 'categories',
@@ -209,6 +223,7 @@ export const seed = async ({
       title: 'Tecnología',
     },
     req,
+    overrideAccess: true,
   })
 
   const newsCategory = await payload.create({
@@ -218,6 +233,7 @@ export const seed = async ({
       title: 'News',
     },
     req,
+    overrideAccess: true,
   })
   await payload.update({
     collection: 'categories',
@@ -227,6 +243,7 @@ export const seed = async ({
       title: 'Noticias',
     },
     req,
+    overrideAccess: true,
   })
 
   const financeCategory = await payload.create({
@@ -236,6 +253,7 @@ export const seed = async ({
       title: 'Finance',
     },
     req,
+    overrideAccess: true,
   })
   await payload.update({
     collection: 'categories',
@@ -245,6 +263,7 @@ export const seed = async ({
       title: 'Finanzas',
     },
     req,
+    overrideAccess: true,
   })
 
   const designCategory = await payload.create({
@@ -254,6 +273,7 @@ export const seed = async ({
       title: 'Design',
     },
     req,
+    overrideAccess: true,
   })
   await payload.update({
     collection: 'categories',
@@ -263,6 +283,7 @@ export const seed = async ({
       title: 'Diseño',
     },
     req,
+    overrideAccess: true,
   })
 
   const softwareCategory = await payload.create({
@@ -272,6 +293,7 @@ export const seed = async ({
       title: 'Software',
     },
     req,
+    overrideAccess: true,
   })
   await payload.update({
     collection: 'categories',
@@ -281,6 +303,7 @@ export const seed = async ({
       title: 'Software',
     },
     req,
+    overrideAccess: true,
   })
 
   const engineeringCategory = await payload.create({
@@ -290,6 +313,7 @@ export const seed = async ({
       title: 'Engineering',
     },
     req,
+    overrideAccess: true,
   })
   await payload.update({
     collection: 'categories',
@@ -299,6 +323,7 @@ export const seed = async ({
       title: 'Ingeniería',
     },
     req,
+    overrideAccess: true,
   })
   // #endregion
 
@@ -317,6 +342,7 @@ export const seed = async ({
     ),
     locale: 'en',
     req,
+    overrideAccess: true,
   })
   await payload.update({
     collection: 'posts',
@@ -329,6 +355,7 @@ export const seed = async ({
     ),
     locale: 'es',
     req,
+    overrideAccess: true,
   })
 
   const post2Doc = await payload.create({
@@ -341,6 +368,7 @@ export const seed = async ({
     ),
     locale: 'en',
     req,
+    overrideAccess: true,
   })
   await payload.update({
     collection: 'posts',
@@ -353,6 +381,7 @@ export const seed = async ({
     ),
     locale: 'es',
     req,
+    overrideAccess: true,
   })
 
   const post3Doc = await payload.create({
@@ -365,6 +394,7 @@ export const seed = async ({
     ),
     locale: 'en',
     req,
+    overrideAccess: true,
   })
   await payload.update({
     collection: 'posts',
@@ -377,6 +407,7 @@ export const seed = async ({
     ),
     locale: 'es',
     req,
+    overrideAccess: true,
   })
 
   // update each post with related posts
@@ -387,6 +418,7 @@ export const seed = async ({
       relatedPosts: [post2Doc.id, post3Doc.id],
     },
     req,
+    overrideAccess: true,
   })
   await payload.update({
     id: post2Doc.id,
@@ -395,6 +427,7 @@ export const seed = async ({
       relatedPosts: [post1Doc.id, post3Doc.id],
     },
     req,
+    overrideAccess: true,
   })
   await payload.update({
     id: post3Doc.id,
@@ -403,6 +436,7 @@ export const seed = async ({
       relatedPosts: [post1Doc.id, post2Doc.id],
     },
     req,
+    overrideAccess: true,
   })
   // #endregion
 
@@ -418,6 +452,7 @@ export const seed = async ({
         .replace(/"\{\{IMAGE_2\}\}"/g, String(image2ID)),
     ),
     req,
+    overrideAccess: true,
   })
   await payload.update({
     collection: 'pages',
@@ -429,6 +464,7 @@ export const seed = async ({
         .replace(/"\{\{IMAGE_2\}\}"/g, String(image2ID)),
     ),
     req,
+    overrideAccess: true,
   })
 
   payload.logger.info(`— Seeding contact form...`)
@@ -438,6 +474,7 @@ export const seed = async ({
     locale: 'en',
     data: JSON.parse(JSON.stringify(contactFormData('en'))),
     req,
+    overrideAccess: true,
   })
 
   const contactFormData_es = JSON.parse(JSON.stringify(contactFormData('es')))
@@ -464,6 +501,7 @@ export const seed = async ({
       })),
     },
     req,
+    overrideAccess: true,
   })
 
   let contactFormID: number | string = contactForm.id
@@ -484,6 +522,7 @@ export const seed = async ({
       ),
     ),
     req,
+    overrideAccess: true,
   })
   await payload.update({
     collection: 'pages',
@@ -496,6 +535,7 @@ export const seed = async ({
       ),
     ),
     req,
+    overrideAccess: true,
   })
   // #endregion
 
@@ -527,6 +567,7 @@ export const seed = async ({
       ],
     },
     req,
+    overrideAccess: true,
   })
 
   await payload.updateGlobal({
@@ -556,6 +597,7 @@ export const seed = async ({
       ],
     },
     req,
+    overrideAccess: true,
   })
 
   payload.logger.info(`— Seeding footer...`)
@@ -591,6 +633,7 @@ export const seed = async ({
       ],
     },
     req,
+    overrideAccess: true,
   })
   await payload.updateGlobal({
     slug: 'footer',
@@ -624,6 +667,7 @@ export const seed = async ({
       ],
     },
     req,
+    overrideAccess: true,
   })
   // #endregion
 

--- a/examples/localization/src/search/beforeSync.ts
+++ b/examples/localization/src/search/beforeSync.ts
@@ -38,6 +38,7 @@ export const beforeSyncWithSearch: BeforeSync = async ({ req, originalDoc, searc
         depth: 0,
         select: { title: true },
         req,
+        overrideAccess: true,
       })
 
       if (doc !== null) {

--- a/examples/localization/src/utilities/getDocument.ts
+++ b/examples/localization/src/utilities/getDocument.ts
@@ -17,6 +17,7 @@ async function getDocument(collection: Collection, slug: string, depth = 0) {
         equals: slug,
       },
     },
+    overrideAccess: true,
   })
 
   return page.docs[0]

--- a/examples/localization/src/utilities/getGlobals.ts
+++ b/examples/localization/src/utilities/getGlobals.ts
@@ -7,13 +7,18 @@ import { TypedLocale } from 'payload'
 
 type Global = keyof Config['globals']
 
-async function getGlobal<T extends Global>(slug: T, depth = 0, locale: TypedLocale): Promise<DataFromGlobalSlug<T>> {
+async function getGlobal<T extends Global>(
+  slug: T,
+  depth = 0,
+  locale: TypedLocale,
+): Promise<DataFromGlobalSlug<T>> {
   const payload = await getPayload({ config: configPromise })
 
   const global = await payload.findGlobal({
     slug,
     depth,
     locale,
+    overrideAccess: true,
   })
 
   return global

--- a/examples/localization/src/utilities/getRedirects.ts
+++ b/examples/localization/src/utilities/getRedirects.ts
@@ -10,6 +10,7 @@ export async function getRedirects(depth = 1) {
     depth,
     limit: 0,
     pagination: false,
+    overrideAccess: true,
   })
 
   return redirects

--- a/examples/multi-tenant/src/collections/Pages/hooks/ensureUniqueSlug.ts
+++ b/examples/multi-tenant/src/collections/Pages/hooks/ensureUniqueSlug.ts
@@ -36,6 +36,7 @@ export const ensureUniqueSlug: FieldHook = async ({ data, originalDoc, req, valu
     where: {
       and: constraints,
     },
+    overrideAccess: true,
   })
 
   if (findDuplicatePages.docs.length > 0 && req.user) {
@@ -46,6 +47,7 @@ export const ensureUniqueSlug: FieldHook = async ({ data, originalDoc, req, valu
       const attemptedTenantChange = await req.payload.findByID({
         id: tenantIDToMatch,
         collection: 'tenants',
+        overrideAccess: true,
       })
 
       throw new ValidationError({

--- a/examples/multi-tenant/src/collections/Users/endpoints/externalUsersLogin.ts
+++ b/examples/multi-tenant/src/collections/Users/endpoints/externalUsersLogin.ts
@@ -35,6 +35,7 @@ export const externalUsersLogin: Endpoint = {
                 equals: tenantSlug,
               },
             },
+        overrideAccess: true,
       })
     ).docs[0]
 
@@ -72,6 +73,7 @@ export const externalUsersLogin: Endpoint = {
           },
         ],
       },
+      overrideAccess: true,
     })
 
     if (foundUser.totalDocs > 0) {
@@ -83,6 +85,7 @@ export const externalUsersLogin: Endpoint = {
             password,
           },
           req,
+          overrideAccess: true,
         })
 
         if (loginAttempt?.token) {

--- a/examples/multi-tenant/src/collections/Users/hooks/ensureUniqueUsername.ts
+++ b/examples/multi-tenant/src/collections/Users/hooks/ensureUniqueUsername.ts
@@ -39,6 +39,7 @@ export const ensureUniqueUsername: FieldHook = async ({ data, originalDoc, req, 
     where: {
       and: constraints,
     },
+    overrideAccess: true,
   })
 
   if (findDuplicateUsers.docs.length > 0 && req.user) {
@@ -49,6 +50,7 @@ export const ensureUniqueUsername: FieldHook = async ({ data, originalDoc, req, 
       const attemptedTenantChange = await req.payload.findByID({
         // @ts-ignore - selectedTenant will match DB ID type
         id: selectedTenant,
+        overrideAccess: true,
         collection: 'tenants',
       })
 

--- a/examples/multi-tenant/src/collections/Users/hooks/setCookieBasedOnDomain.ts
+++ b/examples/multi-tenant/src/collections/Users/hooks/setCookieBasedOnDomain.ts
@@ -12,6 +12,7 @@ export const setCookieBasedOnDomain: CollectionAfterLoginHook = async ({ req, us
         equals: req.headers.get('host'),
       },
     },
+    overrideAccess: true,
   })
 
   // If a matching tenant is found, set the 'payload-tenant' cookie

--- a/examples/multi-tenant/src/seed.ts
+++ b/examples/multi-tenant/src/seed.ts
@@ -8,6 +8,7 @@ export const seed: NonNullable<Config['onInit']> = async (payload): Promise<void
       slug: 'gold',
       domain: 'gold.localhost',
     },
+    overrideAccess: true,
   })
 
   const tenant2 = await payload.create({
@@ -17,6 +18,7 @@ export const seed: NonNullable<Config['onInit']> = async (payload): Promise<void
       slug: 'silver',
       domain: 'silver.localhost',
     },
+    overrideAccess: true,
   })
 
   const tenant3 = await payload.create({
@@ -26,6 +28,7 @@ export const seed: NonNullable<Config['onInit']> = async (payload): Promise<void
       slug: 'bronze',
       domain: 'bronze.localhost',
     },
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -35,6 +38,7 @@ export const seed: NonNullable<Config['onInit']> = async (payload): Promise<void
       password: 'demo',
       roles: ['super-admin'],
     },
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -50,6 +54,7 @@ export const seed: NonNullable<Config['onInit']> = async (payload): Promise<void
       ],
       username: 'tenant1',
     },
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -65,6 +70,7 @@ export const seed: NonNullable<Config['onInit']> = async (payload): Promise<void
       ],
       username: 'tenant2',
     },
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -80,6 +86,7 @@ export const seed: NonNullable<Config['onInit']> = async (payload): Promise<void
       ],
       username: 'tenant3',
     },
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -103,6 +110,7 @@ export const seed: NonNullable<Config['onInit']> = async (payload): Promise<void
       ],
       username: 'multi-admin',
     },
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -112,6 +120,7 @@ export const seed: NonNullable<Config['onInit']> = async (payload): Promise<void
       tenant: tenant1.id,
       title: 'Page for Tenant 1',
     },
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -121,6 +130,7 @@ export const seed: NonNullable<Config['onInit']> = async (payload): Promise<void
       tenant: tenant2.id,
       title: 'Page for Tenant 2',
     },
+    overrideAccess: true,
   })
 
   await payload.create({
@@ -130,5 +140,6 @@ export const seed: NonNullable<Config['onInit']> = async (payload): Promise<void
       tenant: tenant3.id,
       title: 'Page for Tenant 3',
     },
+    overrideAccess: true,
   })
 }

--- a/examples/remix/payload/src/payload.config.ts
+++ b/examples/remix/payload/src/payload.config.ts
@@ -39,10 +39,13 @@ export default buildConfig({
     outputFile: path.resolve(dirname, 'payload-types.ts'),
   },
   async onInit(payload) {
-    const { totalDocs: postsCount } = await payload.count({ collection: 'posts' })
+    const { totalDocs: postsCount } = await payload.count({
+      collection: 'posts',
+      overrideAccess: true,
+    })
 
     if (!postsCount) {
-      await payload.create({ collection: 'posts', data: { title: 'Post 1' } })
+      await payload.create({ collection: 'posts', data: { title: 'Post 1' }, overrideAccess: true })
     }
   },
   db: mongooseAdapter({

--- a/examples/remix/website/app/routes/_index.tsx
+++ b/examples/remix/website/app/routes/_index.tsx
@@ -10,7 +10,7 @@ export const meta: MetaFunction = () => {
 export const loader = async () => {
   const payload = await getPayload({ config })
 
-  const posts = await payload.find({ collection: 'posts', sort: 'createdAt' })
+  const posts = await payload.find({ collection: 'posts', sort: 'createdAt', overrideAccess: true })
 
   return Response.json(posts)
 }
@@ -26,6 +26,7 @@ export async function action({ request }: ActionFunctionArgs) {
     await payload.delete({
       collection: 'posts',
       id: postId,
+      overrideAccess: true,
     })
     return Response.json({ message: 'Post deleted' })
   }
@@ -35,6 +36,7 @@ export async function action({ request }: ActionFunctionArgs) {
     data: {
       title: (body.get('title') as string) || 'Untitled',
     },
+    overrideAccess: true,
   })
 
   return Response.json(post)


### PR DESCRIPTION
Adds an explicit `overrideAccess: true` to every Local API call in `examples/` that
previously relied on the default.

This is preparation for flipping the Local API default to `false`, which lands later
in this stack. It is split out so that the breaking change itself stays small enough
to read.

## This changes no behaviour

The Local API currently defaults `overrideAccess` to `true`. Writing the value explicitly
produces exactly what the default already produced.

| Example | Files |
| --- | --- |
| `localization` | 9 |
| `multi-tenant` | 5 |
| `live-preview` | 3 |
| `remix`, `form-builder`, `draft-preview`, `auth`, `astro` | 2 each |
| `custom-components` | 1 |

## Verification

Examples are standalone projects with no dependencies installed, so they cannot be
typechecked.