### PR TITLE
fix(next): output file tracing include for @libsql/client never matched

### DIFF
--- a/docs/production/deployment.mdx
+++ b/docs/production/deployment.mdx
@@ -279,6 +279,44 @@ ENV PORT 3000
 CMD HOSTNAME="0.0.0.0" node server.js
 ```
 
+## Output file tracing in monorepos
+
+With `output: 'standalone'`, Next.js does not copy your `node_modules` into the build. It traces the imports of each route and copies only the files it finds. Two properties of that tracing regularly break monorepo deployments, and neither reproduces locally - `next dev` has no tracing step at all, so the first sign of trouble is a container that exits on boot.
+
+### Set the tracing root
+
+Next.js infers the root of the trace from the directory that holds your `next.config`. In a monorepo your dependencies live above that, at the workspace root, so point it there explicitly:
+
+```js
+// apps/web/next.config.mjs
+import path from 'path'
+import { withPayload } from '@payloadcms/next/withPayload'
+
+const nextConfig = {
+  output: 'standalone',
+  outputFileTracingRoot: path.join(import.meta.dirname, '../../'),
+}
+
+export default withPayload(nextConfig)
+```
+
+### Files the tracer cannot see
+
+Tracing follows imports, so anything that is not a statically analyzable import can be missed: compiler-injected helpers, optional native bindings, and modules loaded through a dynamic `require`. If a standalone container throws `MODULE_NOT_FOUND` for a package that is plainly in your lockfile, this is usually why.
+
+`@swc/helpers` is a common example - it is injected into compiled output by the SWC transform rather than imported by your source, and under pnpm's symlinked `node_modules` the tracer can miss it. Add the missing files explicitly:
+
+```js
+const nextConfig = {
+  output: 'standalone',
+  outputFileTracingIncludes: {
+    '**/*': ['../../node_modules/@swc/helpers/**/*'],
+  },
+}
+```
+
+Two things to know about these values. They are glob patterns resolved from the Next.js project root - the directory holding `next.config`, not the monorepo root - so a bare package name such as `@swc/helpers` matches nothing at all, and the path has to walk up to wherever the package actually lives. `withPayload` merges its own includes with yours, so passing this through the plugin is safe.
+
 ## Docker Compose
 
 Here is an example of a docker-compose.yml file that can be used for development

--- a/packages/next/src/withPayload/withPayload.js
+++ b/packages/next/src/withPayload/withPayload.js
@@ -87,7 +87,21 @@ export const withPayload = (nextConfig = {}, options = {}) => {
     },
     outputFileTracingIncludes: {
       ...(nextConfig.outputFileTracingIncludes || {}),
-      '**/*': [...(nextConfig.outputFileTracingIncludes?.['**/*'] || []), '@libsql/client'],
+      /**
+       * Next.js resolves these values as glob patterns relative to the Next.js project root, not as
+       * package specifiers - a bare `@libsql/client` matches zero files and silently ships nothing.
+       * Both layouts are listed because a pattern that matches nothing is a no-op, so the unused one
+       * costs the build nothing.
+       *
+       * Note that in a pnpm workspace the store lives at the workspace root, which is outside the
+       * project root these globs resolve from. Those projects need their own `../../node_modules/...`
+       * include - see the deployment docs.
+       */
+      '**/*': [
+        ...(nextConfig.outputFileTracingIncludes?.['**/*'] || []),
+        'node_modules/@libsql/client/**/*',
+        'node_modules/.pnpm/@libsql+client@*/node_modules/@libsql/client/**/*',
+      ],
     },
     turbopack: {
       ...(nextConfig.turbopack || {}),

--- a/packages/next/src/withPayload/withPayload.spec.ts
+++ b/packages/next/src/withPayload/withPayload.spec.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it } from 'vitest'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
 
 import { withPayload } from './withPayload.js'
 
@@ -56,5 +59,91 @@ describe('withPayload', () => {
         process.env.NEXT_BASE_PATH = originalBasePath
       }
     }
+  })
+})
+
+describe('withPayload > outputFileTracingIncludes', () => {
+  const fixtureDirs: string[] = []
+
+  afterEach(async () => {
+    for (const dir of fixtureDirs) {
+      await fs.rm(dir, { force: true, recursive: true })
+    }
+
+    fixtureDirs.length = 0
+  })
+
+  /**
+   * Next.js treats every value of `outputFileTracingIncludes` as a glob pattern resolved from the
+   * Next.js project root - not as a package specifier. It globs each one with
+   * `{ cwd: <projectRoot>, nodir: true }` in `collect-build-traces`, so a bare package name such as
+   * `@libsql/client` silently matches nothing and the include never ships any file.
+   */
+  const matchFromProjectRoot = async ({
+    projectRoot,
+    patterns,
+  }: {
+    patterns: string[]
+    projectRoot: string
+  }): Promise<string[]> => {
+    const matched: string[] = []
+
+    for (const pattern of patterns) {
+      for await (const entry of fs.glob(pattern, { cwd: projectRoot })) {
+        matched.push(entry as string)
+      }
+    }
+
+    return matched
+  }
+
+  const createProjectRoot = async ({ packagePath }: { packagePath: string }): Promise<string> => {
+    const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'with-payload-tracing-'))
+
+    fixtureDirs.push(projectRoot)
+
+    await fs.mkdir(path.join(projectRoot, packagePath), { recursive: true })
+    await fs.writeFile(path.join(projectRoot, packagePath, 'index.js'), 'module.exports = {}')
+
+    return projectRoot
+  }
+
+  const getIncludes = (): string[] => withPayload({}).outputFileTracingIncludes['**/*']
+
+  it('should resolve @libsql/client from a hoisted node_modules layout', async () => {
+    const projectRoot = await createProjectRoot({ packagePath: 'node_modules/@libsql/client' })
+
+    const matched = await matchFromProjectRoot({ projectRoot, patterns: getIncludes() })
+
+    expect(matched).toContain(path.join('node_modules', '@libsql', 'client', 'index.js'))
+  })
+
+  it('should resolve @libsql/client from a pnpm store layout', async () => {
+    const packagePath =
+      'node_modules/.pnpm/@libsql+client@0.14.0_bufferutil@4.1.0/node_modules/@libsql/client'
+
+    const projectRoot = await createProjectRoot({ packagePath })
+
+    const matched = await matchFromProjectRoot({ projectRoot, patterns: getIncludes() })
+
+    expect(matched).toContain(path.join(packagePath, 'index.js'))
+  })
+
+  /**
+   * Guards the shape rather than the single entry: a bare specifier is indistinguishable from a
+   * working include at config time, and only shows up as a missing file at runtime in production.
+   */
+  it('should not ship bare package specifiers as tracing includes', () => {
+    const bareSpecifiers = getIncludes().filter((include) => !include.includes('*'))
+
+    expect(bareSpecifiers).toEqual([])
+  })
+
+  it('should preserve user-provided tracing includes', () => {
+    const result = withPayload({
+      outputFileTracingIncludes: { '**/*': ['my-folder/**/*'] },
+    })
+
+    expect(result.outputFileTracingIncludes['**/*']).toContain('my-folder/**/*')
   })
 })


### PR DESCRIPTION
### What?

`withPayload` adds `@libsql/client` to `outputFileTracingIncludes['**/*']`, but that value never matches anything, so the include has always been a no-op. This makes it resolve, guards the shape with tests, and documents the output-file-tracing behaviour that makes monorepo `output: 'standalone'` deployments drop files.

### Why?

Next.js treats the *values* of `outputFileTracingIncludes` as **glob patterns resolved from the Next.js project root**, not as package specifiers. From `next/dist/build/collect-build-traces.js`:

```js
const glob = (pattern) =>
  new Promise((resolve, reject) => {
    globOrig(pattern, { cwd: dir, nodir: true, dot: true }, ...)
  })
