### PR TITLE
fix(plugin-ecommerce): validate variant cart items in initiatePayment

### DIFF
--- a/packages/plugin-ecommerce/src/endpoints/initiatePayment.spec.ts
+++ b/packages/plugin-ecommerce/src/endpoints/initiatePayment.spec.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('payload', () => ({
+  addDataAndFileToRequest: vi.fn(async () => undefined),
+}))
+
+import { initiatePaymentHandler } from './initiatePayment.js'
+
+const currenciesConfig = {
+  defaultCurrency: 'USD',
+  supportedCurrencies: [{ code: 'USD', decimals: 2, label: 'USD', symbol: '$' }],
+}
+
+type Doc = Record<string, unknown>
+
+const buildReq = ({
+  cartItems,
+  documents,
+}: {
+  cartItems: Doc[]
+  documents: Record<string, Doc>
+}) => {
+  const findByID = vi.fn(async ({ collection, id }: { collection: string; id: number }) => {
+    if (collection === 'carts') {
+      return {
+        id,
+        currency: 'USD',
+        customerEmail: 'customer@example.com',
+        items: cartItems,
+        subtotal: 1000,
+      }
+    }
+
+    return documents[`${collection}:${id}`]
+  })
+
+  return {
+    data: { cartID: 1, customerEmail: 'customer@example.com' },
+    findByID,
+    payload: { findByID, logger: { error: vi.fn() } },
+    query: {},
+    user: null,
+  }
+}
+
+const paymentMethod = {
+  initiatePayment: vi.fn(async () => ({ ok: true })),
+}
+
+const handler = initiatePaymentHandler({
+  currenciesConfig,
+  paymentMethod,
+} as never)
+
+describe('initiatePaymentHandler', () => {
+  beforeEach(() => {
+    paymentMethod.initiatePayment.mockClear()
+  })
+
+  it('rejects a variant item whose quantity exceeds the variant inventory', async () => {
+    const req = buildReq({
+      cartItems: [{ product: 2, quantity: 5, variant: 7 }],
+      documents: {
+        'variants:7': { id: 7, inventory: 2, priceInUSD: 1000 },
+      },
+    })
+
+    const response = await handler(req as never)
+
+    expect(response.status).toBe(400)
+    expect(paymentMethod.initiatePayment).not.toHaveBeenCalled()
+  })
+
+  it('accepts a variant item whose quantity fits the variant inventory', async () => {
+    const req = buildReq({
+      cartItems: [{ product: 2, quantity: 2, variant: 7 }],
+      documents: {
+        'variants:7': { id: 7, inventory: 2, priceInUSD: 1000 },
+      },
+    })
+
+    const response = await handler(req as never)
+
+    expect(response.status).toBe(200)
+    expect(paymentMethod.initiatePayment).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns 404 for a variant item whose variant does not exist', async () => {
+    const req = buildReq({
+      cartItems: [{ product: 2, quantity: 1, variant: 7 }],
+      documents: {},
+    })
+
+    const response = await handler(req as never)
+
+    expect(response.status).toBe(404)
+    expect(paymentMethod.initiatePayment).not.toHaveBeenCalled()
+  })
+
+  it('still rejects a product-only item whose quantity exceeds the product inventory', async () => {
+    const req = buildReq({
+      cartItems: [{ product: 2, quantity: 5 }],
+      documents: {
+        'products:2': { id: 2, inventory: 2, priceInUSD: 1000 },
+      },
+    })
+
+    const response = await handler(req as never)
+
+    expect(response.status).toBe(400)
+    expect(paymentMethod.initiatePayment).not.toHaveBeenCalled()
+  })
+})

--- a/packages/plugin-ecommerce/src/endpoints/initiatePayment.ts
+++ b/packages/plugin-ecommerce/src/endpoints/initiatePayment.ts
@@ -250,64 +250,64 @@ export const initiatePaymentHandler: InitiatePayment =
             },
           )
         }
+      }
 
-        if (item.variant) {
-          const id = typeof item.variant === 'object' ? item.variant.id : item.variant
+      if (item.product && item.variant) {
+        const id = typeof item.variant === 'object' ? item.variant.id : item.variant
 
-          const variant = await payload.findByID({
-            id,
-            collection: variantsSlug,
-            depth: 0,
-            select: {
-              inventory: true,
-              [priceField]: true,
+        const variant = await payload.findByID({
+          id,
+          collection: variantsSlug,
+          depth: 0,
+          select: {
+            inventory: true,
+            [priceField]: true,
+          },
+        })
+
+        if (!variant) {
+          return Response.json(
+            {
+              message: `Variant with ID ${item.variant} not found.`,
             },
-          })
+            {
+              status: 404,
+            },
+          )
+        }
 
-          if (!variant) {
-            return Response.json(
-              {
-                message: `Variant with ID ${item.variant} not found.`,
-              },
-              {
-                status: 404,
-              },
-            )
+        try {
+          if (productsValidation) {
+            await productsValidation({
+              currenciesConfig,
+              currency,
+              product: item.product,
+              quantity,
+              variant,
+            })
+          } else {
+            await defaultProductsValidation({
+              currenciesConfig,
+              currency,
+              product: item.product,
+              quantity,
+              variant,
+            })
           }
+        } catch (error) {
+          payload.logger.error(
+            error,
+            'Error validating product or variant during payment initiation.',
+          )
 
-          try {
-            if (productsValidation) {
-              await productsValidation({
-                currenciesConfig,
-                currency,
-                product: item.product,
-                quantity,
-                variant,
-              })
-            } else {
-              await defaultProductsValidation({
-                currenciesConfig,
-                currency,
-                product: item.product,
-                quantity,
-                variant,
-              })
-            }
-          } catch (error) {
-            payload.logger.error(
-              error,
-              'Error validating product or variant during payment initiation.',
-            )
-
-            return Response.json(
-              {
-                message: error,
-              },
-              {
-                status: 400,
-              },
-            )
-          }
+          return Response.json(
+            {
+              message: error,
+            },
+            {
+              status: 400,
+            },
+          )
         }
       }
     }


### PR DESCRIPTION
### What?

Cart items that carry a variant are now validated in `initiatePayment`, the same way product-only items already are.

### Why?

The variant validation block was nested inside the branch guarded by `item.product && !item.variant`, so it could never run. Any cart item with a variant reached the payment adapter with no stock or price-field check. Details and reproduction in #17866.

### How?

The variant block is moved out to a sibling branch guarded by `item.product && item.variant`. No behaviour changes for product-only items.

Added `initiatePayment.spec.ts` covering: a variant over inventory is refused with 400, a variant within inventory proceeds to the adapter, a missing variant returns 404, and a product-only item over inventory still returns 400. On the previous code the two variant cases fail; with this change all four pass.

Fixes #17866
