### PR TITLE
docs: updates examples for lexical to markdown conversion

### DIFF
--- a/docs/rich-text/converters.mdx
+++ b/docs/rich-text/converters.mdx
@@ -63,6 +63,8 @@ const customEditorConfig = await editorConfigFactory.fromFeatures({
 })
 ```
 
+Re-declaring a default feature here overrides it, as the last feature with a given key wins. This is how you configure conversion behavior that lives on a feature rather than on a converter - for example passing `internalDocToHref` to `LinkFeature` for the [Markdown converter](/docs/rich-text/converting-markdown#internal-links).
+
 ### Option 4: Extract from an Instantiated Editor
 
 If you've created a global or reusable Lexical editor instance, you can access its configuration. This method is typically less efficient and not recommended:

--- a/docs/rich-text/converting-jsx.mdx
+++ b/docs/rich-text/converting-jsx.mdx
@@ -83,6 +83,8 @@ export const MyComponent: React.FC<{
 }
 ```
 
+The Markdown converter needs the same function, but takes it in a different place - see [Converting Markdown](/docs/rich-text/converting-markdown#internal-links).
+
 ### Lexical Blocks
 
 If your rich text includes custom Blocks or Inline Blocks, you must supply custom converters that match each block's slug. This converter is not included by default, as Payload doesn't know how to render your custom blocks.

--- a/docs/rich-text/converting-markdown.mdx
+++ b/docs/rich-text/converting-markdown.mdx
@@ -29,6 +29,90 @@ const markdown = convertLexicalToMarkdown({
 })
 ```
 
+### Internal Links
+
+By default, Payload doesn't know how to convert **internal** links to Markdown, as it doesn't know what the corresponding URL of the internal link is. Internal links store a reference to a document rather than a URL, so only your app knows how that reference maps to a route. You'll notice the following warning in the console when converting content that contains internal links:
+
+```
+Lexical → Markdown converter: found internal link but internalDocToHref is not provided — link will have an empty href
+```
+
+Unlike the [JSX converter](/docs/rich-text/converting-jsx#internal-links), which takes the same function via `LinkJSXConverter`, `convertLexicalToMarkdown` does not accept a `converters` argument. Markdown transformers are defined on the features, so the `internalDocToHref` function is passed to the `LinkFeature` of the editor config that you provide as `editorConfig`:
+
+```ts
+import type { SerializedLinkNode } from '@payloadcms/richtext-lexical'
+import type { SerializedEditorState } from '@payloadcms/richtext-lexical/lexical'
+
+import {
+  convertLexicalToMarkdown,
+  editorConfigFactory,
+  LinkFeature,
+} from '@payloadcms/richtext-lexical'
+
+// Your richtext data here
+const data: SerializedEditorState = {}
+
+const internalDocToHref = ({ linkNode }: { linkNode: SerializedLinkNode }) => {
+  const { relationTo, value } = linkNode.fields.doc!
+
+  // The doc must already be populated to read a slug from it.
+  // With `depth: 0` you only receive the ID here.
+  if (typeof value !== 'object') {
+    return `/${relationTo}/${value}`
+  }
+
+  const slug = value.slug
+
+  switch (relationTo) {
+    case 'posts':
+      return `/posts/${slug}`
+    case 'categories':
+      return `/category/${slug}`
+    case 'pages':
+      return `/${slug}`
+    default:
+      return `/${relationTo}/${slug}`
+  }
+}
+
+const markdown = convertLexicalToMarkdown({
+  data,
+  editorConfig: await editorConfigFactory.fromFeatures({
+    config, // <= make sure you have access to your Payload Config
+    features: ({ defaultFeatures }) => [
+      ...defaultFeatures,
+      // Re-declaring LinkFeature overrides the default one -
+      // the last feature with a given key wins.
+      LinkFeature({ internalDocToHref }),
+    ],
+  }),
+})
+```
+
+Note that `editorConfigFactory.default({ config })` always builds its config from the default features, so it cannot carry an `internalDocToHref`. Use `fromFeatures` as shown above, or set the prop on the field's own editor and retrieve the config with `fromField`:
+
+```ts
+{
+  name: 'nameOfYourRichTextField',
+  type: 'richText',
+  editor: lexicalEditor({
+    features: ({ defaultFeatures }) => [
+      ...defaultFeatures,
+      LinkFeature({ internalDocToHref }),
+    ],
+  }),
+}
+```
+
+<Banner type="warning">
+  `internalDocToHref` is **synchronous** and **server-side only**. There is no
+  `populate` helper available like there is in the async HTML converter, so
+  convert against fully populated data (`depth` of at least `1`), or resolve
+  document IDs to URLs ahead of time and close over a lookup map. The
+  client-side link transformer runs without this function, which only affects
+  Markdown shortcuts typed into the editor, not converted output.
+</Banner>
+
 ### Example - outputting Markdown from the Collection
 
 ```ts
@@ -39,6 +123,7 @@ import {
   convertLexicalToMarkdown,
   editorConfigFactory,
   lexicalEditor,
+  LinkFeature,
 } from '@payloadcms/richtext-lexical'
 
 const Pages: CollectionConfig = {
@@ -47,7 +132,14 @@ const Pages: CollectionConfig = {
     {
       name: 'nameOfYourRichTextField',
       type: 'richText',
-      editor: lexicalEditor(),
+      editor: lexicalEditor({
+        features: ({ defaultFeatures }) => [
+          ...defaultFeatures,
+          // Required for internal links to export with a href.
+          // See "Internal Links" above.
+          LinkFeature({ internalDocToHref }),
+        ],
+      }),
     },
     {
       name: 'markdown',
@@ -161,6 +253,7 @@ import {
   convertLexicalToMarkdown,
   editorConfigFactory,
   lexicalEditor,
+  LinkFeature,
 } from '@payloadcms/richtext-lexical'
 
 const BannerBlock: Block = {
@@ -179,7 +272,14 @@ const BannerBlock: Block = {
     {
       name: 'content',
       type: 'richText',
-      editor: lexicalEditor(),
+      // Nested editors need their own LinkFeature configuration -
+      // the block's content is converted using this field's editor config.
+      editor: lexicalEditor({
+        features: ({ defaultFeatures }) => [
+          ...defaultFeatures,
+          LinkFeature({ internalDocToHref }),
+        ],
+      }),
     },
   ],
   jsx: {
@@ -222,6 +322,9 @@ const Pages: CollectionConfig = {
           BlocksFeature({
             blocks: [BannerBlock],
           }),
+          // Required for internal links to export with a href.
+          // See "Internal Links" above.
+          LinkFeature({ internalDocToHref }),
         ],
       }),
     },

--- a/docs/rich-text/official-features.mdx
+++ b/docs/rich-text/official-features.mdx
@@ -194,6 +194,14 @@ type LinkFeatureServerProps = {
       }) => (Field | FieldAffectingData)[])
     | Field[]
   /**
+   * Resolves an internal link node to a URL string
+   * for use in the markdown converter. Internal links
+   * store a doc reference rather than a URL, so without
+   * this the markdown output will have an empty href:
+   * `[link text]()`.
+   */
+  internalDocToHref?: (args: { linkNode: SerializedLinkNode }) => string
+  /**
    * Sets a maximum population depth for the internal
    * doc default field of link, regardless of the
    * remaining depth when the field is reached.
@@ -227,8 +235,13 @@ LinkFeature({
   enabledCollections: ['pages', 'posts'], // Collections for internal links
   maxDepth: 2, // Population depth for internal links
   disableAutoLinks: false, // Allow auto-conversion of URLs
+  // Resolves internal links when converting to Markdown
+  internalDocToHref: ({ linkNode }) =>
+    `/${(linkNode.fields.doc?.value as { slug: string }).slug}`,
 })
 ```
+
+See [Converting Markdown](/docs/rich-text/converting-markdown#internal-links) for details on `internalDocToHref`.
 
 ### RelationshipFeature
 


### PR DESCRIPTION
The `internalDocToHref` callback for Lexical -> Markdown conversion shipped in `v3.84.0` but was never documented, so internal links silently exported with an empty href and the resulting console warning had no documented fix.

- Adds an "Internal Links" section to the Converting Markdown page, mirroring the Converting JSX page
- Updates the existing examples on that page so they no longer reproduce the warning

Fixes #16967