### PR TITLE
docs: fix CLAUDE.md path in agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,1 @@
-Please read the /CLAUDE.md file for context.
+Please read `./CLAUDE.md` for context.


### PR DESCRIPTION
## Summary 
- Make the CLAUDE.md reference explicitly repository-relative
- Avoid interpreting the leading slash as the filesystem root

We were noticing codex inconsistently respecting rules and standards specified in the root `CLAUDE.md`. Hoping this fixes it.