### PR TITLE
fix(next): output file tracing include for @libsql/client never matched

### DIFF
--- a/docs/production/deployment.mdx
+++ b/docs/production/deployment.mdx
@@ -273,6 +273,44 @@ ENV PORT 3000
 CMD HOSTNAME="0.0.0.0" node server.js
 ```
 
+## Output file tracing in monorepos
+
+With `output: 'standalone'`, Next.js does not copy your `node_modules` into the build. It traces the imports of each route and copies only the files it finds. Two properties of that tracing regularly break monorepo deployments, and neither reproduces locally - `next dev` has no tracing step at all, so the first sign of trouble is a container that exits on boot.
+
+### Set the tracing root
+
+Next.js infers the root of the trace from the directory that holds your `next.config`. In a monorepo your dependencies live above that, at the workspace root, so point it there explicitly:
+
+```js
+// apps/web/next.config.mjs
+import path from 'path'
+import { withPayload } from '@payloadcms/next/withPayload'
+
+const nextConfig = {
+  output: 'standalone',
+  outputFileTracingRoot: path.join(import.meta.dirname, '../../'),
+}
+
+export default withPayload(nextConfig)
+```
+
+### Files the tracer cannot see
+
+Tracing follows imports, so anything that is not a statically analyzable import can be missed: compiler-injected helpers, optional native bindings, and modules loaded through a dynamic `require`. If a standalone container throws `MODULE_NOT_FOUND` for a package that is plainly in your lockfile, this is usually why.
+
+`@swc/helpers` is a common example - it is injected into compiled output by the SWC transform rather than imported by your source, and under pnpm's symlinked `node_modules` the tracer can miss it. Add the missing files explicitly:
+
+```js
+const nextConfig = {
+  output: 'standalone',
+  outputFileTracingIncludes: {
+    '**/*': ['../../node_modules/@swc/helpers/**/*'],
+  },
+}
+```
+
+Two things to know about these values. They are glob patterns resolved from the Next.js project root - the directory holding `next.config`, not the monorepo root - so a bare package name such as `@swc/helpers` matches nothing at all, and the path has to walk up to wherever the package actually lives. `withPayload` merges its own includes with yours, so passing this through the plugin is safe.
+
 ## Docker Compose
 
 Here is an example of a docker-compose.yml file that can be used for development

--- a/docs/production/deployment.mdx
+++ b/docs/production/deployment.mdx
@@ -284,11 +284,14 @@ Next.js infers the root of the trace from the directory that holds your `next.co
 ```js
 // apps/web/next.config.mjs
 import path from 'path'
+import { fileURLToPath } from 'url'
 import { withPayload } from '@payloadcms/next/withPayload'
+
+const dirname = path.dirname(fileURLToPath(import.meta.url))
 
 const nextConfig = {
   output: 'standalone',
-  outputFileTracingRoot: path.join(import.meta.dirname, '../../'),
+  outputFileTracingRoot: path.join(dirname, '../../'),
 }
 
 export default withPayload(nextConfig)

--- a/packages/next/src/withPayload/withPayload.js
+++ b/packages/next/src/withPayload/withPayload.js
@@ -105,7 +105,21 @@ export const withPayload = (nextConfig = {}, options = {}) => {
     },
     outputFileTracingIncludes: {
       ...(nextConfig.outputFileTracingIncludes || {}),
-      '**/*': [...(nextConfig.outputFileTracingIncludes?.['**/*'] || []), '@libsql/client'],
+      /**
+       * Next.js resolves these values as glob patterns relative to the Next.js project root, not as
+       * package specifiers - a bare `@libsql/client` matches zero files and silently ships nothing.
+       * Both layouts are listed because a pattern that matches nothing is a no-op, so the unused one
+       * costs the build nothing.
+       *
+       * Note that in a pnpm workspace the store lives at the workspace root, which is outside the
+       * project root these globs resolve from. Those projects need their own `../../node_modules/...`
+       * include - see the deployment docs.
+       */
+      '**/*': [
+        ...(nextConfig.outputFileTracingIncludes?.['**/*'] || []),
+        'node_modules/@libsql/client/**/*',
+        'node_modules/.pnpm/@libsql+client@*/node_modules/@libsql/client/**/*',
+      ],
     },
     turbopack: {
       ...(nextConfig.turbopack || {}),

--- a/packages/next/src/withPayload/withPayload.spec.ts
+++ b/packages/next/src/withPayload/withPayload.spec.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it } from 'vitest'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
 
 import { withPayload } from './withPayload.js'
 
@@ -44,5 +47,94 @@ describe('withPayload', () => {
         process.env.NEXT_BASE_PATH = originalBasePath
       }
     }
+  })
+
+  describe('outputFileTracingIncludes', () => {
+    const fixtureDirs: string[] = []
+
+    afterEach(async () => {
+      for (const dir of fixtureDirs) {
+        await fs.rm(dir, { force: true, recursive: true })
+      }
+
+      fixtureDirs.length = 0
+    })
+
+    /**
+     * Next.js treats every value of `outputFileTracingIncludes` as a glob pattern resolved from the
+     * Next.js project root - not as a package specifier. It globs each one with
+     * `{ cwd: <projectRoot>, nodir: true }` in `collect-build-traces`, so a bare package name such as
+     * `@libsql/client` silently matches nothing and the include never ships any file.
+     */
+    const matchFromProjectRoot = async ({
+      projectRoot,
+      patterns,
+    }: {
+      patterns: string[]
+      projectRoot: string
+    }): Promise<string[]> => {
+      const matched: string[] = []
+
+      for (const pattern of patterns) {
+        for await (const entry of fs.glob(pattern, { cwd: projectRoot })) {
+          matched.push(entry)
+        }
+      }
+
+      return matched
+    }
+
+    const createProjectRoot = async ({ packagePath }: { packagePath: string }): Promise<string> => {
+      const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'with-payload-tracing-'))
+
+      fixtureDirs.push(projectRoot)
+
+      await fs.mkdir(path.join(projectRoot, packagePath), { recursive: true })
+      await fs.writeFile(path.join(projectRoot, packagePath, 'index.js'), 'module.exports = {}')
+
+      return projectRoot
+    }
+
+    const getIncludes = (): string[] => withPayload({}).outputFileTracingIncludes['**/*']
+
+    it('should resolve @libsql/client from a hoisted node_modules layout', async () => {
+      const projectRoot = await createProjectRoot({ packagePath: 'node_modules/@libsql/client' })
+
+      const matched = await matchFromProjectRoot({ projectRoot, patterns: getIncludes() })
+
+      expect(matched).toContain(path.join('node_modules', '@libsql', 'client', 'index.js'))
+    })
+
+    it('should resolve @libsql/client from a pnpm store layout', async () => {
+      const packagePath =
+        'node_modules/.pnpm/@libsql+client@0.14.0_bufferutil@4.1.0/node_modules/@libsql/client'
+
+      const projectRoot = await createProjectRoot({ packagePath })
+
+      const matched = await matchFromProjectRoot({ projectRoot, patterns: getIncludes() })
+
+      expect(matched).toContain(path.join(packagePath, 'index.js'))
+    })
+
+    /**
+     * Guards the shape rather than the single entry: a bare specifier is indistinguishable from a
+     * working include at config time, and only shows up as a missing file at runtime in production.
+     */
+    it('should not ship bare package specifiers as tracing includes', () => {
+      // An npm package name (`@libsql/client`, `sharp`) as opposed to a path glob (`src/x/**/*`)
+      const packageSpecifier = /^(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/
+
+      const bareSpecifiers = getIncludes().filter((include) => packageSpecifier.test(include))
+
+      expect(bareSpecifiers).toEqual([])
+    })
+
+    it('should preserve user-provided tracing includes', () => {
+      const result = withPayload({
+        outputFileTracingIncludes: { '**/*': ['my-folder/**/*'] },
+      })
+
+      expect(result.outputFileTracingIncludes['**/*']).toContain('my-folder/**/*')
+    })
   })
 })


### PR DESCRIPTION
### What?

`withPayload` adds `@libsql/client` to `outputFileTracingIncludes['**/*']`. Next.js resolves those values as **glob patterns relative to the Next.js project root**, not as package specifiers, so it matches zero files and the include has been a silent no-op since it was added.

### Why?

Being precise about the impact, because I tested it rather than assuming: **on a real `@payloadcms/db-sqlite` app this fix changes nothing.** The adapter statically imports `createClient`, tracing already reaches the package, and the standalone output is byte-for-byte the same list of 132 files before and after. What is broken is the guarantee, not any user's build - the entry contributes nothing in the case it was added for, and Next.js never warns about an include that matches nothing.

### How?

Path globs for the hoisted and pnpm store layouts, plus a test that fails for any include shaped like a package specifier rather than a path. Also adds a docs section on output file tracing in monorepos, which is where this class of failure actually bites people.

---

## How this was tested

Two harnesses. **(A)** a minimal Next.js 16.3.1 app with `output: 'standalone'` and `@libsql/client` installed but *not* imported, which isolates the include from normal import tracing. **(B)** a real Payload app - the `blank` template switched to `@payloadcms/db-sqlite`, all packages installed from npm at 3.88.0, so the full adapter graph is present. In both, the only variable between runs is the include values in `withPayload`. Every screenshot is captured output; raw text is under each one.

### 1. Does the include actually resolve? (harness A)

![npm layout](https://raw.githubusercontent.com/zawoj/payload/pr-assets/.pr-assets/libsql-tracing/01-build-npm.png)

![pnpm layout](https://raw.githubusercontent.com/zawoj/payload/pr-assets/.pr-assets/libsql-tracing/02-build-pnpm.png)

| layout | before | after |
| --- | --- | --- |
| npm (hoisted `node_modules`) | **0 files** | 24 files |
| pnpm (symlink + `.pnpm` store) | **0 files** | 48 files |

pnpm reports 48 because both patterns match there - the app-level symlink and the store path - which is expected and costs 180 KB.

<details><summary>raw output</summary>

```
package manager: npm   |   next: Next.js v16.3.1
$ next build   # output: 'standalone', @libsql/client installed but not imported
$ find .next/standalone -path '*@libsql*' -type f | wc -l

  before (main / 3.x today):           0 files
  after  (this PR):                    24 files

