### PR TITLE
refactor!: improve access defaults for jobs

### DIFF
--- a/docs/jobs-queue/jobs.mdx
+++ b/docs/jobs-queue/jobs.mdx
@@ -229,9 +229,13 @@ Each job document contains:
 
 #### Access Control
 
-By default, Payload's job operations bypass access control when used from the Local API. You can enable access control by passing `overrideAccess: false` to any job operation.
+Use Payload's dedicated Jobs APIs and endpoints, such as `payload.jobs.*`, `/run`, and `/handle-schedules`. Calling generic Local API, REST, or GraphQL CRUD directly on `payload-jobs` is not recommended because it bypasses the job operations and does not run `jobs.access.*`.
 
-To define custom access control for jobs, add an `access` property to your Jobs Config:
+Raw collection create, read, update, and delete access is denied by default. You can adjust these rules through `jobsCollectionOverrides`. REST and GraphQL always run them; Local API CRUD runs them when you pass `overrideAccess: false`.
+
+The dedicated job operations use `jobs.access.queue`, `run`, and `cancel`. Local API calls run these functions when you pass `overrideAccess: false`. The `/run` and `/handle-schedules` endpoints always check `jobs.access.run`.
+
+Configure access for the dedicated job operations in your Jobs Config:
 
 ```ts
 import type { SanitizedConfig } from 'payload'
@@ -257,9 +261,9 @@ const config: SanitizedConfig = {
 }
 ```
 
-Each access control function receives the current `req` object and should return a boolean. If no access control is defined, the default behavior allows any authenticated user to perform the operation.
+These functions receive the current `req` and return a boolean. By default, they allow authenticated users.
 
-To use access control in the Local API:
+Pass `overrideAccess: false` to run them from the Local API:
 
 ```ts
 const req = await createLocalReq({ user }, payload)
@@ -271,12 +275,6 @@ await payload.jobs.queue({
   req, // Pass the request with user context
 })
 ```
-
-<Banner type="warning">
-  It is not recommended to modify the `payload-jobs` collection's access control
-  directly, as that pattern may be deprecated in future versions. Instead—use
-  the `access` property in your Jobs Config to control job operations.
-</Banner>
 
 #### Cancelling Jobs
 

--- a/docs/jobs-queue/overview.mdx
+++ b/docs/jobs-queue/overview.mdx
@@ -233,9 +233,11 @@ On serverless platforms, use API endpoints called by external cron services:
 
 Never use `autoRun` on serverless platforms.
 
-### Visualizing Jobs in the Admin UI
+### Inspecting Jobs
 
-By default, the internal `payload-jobs` collection is hidden from the Payload Admin Panel. To make this collection visible for debugging or inspection purposes, you can override its configuration using `jobsCollectionOverrides`.
+The internal `payload-jobs` collection is hidden from the Admin Panel and denies generic access by default because job data can contain sensitive inputs, outputs, errors, and logs. Trusted server code can inspect jobs through the Local API with access override enabled.
+
+To provide trusted administrators with read-only access in the Admin Panel, explicitly override the collection configuration:
 
 ```ts
 import { buildConfig } from 'payload'
@@ -244,14 +246,24 @@ export default buildConfig({
   // ... other config
   jobs: {
     // ... other job settings
-    jobsCollectionOverrides: ({ defaultJobsCollection }) => {
-      if (!defaultJobsCollection.admin) {
-        defaultJobsCollection.admin = {}
-      }
-
-      defaultJobsCollection.admin.hidden = false
-      return defaultJobsCollection
-    },
+    jobsCollectionOverrides: ({ defaultJobsCollection }) => ({
+      ...defaultJobsCollection,
+      access: {
+        ...defaultJobsCollection.access,
+        read: ({ req }) => Boolean(req.user?.roles?.includes('admin')),
+      },
+      admin: {
+        ...defaultJobsCollection.admin,
+        hidden: false,
+      },
+    }),
   },
 })
 ```
+
+This keeps generic create, update, and delete operations denied.
+
+<Banner type="warning">
+  Enabling raw collection access can expose job data and execution-control
+  fields. Prefer read-only access for trusted administrators.
+</Banner>

