### PR TITLE
fix: fall back to Referer origin when Sec-Fetch-Site is absent

### DIFF
--- a/packages/payload/src/auth/extractJWT.spec.ts
+++ b/packages/payload/src/auth/extractJWT.spec.ts
@@ -1,0 +1,117 @@
+import type { BasePayload } from '../index.js'
+
+import { describe, expect, it } from 'vitest'
+
+import { extractJWT } from './extractJWT.js'
+
+type MinimalPayload = Pick<BasePayload, 'config'>
+
+const makePayload = (csrf: string[], cookiePrefix = 'payload'): MinimalPayload =>
+  ({
+    config: {
+      auth: { jwtOrder: ['JWT', 'Bearer', 'cookie'] },
+      cookiePrefix,
+      csrf,
+    },
+  }) as unknown as MinimalPayload
+
+const makeHeaders = (entries: Record<string, string>): Headers => new Headers(entries)
+
+describe('extractJWT', () => {
+  describe('cookie strategy', () => {
+    it('returns null when there is no token cookie', () => {
+      const headers = makeHeaders({})
+      const payload = makePayload(['https://myapp.com'])
+
+      expect(extractJWT({ headers, payload: payload as BasePayload })).toBeNull()
+    })
+
+    it('accepts a matching Origin against the csrf allowlist', () => {
+      const headers = makeHeaders({
+        Cookie: 'payload-token=abc',
+        Origin: 'https://myapp.com',
+      })
+      const payload = makePayload(['https://myapp.com'])
+
+      expect(extractJWT({ headers, payload: payload as BasePayload })).toBe('abc')
+    })
+
+    it('rejects a non-matching Origin against the csrf allowlist', () => {
+      const headers = makeHeaders({
+        Cookie: 'payload-token=abc',
+        Origin: 'https://attacker.com',
+      })
+      const payload = makePayload(['https://myapp.com'])
+
+      expect(extractJWT({ headers, payload: payload as BasePayload })).toBeNull()
+    })
+
+    it('accepts Sec-Fetch-Site: same-origin when Origin is absent', () => {
+      const headers = makeHeaders({
+        Cookie: 'payload-token=abc',
+        'Sec-Fetch-Site': 'same-origin',
+      })
+      const payload = makePayload(['https://myapp.com'])
+
+      expect(extractJWT({ headers, payload: payload as BasePayload })).toBe('abc')
+    })
+
+    it('rejects Sec-Fetch-Site: cross-site when Origin is absent', () => {
+      const headers = makeHeaders({
+        Cookie: 'payload-token=abc',
+        'Sec-Fetch-Site': 'cross-site',
+      })
+      const payload = makePayload(['https://myapp.com'])
+
+      expect(extractJWT({ headers, payload: payload as BasePayload })).toBeNull()
+    })
+
+    it('falls back to a matching Referer origin when both Origin and Sec-Fetch-Site are absent (regression #17565)', () => {
+      const headers = makeHeaders({
+        Cookie: 'payload-token=abc',
+        Referer: 'http://myapp.local/admin/login',
+      })
+      const payload = makePayload(['http://myapp.local'])
+
+      expect(extractJWT({ headers, payload: payload as BasePayload })).toBe('abc')
+    })
+
+    it('rejects a non-matching Referer origin when both Origin and Sec-Fetch-Site are absent', () => {
+      const headers = makeHeaders({
+        Cookie: 'payload-token=abc',
+        Referer: 'http://attacker.local/admin/login',
+      })
+      const payload = makePayload(['http://myapp.local'])
+
+      expect(extractJWT({ headers, payload: payload as BasePayload })).toBeNull()
+    })
+
+    it('rejects a malformed Referer when both Origin and Sec-Fetch-Site are absent', () => {
+      const headers = makeHeaders({
+        Cookie: 'payload-token=abc',
+        Referer: 'not-a-url',
+      })
+      const payload = makePayload(['http://myapp.local'])
+
+      expect(extractJWT({ headers, payload: payload as BasePayload })).toBeNull()
+    })
+
+    it('rejects when Origin, Sec-Fetch-Site, and Referer are all absent and csrf is configured', () => {
+      const headers = makeHeaders({
+        Cookie: 'payload-token=abc',
+      })
+      const payload = makePayload(['https://myapp.com'])
+
+      expect(extractJWT({ headers, payload: payload as BasePayload })).toBeNull()
+    })
+
+    it('accepts the cookie when csrf is not configured, even without Origin, Sec-Fetch-Site, or Referer', () => {
+      const headers = makeHeaders({
+        Cookie: 'payload-token=abc',
+      })
+      const payload = makePayload([])
+
+      expect(extractJWT({ headers, payload: payload as BasePayload })).toBe('abc')
+    })
+  })
+})

--- a/packages/payload/src/auth/extractJWT.ts
+++ b/packages/payload/src/auth/extractJWT.ts
@@ -48,6 +48,24 @@ const extractionMethods: Record<string, ExtractionMethod> = {
       return cookieToken
     }
 
+    // Sec-Fetch-Site is omitted by browsers for same-origin navigations over plain HTTP on
+    // non-localhost hosts (it is only sent to potentially trustworthy origins). Its absence is
+    // therefore inconclusive rather than cross-site — fall back to validating the Referer
+    // header's origin against the same csrf allowlist.
+    if (!secFetchSite) {
+      const referer = headers.get('Referer')
+
+      if (referer) {
+        try {
+          if (payload.config.csrf.includes(new URL(referer).origin)) {
+            return cookieToken
+          }
+        } catch {
+          // Malformed Referer — fall through to reject
+        }
+      }
+    }
+
     // Reject cross-site requests and missing header (non-browser clients)
     return null
   },


### PR DESCRIPTION
## Summary

- `extractJWT`'s cookie strategy treated a missing `Sec-Fetch-Site` header the same as a cross-site request and rejected the cookie outright.
- Browsers omit `Sec-Fetch-Site` for same-origin navigations served over plain HTTP on a non-`localhost` host (Fetch Metadata is only sent to potentially trustworthy origins per the [W3C spec](https://www.w3.org/TR/fetch-metadata/)). This broke cookie auth for local dev setups served over `http://` on a hostname (Docksal, DDEV, Lando, plain reverse proxies).
- When `Origin` and `Sec-Fetch-Site` are both absent and `csrf` is configured, this adds a fallback that validates the `Referer` header's origin against the existing `csrf` allowlist before rejecting. This does not weaken the existing CSRF checks — cross-site `Sec-Fetch-Site` values are still rejected outright, and the `Referer` origin is checked against the same allowlist already used for `Origin`.

Fixes #17565

## Test plan

- Added `packages/payload/src/auth/extractJWT.spec.ts` covering the cookie strategy: matching/non-matching `Origin`, `Sec-Fetch-Site: same-origin` / `cross-site`, the new `Referer`-fallback (match, mismatch, malformed), all-headers-absent rejection, and the no-csrf-configured passthrough.
- `pnpm vitest run --project unit packages/payload/src/auth/` — 3 files / 19 tests passed (includes existing `cookies.spec.ts` and `strategies/local/authenticate.spec.ts`, confirming no regressions in adjacent auth code).
- `eslint` on both changed files — 0 errors.