package manager: pnpm  |   next: Next.js v16.3.1
  before (main / 3.x today):           0 files
  after  (this PR):                    48 files
```

</details>

### 2. Does it hold up on a real `@payloadcms/db-sqlite` app? (harness B)

This is the honest test of whether the fix is worth anything, and the answer is nuanced.

![real db-sqlite app](https://raw.githubusercontent.com/zawoj/payload/pr-assets/.pr-assets/libsql-tracing/06-real-db-sqlite-app.png)

The traced output is **identical** - 132 files before and after, `comm -3` reports no difference. Turbopack build (the bundler #14845 was about), Next 16.3.0. The built `.next/standalone/server.js` then ran under `NODE_ENV=production` against a migrated SQLite database and served real queries through libsql: `POST /api/users/first-register` returned "Successfully registered first user.", `POST /api/users/login` returned "Authentication Passed", and reading `payload.db` directly shows the row. That holds on both revisions.

So: nothing was broken before this PR, and nothing changes for `db-sqlite` users after it. The include is dead either way; this makes it do what it claims, and the tests stop the shape from recurring.

<details><summary>raw output</summary>

```
# Real Payload app: blank template + @payloadcms/db-sqlite 3.88.0, Next 16.3.0 (Turbopack)

  before (published 3.88.0):           132 files
  after  (this PR):                    132 files
  comm -3 before after:                no difference - identical file lists

