### PR TITLE
fix(plugin-import-export): avoid prefixing row fields

### DIFF
--- a/packages/plugin-import-export/src/components/FieldsToExport/reduceFields.spec.ts
+++ b/packages/plugin-import-export/src/components/FieldsToExport/reduceFields.spec.ts
@@ -198,5 +198,18 @@ describe('reduceFields', () => {
 
       expect(result['meta.title']).toBe('Meta > Title')
     })
+
+    it('should not prefix sub-field labels with "unnamed field" for an unnamed group', () => {
+      const fields: ClientField[] = [
+        {
+          type: 'group',
+          fields: [{ name: 'title', type: 'text', label: 'Title' }],
+        } as ClientField,
+      ]
+
+      const result = labels(reduceFields({ fields }))
+
+      expect(result.title).toBe('Title')
+    })
   })
 })

--- a/packages/plugin-import-export/src/components/FieldsToExport/reduceFields.spec.ts
+++ b/packages/plugin-import-export/src/components/FieldsToExport/reduceFields.spec.ts
@@ -1,10 +1,29 @@
+import type { ReactNode } from 'react'
+
 import type { ClientField } from 'payload'
 
+import { isValidElement } from 'react'
 import { describe, expect, it } from 'vitest'
 
 import { reduceFields } from './reduceFields.js'
 
 const values = (result: ReturnType<typeof reduceFields>) => result.map((f) => f.value)
+
+const labelText = (node: ReactNode): string => {
+  if (typeof node === 'string') {
+    return node
+  }
+  if (Array.isArray(node)) {
+    return node.map(labelText).join('')
+  }
+  if (isValidElement(node)) {
+    return labelText((node.props as { children?: ReactNode }).children)
+  }
+  return ''
+}
+
+const labels = (result: ReturnType<typeof reduceFields>) =>
+  Object.fromEntries(result.map((f) => [f.value, labelText(f.label)]))
 
 describe('reduceFields', () => {
   describe('excludeUnsortable', () => {
@@ -144,6 +163,40 @@ describe('reduceFields', () => {
 
       expect(result).toContain('meta.title')
       expect(result).not.toContain('meta.description')
+    })
+  })
+
+  describe('labelPrefix', () => {
+    it('should not prefix row sub-field labels with "unnamed field"', () => {
+      const fields: ClientField[] = [
+        {
+          type: 'row',
+          fields: [
+            { name: 'test1', type: 'text', label: 'Test1' },
+            { name: 'test2', type: 'text', label: 'Test2' },
+          ],
+        },
+      ]
+
+      const result = labels(reduceFields({ fields }))
+
+      expect(result.test1).toBe('Test1')
+      expect(result.test2).toBe('Test2')
+    })
+
+    it('should still prefix sub-field labels with a named group label', () => {
+      const fields: ClientField[] = [
+        {
+          name: 'meta',
+          type: 'group',
+          label: 'Meta',
+          fields: [{ name: 'title', type: 'text', label: 'Title' }],
+        },
+      ]
+
+      const result = labels(reduceFields({ fields }))
+
+      expect(result['meta.title']).toBe('Meta > Title')
     })
   })
 })

--- a/packages/plugin-import-export/src/components/FieldsToExport/reduceFields.tsx
+++ b/packages/plugin-import-export/src/components/FieldsToExport/reduceFields.tsx
@@ -69,13 +69,20 @@ export const reduceFields = ({
       }
 
       if (!isArrayOrBlocks && fieldHasSubFields(field)) {
+        const affectsData = fieldAffectsData(field)
+
         return [
           ...fieldsToUse,
           ...reduceFields({
             disabledFields,
             excludeUnsortable,
             fields: field.fields,
-            labelPrefix: combineLabel({ field, prefix: labelPrefix }),
+            labelPrefix: affectsData
+              ? combineLabel({
+                  field,
+                  prefix: labelPrefix,
+                })
+              : labelPrefix,
             path: createNestedClientFieldPath(path, field),
           }),
         ]


### PR DESCRIPTION
### What?

Fixes an issue where Row fields were adding an `unnamed field` prefix to their child fields in the Export Options Fields dropdown.

### Why?

Row fields don't affect data themselves, so they shouldn't add a label prefix to the fields inside them.

### How?

Only apply `combineLabel` when the field affects data. This prevents Row and unnamed Group fields from adding a prefix while keeping the existing behaviour for named Groups.

Added regression tests for Row fields, unnamed Groups, and named Groups.

Fixes #17882