### PR TITLE
feat: stubs out cohort telemetry

### DIFF
--- a/packages/payload/src/utilities/telemetry/getProjectContext.ts
+++ b/packages/payload/src/utilities/telemetry/getProjectContext.ts
@@ -1,0 +1,64 @@
+import type { Payload } from '../../types/index.js'
+
+export type FigmaProduct = 'make'
+
+export type ProjectCohort = 'cloud' | 'enterprise' | 'figma' | 'oss'
+
+type Args = {
+  env?: NodeJS.ProcessEnv
+  packages?: string[]
+  payload: Payload
+  plugins: string[]
+}
+
+export const enterprisePackageNames = new Set([
+  '@payloadcms/ai-model-adapter',
+  '@payloadcms/plugin-ab-testing',
+  '@payloadcms/plugin-admin-only',
+  '@payloadcms/plugin-ai-embeddings',
+  '@payloadcms/plugin-ai-translate',
+  '@payloadcms/plugin-audit-logs',
+  '@payloadcms/plugin-csm',
+  '@payloadcms/plugin-email-builder',
+  '@payloadcms/plugin-environments',
+  '@payloadcms/plugin-oauth2',
+  '@payloadcms/plugin-publication-workflows',
+  '@payloadcms/plugin-visual-editing',
+  '@payloadcms/visual-editing',
+])
+
+export const getProjectContext = ({
+  env = process.env,
+  packages = [],
+  payload,
+  plugins,
+}: Args): { figmaProduct?: FigmaProduct; projectCohorts: ProjectCohort[] } => {
+  const projectCohorts: ProjectCohort[] = []
+
+  if ([...packages, ...plugins].some((name) => enterprisePackageNames.has(name))) {
+    projectCohorts.push('enterprise')
+  }
+
+  let figmaProduct: FigmaProduct | undefined
+
+  if (payload.config.custom?.figma) {
+    projectCohorts.push('figma')
+
+    const isMakeSandbox = env.FIGMA === '1' || env.FIGMA === 'true'
+    figmaProduct = isMakeSandbox ? 'make' : undefined
+  }
+
+  const hasPayloadCloudConfig = payload.config.globals.some(
+    (global) => global.slug === 'payload-cloud-instance',
+  )
+
+  if (env.PAYLOAD_CLOUD === 'true' && hasPayloadCloudConfig) {
+    projectCohorts.push('cloud')
+  }
+
+  if (projectCohorts.length === 0) {
+    projectCohorts.push('oss')
+  }
+
+  return { figmaProduct, projectCohorts }
+}

--- a/packages/payload/src/utilities/telemetry/index.ts
+++ b/packages/payload/src/utilities/telemetry/index.ts
@@ -8,9 +8,11 @@ import { fileURLToPath } from 'url'
 import type { Payload } from '../../types/index.js'
 import type { AdminInitEvent } from './events/adminInit.js'
 import type { ServerInitEvent } from './events/serverInit.js'
+import type { FigmaProduct, ProjectCohort } from './getProjectContext.js'
 
 import { findUp } from '../findUp.js'
 import { Conf } from './conf/index.js'
+import { getProjectContext } from './getProjectContext.js'
 import { oneWayHash } from './oneWayHash.js'
 
 export type BaseEvent = {
@@ -18,6 +20,7 @@ export type BaseEvent = {
   dbAdapter: string
   emailAdapter: null | string
   envID: string
+  figmaProduct?: FigmaProduct
   isCI: boolean
   locales: string[]
   localizationDefaultLocale: null | string
@@ -27,6 +30,7 @@ export type BaseEvent = {
   payloadVersion: string
   /** Slugs of installed first-party (`@payloadcms/`) plugins. */
   plugins: string[]
+  projectCohorts: ProjectCohort[]
   projectID: string
   projectIDSource: 'cwd' | 'git' | 'packageJSON' | 'serverURL'
   uploadAdapters: string[]
@@ -57,6 +61,7 @@ export const sendTelemetryEvent = async <TEvent extends { type: string }>({
       // Only generate the base event once
       if (!baseEvent) {
         const { projectID, source: projectIDSource } = getProjectID(payload, packageJSON!)
+        const plugins = getInstalledPluginSlugs(payload)
         baseEvent = {
           ciName: ciInfo.isCI ? ciInfo.name : null,
           envID: getEnvID(),
@@ -66,10 +71,15 @@ export const sendTelemetryEvent = async <TEvent extends { type: string }>({
           payloadVersion: getPayloadVersion(packageJSON!),
           projectID,
           projectIDSource,
+          ...getProjectContext({
+            packages: Object.keys(packageJSON!.dependencies ?? {}),
+            payload,
+            plugins,
+          }),
           ...getLocalizationInfo(payload),
           dbAdapter: payload.db.name,
           emailAdapter: payload.email?.name || null,
-          plugins: getInstalledPluginSlugs(payload),
+          plugins,
           uploadAdapters: payload.config.upload.adapters,
         }
       }


### PR DESCRIPTION
Adds `projectCohorts` and `figmaProduct` groups to our captured telemetry.

Note: the `enterprise` cohort is a partial solution currently (only captures enterprise clients using enterprise plugins) - we will be strengthening this with an additional identifier soon.