$ node .next/standalone/server.js     # NODE_ENV=production, schema already migrated
  POST /api/users/first-register  ->  "Successfully registered first user."
  POST /api/users/login           ->  "Authentication Passed"   user: verify@payload.test
  sqlite3 payload.db "select id, email from users"  ->  1 | verify@payload.test
```

</details>

### 3. The pnpm workspace limitation, measured

In a pnpm **workspace** the store sits at the workspace root, outside the project root these globs resolve from. I built one (`apps/web` + root store) to confirm rather than assert it:

![pnpm workspace](https://raw.githubusercontent.com/zawoj/payload/pr-assets/.pr-assets/libsql-tracing/07-pnpm-workspace.png)

```
     0  node_modules/@libsql/client/**/*
     0  node_modules/.pnpm/@libsql+client@*/node_modules/@libsql/client/**/*
    26  ../../node_modules/.pnpm/@libsql+client@*/node_modules/@libsql/client/**/*
```

Neither shipped pattern reaches it; only a user-supplied `../../node_modules/...` include does. That is inherent to the tracing API rather than something `withPayload` can fix from inside the package, which is exactly what the new docs section tells people.

### 4. Do the new tests fail without the fix?

![tests before](https://raw.githubusercontent.com/zawoj/payload/pr-assets/.pr-assets/libsql-tracing/04-tests-before.png)

![tests after](https://raw.githubusercontent.com/zawoj/payload/pr-assets/.pr-assets/libsql-tracing/05-tests-after.png)

The two resolution tests glob a temp fixture shaped like a project root the way Next.js does; the shape test reports `expected [ '@libsql/client' ] to deeply equal []`, which is the bug stated as an assertion.

Also run: full `pnpm test:unit` (no regressions against a baseline on the same tree), `tsc --noEmit` on `packages/next`, eslint and prettier.

### Notes for review

- **Deleting the entry is a legitimate alternative, and section 2 is the argument for it.** Since tracing already covers `@libsql/client` in every real `db-sqlite` app, the line has never earned its keep. I kept it as a repaired safety net because it costs nothing when it matches nothing and it would catch a future tracing regression - but if you would rather drop dead config, I will happily flip this to a deletion; the tests and docs stand either way.
- `@libsql/client`'s own dependencies (`libsql`, `@libsql/core`, `@libsql/hrana-client`, ...) are not covered by the include, since an include copies globbed files without tracing their imports. I did not widen it, having no evidence about what a working standalone libsql build needs beyond what tracing already provides.
- The `'**/*'` **key** is fine - keys are matched against route paths with picomatch, a different mechanism from the values. Left unchanged; the same key drives the `drizzle-kit` excludes.
- This applies to `main` as well; happy to open that PR too.