--- a/docs/jobs-queue/queues.mdx
+++ b/docs/jobs-queue/queues.mdx
@@ -612,17 +612,7 @@ autoRun: [{ queue: 'default' }] // won't pick up the job
 
 **Check the jobs collection**
 
-Enable the jobs collection in admin:
-
-```ts
-jobsCollectionOverrides: ({ defaultJobsCollection }) => ({
-  ...defaultJobsCollection,
-  admin: {
-    ...defaultJobsCollection.admin,
-    hidden: false,
-  },
-})
-```
+See [Inspecting Jobs](/docs/jobs-queue/overview#inspecting-jobs) to inspect jobs from trusted server code or enable read-only Admin Panel access.
 
 Look for jobs with:
 

--- a/packages/next/src/utilities/handleServerFunctions.ts
+++ b/packages/next/src/utilities/handleServerFunctions.ts
@@ -4,7 +4,10 @@ import { _internal_renderFieldHandler, copyDataFromLocaleHandler } from '@payloa
 import { buildFormStateHandler } from '@payloadcms/ui/utilities/buildFormState'
 import { buildTableStateHandler } from '@payloadcms/ui/utilities/buildTableState'
 import { getFolderResultsComponentAndDataHandler } from '@payloadcms/ui/utilities/getFolderResultsComponentAndData'
-import { schedulePublishHandler } from '@payloadcms/ui/utilities/schedulePublishHandler'
+import {
+  getUpcomingScheduledPublishHandler,
+  schedulePublishHandler,
+} from '@payloadcms/ui/utilities/schedulePublishHandler'
 
 import { getDefaultLayoutHandler } from '../views/Dashboard/Default/ModularDashboard/renderWidget/getDefaultLayoutServerFn.js'
 import { renderWidgetHandler } from '../views/Dashboard/Default/ModularDashboard/renderWidget/renderWidgetServerFn.js'
@@ -19,6 +22,7 @@ const baseServerFunctions: Record<string, ServerFunction<any, any>> = {
   'form-state': buildFormStateHandler,
   'get-default-layout': getDefaultLayoutHandler,
   'get-folder-results-component-and-data': getFolderResultsComponentAndDataHandler,
+  'get-upcoming-scheduled-publish': getUpcomingScheduledPublishHandler,
   'render-document': renderDocumentHandler,
   'render-document-slots': renderDocumentSlotsHandler,
   'render-field': _internal_renderFieldHandler,

--- a/packages/payload/src/queues/config/collection.ts
+++ b/packages/payload/src/queues/config/collection.ts
@@ -120,6 +120,12 @@ export const getDefaultJobsCollection: (jobsConfig: SanitizedConfig['jobs']) => 
 
   const jobsCollection: CollectionConfig = {
     slug: jobsCollectionSlug,
+    access: {
+      create: () => false,
+      delete: () => false,
+      read: () => false,
+      update: () => false,
+    },
     admin: {
       group: 'System',
       hidden: true,

--- a/packages/payload/src/queues/config/types/index.ts
+++ b/packages/payload/src/queues/config/types/index.ts
@@ -161,6 +161,8 @@ export type JobsConfig = {
   /**
    * Override any settings on the default Jobs collection. Accepts the default collection and allows you to return
    * a new collection.
+   *
+   * @experimental
    */
   jobsCollectionOverrides?: (args: { defaultJobsCollection: CollectionConfig }) => CollectionConfig
   /**

--- a/packages/payload/src/queues/endpoints/handleSchedules.ts
+++ b/packages/payload/src/queues/endpoints/handleSchedules.ts
@@ -1,5 +1,6 @@
 import type { Endpoint } from '../../config/types.js'
 
+import { defaultAccess } from '../../auth/defaultAccess.js'
 import { handleSchedules } from '../operations/handleSchedules/index.js'
 import { configHasJobs } from './run.js'
 
@@ -21,7 +22,7 @@ export const handleSchedulesJobsEndpoint: Endpoint = {
       )
     }
 
-    const accessFn = jobsConfig.access?.run ?? (() => true)
+    const accessFn = jobsConfig.access?.run ?? defaultAccess
 
     const hasAccess = await accessFn({ req })
 

--- a/packages/payload/src/queues/endpoints/run.ts
+++ b/packages/payload/src/queues/endpoints/run.ts
@@ -1,6 +1,7 @@
 import type { Endpoint } from '../../config/types.js'
 import type { SanitizedJobsConfig } from '../config/types/index.js'
 
+import { defaultAccess } from '../../auth/defaultAccess.js'
 import { runJobs, type RunJobsArgs } from '../operations/runJobs/index.js'
 
 /**
@@ -21,7 +22,7 @@ export const runJobsEndpoint: Endpoint = {
       )
     }
 
-    const accessFn = jobsConfig.access?.run ?? (() => true)
+    const accessFn = jobsConfig.access?.run ?? defaultAccess
 
     const hasAccess = await accessFn({ req })
 

--- a/packages/ui/src/elements/PublishButton/ScheduleDrawer/buildUpcomingScheduleWhere.ts
+++ b/packages/ui/src/elements/PublishButton/ScheduleDrawer/buildUpcomingScheduleWhere.ts
@@ -1,0 +1,51 @@
+import type { Where } from 'payload'
+
+type Args = {
+  collectionSlug?: string
+  globalSlug?: string
+  id?: number | string
+}
+
+/**
+ * Builds the `where` query used to find upcoming scheduled
+ * publish/unpublish jobs for a given document or global.
+ */
+export const buildUpcomingScheduleWhere = ({ id, collectionSlug, globalSlug }: Args): Where => {
+  const where: Where = {
+    and: [
+      {
+        taskSlug: {
+          equals: 'schedulePublish',
+        },
+      },
+      {
+        waitUntil: {
+          greater_than: new Date(),
+        },
+      },
+    ],
+  }
+
+  if (collectionSlug) {
+    where.and.push({
+      'input.doc.value': {
+        equals: String(id),
+      },
+    })
+    where.and.push({
+      'input.doc.relationTo': {
+        equals: collectionSlug,
+      },
+    })
+  }
+
+  if (globalSlug) {
+    where.and.push({
+      'input.global': {
+        equals: globalSlug,
+      },
+    })
+  }
+
+  return where
+}

--- a/packages/ui/src/elements/PublishButton/ScheduleDrawer/index.tsx
+++ b/packages/ui/src/elements/PublishButton/ScheduleDrawer/index.tsx
@@ -1,15 +1,13 @@
 /* eslint-disable no-console */
 'use client'
 
-import type { Column, SchedulePublish, Where } from 'payload'
+import type { Column, SchedulePublish } from 'payload'
 
 import { TZDateMini as TZDate } from '@date-fns/tz/date/mini'
 import { useModal } from '@faceless-ui/modal'
 import { getTranslation } from '@payloadcms/translations'
 import { endOfToday, isToday, startOfDay } from 'date-fns'
 import { transpose } from 'date-fns/transpose'
-import { formatAdminURL } from 'payload/shared'
-import * as qs from 'qs-esm'
 import React, { useCallback, useMemo } from 'react'
 import { toast } from 'sonner'
 
@@ -22,7 +20,6 @@ import { useDocumentInfo } from '../../../providers/DocumentInfo/index.js'
 import { useDocumentTitle } from '../../../providers/DocumentTitle/index.js'
 import { useServerFunctions } from '../../../providers/ServerFunctions/index.js'
 import { useTranslation } from '../../../providers/Translation/index.js'
-import { requests } from '../../../utilities/api.js'
 import { Banner } from '../../Banner/index.js'
 import { DrawerCloseButton } from '../../BulkUpload/DrawerCloseButton/index.js'
 import { Button } from '../../Button/index.js'
@@ -58,13 +55,12 @@ export const ScheduleDrawer: React.FC<Props> = ({ slug, defaultType, schedulePub
         timezones: { defaultTimezone, supportedTimezones },
       },
       localization,
-      routes: { api },
     },
   } = useConfig()
   const { id, collectionSlug, globalSlug } = useDocumentInfo()
   const { title } = useDocumentTitle()
   const { i18n, t } = useTranslation()
-  const { schedulePublish } = useServerFunctions()
+  const { getUpcomingScheduledPublish, schedulePublish } = useServerFunctions()
   const [type, setType] = React.useState<PublishType>(defaultType || 'publish')
   const [date, setDate] = React.useState<Date>()
   const [timezone, setTimezone] = React.useState<string>(defaultTimezone)
@@ -94,55 +90,7 @@ export const ScheduleDrawer: React.FC<Props> = ({ slug, defaultType, schedulePub
   }, [localization, i18n])
 
   const fetchUpcoming = React.useCallback(async () => {
-    const query: { sort: string; where: Where } = {
-      sort: 'waitUntil',
-      where: {
-        and: [
-          {
-            taskSlug: {
-              equals: 'schedulePublish',
-            },
-          },
-          {
-            waitUntil: {
-              greater_than: new Date(),
-            },
-          },
-        ],
-      },
-    }
-
-    if (collectionSlug) {
-      query.where.and.push({
-        'input.doc.value': {
-          equals: String(id),
-        },
-      })
-      query.where.and.push({
-        'input.doc.relationTo': {
-          equals: collectionSlug,
-        },
-      })
-    }
-
-    if (globalSlug) {
-      query.where.and.push({
-        'input.global': {
-          equals: globalSlug,
-        },
-      })
-    }
-
-    const { docs } = await requests
-      .post(formatAdminURL({ apiRoute: api, path: `/payload-jobs` }), {
-        body: qs.stringify(query),
-        headers: {
-          'Accept-Language': i18n.language,
-          'Content-Type': 'application/x-www-form-urlencoded',
-          'X-Payload-HTTP-Method-Override': 'GET',
-        },
-      })
-      .then((res) => res.json())
+    const docs = await getUpcomingScheduledPublish({ id, collectionSlug, globalSlug })
 
     setUpcomingColumns(
       buildUpcomingColumns({
@@ -157,7 +105,17 @@ export const ScheduleDrawer: React.FC<Props> = ({ slug, defaultType, schedulePub
       }),
     )
     setUpcoming(docs)
-  }, [collectionSlug, globalSlug, api, i18n, dateFormat, localization, supportedTimezones, t, id])
+  }, [
+    collectionSlug,
+    globalSlug,
+    getUpcomingScheduledPublish,
+    i18n,
+    dateFormat,
+    localization,
+    supportedTimezones,
+    t,
+    id,
+  ])
 
   const deleteHandler = React.useCallback(
     async (id: number | string) => {

--- a/packages/ui/src/elements/PublishButton/ScheduleDrawer/types.ts
+++ b/packages/ui/src/elements/PublishButton/ScheduleDrawer/types.ts
@@ -7,5 +7,5 @@ export type UpcomingEvent = {
     timezone?: string
     type: PublishType
   }
-  waitUntil: Date
+  waitUntil: Date | string
 }

--- a/packages/ui/src/providers/ServerFunctions/index.tsx
+++ b/packages/ui/src/providers/ServerFunctions/index.tsx
@@ -26,6 +26,8 @@ import type { buildTableStateHandler } from '../../utilities/buildTableState.js'
 import type { CopyDataFromLocaleArgs } from '../../utilities/copyDataFromLocale.js'
 import type { getFolderResultsComponentAndDataHandler } from '../../utilities/getFolderResultsComponentAndData.js'
 import type {
+  getUpcomingScheduledPublishHandler,
+  GetUpcomingScheduledPublishHandlerArgs,
   schedulePublishHandler,
   SchedulePublishHandlerArgs,
 } from '../../utilities/schedulePublishHandler.js'
@@ -41,6 +43,12 @@ type SchedulePublishClient = (
     signal?: AbortSignal
   } & Omit<SchedulePublishHandlerArgs, 'clientConfig' | 'req'>,
 ) => ReturnType<typeof schedulePublishHandler>
+
+type GetUpcomingScheduledPublishClient = (
+  args: {
+    signal?: AbortSignal
+  } & Omit<GetUpcomingScheduledPublishHandlerArgs, 'clientConfig' | 'req'>,
+) => ReturnType<typeof getUpcomingScheduledPublishHandler>
 
 type GetTableStateClient = (
   args: {
@@ -119,6 +127,7 @@ export type ServerFunctionsContextType = {
   getFolderResultsComponentAndData: GetFolderResultsComponentAndDataClient
   getFormState: GetFormStateClient
   getTableState: GetTableStateClient
+  getUpcomingScheduledPublish: GetUpcomingScheduledPublishClient
   renderDocument: RenderDocumentServerFunctionHookFn
   schedulePublish: SchedulePublishClient
   serverFunction: ServerFunctionClient
@@ -180,6 +189,24 @@ export const ServerFunctionsProvider: React.FC<{
       }
 
       return { error }
+    },
+    [serverFunction],
+  )
+
+  const getUpcomingScheduledPublish = useCallback<GetUpcomingScheduledPublishClient>(
+    async (args) => {
+      const { signal: remoteSignal, ...rest } = args
+
+      if (remoteSignal?.aborted) {
+        return []
+      }
+
+      const result = (await serverFunction({
+        name: 'get-upcoming-scheduled-publish',
+        args: rest,
+      })) as Awaited<ReturnType<typeof getUpcomingScheduledPublishHandler>>
+
+      return remoteSignal?.aborted ? [] : result
     },
     [serverFunction],
   )
@@ -331,6 +358,7 @@ export const ServerFunctionsProvider: React.FC<{
         getFolderResultsComponentAndData,
         getFormState,
         getTableState,
+        getUpcomingScheduledPublish,
         renderDocument,
         schedulePublish,
         serverFunction,

--- a/packages/ui/src/utilities/schedulePublishHandler.ts
+++ b/packages/ui/src/utilities/schedulePublishHandler.ts
@@ -1,4 +1,11 @@
-import { canAccessAdmin, type SchedulePublishTaskInput, type ServerFunction } from 'payload'
+import type { SchedulePublishTaskInput, ServerFunction } from 'payload'
+
+import { canAccessAdmin, docAccessOperation, docAccessOperationGlobal, Forbidden } from 'payload'
+import { hasScheduledPublishEnabled } from 'payload/shared'
+
+import type { UpcomingEvent } from '../elements/PublishButton/ScheduleDrawer/types.js'
+
+import { buildUpcomingScheduleWhere } from '../elements/PublishButton/ScheduleDrawer/buildUpcomingScheduleWhere.js'
 
 export type SchedulePublishHandlerArgs = {
   date?: Date
@@ -9,6 +16,74 @@ export type SchedulePublishHandlerArgs = {
   localeToPublish?: string
   timezone?: string
 } & Pick<SchedulePublishTaskInput, 'doc' | 'global' | 'type'>
+
+export type GetUpcomingScheduledPublishHandlerArgs = {
+  collectionSlug?: string
+  globalSlug?: string
+  id?: number | string
+}
+
+export const getUpcomingScheduledPublishHandler: ServerFunction<
+  GetUpcomingScheduledPublishHandlerArgs,
+  Promise<UpcomingEvent[]>
+> = async ({ id, collectionSlug, globalSlug, req }) => {
+  const { payload } = req
+
+  await canAccessAdmin({ req })
+
+  const collectionConfig = collectionSlug ? payload.collections[collectionSlug]?.config : undefined
+  const globalConfig = globalSlug
+    ? payload.config.globals.find(({ slug }) => slug === globalSlug)
+    : undefined
+  const entityConfig = collectionConfig || globalConfig
+  const hasValidTarget = Boolean(
+    entityConfig &&
+      hasScheduledPublishEnabled(entityConfig) &&
+      ((collectionConfig && id !== undefined && !globalSlug) || (globalConfig && !collectionSlug)),
+  )
+
+  if (!hasValidTarget) {
+    throw new Forbidden(req.t)
+  }
+
+  const hasPublishPermission = collectionConfig
+    ? (
+        await docAccessOperation({
+          id,
+          collection: { config: collectionConfig },
+          data: { _status: 'published' },
+          req,
+        })
+      ).update
+    : (
+        await docAccessOperationGlobal({
+          data: { _status: 'published' },
+          globalConfig,
+          req,
+        })
+      ).update
+
+  if (!hasPublishPermission) {
+    throw new Forbidden(req.t)
+  }
+
+  const { docs } = await payload.db.find<UpcomingEvent>({
+    collection: 'payload-jobs',
+    limit: 0,
+    sort: 'waitUntil',
+    where: buildUpcomingScheduleWhere({ id, collectionSlug, globalSlug }),
+  })
+
+  return docs.map((job) => ({
+    id: job.id,
+    input: {
+      type: job.input?.type === 'unpublish' ? 'unpublish' : 'publish',
+      locale: job.input?.locale,
+      timezone: job.input?.timezone,
+    },
+    waitUntil: job.waitUntil,
+  }))
+}
 
 export const schedulePublishHandler: ServerFunction<SchedulePublishHandlerArgs> = async ({
   type,
@@ -29,7 +104,9 @@ export const schedulePublishHandler: ServerFunction<SchedulePublishHandlerArgs> 
       await payload.delete({
         collection: 'payload-jobs',
         req,
-        where: { id: { equals: deleteID } },
+        where: {
+          and: [{ id: { equals: deleteID } }, { taskSlug: { equals: 'schedulePublish' } }],
+        },
       })
     }
 

--- a/test/queues/int.spec.ts
+++ b/test/queues/int.spec.ts
@@ -74,6 +74,100 @@ describe('Queues - Payload', () => {
   })
 
   describe('access control', () => {
+    it('should deny raw job creation when access control is enabled', async () => {
+      const req = await createLocalReq({ user }, payload)
+
+      await expect(
+        payload.create({
+          collection: 'payload-jobs',
+          data: {
+            input: {
+              message: 'raw job',
+            },
+            taskSlug: 'CreateSimple',
+          },
+          overrideAccess: false,
+          req,
+        }),
+      ).rejects.toThrow()
+    })
+
+    it('should deny raw job reads when access control is enabled', async () => {
+      const req = await createLocalReq({ user }, payload)
+      const job = await payload.jobs.queue({
+        input: {
+          message: 'protected job',
+        },
+        task: 'CreateSimple',
+      })
+
+      await expect(
+        payload.findByID({
+          id: job.id,
+          collection: 'payload-jobs',
+          overrideAccess: false,
+          req,
+        }),
+      ).rejects.toThrow()
+    })
+
+    it('should deny raw job updates when access control is enabled', async () => {
+      const req = await createLocalReq({ user }, payload)
+      const job = await payload.jobs.queue({
+        input: {
+          message: 'protected job',
+        },
+        task: 'CreateSimple',
+      })
+
+      await expect(
+        payload.update({
+          id: job.id,
+          collection: 'payload-jobs',
+          data: {
+            input: {
+              message: 'attacker update',
+            },
+          },
+          overrideAccess: false,
+          req,
+        }),
+      ).rejects.toThrow()
+
+      const unchangedJob = await payload.findByID({
+        id: job.id,
+        collection: 'payload-jobs',
+      })
+
+      expect(unchangedJob.input).toEqual({ message: 'protected job' })
+    })
+
+    it('should deny raw job deletion when access control is enabled', async () => {
+      const req = await createLocalReq({ user }, payload)
+      const job = await payload.jobs.queue({
+        input: {
+          message: 'protected job',
+        },
+        task: 'CreateSimple',
+      })
+
+      await expect(
+        payload.delete({
+          id: job.id,
+          collection: 'payload-jobs',
+          overrideAccess: false,
+          req,
+        }),
+      ).rejects.toThrow()
+
+      const unchangedJob = await payload.findByID({
+        id: job.id,
+        collection: 'payload-jobs',
+      })
+
+      expect(unchangedJob.id).toBe(job.id)
+    })
+
     it('will run access control on jobs runner run endpoint', async () => {
       const response = await restClient.GET('/payload-jobs/run?silent=true', {
         headers: {

--- a/test/versions/int.spec.ts
+++ b/test/versions/int.spec.ts
@@ -1,6 +1,9 @@
 import type { JsonObject, Payload } from 'payload'
 
-import { schedulePublishHandler } from '@payloadcms/ui/utilities/schedulePublishHandler'
+import {
+  getUpcomingScheduledPublishHandler,
+  schedulePublishHandler,
+} from '@payloadcms/ui/utilities/schedulePublishHandler'
 import fs from 'fs'
 import path from 'path'
 import { createLocalReq, getFileByPath, saveVersion, ValidationError } from 'payload'
@@ -3937,6 +3940,57 @@ describe('Versions', () => {
         expect(event).toBeDefined()
       })
 
+      it('should get upcoming scheduled publish events without reading the jobs collection', async () => {
+        const req = await createLocalReq({ user }, payload)
+
+        await schedulePublishHandler({
+          type: 'publish',
+          date: new Date(Date.now() + 60_000),
+          doc: {
+            relationTo: draftCollectionSlug,
+            value: String(draftDoc.id),
+          },
+          locale: 'all',
+          req,
+          user,
+        })
+
+        const events = await getUpcomingScheduledPublishHandler({
+          id: draftDoc.id,
+          collectionSlug: draftCollectionSlug,
+          req,
+        })
+
+        expect(events).toHaveLength(1)
+        expect(events[0]).toMatchObject({
+          input: {
+            type: 'publish',
+          },
+        })
+        expect(events[0]).not.toHaveProperty('taskSlug')
+        expect(events[0]?.input).not.toHaveProperty('user')
+      })
+
+      it('should not get scheduled publish events without publish permission', async () => {
+        const req = await createLocalReq({ user }, payload)
+
+        await payload.update({
+          id: draftDoc.id,
+          collection: draftCollectionSlug,
+          data: {
+            restrictedToUpdate: true,
+          },
+        })
+
+        await expect(
+          getUpcomingScheduledPublishHandler({
+            id: draftDoc.id,
+            collectionSlug: draftCollectionSlug,
+            req,
+          }),
+        ).rejects.toMatchObject({ status: 403 })
+      })
+
       it('should delete using schedule-publish', async () => {
         const currentDate = new Date()
 
@@ -3992,6 +4046,30 @@ describe('Versions', () => {
           collectionSlugs: ['payload-jobs', draftCollectionSlug],
           payload,
         })
+      })
+
+      it('should not delete a job that is not a scheduled publish', async () => {
+        const req = await createLocalReq({ user }, payload)
+        const unrelatedJob = await payload.db.create({
+          collection: 'payload-jobs',
+          data: {
+            input: {},
+            taskSlug: 'inline',
+          },
+        })
+
+        await schedulePublishHandler({
+          deleteID: unrelatedJob.id,
+          req,
+          user,
+        })
+
+        const result = await payload.findByID({
+          id: unrelatedJob.id,
+          collection: 'payload-jobs',
+        })
+
+        expect(result.id).toBe(unrelatedJob.id)
       })
     })
   })


### PR DESCRIPTION
This backports [the v4 jobs access changes](https://github.com/payloadcms/payload/pull/17768) to Payload v3.

It denies generic CRUD access to the internal `payload-jobs` collection by default, which is a better, more secure default than requiring users to configure it themselves. Projects can still customize raw collection access through `jobsCollectionOverrides`.

## Breaking changes

Generic CRUD access to the internal `payload-jobs` collection is now denied by default. This affects REST and GraphQL requests, along with Local API calls that use `overrideAccess: false`.

Projects that intentionally inspect or manage jobs through raw collection CRUD must define the required access rules through `jobsCollectionOverrides`. For example, making the collection visible in the Admin Panel now also requires explicitly enabling read access. Dedicated job operations such as `payload.jobs.queue()`, `payload.jobs.run()`, and `payload.jobs.cancel()` continue to use the Jobs Config access rules.