### PR TITLE
docs: overrideAccess now defaults to false

### DIFF
--- a/docs/access-control/collections.mdx
+++ b/docs/access-control/collections.mdx
@@ -255,6 +255,7 @@ export const canDeleteCustomer: Access<Customer> = async ({ req, id }) => {
   // Query another Collection using the `id`
   const result = await req.payload.find({
     collection: 'contracts',
+    overrideAccess: true,
     limit: 0,
     depth: 0,
     where: {

--- a/docs/access-control/overview.mdx
+++ b/docs/access-control/overview.mdx
@@ -44,10 +44,10 @@ const defaultPayloadAccess = ({ req: { payload, user } }) => {
 ```
 
 <Banner type="warning">
-  **Important:** In the [Local API](../local-api/overview), all Access Control
-  is _skipped_ by default. This allows your server to have full control over
-  your application. To opt back in, you can set the `overrideAccess` option to
-  `false` in your requests.
+  **Important:** [Local API](../local-api/overview) operations require an
+  `overrideAccess` value. Pass `false` to enforce Access Control, along with the
+  `user` to check against, or `true` to skip it. See [Local API Access
+  Control](../local-api/access-control).
 </Banner>
 
 ## Base Access Control

--- a/docs/admin/locked-documents.mdx
+++ b/docs/admin/locked-documents.mdx
@@ -72,6 +72,7 @@ By default, `overrideLock` is set to `true`, which means that document locks are
 ```ts
 const result = await payload.update({
   collection: 'posts',
+  overrideAccess: true,
   id: '123',
   data: {
     title: 'New title',

--- a/docs/authentication/custom-strategies.mdx
+++ b/docs/authentication/custom-strategies.mdx
@@ -11,7 +11,8 @@ keywords: authentication, config, configuration, overview, documentation, Conten
   developer. Otherwise, just let Payload's built-in authentication handle user
   auth for you.
 
-  **Development Note:** Changes to custom authentication strategies require a full server restart to take effect. Auth strategies are not hot-reloaded during development. Consider using tools like `nodemon` for auto-restart functionality.
+**Development Note:** Changes to custom authentication strategies require a full server restart to take effect. Auth strategies are not hot-reloaded during development. Consider using tools like `nodemon` for auto-restart functionality.
+
 </Banner>
 
 ### Creating a strategy
@@ -54,6 +55,7 @@ export const Users: CollectionConfig = {
         authenticate: async ({ payload, headers }) => {
           const usersQuery = await payload.find({
             collection: 'users',
+            overrideAccess: true,
             where: {
               code: {
                 equals: headers.get('code'),
@@ -67,21 +69,23 @@ export const Users: CollectionConfig = {
           return {
             // Send the user with the collection slug back to authenticate,
             // or send null if no user should be authenticated
-            user: usersQuery.docs[0] ? {
-              collection: 'users',
-              ...usersQuery.docs[0],
-            } : null,
+            user: usersQuery.docs[0]
+              ? {
+                  collection: 'users',
+                  ...usersQuery.docs[0],
+                }
+              : null,
 
             // Optionally, you can return headers
             // that you'd like Payload to set here when
             // it returns the response
             responseHeaders: new Headers({
-              'some-header': 'my header value'
-            })
+              'some-header': 'my header value',
+            }),
           }
-        }
-      }
-    ]
+        },
+      },
+    ],
     // highlight-end
   },
   fields: [
@@ -95,6 +99,6 @@ export const Users: CollectionConfig = {
       name: 'secret',
       type: 'text',
     },
-  ]
+  ],
 }
 ```

--- a/docs/authentication/operations.mdx
+++ b/docs/authentication/operations.mdx
@@ -159,6 +159,7 @@ mutation {
 ```ts
 const result = await payload.login({
   collection: 'collection-slug',
+  overrideAccess: false,
   data: {
     email: 'dev@payloadcms.com',
     password: 'get-out',

--- a/docs/configuration/cli.mdx
+++ b/docs/configuration/cli.mdx
@@ -162,6 +162,7 @@ export const seedCommand = defineCLICommand({
 
     await payload.create({
       collection: 'pages',
+      overrideAccess: true,
       data: { title: 'My page' },
     })
 

--- a/docs/configuration/localization.mdx
+++ b/docs/configuration/localization.mdx
@@ -116,6 +116,7 @@ localization: {
       const fullTenant = await req.payload.findByID({
         id: getTenantFromCookie(req.headers, 'text') as string,
         collection: 'tenants',
+        overrideAccess: true,
         req,
       })
       if (fullTenant && fullTenant.supportedLocales?.length) {
@@ -191,6 +192,7 @@ When the `_status` field is localized, publishing and unpublishing are scoped to
 // Publishes ONLY the Spanish status; English, German, etc. are unchanged
 await payload.update({
   collection: 'posts',
+  overrideAccess: true,
   id,
   locale: 'es',
   data: { _status: 'published' },
@@ -203,6 +205,7 @@ To publish or unpublish every locale at once, use `publishAllLocales` or `unpubl
 // Publishes every locale
 await payload.update({
   collection: 'posts',
+  overrideAccess: true,
   id,
   publishAllLocales: true,
   data: { _status: 'published' },
@@ -211,6 +214,7 @@ await payload.update({
 // Unpublishes every locale
 await payload.update({
   collection: 'posts',
+  overrideAccess: true,
   id,
   unpublishAllLocales: true,
   data: { _status: 'draft' },
@@ -291,6 +295,7 @@ locale, array of locales, as well as `'null'`, `'false'`, `false`, and `'none'`.
 ```js
 const posts = await payload.find({
   collection: 'posts',
+  overrideAccess: true,
   locale: 'es',
   fallbackLocale: false,
 })

--- a/docs/custom-components/dashboard.mdx
+++ b/docs/custom-components/dashboard.mdx
@@ -80,7 +80,11 @@ export default async function UserStatsWidget({ req }: WidgetServerProps) {
   const { payload } = req
 
   // Fetch data server-side
-  const userCount = await payload.count({ collection: 'users' })
+  const userCount = await payload.count({
+    collection: 'users',
+    overrideAccess: false,
+    req,
+  })
 
   return (
     <div className="card">

--- a/docs/custom-components/overview.mdx
+++ b/docs/custom-components/overview.mdx
@@ -241,6 +241,7 @@ async function MyServerComponent({
 }) {
   const page = await payload.findByID({
     collection: 'pages',
+    overrideAccess: true,
     id: '123',
   })
 
@@ -452,6 +453,7 @@ import React from 'react'
 export default async function MyServerComponent({ payload, locale }) {
   const localizedPage = await payload.findByID({
     collection: 'pages',
+    overrideAccess: true,
     id: '123',
     locale,
   })

--- a/docs/database/transactions.mdx
+++ b/docs/database/transactions.mdx
@@ -33,6 +33,7 @@ const afterChange: CollectionAfterChangeHook = async ({ req }) => {
   await req.payload.create({
     req,
     collection: 'my-slug',
+    overrideAccess: true,
     data: {
       some: 'data',
     },
@@ -51,6 +52,7 @@ const afterChange: CollectionAfterChangeHook = async ({ req }) => {
   const dangerouslyIgnoreAsync = req.payload.create({
     req,
     collection: 'my-slug',
+    overrideAccess: true,
     data: {
       some: 'other data',
     },
@@ -60,6 +62,7 @@ const afterChange: CollectionAfterChangeHook = async ({ req }) => {
   // because the req (and its transactionID) is not passed through
   const safelyIgnoredAsync = req.payload.create({
     collection: 'my-slug',
+    overrideAccess: true,
     data: {
       some: 'other data',
     },
@@ -94,6 +97,7 @@ const standalonePayloadScript = async () => {
     // Make an update using the Local API
     await payload.update({
       collection: 'posts',
+      overrideAccess: true,
       data: {
         some: 'data',
       },
@@ -128,6 +132,7 @@ In addition to allowing database transactions to be disabled at the adapter leve
 ```ts
 await payload.update({
   collection: 'posts',
+  overrideAccess: true,
   data: {
     some: 'data',
   },

--- a/docs/ecommerce/payments.mdx
+++ b/docs/ecommerce/payments.mdx
@@ -272,6 +272,7 @@ export const initiatePayment: NonNullable<PaymentAdapter>['initiatePayment'] =
       // Create a transaction for the payment intent in the database
       const transaction = await payload.create({
         collection: transactionsSlug,
+        overrideAccess: true,
         data: {},
       })
 
@@ -349,6 +350,7 @@ export const confirmOrder: NonNullable<PaymentAdapter>['confirmOrder'] =
       // Find our existing transaction by the payment intent ID
       const transactionsResults = await payload.find({
         collection: transactionsSlug,
+        overrideAccess: true,
         where: {
           'stripe.paymentIntentID': {
             equals: paymentIntentID,
@@ -365,6 +367,7 @@ export const confirmOrder: NonNullable<PaymentAdapter>['confirmOrder'] =
       // Create the order in the database
       const order = await payload.create({
         collection: ordersSlug,
+        overrideAccess: true,
         data: {},
       })
 
@@ -374,6 +377,7 @@ export const confirmOrder: NonNullable<PaymentAdapter>['confirmOrder'] =
       await payload.update({
         id: cartID,
         collection: 'carts',
+        overrideAccess: true,
         data: {
           purchasedAt: timestamp,
         },
@@ -383,6 +387,7 @@ export const confirmOrder: NonNullable<PaymentAdapter>['confirmOrder'] =
       await payload.update({
         id: transaction.id,
         collection: transactionsSlug,
+        overrideAccess: true,
         data: {
           order: order.id,
           status: 'succeeded',

--- a/docs/email/overview.mdx
+++ b/docs/email/overview.mdx
@@ -237,6 +237,7 @@ If you store files in a Payload collection with `upload: true`, you can attach t
 ```ts
 const mediaDoc = await payload.findByID({
   collection: 'media',
+  overrideAccess: true,
   id: 'your-file-id',
 })
 
@@ -277,6 +278,7 @@ await payload.sendEmail({
 ```ts
 const mediaDoc = await payload.findByID({
   collection: 'media',
+  overrideAccess: true,
   id: 'your-file-id',
 })
 

--- a/docs/fields/join.mdx
+++ b/docs/fields/join.mdx
@@ -247,6 +247,7 @@ By adding `joins` to the Local API you can customize the request for each join f
 ```js
 const result = await payload.find({
   collection: 'categories',
+  overrideAccess: true,
   where: {
     title: {
       equals: 'My Category',

--- a/docs/fields/point.mdx
+++ b/docs/fields/point.mdx
@@ -90,6 +90,7 @@ const polygon: Point[] = [
 
 payload.find({
   collection: 'points',
+  overrideAccess: true,
   where: {
     point: {
       within: {
@@ -117,6 +118,7 @@ const polygon: Point[] = [
 
 payload.find({
   collection: 'points',
+  overrideAccess: true,
   where: {
     point: {
       intersects: {

--- a/docs/hierarchy/overview.mdx
+++ b/docs/hierarchy/overview.mdx
@@ -77,6 +77,7 @@ When hierarchy is enabled, virtual path fields are automatically added to your c
 ```ts
 const page = await payload.findByID({
   collection: 'pages',
+  overrideAccess: true,
   id: 'page-id',
   context: { computeHierarchyPaths: true }, // Request path computation
 })
@@ -109,6 +110,7 @@ const url = `/${page._h_slugPath}` // "/store/products/widgets"
 ```tsx
 const page = await payload.findByID({
   collection: 'pages',
+  overrideAccess: true,
   id: 'page-id',
   context: { computeHierarchyPaths: true },
 })
@@ -129,6 +131,7 @@ Pass `computeHierarchyPaths: true` in the context:
 // Single document
 const page = await payload.findByID({
   collection: 'pages',
+  overrideAccess: true,
   id: 'page-id',
   context: { computeHierarchyPaths: true },
 })
@@ -136,6 +139,7 @@ const page = await payload.findByID({
 // Query multiple documents
 const pages = await payload.find({
   collection: 'pages',
+  overrideAccess: true,
   where: { parent: { equals: null } },
   context: { computeHierarchyPaths: true },
 })
@@ -160,6 +164,7 @@ Paths are automatically computed when you explicitly select them:
 ```ts
 const page = await payload.findByID({
   collection: 'pages',
+  overrideAccess: true,
   id: 'page-id',
   select: {
     title: true,
@@ -182,6 +187,7 @@ const page = await payload.findByID({
 // Load 50 folders with same parent
 const folders = await payload.find({
   collection: 'folders',
+  overrideAccess: true,
   where: { parent: { equals: 'parent-id' } },
   context: { computeHierarchyPaths: true },
 })
@@ -365,6 +371,7 @@ When creating a document with a polymorphic parent, specify both the collection 
 // Create a page
 const blogPage = await payload.create({
   collection: 'pages',
+  overrideAccess: true,
   data: {
     title: 'Blog',
     parent: null,
@@ -374,6 +381,7 @@ const blogPage = await payload.create({
 // Create a post under the page (cross-collection parent)
 const post = await payload.create({
   collection: 'posts',
+  overrideAccess: true,
   data: {
     title: 'First Post',
     parent: {
@@ -386,6 +394,7 @@ const post = await payload.create({
 // Create a reply post under the post (same-collection parent)
 const reply = await payload.create({
   collection: 'posts',
+  overrideAccess: true,
   data: {
     title: 'Reply',
     parent: {
@@ -404,6 +413,7 @@ Paths are computed across collections automatically:
 // Get post with computed paths
 const post = await payload.findByID({
   collection: 'posts',
+  overrideAccess: true,
   id: post.id,
   context: { computeHierarchyPaths: true },
 })
@@ -414,6 +424,7 @@ const post = await payload.findByID({
 // Get reply with nested path
 const reply = await payload.findByID({
   collection: 'posts',
+  overrideAccess: true,
   id: reply.id,
   context: { computeHierarchyPaths: true },
 })
@@ -509,11 +520,13 @@ Circular reference detection works across collections:
 
 const pageA = await payload.create({
   collection: 'pages',
+  overrideAccess: true,
   data: { title: 'Page A', parent: null },
 })
 
 const postB = await payload.create({
   collection: 'posts',
+  overrideAccess: true,
   data: {
     title: 'Post B',
     parent: { relationTo: 'pages', value: pageA.id },
@@ -523,6 +536,7 @@ const postB = await payload.create({
 // ❌ This throws an error
 await payload.update({
   collection: 'pages',
+  overrideAccess: true,
   id: pageA.id,
   data: { parent: { relationTo: 'posts', value: postB.id } },
 })
@@ -718,6 +732,7 @@ Hierarchy maintains parent-child relationships through a simple `parent` field:
 // Move "Page C" from under "Page A" to under "Page B"
 await payload.update({
   collection: 'pages',
+  overrideAccess: true,
   id: 'page-c',
   data: { parent: 'page-b' }, // Changed from page-a
 })
@@ -745,6 +760,7 @@ When you change a document's title, paths are automatically updated on the next 
 // Change a parent's title from "Products" to "Items"
 await payload.update({
   collection: 'pages',
+  overrideAccess: true,
   id: 'parent-id',
   data: { title: 'Items' },
 })
@@ -752,6 +768,7 @@ await payload.update({
 // Next time a child is read with path computation:
 const child = await payload.findByID({
   collection: 'pages',
+  overrideAccess: true,
   id: 'child-id',
   context: { computeHierarchyPaths: true },
 })
@@ -781,6 +798,7 @@ When you move or rename a document, descendants are not updated:
 // Moving a folder with 50 descendant pages
 await payload.update({
   collection: 'pages',
+  overrideAccess: true,
   id: 'folder-id',
   data: { parent: 'new-parent' },
 })
@@ -813,6 +831,7 @@ When versioning with drafts is enabled, paths are computed based on the current 
 // Reading published version
 const published = await payload.findByID({
   collection: 'pages',
+  overrideAccess: true,
   id: 'page-id',
   context: { computeHierarchyPaths: true },
   // draft: false (default)
@@ -822,6 +841,7 @@ const published = await payload.findByID({
 // Reading draft version
 const draft = await payload.findByID({
   collection: 'pages',
+  overrideAccess: true,
   id: 'page-id',
   draft: true,
   context: { computeHierarchyPaths: true },
@@ -869,6 +889,7 @@ When you publish a draft with a changed parent for one locale:
 // Draft changes parent
 await payload.update({
   collection: 'pages',
+  overrideAccess: true,
   id: 'doc-id',
   data: { parent: 'parent-2' },
   draft: true,
@@ -877,6 +898,7 @@ await payload.update({
 // Publish only French
 await payload.update({
   collection: 'pages',
+  overrideAccess: true,
   id: 'doc-id',
   locale: 'fr',
   data: { _status: 'published' },
@@ -892,6 +914,7 @@ await payload.update({
 // ✅ Clear: publishes parent change for all locales
 await payload.update({
   collection: 'pages',
+  overrideAccess: true,
   id: 'doc-id',
   data: { parent: 'new-parent' },
   // publishAllLocales is default
@@ -938,6 +961,7 @@ For collections with many documents:
 // ❌ Unnecessary path computation for a tag relationship
 const post = await payload.findByID({
   collection: 'posts',
+  overrideAccess: true,
   id: 'post-id',
   depth: 2, // Populates category relationship
   context: { computeHierarchyPaths: true }, // Computes paths for category too
@@ -946,6 +970,7 @@ const post = await payload.findByID({
 // ✅ Only compute paths when you'll use them
 const post = await payload.findByID({
   collection: 'posts',
+  overrideAccess: true,
   id: 'post-id',
   depth: 2,
   // No path computation - category.parent populated but no _h_slugPath
@@ -962,6 +987,7 @@ import type { Page } from './payload-types'
 // Fetched document type includes all hierarchy fields
 const page = await payload.findByID({
   collection: 'pages',
+  overrideAccess: true,
   id: 'page-id',
   context: { computeHierarchyPaths: true },
 })

--- a/docs/hooks/context.mdx
+++ b/docs/hooks/context.mdx
@@ -76,6 +76,7 @@ const Customer: CollectionConfig = {
         await req.payload.update({
           // DANGER: updating the same slug as the collection in an afterChange will create an infinite loop!
           collection: 'customers',
+          overrideAccess: true,
           id: doc.id,
           data: {
             ...(await fetchCustomerData(data.customerID)),
@@ -108,6 +109,7 @@ const MyCollection: CollectionConfig = {
         }
         await req.payload.update({
           collection: contextHooksSlug,
+          overrideAccess: true,
           id: doc.id,
           data: {
             ...(await fetchCustomerData(data.customerID)),

--- a/docs/integrations/vercel-content-link.mdx
+++ b/docs/integrations/vercel-content-link.mdx
@@ -92,6 +92,7 @@ If you're using the Local API, include the `encodeSourceMaps` via the `context` 
 if (isDraftMode || process.env.VERCEL_ENV === 'preview') {
   const res = await payload.find({
     collection: 'pages',
+    overrideAccess: true,
     where: {
       slug: {
         equals: slug,

--- a/docs/jobs-queue/jobs.mdx
+++ b/docs/jobs-queue/jobs.mdx
@@ -189,6 +189,7 @@ const job = await payload.jobs.queue({
 // Later, check the job status
 const updatedJob = await payload.findByID({
   collection: 'payload-jobs',
+  overrideAccess: true,
   id: job.id,
 })
 
@@ -237,6 +238,8 @@ Use Payload's dedicated Jobs APIs and endpoints, such as `payload.jobs.*`, `/run
 Raw collection create, read, update, and delete access is denied by default. You can adjust these rules through `jobsCollectionOverrides`. REST and GraphQL always run them; Local API CRUD runs them when you pass `overrideAccess: false`.
 
 The dedicated job operations use `jobs.access.queue`, `run`, and `cancel`. Local API calls run these functions when you pass `overrideAccess: false`. The `/run` and `/handle-schedules` endpoints always check `jobs.access.run`.
+
+On `payload.jobs.*`, `overrideAccess` is optional and still defaults to `true`. This is the exception to the [Local API](../local-api/access-control), where the property is required and has no default.
 
 Configure access for the dedicated job operations in your Jobs Config:
 

--- a/docs/jobs-queue/jobs.mdx
+++ b/docs/jobs-queue/jobs.mdx
@@ -239,7 +239,7 @@ Raw collection create, read, update, and delete access is denied by default. You
 
 The dedicated job operations use `jobs.access.queue`, `run`, and `cancel`. Local API calls run these functions when you pass `overrideAccess: false`. The `/run` and `/handle-schedules` endpoints always check `jobs.access.run`.
 
-On `payload.jobs.*`, `overrideAccess` is optional and still defaults to `true`. This is the exception to the [Local API](../local-api/access-control), where the property is required and has no default.
+On `payload.jobs.*`, `overrideAccess` still defaults to `true`. This is the exception to the [Local API](../local-api/access-control), which now defaults to `false`.
 
 Configure access for the dedicated job operations in your Jobs Config:
 

--- a/docs/jobs-queue/queues.mdx
+++ b/docs/jobs-queue/queues.mdx
@@ -593,6 +593,7 @@ autoRun: [{ cron: '* * * * *', queue: 'reports' }] // Now they match!
 ```ts
 const jobs = await payload.find({
   collection: 'payload-jobs',
+  overrideAccess: true,
   where: {
     completedAt: { exists: false },
   },
@@ -659,6 +660,7 @@ Check the job logs in the `payload-jobs` collection:
 ```ts
 const job = await payload.findByID({
   collection: 'payload-jobs',
+  overrideAccess: true,
   id: jobId,
 })
 

--- a/docs/jobs-queue/quick-start-example.mdx
+++ b/docs/jobs-queue/quick-start-example.mdx
@@ -162,6 +162,7 @@ export default buildConfig({
 
           const analytics = await req.payload.find({
             collection: 'analytics',
+            overrideAccess: true,
             where: {
               createdAt: {
                 greater_than_equal: yesterday.toISOString(),
@@ -172,6 +173,7 @@ export default buildConfig({
           // Save the report
           const report = await req.payload.create({
             collection: 'reports',
+            overrideAccess: true,
             data: {
               date: new Date().toISOString(),
               totalEvents: analytics.totalDocs,

--- a/docs/jobs-queue/schedules.mdx
+++ b/docs/jobs-queue/schedules.mdx
@@ -364,6 +364,7 @@ export const DailyDigestTask: TaskConfig<'DailyDigest'> = {
   handler: async ({ req }) => {
     const users = await req.payload.find({
       collection: 'users',
+      overrideAccess: true,
       where: { digestEnabled: { equals: true } },
     })
 
@@ -391,6 +392,7 @@ export const WeeklyReportTask: TaskConfig<'WeeklyReport'> = {
     const report = await generateWeeklyReport()
     await req.payload.create({
       collection: 'reports',
+      overrideAccess: true,
       data: report,
     })
 
@@ -414,6 +416,7 @@ export const SyncDataTask: TaskConfig<'SyncData'> = {
     const data = await fetchFromExternalAPI()
     await req.payload.create({
       collection: 'synced-data',
+      overrideAccess: true,
       data,
     })
 
@@ -461,6 +464,7 @@ Test your cron expressions at [crontab.guru](https://crontab.guru) (for 5-field 
 ```ts
 const stats = await payload.findGlobal({
   slug: 'payload-jobs-stats',
+  overrideAccess: true,
 })
 
 console.log(stats.lastScheduled) // Check when each task was last scheduled

--- a/docs/jobs-queue/tasks.mdx
+++ b/docs/jobs-queue/tasks.mdx
@@ -77,6 +77,7 @@ export default buildConfig({
         handler: async ({ input, job, req }) => {
           const newPost = await req.payload.create({
             collection: 'post',
+            overrideAccess: true,
             req,
             data: {
               title: input.title,
@@ -132,6 +133,7 @@ export default buildConfig({
           // Send daily digest emails
           const users = await req.payload.find({
             collection: 'users',
+            overrideAccess: true,
             where: { subscribed: { equals: true } },
           })
 
@@ -221,6 +223,7 @@ Creating or updating documents based on other document changes:
   handler: async ({ input, req }) => {
     const posts = await req.payload.find({
       collection: 'posts',
+      overrideAccess: true,
       where: {
         category: {
           equals: input.categoryId,
@@ -232,6 +235,7 @@ Creating or updating documents based on other document changes:
     for (const post of posts.docs) {
       await req.payload.update({
         collection: 'posts',
+        overrideAccess: true,
         id: post.id,
         data: {
           categoryUpdatedAt: new Date().toISOString(),
@@ -266,6 +270,7 @@ Calling third-party services without blocking your API:
   handler: async ({ input, req }) => {
     const doc = await req.payload.findByID({
       collection: 'documents',
+      overrideAccess: true,
       id: input.documentId,
     })
 
@@ -308,6 +313,7 @@ Sometimes you want to fail a task based on business logic:
   handler: async ({ input, req }) => {
     const order = await req.payload.findByID({
       collection: 'orders',
+      overrideAccess: true,
       id: input.orderId,
     })
 
@@ -336,6 +342,7 @@ Tasks fail by throwing errors. When a task encounters any type of failure—whet
 handler: async ({ input, req }) => {
   const order = await req.payload.findByID({
     collection: 'orders',
+    overrideAccess: true,
     id: input.orderId,
   })
 
@@ -384,6 +391,7 @@ await payload.jobs.run()
 // Check the job status
 const completedJob = await payload.findByID({
   collection: 'payload-jobs',
+  overrideAccess: true,
   id: job.id,
 })
 
@@ -469,6 +477,7 @@ export const createPostHandler: TaskHandler<'createPost'> = async ({
 }) => {
   const newPost = await req.payload.create({
     collection: 'post',
+    overrideAccess: true,
     req,
     data: {
       title: input.title,

--- a/docs/jobs-queue/workflows.mdx
+++ b/docs/jobs-queue/workflows.mdx
@@ -155,6 +155,7 @@ export default buildConfig({
             task: async ({ req }) => {
               const newPost = await req.payload.update({
                 collection: 'post',
+                overrideAccess: true,
                 id: '2',
                 req,
                 retries: 3,
@@ -367,11 +368,13 @@ export default buildConfig({
               // documentId can run at the same time
               const doc = await req.payload.findByID({
                 collection: 'posts',
+                overrideAccess: true,
                 id: job.input.documentId,
               })
 
               await req.payload.update({
                 collection: 'posts',
+                overrideAccess: true,
                 id: job.input.documentId,
                 data: { syncedAt: new Date().toISOString() },
               })

--- a/docs/live-preview/client.mdx
+++ b/docs/live-preview/client.mdx
@@ -280,6 +280,7 @@ It is possible that either you are setting an improper [`depth`](../queries/dept
 // Your initial request
 const { docs } = await payload.find({
   collection: 'pages',
+  overrideAccess: true,
   depth: 1, // Ensure this is set to the proper depth for your application
   where: {
     slug: {

--- a/docs/live-preview/server.mdx
+++ b/docs/live-preview/server.mdx
@@ -49,6 +49,7 @@ export default async function Page() {
 
   const page = await payload.findByID({
     collection: 'pages',
+    overrideAccess: true,
     id: '123',
     draft: true,
     trash: true, // add this if trash is enabled in your collection and want to preview trashed documents

--- a/docs/local-api/access-control.mdx
+++ b/docs/local-api/access-control.mdx
@@ -6,37 +6,26 @@ desc: Learn how to implement and enforce access control in Payload's Local API o
 keywords: server functions, local API, Payload, CMS, access control, permissions, user context, server-side logic, custom workflows, data management, headless CMS, TypeScript, Node.js, backend
 ---
 
-In Payload, local API operations **override access control by default**. This means that operations will run without checking if the current user has permission to perform the action. This is useful in certain scenarios where access control is not necessary, but it is important to be aware of when to enforce it for security reasons.
+Every Local API operation requires an `overrideAccess` value. There is no default — each call states whether it runs on behalf of a user or as trusted server-side work.
 
-### Default Behavior: Access Control Skipped
+- `overrideAccess: false` — respect Access Control. Pass the `user` alongside it.
+- `overrideAccess: true` — skip Access Control. The operation runs with full permissions.
 
-By default, **local API operations skip access control**. This allows operations to execute without the system checking if the current user has appropriate permissions. This might be helpful in admin or server-side scripts where the user context is not required to perform the operation.
-
-#### For example:
-
-```ts
-// Access control is this operation would be skipped by default
-const test = await payload.create({
-  collection: 'users',
-  data: {
-    email: 'test@test.com',
-    password: 'test',
-  },
-})
-```
+<Banner type="warning">
+  In Payload 3 this property was optional and defaulted to `true`, which meant
+  an operation that said nothing skipped Access Control. See the [migration
+  guide](../migration-guide/v4#overrideaccess-is-now-required-on-local-api-operations).
+</Banner>
 
 ### Respecting Access Control
 
-If you want to respect access control and ensure that the operation is performed only if the user has appropriate permissions, you need to explicitly pass the `user` object and set the `overrideAccess` option to `false`.
-
-- `overrideAccess: false`: This ensures that access control is **not skipped** and the operation respects the current user's permissions.
-- `user`: Pass the authenticated user context to the operation. This ensures the system checks whether the user has the right permissions to perform the action.
+Use `overrideAccess: false` whenever the operation acts for a person — server functions, API routes, custom endpoints, and anything reached from the front end. Pass the authenticated `user` so Payload knows whose permissions to check.
 
 ```ts
 const authedCreate = await payload.create({
   collection: 'users',
-  overrideAccess: false, // This ensures access control will be applied
-  user, // Pass the authenticated user to check permissions
+  overrideAccess: false, // access control is enforced
+  user, // whose permissions to check
   data: {
     email: 'test@test.com',
     password: 'test',
@@ -44,4 +33,25 @@ const authedCreate = await payload.create({
 })
 ```
 
-This example will only allow the document to be created if the `user` we passed has the appropriate access control permissions.
+This creates the document only if `user` has permission to do so. Without the `user`, Payload treats the request as unauthenticated and applies the access rules for an anonymous visitor.
+
+### Skipping Access Control
+
+Use `overrideAccess: true` for trusted server-side work with no user behind it — seed scripts, migrations, cron jobs, and webhook handlers.
+
+```ts
+const seeded = await payload.create({
+  collection: 'users',
+  overrideAccess: true, // access control is skipped
+  data: {
+    email: 'test@test.com',
+    password: 'test',
+  },
+})
+```
+
+### Choosing a value
+
+Ask who the operation is for. If a person triggered it, use `false` and pass their `user`. If your server triggered it on its own schedule, use `true`.
+
+When you are unsure, `false` is the safer choice: the operation returns less than you expected rather than more.

--- a/docs/local-api/access-control.mdx
+++ b/docs/local-api/access-control.mdx
@@ -6,15 +6,15 @@ desc: Learn how to implement and enforce access control in Payload's Local API o
 keywords: server functions, local API, Payload, CMS, access control, permissions, user context, server-side logic, custom workflows, data management, headless CMS, TypeScript, Node.js, backend
 ---
 
-Every Local API operation requires an `overrideAccess` value. There is no default — each call states whether it runs on behalf of a user or as trusted server-side work.
+Every Local API operation accepts an `overrideAccess` option. As of Payload 4, it defaults to `false` — Local API operations **respect Access Control by default**.
 
-- `overrideAccess: false` — respect Access Control. Pass the `user` alongside it.
+- `overrideAccess: false` (default) — respect Access Control. Pass the `user` alongside it.
 - `overrideAccess: true` — skip Access Control. The operation runs with full permissions.
 
 <Banner type="warning">
-  In Payload 3 this property was optional and defaulted to `true`, which meant
-  an operation that said nothing skipped Access Control. See the [migration
-  guide](../migration-guide/v4#overrideaccess-is-now-required-on-local-api-operations).
+  In Payload 3 this property defaulted to `true`, which meant an operation that
+  said nothing skipped Access Control. See the [migration
+  guide](../migration-guide/v4#overrideaccess-now-defaults-to-false-on-local-api-operations).
 </Banner>
 
 ### Respecting Access Control
@@ -52,6 +52,6 @@ const seeded = await payload.create({
 
 ### Choosing a value
 
-Ask who the operation is for. If a person triggered it, use `false` and pass their `user`. If your server triggered it on its own schedule, use `true`.
+Ask who the operation is for. If a person triggered it, pass their `user` — you can set `overrideAccess: false` explicitly, or simply omit the property, since that's now the default. If your server triggered it on its own schedule, set `overrideAccess: true` explicitly.
 
-When you are unsure, `false` is the safer choice: the operation returns less than you expected rather than more.
+When you are unsure, leave the default in place: the operation returns less than you expected rather than more.

--- a/docs/local-api/outside-nextjs.mdx
+++ b/docs/local-api/outside-nextjs.mdx
@@ -30,6 +30,7 @@ const seed = async () => {
 
   const user = await payload.create({
     collection: 'users',
+    overrideAccess: true,
     data: {
       email: 'dev@payloadcms.com',
       password: 'some-password',
@@ -38,6 +39,7 @@ const seed = async () => {
 
   const page = await payload.create({
     collection: 'pages',
+    overrideAccess: true,
     data: {
       title: 'My Homepage',
       // other data to seed here

--- a/docs/local-api/overview.mdx
+++ b/docs/local-api/overview.mdx
@@ -73,7 +73,7 @@ You can specify more options within the Local API vs. REST or GraphQL due to the
 | `select`             | Specify [select](../queries/select) to control which fields to include to the result.                                                                                                                                                                                                                                                                                 |
 | `populate`           | Specify [populate](../queries/select#populate) to control which fields to include to the result from populated documents.                                                                                                                                                                                                                                             |
 | `fallbackLocale`     | Specify a [fallback locale](/docs/configuration/localization) to use for any returned documents. This can be a single locale or array of locales.                                                                                                                                                                                                                     |
-| `overrideAccess`     | **Required.** Set to `false` to respect [Access Control](./access-control), or `true` to skip it.                                                                                                                                                                                                                                                                     |
+| `overrideAccess`     | Skip [Access Control](./access-control). Set to `true` to bypass it for trusted server-side work; defaults to `false`, which respects it.                                                                                                                                                                                                                             |
 | `overrideLock`       | By default, document locks are ignored (`true`). Set to `false` to enforce locks and prevent operations when a document is locked by another user. [More details](../admin/locked-documents).                                                                                                                                                                         |
 | `user`               | The user to run access control checks against. Pass this whenever `overrideAccess` is `false`.                                                                                                                                                                                                                                                                        |
 | `showHiddenFields`   | Opt-in to receiving hidden fields. By default, they are hidden from returned documents in accordance to your config.                                                                                                                                                                                                                                                  |
@@ -99,8 +99,8 @@ const post = await payload.find({
 <Banner type="warning">
   **Note:**
 
-Every Local API operation requires an `overrideAccess` value. Pass `false` to respect Access
-Control, along with the `user` to check against, or `true` to skip it. See [Access
+By default, Local API operations respect Access Control. Pass `overrideAccess: true` to skip
+it, for trusted server-side work such as cron jobs, seeding, and migrations. See [Access
 Control](./access-control).
 
 </Banner>

--- a/docs/local-api/overview.mdx
+++ b/docs/local-api/overview.mdx
@@ -38,6 +38,7 @@ const afterChangeHook: CollectionAfterChangeHook = async ({
 }) => {
   const posts = await payload.find({
     collection: 'posts',
+    overrideAccess: true,
   })
 }
 ```
@@ -72,9 +73,9 @@ You can specify more options within the Local API vs. REST or GraphQL due to the
 | `select`             | Specify [select](../queries/select) to control which fields to include to the result.                                                                                                                                                                                                                                                                                 |
 | `populate`           | Specify [populate](../queries/select#populate) to control which fields to include to the result from populated documents.                                                                                                                                                                                                                                             |
 | `fallbackLocale`     | Specify a [fallback locale](/docs/configuration/localization) to use for any returned documents. This can be a single locale or array of locales.                                                                                                                                                                                                                     |
-| `overrideAccess`     | Skip access control. By default, this property is set to true within all Local API operations.                                                                                                                                                                                                                                                                        |
+| `overrideAccess`     | **Required.** Set to `false` to respect [Access Control](./access-control), or `true` to skip it.                                                                                                                                                                                                                                                                     |
 | `overrideLock`       | By default, document locks are ignored (`true`). Set to `false` to enforce locks and prevent operations when a document is locked by another user. [More details](../admin/locked-documents).                                                                                                                                                                         |
-| `user`               | If you set `overrideAccess` to `false`, you can pass a user to use against the access control checks.                                                                                                                                                                                                                                                                 |
+| `user`               | The user to run access control checks against. Pass this whenever `overrideAccess` is `false`.                                                                                                                                                                                                                                                                        |
 | `showHiddenFields`   | Opt-in to receiving hidden fields. By default, they are hidden from returned documents in accordance to your config.                                                                                                                                                                                                                                                  |
 | `pagination`         | Set to `false` to disable pagination calculations and document count queries. Payload still applies any positive `limit`.                                                                                                                                                                                                                                             |
 | `context`            | [Context](/docs/hooks/context), which will then be passed to `context` and `req.context`, which can be read by hooks. Useful if you want to pass additional information to the hooks which shouldn't be necessarily part of the document, for example a `triggerBeforeChange` option which can be read by the BeforeChange hook to determine if it should run or not. |
@@ -90,6 +91,7 @@ When your database uses transactions you need to thread req through to all local
 ```js
 const post = await payload.find({
   collection: 'posts',
+  overrideAccess: true,
   req, // passing req is recommended
 })
 ```
@@ -97,8 +99,9 @@ const post = await payload.find({
 <Banner type="warning">
   **Note:**
 
-By default, all access control checks are disabled in the Local API, but you can re-enable them if
-you'd like, as well as pass a specific user to run the operation with.
+Every Local API operation requires an `overrideAccess` value. Pass `false` to respect Access
+Control, along with the `user` to check against, or `true` to skip it. See [Access
+Control](./access-control).
 
 </Banner>
 
@@ -498,6 +501,7 @@ Here is an example of usage:
 // Properly inferred as `Post` type
 const post = await payload.create({
   collection: 'posts',
+  overrideAccess: true,
 
   // Data will now be typed as Post and give you type hints
   data: {

--- a/docs/local-api/server-functions.mdx
+++ b/docs/local-api/server-functions.mdx
@@ -54,6 +54,7 @@ export async function createPost(data) {
   try {
     const post = await payload.create({
       collection: 'posts',
+      overrideAccess: true,
       data,
     })
     return post
@@ -113,6 +114,7 @@ export async function updatePost(id, data) {
   try {
     const post = await payload.update({
       collection: 'posts',
+      overrideAccess: true,
       id, // the document id is required
       data,
     })
@@ -242,6 +244,7 @@ export async function createPostWithUpload(data, upload) {
 
     const post = await payload.create({
       collection: 'posts',
+      overrideAccess: true,
       data: postData,
     })
 
@@ -330,7 +333,11 @@ Example of good error handling:
 export async function createPost(data) {
   try {
     const payload = await getPayload({ config })
-    return await payload.create({ collection: 'posts', data })
+    return await payload.create({
+      collection: 'posts',
+      data,
+      overrideAccess: true,
+    })
   } catch (error) {
     console.error('Error creating post:', error)
     return { error: 'Failed to create post' }
@@ -359,6 +366,11 @@ export async function deletePost(postId, user) {
   }
 
   const payload = await getPayload({ config })
-  return await payload.delete({ collection: 'posts', id: postId })
+  return await payload.delete({
+    collection: 'posts',
+    id: postId,
+    overrideAccess: false,
+    user,
+  })
 }
 ```

--- a/docs/migration-guide/v4.mdx
+++ b/docs/migration-guide/v4.mdx
@@ -22,34 +22,27 @@ The codemod is idempotent and safe to run on a partially-migrated project.
 
 ## Breaking Changes
 
-### `overrideAccess` is now required on Local API operations
+### `overrideAccess` now defaults to `false` on Local API operations
 
-Local API operations previously defaulted `overrideAccess` to `true`, so omitting it skipped Access Control. The property is now required — every call states which mode it wants.
+Local API operations previously defaulted `overrideAccess` to `true`, so omitting it skipped Access Control. It now defaults to `false`, so an omitted value respects Access Control instead.
 
 ```diff
 const posts = await payload.find({
   collection: 'posts',
-+ overrideAccess: false,
-  user,
++ overrideAccess: true, // preserves the Payload 3 default
 })
 ```
 
-- `overrideAccess: false` — respect Access Control. Use this whenever the operation acts on behalf of a user, and pass `user` alongside it.
+- `overrideAccess: false` (the new default) — respect Access Control. Use this whenever the operation acts on behalf of a user, and pass `user` alongside it.
 - `overrideAccess: true` — bypass Access Control. Use this for trusted server-side work such as cron jobs, seeding, and migrations.
 
-It is required because omitting it used to skip Access Control. That made "no Access Control" the result of not deciding, which is the wrong default for a security control.
-
-**TypeScript projects** get a compile error naming every call site. The codemod inserts `overrideAccess: true`, which preserves the Payload 3 behavior:
+The property stays optional, and there is no compile error for either TypeScript or JavaScript projects — a call that omitted `overrideAccess` before still compiles after upgrading, it just behaves differently: it now enforces Access Control instead of skipping it. Run the codemod to find every affected call site and restore the previous behavior explicitly:
 
 ```bash
 npx @payloadcms/codemod
 ```
 
-Review the results afterwards and change every call that acts on behalf of a user to `overrideAccess: false`.
-
-**JavaScript projects**, and any call reaching the Local API through `as any` or a loosely typed options object, get no compile error. Those calls now behave as `overrideAccess: false` and respect Access Control. Payload logs a warning once per operation naming the call. Run the codemod on these projects too.
-
-There is no runtime error for a missing value. It resolves to `false`, which is the strict outcome, so an un-migrated project returns too little rather than exposing too much.
+Review the results afterwards. Leave the property off, or set it to `overrideAccess: false`, wherever the operation acts on behalf of a user — that is the more secure outcome and is now the default.
 
 #### Cases the codemod leaves behind
 

--- a/docs/migration-guide/v4.mdx
+++ b/docs/migration-guide/v4.mdx
@@ -22,6 +22,47 @@ The codemod is idempotent and safe to run on a partially-migrated project.
 
 ## Breaking Changes
 
+### `overrideAccess` is now required on Local API operations
+
+Local API operations previously defaulted `overrideAccess` to `true`, so omitting it skipped Access Control. The property is now required — every call states which mode it wants.
+
+```diff
+const posts = await payload.find({
+  collection: 'posts',
++ overrideAccess: false,
+  user,
+})
+```
+
+- `overrideAccess: false` — respect Access Control. Use this whenever the operation acts on behalf of a user, and pass `user` alongside it.
+- `overrideAccess: true` — bypass Access Control. Use this for trusted server-side work such as cron jobs, seeding, and migrations.
+
+It is required because omitting it used to skip Access Control. That made "no Access Control" the result of not deciding, which is the wrong default for a security control.
+
+**TypeScript projects** get a compile error naming every call site. The codemod inserts `overrideAccess: true`, which preserves the Payload 3 behavior:
+
+```bash
+npx @payloadcms/codemod
+```
+
+Review the results afterwards and change every call that acts on behalf of a user to `overrideAccess: false`.
+
+**JavaScript projects**, and any call reaching the Local API through `as any` or a loosely typed options object, get no compile error. Those calls now behave as `overrideAccess: false` and respect Access Control. Payload logs a warning once per operation naming the call. Run the codemod on these projects too.
+
+There is no runtime error for a missing value. It resolves to `false`, which is the strict outcome, so an un-migrated project returns too little rather than exposing too much.
+
+#### Cases the codemod leaves behind
+
+Run a typecheck after the codemod. Three patterns it cannot resolve:
+
+- **Spread arguments** — `payload.find({ ...args })`. The codemod cannot tell whether `args` already supplies the property.
+- **Aliased receivers** — `const db = payload; db.find({ ... })`. It matches `payload` and `.payload` only.
+- **Casts** — anything reaching the operation through `as any`.
+
+#### The jobs queue is unchanged
+
+`payload.jobs.queue`, `run`, `runByID`, `cancel`, and `cancelByID` keep their Payload 3 behavior. `overrideAccess` stays optional on those methods and still defaults to `true`. Migrating your collection, global, and auth calls does not cover your jobs calls.
+
 ### Collection and Global Access Control callbacks receive `slug`
 
 Collection and Global Access Control callback arguments now include the document's `slug`. This additive property is unlikely to affect most projects, but code that manually invokes access callbacks or `executeAccess` must now pass `slug`. Code that validates, enumerates, or compares the exact callback argument shape may also need updating.
@@ -150,6 +191,7 @@ If your application relies on two populated levels, prefer specifying `depth: 2`
 ```ts
 const posts = await payload.find({
   collection: 'posts',
+  overrideAccess: true,
   depth: 2,
 })
 ```

--- a/docs/plugins/build-your-own.mdx
+++ b/docs/plugins/build-your-own.mdx
@@ -118,6 +118,7 @@ describe('Plugin tests', () => {
   it('seeds data accordingly', async () => {
     const newCollectionQuery = await payload.find({
       collection: 'newCollection',
+      overrideAccess: true,
       sort: 'createdAt',
     })
 
@@ -148,6 +149,7 @@ export const seed = async (payload: Payload): Promise<void> => {
 
   await payload.create({
     collection: 'new-collection',
+    overrideAccess: true,
     data: {
       title: 'Seeded title',
     },

--- a/docs/plugins/import-export.mdx
+++ b/docs/plugins/import-export.mdx
@@ -735,7 +735,7 @@ There are four possible ways that the plugin allows for exporting documents, the
 
 1. Direct download - Using a `POST` to `/api/exports/download` and streams the response as a file download
 2. File storage - Goes to the `exports` collection as an uploads enabled collection
-3. Local API - A create call to the exports collection: `payload.create({ collection: 'exports', data: { collectionSlug: 'pages', format: 'json' } })`
+3. Local API - A create call to the exports collection: `payload.create({ collection: 'exports', data: { collectionSlug: 'pages', format: 'json' }, overrideAccess: true })`
 4. Jobs Queue - `payload.jobs.queue({ task: 'createCollectionExport', input: parameters })`
 
 In the Export drawer you can choose:
@@ -787,7 +787,7 @@ The plugin allows importing data from CSV or JSON files. There are several ways 
 
 1. **Admin UI** - Use the Import drawer from the list view of a collection
 2. **File storage** - Create an import document in the `imports` collection with an uploaded file
-3. **Local API** - Create an import document: `payload.create({ collection: 'imports', data: { collectionSlug: 'pages', importMode: 'create' }, file: { ... } })`
+3. **Local API** - Create an import document: `payload.create({ collection: 'imports', data: { collectionSlug: 'pages', importMode: 'create' }, file: { ... }, overrideAccess: true })`
 4. **Jobs Queue** - `payload.jobs.queue({ task: 'createCollectionImport', input: parameters })`
 
 ### Import Parameters
@@ -804,6 +804,7 @@ The `matchField` option allows you to match documents by a field other than `id`
 ```ts
 payload.create({
   collection: 'imports',
+  overrideAccess: true,
   data: {
     collectionSlug: 'users',
     importMode: 'upsert',

--- a/docs/plugins/mcp.mdx
+++ b/docs/plugins/mcp.mdx
@@ -621,6 +621,8 @@ mcpPlugin({
         const user = await req.payload.findByID({
           id: params.userId,
           collection: 'users',
+          overrideAccess: false,
+          req,
         })
         return {
           contents: [{ uri: uri.href, text: JSON.stringify(user) }],

--- a/docs/plugins/search.mdx
+++ b/docs/plugins/search.mdx
@@ -180,6 +180,7 @@ This function is called once per locale per document and should return `true` to
       // Only index locales that are enabled for this document's tenant
       const tenant = await req.payload.findByID({
         collection: 'tenants',
+        overrideAccess: true,
         id: doc.tenant.id,
       })
 

--- a/docs/queries/depth.mdx
+++ b/docs/queries/depth.mdx
@@ -48,6 +48,7 @@ import type { Payload } from 'payload'
 const getPosts = async (payload: Payload) => {
   const posts = await payload.find({
     collection: 'posts',
+    overrideAccess: true,
     // highlight-start
     depth: 2,
     // highlight-end

--- a/docs/queries/overview.mdx
+++ b/docs/queries/overview.mdx
@@ -218,6 +218,7 @@ import type { Payload } from 'payload'
 const getPosts = async (payload: Payload) => {
   const posts = await payload.find({
     collection: 'posts',
+    overrideAccess: true,
     where: {
       color: {
         equals: 'mint',
@@ -328,6 +329,7 @@ Relationships will only populate down to the specified depth, and any relationsh
 ```ts
 const posts = await payload.find({
   collection: 'posts',
+  overrideAccess: true,
   where: { ... },
   // highlight-start
   depth: 0, // Only return the IDs of related documents
@@ -344,6 +346,7 @@ Set the [Limit](./pagination#limit) if you can reliably predict the number of ma
 ```ts
 const posts = await payload.find({
   collection: 'posts',
+  overrideAccess: true,
   where: {
     slug: {
       equals: 'unique-post-slug',
@@ -390,6 +393,7 @@ To learn more, see the [Select documentation](./select).
 ```ts
 const posts = await payload.find({
   collection: 'posts',
+  overrideAccess: true,
   where: {
     slug: {
       equals: 'unique-post-slug',

--- a/docs/queries/pagination.mdx
+++ b/docs/queries/pagination.mdx
@@ -34,6 +34,7 @@ import type { Payload } from 'payload'
 const getPosts = async (payload: Payload) => {
   const posts = await payload.find({
     collection: 'posts',
+    overrideAccess: true,
     // highlight-start
     limit: 10,
     page: 2,
@@ -123,6 +124,7 @@ To do this, set the `limit` option in your query:
 ```ts
 await payload.find({
   collection: 'posts',
+  overrideAccess: true,
   where: {
     slug: {
       equals: 'post-1',
@@ -150,6 +152,7 @@ import type { Payload } from 'payload'
 const getPost = async (payload: Payload) => {
   const posts = await payload.find({
     collection: 'posts',
+    overrideAccess: true,
     where: {
       title: { equals: 'My Post' },
     },

--- a/docs/queries/select.mdx
+++ b/docs/queries/select.mdx
@@ -21,6 +21,7 @@ import type { Payload } from 'payload'
 const getPosts = async (payload: Payload) => {
   const posts = await payload.find({
     collection: 'posts',
+    overrideAccess: true,
     // highlight-start
     select: {
       text: true,
@@ -41,6 +42,7 @@ const getPosts = async (payload: Payload) => {
 const getPosts = async (payload: Payload) => {
   const posts = await payload.find({
     collection: 'posts',
+    overrideAccess: true,
     // Select everything except for array and group.number
     // highlight-start
     select: {
@@ -63,6 +65,7 @@ The `id` field is always included in the result, regardless of your `select` que
 ```ts
 const post = await payload.findByID({
   collection: 'posts',
+  overrideAccess: true,
   id: '1',
   select: {},
 })
@@ -261,6 +264,7 @@ import type { Payload } from 'payload'
 const getPosts = async (payload: Payload) => {
   const posts = await payload.find({
     collection: 'posts',
+    overrideAccess: true,
     populate: {
       // Select only `text` from populated docs in the "pages" collection
       // Now, no matter what the `defaultPopulate` is set to on the "pages" collection,

--- a/docs/queries/sort.mdx
+++ b/docs/queries/sort.mdx
@@ -27,6 +27,7 @@ import type { Payload } from 'payload'
 const getPosts = async (payload: Payload) => {
   const posts = await payload.find({
     collection: 'posts',
+    overrideAccess: true,
     sort: '-createdAt', // highlight-line
   })
 
@@ -42,6 +43,7 @@ import type { Payload } from 'payload'
 const getPosts = async (payload: Payload) => {
   const posts = await payload.find({
     collection: 'posts',
+    overrideAccess: true,
     sort: ['priority', '-createdAt'], // highlight-line
   })
 

--- a/docs/rest-api/overview.mdx
+++ b/docs/rest-api/overview.mdx
@@ -631,6 +631,8 @@ export const Orders: CollectionConfig = {
         const data = await req.json()
         await req.payload.update({
           collection: 'tracking',
+          overrideAccess: false,
+          req,
           data: {
             // data to update the document with
           },
@@ -687,6 +689,7 @@ import { addDataAndFileToRequest } from 'payload'
     await addDataAndFileToRequest(req)
     await req.payload.update({
       collection: 'tracking',
+      overrideAccess: true,
       data: {
         // data to update the document with
       }

--- a/docs/rich-text/converting-html.mdx
+++ b/docs/rich-text/converting-html.mdx
@@ -268,7 +268,8 @@ const payload = await getPayload({ config })
 
 // Step 1: Upload the image to Payload
 const uploadedMedia = await payload.create({
-  collection: 'media', // Your upload collection slug
+  collection: 'media',
+  overrideAccess: true, // Your upload collection slug
   data: {
     alt: 'My image description',
   },
@@ -337,6 +338,7 @@ async function convertHTMLWithImageUpload(htmlString: string) {
       // Upload to Payload
       const uploadedMedia = await payload.create({
         collection: 'media',
+        overrideAccess: true,
         data: {
           alt: img.getAttribute('alt') || '',
         },
@@ -402,6 +404,7 @@ const lexicalJSON = buildEditorState({
 // Save to your collection
 await payload.create({
   collection: 'pages',
+  overrideAccess: true,
   data: {
     title: 'My Page',
     content: lexicalJSON,

--- a/docs/trash/overview.mdx
+++ b/docs/trash/overview.mdx
@@ -85,6 +85,7 @@ Return all documents including trashed:
 ```ts
 const result = await payload.find({
   collection: 'posts',
+  overrideAccess: true,
   trash: true,
 })
 ```
@@ -94,6 +95,7 @@ Return only trashed documents:
 ```ts
 const result = await payload.find({
   collection: 'posts',
+  overrideAccess: true,
   trash: true,
   where: {
     deletedAt: {
@@ -108,6 +110,7 @@ Return only non-trashed documents:
 ```ts
 const result = await payload.find({
   collection: 'posts',
+  overrideAccess: true,
   trash: false,
 })
 ```

--- a/docs/upload/overview.mdx
+++ b/docs/upload/overview.mdx
@@ -774,6 +774,7 @@ const localFilePath = path.resolve(__dirname, filename)
 
 await payload.create({
   collection: 'media',
+  overrideAccess: true,
   data: {
     alt,
   },

--- a/docs/versions/drafts.mdx
+++ b/docs/versions/drafts.mdx
@@ -60,6 +60,7 @@ POST /api/your-collection?draft=true
 // Local API
 await payload.create({
   collection: 'your-collection',
+  overrideAccess: true,
   data: {
     // your data here
   },

--- a/packages/payload/skills/payload/SKILL.md
+++ b/packages/payload/skills/payload/SKILL.md
@@ -230,6 +230,7 @@ export const ownPostsOnly: Access = ({ req }) => {
 // Local API
 const posts = await payload.find({
   collection: 'posts',
+  overrideAccess: true,
   where: {
     status: { equals: 'published' },
     'author.name': { contains: 'john' },
@@ -242,6 +243,7 @@ const posts = await payload.find({
 // Query with populated relationships
 const post = await payload.findByID({
   collection: 'posts',
+  overrideAccess: true,
   id: '123',
   depth: 2, // Populates relationships (default is 2)
 })
@@ -250,6 +252,7 @@ const post = await payload.findByID({
 // Without depth, relationships return IDs only
 const post = await payload.findByID({
   collection: 'posts',
+  overrideAccess: true,
   id: '123',
   depth: 0,
 })
@@ -265,23 +268,32 @@ For all query operators and REST/GraphQL examples, see [QUERIES.md](reference/QU
 import { getPayload } from 'payload'
 import config from '@payload-config'
 
-export async function GET() {
+export async function GET(request: Request) {
   const payload = await getPayload({ config })
+  const { user } = await payload.auth({ headers: request.headers })
 
   const posts = await payload.find({
     collection: 'posts',
+    overrideAccess: false, // this route answers for whoever called it
+    user,
   })
 
   return Response.json(posts)
 }
 
 // In Server Components
+import { headers } from 'next/headers'
 import { getPayload } from 'payload'
 import config from '@payload-config'
 
 export default async function Page() {
   const payload = await getPayload({ config })
-  const { docs } = await payload.find({ collection: 'posts' })
+  const { user } = await payload.auth({ headers: await headers() })
+  const { docs } = await payload.find({
+    collection: 'posts',
+    overrideAccess: false,
+    user,
+  })
 
   return <div>{docs.map(post => <h1 key={post.id}>{post.title}</h1>)}</div>
 }
@@ -291,27 +303,30 @@ export default async function Page() {
 
 ### 1. Local API Access Control (CRITICAL)
 
-**By default, Local API operations bypass ALL access control**, even when passing a user.
+**`overrideAccess: true` bypasses ALL access control**, even when a user is passed.
 
 ```ts
 // ❌ SECURITY BUG: Passes user but ignores their permissions
 await payload.find({
   collection: 'posts',
-  user: someUser, // Access control is BYPASSED!
+  user: someUser,
+  overrideAccess: true, // Access control is BYPASSED!
 })
 
 // ✅ SECURE: Actually enforces the user's permissions
 await payload.find({
   collection: 'posts',
   user: someUser,
-  overrideAccess: false, // REQUIRED for access control
+  overrideAccess: false, // respect Access Control — this call acts for a user
 })
 ```
 
-**When to use each:**
+`overrideAccess` is **required**. There is no default — every call states its intent.
 
-- `overrideAccess: true` (default) - Server-side operations you trust (cron jobs, system tasks)
-- `overrideAccess: false` - When operating on behalf of a user (API routes, webhooks)
+- `overrideAccess: false` - operating on behalf of a user (API routes, webhooks, server functions). Pass `user` alongside it.
+- `overrideAccess: true` - server-side work you trust (cron jobs, seeds, migrations, system tasks)
+
+It is required because omitting it used to skip access control, which made "no access control" the result of not deciding. Never copy a value from a nearby call — pick the one this call means.
 
 See [QUERIES.md#access-control-in-local-api](reference/QUERIES.md#access-control-in-local-api).
 
@@ -326,6 +341,7 @@ hooks: {
     async ({ doc, req }) => {
       await req.payload.create({
         collection: 'audit-log',
+        overrideAccess: true,
         data: { docId: doc.id },
         // Missing req - runs in separate transaction!
       })
@@ -339,6 +355,7 @@ hooks: {
     async ({ doc, req }) => {
       await req.payload.create({
         collection: 'audit-log',
+        overrideAccess: true,
         data: { docId: doc.id },
         req, // Maintains atomicity
       })
@@ -360,6 +377,7 @@ hooks: {
     async ({ doc, req }) => {
       await req.payload.update({
         collection: 'posts',
+        overrideAccess: true,
         id: doc.id,
         data: { views: doc.views + 1 },
         req,
@@ -376,6 +394,7 @@ hooks: {
 
       await req.payload.update({
         collection: 'posts',
+        overrideAccess: true,
         id: doc.id,
         data: { views: doc.views + 1 },
         context: { skipHooks: true },
@@ -439,7 +458,7 @@ import type { Post, User } from '@/payload-types'
 
 ## Common Gotchas
 
-1. **Local API bypasses access control** unless you pass `overrideAccess: false`
+1. **`overrideAccess` is required on every Local API call** — there is no default to fall back on
 2. **Missing `req` in nested operations** breaks transaction atomicity
 3. **Hook loops** — operations in hooks can re-trigger the same hooks; use `req.context` flags
 4. **Field-level access** returns boolean only, no query constraints
@@ -466,7 +485,7 @@ import type { Post, User } from '@/payload-types'
 ### Security
 
 - Default to restrictive access, gradually add permissions
-- Use `overrideAccess: false` when passing `user` to Local API
+- Use `overrideAccess: false` whenever the call acts for a user, and pass that `user`
 - Field-level access only returns boolean (no query constraints)
 - Never trust client-provided data
 - Use `saveToJWT: true` for roles to avoid database lookups

--- a/packages/payload/skills/payload/SKILL.md
+++ b/packages/payload/skills/payload/SKILL.md
@@ -306,27 +306,26 @@ export default async function Page() {
 **`overrideAccess: true` bypasses ALL access control**, even when a user is passed.
 
 ```ts
-// ❌ SECURITY BUG: Passes user but ignores their permissions
+// ❌ SECURITY BUG: Passes user but bypasses their permissions anyway
 await payload.find({
   collection: 'posts',
   user: someUser,
   overrideAccess: true, // Access control is BYPASSED!
 })
 
-// ✅ SECURE: Actually enforces the user's permissions
+// ✅ SECURE: Respects the user's permissions — this is the default, overrideAccess can be omitted
 await payload.find({
   collection: 'posts',
   user: someUser,
-  overrideAccess: false, // respect Access Control — this call acts for a user
 })
 ```
 
-`overrideAccess` is **required**. There is no default — every call states its intent.
+`overrideAccess` defaults to `false` — Local API operations respect Access Control unless told otherwise.
 
-- `overrideAccess: false` - operating on behalf of a user (API routes, webhooks, server functions). Pass `user` alongside it.
+- Omit it, or set `overrideAccess: false` - operating on behalf of a user (API routes, webhooks, server functions). Pass `user` alongside it.
 - `overrideAccess: true` - server-side work you trust (cron jobs, seeds, migrations, system tasks)
 
-It is required because omitting it used to skip access control, which made "no access control" the result of not deciding. Never copy a value from a nearby call — pick the one this call means.
+Never set `overrideAccess: true` out of habit or by copying a nearby call — pick the value this call means.
 
 See [QUERIES.md#access-control-in-local-api](reference/QUERIES.md#access-control-in-local-api).
 
@@ -458,7 +457,7 @@ import type { Post, User } from '@/payload-types'
 
 ## Common Gotchas
 
-1. **`overrideAccess` is required on every Local API call** — there is no default to fall back on
+1. **Local API respects access control by default** — set `overrideAccess: true` only for trusted server-side work
 2. **Missing `req` in nested operations** breaks transaction atomicity
 3. **Hook loops** — operations in hooks can re-trigger the same hooks; use `req.context` flags
 4. **Field-level access** returns boolean only, no query constraints

--- a/packages/payload/skills/payload/reference/ACCESS-CONTROL-ADVANCED.md
+++ b/packages/payload/skills/payload/reference/ACCESS-CONTROL-ADVANCED.md
@@ -189,6 +189,7 @@ export const activeSubscriptionAccess: Access = async ({ req: { user } }) => {
   try {
     const subscription = await req.payload.findByID({
       collection: 'subscriptions',
+      overrideAccess: true,
       id: user.subscriptionId,
     })
 
@@ -223,6 +224,7 @@ export const tierBasedAccess = (requiredTier: string): Access => {
     try {
       const subscription = await req.payload.findByID({
         collection: 'subscriptions',
+        overrideAccess: true,
         id: user.subscriptionId,
       })
 
@@ -575,9 +577,21 @@ console.log('Public access result:', testAccess.docs.length)
 ```ts
 // ❌ Slow: Multiple sequential async calls
 export const slowAccess: Access = async ({ req: { user } }) => {
-  const org = await req.payload.findByID({ collection: 'orgs', id: user.orgId })
-  const team = await req.payload.findByID({ collection: 'teams', id: user.teamId })
-  const subscription = await req.payload.findByID({ collection: 'subs', id: user.subId })
+  const org = await req.payload.findByID({
+    collection: 'orgs',
+    id: user.orgId,
+    overrideAccess: true,
+  })
+  const team = await req.payload.findByID({
+    collection: 'teams',
+    id: user.teamId,
+    overrideAccess: true,
+  })
+  const subscription = await req.payload.findByID({
+    collection: 'subs',
+    id: user.subId,
+    overrideAccess: true,
+  })
 
   return org.active && team.active && subscription.active
 }
@@ -658,7 +672,7 @@ const optimizedArrayField: ArrayField = {
 // ❌ N+1 Problem: Query per access check
 export const n1Access: Access = async ({ req, id }) => {
   // Runs for EACH document in list
-  const doc = await req.payload.findByID({ collection: 'docs', id })
+  const doc = await req.payload.findByID({ collection: 'docs', id, overrideAccess: true })
   return doc.isPublic
 }
 
@@ -696,7 +710,7 @@ Comprehensive security and implementation guidelines:
 12. **Rate Limit External Calls**: Protect against DoS on external validation services
 13. **Handle Errors Gracefully**: Access functions should return `false` on error, not throw
 14. **Use Environment Vars**: Store configuration (IPs, API keys) in env vars
-15. **Test Local API**: Remember to set `overrideAccess: false` when testing
+15. **Test Local API**: Set `overrideAccess: false` when testing access control
 16. **Consider Performance**: Measure impact of async operations on login time
 17. **Version Control**: Track access control changes in git history
 18. **Principle of Least Privilege**: Grant minimum access required for functionality

--- a/packages/payload/skills/payload/reference/ACCESS-CONTROL.md
+++ b/packages/payload/skills/payload/reference/ACCESS-CONTROL.md
@@ -73,6 +73,7 @@ export const Posts: CollectionConfig = {
     delete: async ({ req, id }) => {
       const hasComments = await req.payload.count({
         collection: 'comments',
+        overrideAccess: true,
         where: { post: { equals: id } },
       })
       return hasComments === 0
@@ -543,6 +544,7 @@ export const projectMemberAccess: Access = async ({ req, id }) => {
   // Check if document exists and user is member
   const project = await payload.findByID({
     collection: 'projects',
+    overrideAccess: true,
     id: id as string,
     depth: 0,
   })
@@ -556,6 +558,7 @@ export const preventDeleteWithDependencies: Access = async ({ req, id }) => {
 
   const dependencyCount = await payload.count({
     collection: 'related-items',
+    overrideAccess: true,
     where: {
       parent: { equals: id },
     },
@@ -651,12 +654,13 @@ access: {
 
 ## Important Notes
 
-1. **Local API Default**: Access control is **skipped by default** in Local API (`overrideAccess: true`). When passing a `user` parameter, you almost always want to set `overrideAccess: false` to respect that user's permissions:
+1. **Local API `overrideAccess`**: The property is **required** on every Local API operation and has no default. When passing a `user`, you almost always want `overrideAccess: false` so that user's permissions apply:
 
    ```ts
-   // ❌ WRONG: Passes user but bypasses access control (default behavior)
+   // ❌ WRONG: Passes user but bypasses access control
    await payload.find({
      collection: 'posts',
+     overrideAccess: true,
      user: someUser, // User is ignored for access control!
    })
 
@@ -664,11 +668,11 @@ access: {
    await payload.find({
      collection: 'posts',
      user: someUser,
-     overrideAccess: false, // Required to enforce access control
+     overrideAccess: false, // enforce access control
    })
    ```
 
-   **Why this matters**: If you pass `user` without `overrideAccess: false`, the operation runs with admin privileges regardless of the user's actual permissions. This is a common security mistake.
+   **Why this matters**: `overrideAccess: true` alongside a `user` runs with admin privileges regardless of that user's actual permissions. This is a common security mistake.
 
 2. **Field Access Limitations**: Field-level access does NOT support query constraints - only boolean returns.
 

--- a/packages/payload/skills/payload/reference/ACCESS-CONTROL.md
+++ b/packages/payload/skills/payload/reference/ACCESS-CONTROL.md
@@ -654,7 +654,7 @@ access: {
 
 ## Important Notes
 
-1. **Local API `overrideAccess`**: The property is **required** on every Local API operation and has no default. When passing a `user`, you almost always want `overrideAccess: false` so that user's permissions apply:
+1. **Local API `overrideAccess`**: Defaults to `false` — Local API operations respect access control unless told otherwise. When passing a `user`, leave it at the default (or set `overrideAccess: false` explicitly) so that user's permissions apply:
 
    ```ts
    // ❌ WRONG: Passes user but bypasses access control

--- a/packages/payload/skills/payload/reference/ADAPTERS.md
+++ b/packages/payload/skills/payload/reference/ADAPTERS.md
@@ -59,6 +59,7 @@ const afterChange: CollectionAfterChangeHook = async ({ req, doc }) => {
   await req.payload.create({
     req, // Pass req to use same transaction
     collection: 'audit-log',
+    overrideAccess: true,
     data: { action: 'created', docId: doc.id },
   })
 }
@@ -68,11 +69,13 @@ const transactionID = await payload.db.beginTransaction()
 try {
   await payload.create({
     collection: 'orders',
+    overrideAccess: true,
     data: orderData,
     req: { transactionID },
   })
   await payload.update({
     collection: 'inventory',
+    overrideAccess: true,
     id: itemId,
     data: { stock: newStock },
     req: { transactionID },
@@ -98,6 +101,7 @@ const resaveChildren: CollectionAfterChangeHook = async ({ collection, doc, req 
   // Find children - pass req
   const children = await req.payload.find({
     collection: 'children',
+    overrideAccess: true,
     where: { parent: { equals: doc.id } },
     req, // Maintains transaction context
   })
@@ -107,6 +111,7 @@ const resaveChildren: CollectionAfterChangeHook = async ({ collection, doc, req 
     await req.payload.update({
       id: child.id,
       collection: 'children',
+      overrideAccess: true,
       data: { updatedField: 'value' },
       req, // Same transaction as parent operation
     })
@@ -117,6 +122,7 @@ const resaveChildren: CollectionAfterChangeHook = async ({ collection, doc, req 
 const brokenHook: CollectionAfterChangeHook = async ({ collection, doc, req }) => {
   const children = await req.payload.find({
     collection: 'children',
+    overrideAccess: true,
     where: { parent: { equals: doc.id } },
     // Missing req - separate transaction or no transaction
   })
@@ -125,6 +131,7 @@ const brokenHook: CollectionAfterChangeHook = async ({ collection, doc, req }) =
     await req.payload.update({
       id: child.id,
       collection: 'children',
+      overrideAccess: true,
       data: { updatedField: 'value' },
       // Missing req - if parent operation fails, these updates persist
     })

--- a/packages/payload/skills/payload/reference/ADVANCED.md
+++ b/packages/payload/skills/payload/reference/ADVANCED.md
@@ -20,6 +20,7 @@ const response = await fetch('/api/users/login', {
 // Local API
 const result = await payload.login({
   collection: 'users',
+  overrideAccess: false,
   data: {
     email: 'user@example.com',
     password: 'password',
@@ -200,6 +201,7 @@ const featuredEndpoint: Endpoint = {
   handler: async (req) => {
     const posts = await req.payload.find({
       collection: 'posts',
+      overrideAccess: true,
       where: { featured: { equals: true } },
     })
     return Response.json(posts)
@@ -361,6 +363,7 @@ const localizedField: TextField = {
 // Query with locale
 const posts = await payload.find({
   collection: 'posts',
+  overrideAccess: true,
   locale: 'es',
 })
 ```

--- a/packages/payload/skills/payload/reference/COLLECTIONS.md
+++ b/packages/payload/skills/payload/reference/COLLECTIONS.md
@@ -246,6 +246,7 @@ export const Pages: CollectionConfig = {
 // Create draft
 await payload.create({
   collection: 'posts',
+  overrideAccess: true,
   data: { title: 'Draft Post' },
   draft: true, // Saves as draft, skips required field validation
 })
@@ -253,6 +254,7 @@ await payload.create({
 // Update as draft
 await payload.update({
   collection: 'posts',
+  overrideAccess: true,
   id: '123',
   data: { title: 'Updated Draft' },
   draft: true,
@@ -261,6 +263,7 @@ await payload.update({
 // Read with drafts (returns newest draft if available)
 const post = await payload.findByID({
   collection: 'posts',
+  overrideAccess: true,
   id: '123',
   draft: true, // Returns draft version if exists
 })

--- a/packages/payload/skills/payload/reference/ENDPOINTS.md
+++ b/packages/payload/skills/payload/reference/ENDPOINTS.md
@@ -68,6 +68,8 @@ export const getRelatedPosts = {
     // Find related posts
     const posts = await req.payload.find({
       collection: 'posts',
+      overrideAccess: false,
+      req,
       where: {
         category: {
           equals: id,
@@ -117,6 +119,8 @@ export const createEndpoint = {
 
     const result = await req.payload.create({
       collection: 'posts',
+      overrideAccess: false,
+      req,
       data,
     })
 
@@ -141,6 +145,8 @@ export const uploadEndpoint = {
 
     const result = await req.payload.create({
       collection: 'media',
+      overrideAccess: false,
+      req,
       data: req.data,
       file: req.file,
     })
@@ -211,6 +217,8 @@ export const searchEndpoint = {
 
     const results = await req.payload.find({
       collection: 'posts',
+      overrideAccess: false,
+      req,
       where: {
         title: {
           contains: query,
@@ -272,6 +280,8 @@ export const endpoint = {
 
     const result = await req.payload.find({
       collection: 'posts',
+      overrideAccess: false,
+      req,
       locale: req.locale,
     })
 
@@ -327,6 +337,8 @@ export const externalUsersLogin = {
     // Find user with tenant constraint
     const userQuery = await req.payload.find({
       collection: 'users',
+      overrideAccess: true,
+      req,
       where: {
         and: [
           { email: { equals: email } },
@@ -344,6 +356,8 @@ export const externalUsersLogin = {
     // Authenticate user
     const result = await req.payload.login({
       collection: 'users',
+      overrideAccess: false,
+      req,
       data: { email, password },
     })
 
@@ -426,6 +440,8 @@ export const previewEndpoint = {
     // Preview data
     const results = await req.payload.find({
       collection,
+      overrideAccess: false,
+      req,
       where,
       limit,
       depth: 0,

--- a/packages/payload/skills/payload/reference/FIELDS.md
+++ b/packages/payload/skills/payload/reference/FIELDS.md
@@ -319,6 +319,7 @@ const locationField: PointField = {
 // Query by distance (sorted by nearest first)
 const nearbyLocations = await payload.find({
   collection: 'stores',
+  overrideAccess: true,
   where: {
     location: {
       near: [10, 20], // [longitude, latitude]
@@ -339,6 +340,7 @@ const polygon: Point[] = [
 
 const withinArea = await payload.find({
   collection: 'stores',
+  overrideAccess: true,
   where: {
     location: {
       within: {
@@ -352,6 +354,7 @@ const withinArea = await payload.find({
 // Query intersecting area
 const intersecting = await payload.find({
   collection: 'stores',
+  overrideAccess: true,
   where: {
     location: {
       intersects: {

--- a/packages/payload/skills/payload/reference/PLUGIN-DEVELOPMENT.md
+++ b/packages/payload/skills/payload/reference/PLUGIN-DEVELOPMENT.md
@@ -246,12 +246,14 @@ const resaveChildrenHook: CollectionAfterChangeHook = async ({ doc, req, operati
     // Resave child documents
     const children = await req.payload.find({
       collection: 'pages',
+      overrideAccess: true,
       where: { parent: { equals: doc.id } },
     })
 
     for (const child of children.docs) {
       await req.payload.update({
         collection: 'pages',
+        overrideAccess: true,
         id: child.id,
         data: child,
       })
@@ -596,12 +598,14 @@ export const myPlugin =
       // Example: Seed data
       const { totalDocs } = await payload.count({
         collection: 'plugin-collection',
+        overrideAccess: true,
         where: { id: { equals: 'seeded-by-plugin' } },
       })
 
       if (totalDocs === 0) {
         await payload.create({
           collection: 'plugin-collection',
+          overrideAccess: true,
           data: { id: 'seeded-by-plugin' },
         })
       }
@@ -1361,6 +1365,7 @@ describe('Plugin integration tests', () => {
   test('should add field to collection', async () => {
     const post = await payload.create({
       collection: 'posts',
+      overrideAccess: true,
       data: {
         title: 'Test',
         addedByPlugin: 'plugin value',
@@ -1371,7 +1376,7 @@ describe('Plugin integration tests', () => {
 
   test('should create plugin collection', async () => {
     expect(payload.collections['plugin-collection']).toBeDefined()
-    const { docs } = await payload.find({ collection: 'plugin-collection' })
+    const { docs } = await payload.find({ collection: 'plugin-collection', overrideAccess: true })
     expect(docs.length).toBeGreaterThan(0)
   })
 

--- a/packages/payload/skills/payload/reference/QUERIES.md
+++ b/packages/payload/skills/payload/reference/QUERIES.md
@@ -65,6 +65,7 @@ const nestedQuery: Where = {
 // Find documents
 const posts = await payload.find({
   collection: 'posts',
+  overrideAccess: true,
   where: {
     status: { equals: 'published' },
     'author.name': { contains: 'john' },
@@ -83,6 +84,7 @@ const posts = await payload.find({
 // Find by ID
 const post = await payload.findByID({
   collection: 'posts',
+  overrideAccess: true,
   id: '123',
   depth: 2,
 })
@@ -90,6 +92,7 @@ const post = await payload.findByID({
 // Create
 const post = await payload.create({
   collection: 'posts',
+  overrideAccess: true,
   data: {
     title: 'New Post',
     status: 'draft',
@@ -99,6 +102,7 @@ const post = await payload.create({
 // Update
 await payload.update({
   collection: 'posts',
+  overrideAccess: true,
   id: '123',
   data: {
     status: 'published',
@@ -108,12 +112,14 @@ await payload.update({
 // Delete
 await payload.delete({
   collection: 'posts',
+  overrideAccess: true,
   id: '123',
 })
 
 // Count
 const count = await payload.count({
   collection: 'posts',
+  overrideAccess: true,
   where: {
     status: { equals: 'published' },
   },
@@ -129,6 +135,7 @@ When performing operations in hooks or nested operations, pass the `req` paramet
 const afterChange: CollectionAfterChangeHook = async ({ doc, req }) => {
   await req.payload.create({
     collection: 'audit-log',
+    overrideAccess: true,
     data: { action: 'created', docId: doc.id },
     req, // Maintains transaction atomicity
   })
@@ -138,6 +145,7 @@ const afterChange: CollectionAfterChangeHook = async ({ doc, req }) => {
 const afterChange: CollectionAfterChangeHook = async ({ doc, req }) => {
   await req.payload.create({
     collection: 'audit-log',
+    overrideAccess: true,
     data: { action: 'created', docId: doc.id },
     // Missing req - runs in separate transaction
   })
@@ -148,14 +156,14 @@ This is critical for MongoDB replica sets and Postgres. See [ADAPTERS.md#threadi
 
 ### Access Control in Local API
 
-**Important**: Local API bypasses access control by default (`overrideAccess: true`). When passing a `user` parameter, you must explicitly set `overrideAccess: false` to respect that user's permissions.
+**Important**: `overrideAccess` is required on every Local API operation. There is no default. Set it to `false` to respect a user's permissions, or `true` to bypass access control.
 
 ```ts
 // ❌ WRONG: User is passed but access control is bypassed
 const posts = await payload.find({
   collection: 'posts',
   user: currentUser,
-  // Missing: overrideAccess: false
+  overrideAccess: true,
   // Result: Operation runs with ADMIN privileges, ignoring user's permissions
 })
 
@@ -163,7 +171,7 @@ const posts = await payload.find({
 const posts = await payload.find({
   collection: 'posts',
   user: currentUser,
-  overrideAccess: false, // Required to enforce access control
+  overrideAccess: false, // enforce access control
   // Result: User only sees posts they have permission to read
 })
 
@@ -171,7 +179,7 @@ const posts = await payload.find({
 const allPosts = await payload.find({
   collection: 'posts',
   // No user parameter
-  // overrideAccess defaults to true
+  overrideAccess: true,
   // Result: Returns all posts regardless of access control
 })
 ```

--- a/packages/payload/skills/payload/reference/QUERIES.md
+++ b/packages/payload/skills/payload/reference/QUERIES.md
@@ -156,10 +156,10 @@ This is critical for MongoDB replica sets and Postgres. See [ADAPTERS.md#threadi
 
 ### Access Control in Local API
 
-**Important**: `overrideAccess` is required on every Local API operation. There is no default. Set it to `false` to respect a user's permissions, or `true` to bypass access control.
+**Important**: `overrideAccess` defaults to `false` — Local API respects access control unless told otherwise. Set it to `true` to bypass access control.
 
 ```ts
-// ❌ WRONG: User is passed but access control is bypassed
+// ❌ WRONG: User is passed but access control is bypassed anyway
 const posts = await payload.find({
   collection: 'posts',
   user: currentUser,


### PR DESCRIPTION
Documents the Local API default flip and updates code samples that assumed the old default.

Stacked on #17869. Review that one first.

## Migration guide

A new entry at the top of Breaking Changes in `docs/migration-guide/v4.mdx`. `overrideAccess` stays optional — there's no compile error for either TypeScript or JavaScript. A call that omitted it before still compiles, it just behaves differently: it now enforces Access Control instead of skipping it. Run the codemod to find every affected call site.

## `docs/local-api/access-control.mdx`

Rewritten rather than patched. The page opened with:

> In Payload, local API operations **override access control by default**.

Re-frames messaging around the new default (`false`, respects Access Control) and when to explicitly opt into `true`.

## Other prose

| File | Change |
| --- | --- |
| `local-api/overview.mdx` | Options table row and the warning banner |
| `jobs-queue/jobs.mdx` | States that the jobs queue is the exception that still defaults to `true` |

## Code samples

Samples throughout the docs and the skill omitted `overrideAccess` entirely, which used to bypass access control. Every one now states a value so the sample keeps demonstrating what it always demonstrated.

The rule applied: **`false` where a user, or a request carrying one, is in scope. `true` otherwise.** Most samples illustrate a feature with no caller involved, so they get `true` — trusted server-side work is still opt-in, it's just no longer free. The `false` cases are the ones that answer for somebody: custom endpoints, MCP handlers, the admin dashboard widget, `payload.login`, and a server function that already had a `user` in scope. Where a handler has a `req`, it is now passed too, since `overrideAccess: false` without one runs as anonymous.

## Payload skill

Beyond the lines that were factually wrong — a comment claiming `false` is "REQUIRED for access control", and prose describing the property as required with no default — two samples needed more than a value.

The API route and Server Component examples sat directly above a section titled **Local API Access Control (CRITICAL)** while demonstrating exactly the pattern that section warns about. Adding `overrideAccess: true` would have made the skill teach the vulnerability on one screen and warn about it on the next. Both now call `payload.auth` and pass the user:

```ts
export async function GET(request: Request) {
  const payload = await getPayload({ config })
  const { user } = await payload.auth({ headers: request.headers })

  const posts = await payload.find({
    collection: 'posts',
    overrideAccess: false, // this route answers for whoever called it
    user,
  })

  return Response.json(posts)
}
```