```

and from Next's own docs for `output`:

> values are **glob patterns resolved from the project root** that specify files to include or exclude in the trace

A bare package name is not a path glob, and with `nodir: true` it could not match even if a directory of that name existed. Measured against a real project root with `@libsql/client` installed:

| pattern | files matched |
| --- | --- |
| `@libsql/client` (shipped today) | **0** |
| `node_modules/@libsql/client/**/*` | 24 |

So since #14845, every `output: 'standalone'` build has silently omitted the files this entry exists to guarantee, and nothing warns at build time - an include that resolves to nothing is indistinguishable from a working one until a container throws `MODULE_NOT_FOUND` in production.

### How?

Two path globs, covering the layouts reachable from a project root:

```js
'node_modules/@libsql/client/**/*',                                     // npm, yarn, hoisted pnpm
'node_modules/.pnpm/@libsql+client@*/node_modules/@libsql/client/**/*', // pnpm strict
```

A pattern that matches nothing is a no-op, so shipping both costs the build nothing regardless of package manager. Neither scans the app directory - both are anchored at the project root.

I considered resolving the real path at config time with `createRequire` instead. Under pnpm strict, `@libsql/client` is a transitive dependency of `@payloadcms/db-sqlite` and is resolvable from neither the app root nor `@payloadcms/next`, so it would need a two-hop resolve chain inside a file that has to stay dependency-free plain JS. Static globs seemed like the better trade.

### Test coverage added

`packages/next/src/withPayload/withPayload.spec.ts` (`pnpm test:unit`):

| test | what it guards |
| --- | --- |
| `should resolve @libsql/client from a hoisted node_modules layout` | the npm/yarn case actually matches files |
| `should resolve @libsql/client from a pnpm store layout` | the pnpm strict case actually matches files |
| `should not ship bare package specifiers as tracing includes` | the **class** of bug, for any future entry |
| `should preserve user-provided tracing includes` | the merge with user config |

The first two build a temp fixture shaped like a project root and glob every emitted include the same way Next.js does, so they fail if the pattern shape stops resolving. The third is the one I'd argue matters most: it is why this bug survived, not just that it existed.

### Why the tests missed it

1. **The config surface had no behavioural coverage.** `withPayload.spec.ts` tested `basePath` and `devIndicators` - values a caller reads back directly. `outputFileTracingIncludes` is only meaningful once Next.js globs it during `next build`, and nothing asserted the emitted value was a resolvable glob.
2. **The failure is invisible everywhere the suite runs.** Tracing only happens in `next build`; `next dev` has no tracing step. A test could assert `includes).toContain('@libsql/client')` and pass forever while shipping nothing.
3. **The failure mode is silent by design.** Next.js does not warn when an include glob resolves to zero files, so the only signal is a missing module at runtime in a standalone container - the environment least likely to be exercised in CI.

### Docs

Adds **Output file tracing in monorepos** to `docs/production/deployment.mdx`, covering `outputFileTracingRoot` and the files tracing structurally cannot see. This comes out of a Discord report where a Payload app on Next 16.3.1 with `output: 'standalone'` crashed on `@swc/helpers/esm` under pnpm: SWC injects that import into compiled output rather than it being imported from source, so the tracer misses it. That one is a Next.js issue, not a Payload one, and the same project-root-relative glob semantics are what make the workaround non-obvious - which is why it belongs next to this fix.

### Verification

- `pnpm test:unit` on `packages/next/src/withPayload/withPayload.spec.ts`: 8/8 pass; the 3 new assertions fail on the unpatched source with `expected [ '@libsql/client' ] to deeply equal []` and 0 glob matches.
- Full `pnpm test:unit`: 1893 passed / 1 failed vs. a **1889 passed / 1 failed** baseline on the same tree without this change - identical failure set, +4 new tests. The pre-existing failures are stale-`dist` import errors unrelated to this change.
- `tsc --noEmit -p packages/next/tsconfig.json`: no new errors (the remaining ones are pre-existing `TS6305` stale-`dist` errors).
- `eslint` on both changed source files: clean.
- Both files are prettier-clean; `deployment.mdx` and `withPayload.js` were not prettier-clean at HEAD and now are, from the pre-commit hook.

#### Not verified

- **No end-to-end standalone build.** I did not run `next build` with `output: 'standalone'` against a real `@payloadcms/db-sqlite` app and diff `.next/standalone`. The glob behaviour is verified against a fixture with Node's `fs.glob` and against a real `node_modules` with Next's own compiled glob, but the resulting runtime behaviour of a libsql standalone container is unverified.
- **The pnpm store path shape** (`@libsql+client@<version>`) is a pnpm implementation detail. If it changes, that pattern degrades to a no-op - today's behaviour, not a regression.

### Notes for review

- **`libsql` native bindings.** `libsql` and its platform packages (`@libsql/darwin-arm64` and friends) are in `serverExternalPackages` but not in the includes. They plausibly have the same problem, but I could not verify what a working standalone libsql build needs, so I deliberately left them alone rather than guessing.
- **The `'**/*'` key is fine.** Keys are matched against *route paths* with picomatch (`contains: true`), which is a different mechanism from the values. Left unchanged; the same key drives the `drizzle-kit` excludes.
- **`3.x` is affected identically** (`packages/next/src/withPayload/withPayload.js:108` on that branch). Targeted `main` per the PR template; happy to open the backport if wanted.
