### PR TITLE
ci: bump lock-threads to v6.0.2 so the lock job can run

### DIFF
--- a/.github/workflows/lock-issues.yml
+++ b/.github/workflows/lock-issues.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Lock issues
-        uses: dessant/lock-threads@7266a7ce5c1df01b1c6db85bf8cd86c737dadbe7 # v6.0.0
+        uses: dessant/lock-threads@89ae32b08ed1a541efecbab17912962a5e38981c # v6.0.2
         with:
           process-only: 'issues'
           issue-inactive-days: '7'


### PR DESCRIPTION
### What?

Bumps `dessant/lock-threads` in `lock-issues.yml` from the v6.0.0 commit to the v6.0.2 commit. One line.

### Why?

The daily lock job has failed on every run for weeks. The last 10 runs are all failures, each with:

```
##[error]"github-token" length must be less than or equal to 100 characters long
```

(from run 32334592697; earlier runs are identical)

The interesting part is that this workflow is already on v6, and that is not enough. The action validates its inputs with a Joi schema, and the `github-token` rule was `max(100)` in v4, v5.0.x, v6.0.0 **and** v6.0.1. The raise to `max(1000)` landed only in v6.0.2. The Actions token has grown past 100 characters, so v6.0.0 rejects it during validation and exits before doing any work. The workflow does not pass `github-token` explicitly, but the action declares `default: ${{ github.token }}`, so the default is substituted and validated all the same.

I checked the four inputs this workflow passes (`process-only`, `issue-inactive-days`, `exclude-any-issue-labels`, `log-output`, plus `issue-comment`) against the v6.0.2 schema and all exist there unchanged, so the pin bump is the whole fix.

Worth noting: the open dependabot group bump #16068 predates the current pin (its diff still shows `v5 -> v6`) and lands on the moving tag; it would fix this too if rebased, but a targeted pin with the diagnosis in the history seemed more useful, and this keeps the SHA-pinned style.

### How?

Replaces the pinned SHA with `89ae32b08ed1a541efecbab17912962a5e38981c`, the commit the v6.0.2 release tag resolves to.

I could not run this against the repo since the workflow only triggers on schedule, but the same one-line bump fixed the identical failure in other repos this week, and repos already on the v6.0.2 commit run green.
