### PR TITLE
fix(next): replace deprecated graphql-playground-html with GraphiQL

### DIFF
--- a/docs/graphql/overview.mdx
+++ b/docs/graphql/overview.mdx
@@ -119,7 +119,7 @@ User [preferences](../admin/preferences) for the [Admin Panel](../admin/overview
 
 ## GraphQL Playground
 
-GraphQL Playground is enabled by default for development purposes, but disabled in production. You can enable it in production by passing `graphQL.disablePlaygroundInProduction` a `false` setting in the main Payload Config.
+Payload serves an in-browser [GraphiQL](https://github.com/graphql/graphiql) IDE (including the point-and-click Explorer plugin) so you can explore and run queries against your API. It is enabled by default for development purposes, but disabled in production. You can enable it in production by passing `graphQL.disablePlaygroundInProduction` a `false` setting in the main Payload Config.
 
 You can even log in using the `login[collection-singular-label-here]` mutation to use the Playground as an authenticated user.
 
@@ -129,7 +129,7 @@ You can even log in using the `login[collection-singular-label-here]` mutation t
 To see more regarding how the above queries and mutations are used, visit your GraphQL playground
 (by default at
 [`${SERVER_URL}/api/graphql-playground`](http://localhost:3000/api/graphql-playground))
-while your server is running. There, you can use the "Schema" and "Docs" buttons on the right to
+while your server is running. There, you can use the "Docs" and "Explorer" buttons to
 see a ton of detail about how GraphQL operates within Payload.
 
 </Banner>

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -103,7 +103,6 @@
     "dequal": "2.0.3",
     "file-type": "22.0.1",
     "graphql-http": "1.22.4",
-    "graphql-playground-html": "1.6.30",
     "http-status": "2.1.0",
     "path-to-regexp": "6.3.0",
     "qs-esm": "8.0.1",

--- a/packages/next/src/routes/graphql/playground.ts
+++ b/packages/next/src/routes/graphql/playground.ts
@@ -1,4 +1,3 @@
-import { renderPlaygroundPage } from 'graphql-playground-html'
 import { createPayloadRequest, type SanitizedConfig } from 'payload'
 import { formatAdminURL } from 'payload/shared'
 
@@ -18,21 +17,91 @@ export const GET = (config: Promise<SanitizedConfig>) => async (request: Request
       apiRoute: req.payload.config.routes.api,
       path: req.payload.config.routes.graphQL as `/${string}`,
     })
-    return new Response(
-      renderPlaygroundPage({
-        endpoint,
-        settings: {
-          'request.credentials': 'include',
-        },
-      }),
-      {
-        headers: {
-          'Content-Type': 'text/html',
-        },
-        status: 200,
+    return new Response(renderGraphiQLPage(endpoint), {
+      headers: {
+        'Content-Type': 'text/html',
       },
-    )
+      status: 200,
+    })
   } else {
     return new Response('Route Not Found', { status: 404 })
   }
 }
+
+// Pinned CDN assets for the GraphiQL IDE. Versions are pinned and each asset carries
+// a Subresource Integrity (SRI) hash so the browser rejects tampered CDN responses.
+// GraphiQL replaces the deprecated, unmaintained graphql-playground; the explorer
+// plugin provides the point-and-click schema navigator. Assets are loaded from the
+// CDN at runtime rather than bundled, so this adds no weight to @payloadcms/next.
+const cdnAssets = {
+  explorerScript: {
+    integrity: 'sha384-5p6hGdlOTvUy6Wf0GauxCz+xM9YB/YYvcGG+bf9msr2eyd+KVIxgRkepHgUijedJ',
+    url: 'https://unpkg.com/@graphiql/plugin-explorer@3.2.6/dist/index.umd.js',
+  },
+  explorerStyle: {
+    integrity: 'sha384-YN9MumWidbWKuNj8VfH5ggrFvm9YqAoIOMnKYpeGL3dr7Eg1qnQ+SAqSthdNZCjz',
+    url: 'https://unpkg.com/@graphiql/plugin-explorer@3.2.6/dist/style.css',
+  },
+  graphiqlScript: {
+    integrity: 'sha384-8NGfVj4CVlqHajlZj+bPJT4thxPMHMJYn7DWK2CvtopLd02E7qsPHazniBYvVjOO',
+    url: 'https://unpkg.com/graphiql@3.9.0/graphiql.min.js',
+  },
+  graphiqlStyle: {
+    integrity: 'sha384-QMux00XgRtwRLSYIY3kw2rj1ovk5AuuliAchk+HSQbqdbGFnz9GYuqIlOqxhwCE2',
+    url: 'https://unpkg.com/graphiql@3.9.0/graphiql.min.css',
+  },
+  react: {
+    integrity: 'sha384-DGyLxAyjq0f9SPpVevD6IgztCFlnMF6oW/XQGmfe+IsZ8TqEiDrcHkMLKI6fiB/Z',
+    url: 'https://unpkg.com/react@18.3.1/umd/react.production.min.js',
+  },
+  reactDom: {
+    integrity: 'sha384-gTGxhz21lVGYNMcdJOyq01Edg0jhn/c22nsx0kyqP0TxaV5WVdsSH1fSDUf5YJj1',
+    url: 'https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js',
+  },
+}
+
+// GraphiQL's UMD bundles must load in dependency order: react, then react-dom, then
+// graphiql (reads React/ReactDOM), then the explorer plugin (reads GraphiQL.React and
+// GraphiQL.GraphQL). Plain (non-async) script tags preserve that order.
+const renderGraphiQLPage = (endpoint: string): string => `<!doctype html>
+<html lang="en">
+  <head>
+    <title>GraphiQL</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+      body {
+        margin: 0;
+      }
+      #graphiql {
+        height: 100dvh;
+      }
+      .graphiql-loading {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        height: 100dvh;
+        font-family: sans-serif;
+      }
+    </style>
+    <link rel="stylesheet" href="${cdnAssets.graphiqlStyle.url}" integrity="${cdnAssets.graphiqlStyle.integrity}" crossorigin="anonymous" />
+    <link rel="stylesheet" href="${cdnAssets.explorerStyle.url}" integrity="${cdnAssets.explorerStyle.integrity}" crossorigin="anonymous" />
+  </head>
+  <body>
+    <div id="graphiql"><div class="graphiql-loading">Loading GraphiQL…</div></div>
+    <script src="${cdnAssets.react.url}" integrity="${cdnAssets.react.integrity}" crossorigin="anonymous"></script>
+    <script src="${cdnAssets.reactDom.url}" integrity="${cdnAssets.reactDom.integrity}" crossorigin="anonymous"></script>
+    <script src="${cdnAssets.graphiqlScript.url}" integrity="${cdnAssets.graphiqlScript.integrity}" crossorigin="anonymous"></script>
+    <script src="${cdnAssets.explorerScript.url}" integrity="${cdnAssets.explorerScript.integrity}" crossorigin="anonymous"></script>
+    <script>
+      const endpoint = ${JSON.stringify(endpoint)}
+      const fetcher = GraphiQL.createFetcher({
+        url: endpoint,
+        fetch: (input, init) => fetch(input, { ...init, credentials: 'include' }),
+      })
+      const explorer = GraphiQLPluginExplorer.explorerPlugin()
+      const root = ReactDOM.createRoot(document.getElementById('graphiql'))
+      root.render(React.createElement(GraphiQL, { fetcher, plugins: [explorer] }))
+    </script>
+  </body>
+</html>`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -828,9 +828,6 @@ importers:
       graphql-http:
         specifier: 1.22.4
         version: 1.22.4(graphql@16.8.1)
-      graphql-playground-html:
-        specifier: 1.6.30
-        version: 1.6.30
       http-status:
         specifier: 2.1.0
         version: 2.1.0
@@ -10218,9 +10215,6 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
-  cssfilter@0.0.10:
-    resolution: {integrity: sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw==}
-
   cssstyle@5.3.7:
     resolution: {integrity: sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==}
     engines: {node: '>=20'}
@@ -11720,9 +11714,6 @@ packages:
     engines: {node: '>=12'}
     peerDependencies:
       graphql: 16.8.1
-
-  graphql-playground-html@1.6.30:
-    resolution: {integrity: sha512-tpCujhsJMva4aqE8ULnF7/l3xw4sNRZcSHu+R00VV+W0mfp+Q20Plvcrp+5UXD+2yS6oyCXncA+zoQJQqhGCEw==}
 
   graphql-scalars@1.22.2:
     resolution: {integrity: sha512-my9FB4GtghqXqi/lWSVAOPiTzTnnEzdOXCsAC2bb5V7EFNQjVjwy3cSSbUvgYOtDuDibd+ZsCDhz+4eykYOlhQ==}
@@ -15757,11 +15748,6 @@ packages:
 
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
-
-  xss@1.0.15:
-    resolution: {integrity: sha512-FVdlVVC67WOIPvfOwhoMETV72f6GbW7aOabBC3WxN/oUdoEMDyLz4OgRv5/gck2ZeNqEQu+Tb0kloovXOfpYVg==}
-    engines: {node: '>= 0.10.0'}
-    hasBin: true
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -24127,8 +24113,6 @@ snapshots:
 
   cssesc@3.0.0: {}
 
-  cssfilter@0.0.10: {}
-
   cssstyle@5.3.7:
     dependencies:
       '@asamuzakjp/css-color': 4.1.2
@@ -26013,10 +25997,6 @@ snapshots:
   graphql-http@1.22.4(graphql@16.8.1):
     dependencies:
       graphql: 16.8.1
-
-  graphql-playground-html@1.6.30:
-    dependencies:
-      xss: 1.0.15
 
   graphql-scalars@1.22.2(graphql@16.8.1):
     dependencies:
@@ -30580,11 +30560,6 @@ snapshots:
       js-yaml: 4.3.0
 
   xmlchars@2.2.0: {}
-
-  xss@1.0.15:
-    dependencies:
-      commander: 2.20.3
-      cssfilter: 0.0.10
 
   xtend@4.0.2: {}
 


### PR DESCRIPTION
## What

Replaces the deprecated, unmaintained `graphql-playground-html` dependency with **GraphiQL** (maintained by the GraphQL Foundation) plus the **Explorer plugin**, served from a pinned CDN with Subresource Integrity (SRI) hashes on every asset.

## Why

- `graphql-playground-html` (GraphQL Playground) has been **unmaintained since 2019** and carries known vulnerabilities; the GraphQL WG has discussed archiving it.
- GraphiQL is its actively-maintained successor, and the Explorer plugin provides the point-and-click schema navigation users expect.
- This **removes a runtime dependency** with **no bundle-size cost**: the IDE is loaded from a CDN at page load, exactly as before — nothing is bundled into `@payloadcms/next`.

## How

- `packages/next/src/routes/graphql/playground.ts` now emits a self-contained HTML page that loads `graphiql@3.9.0`, `@graphiql/plugin-explorer@3.2.6`, and `react`/`react-dom@18.3.1` from unpkg. Each `<script>`/`<link>` is **pinned** and carries an SRI `integrity` hash + `crossorigin="anonymous"`, closing the supply-chain gap the previous (unpinned, no-integrity) setup left open.
- Unchanged: the route path (`/api/graphql-playground`), the gating logic, the `graphQL.disablePlaygroundInProduction` flag, and `credentials: 'include'` (so authenticated queries via `login<collection>` still work).
- Removed `graphql-playground-html` from `package.json` and pruned it (plus its now-orphaned `xss`/`cssfilter`) from the lockfile.

## Testing

- `pnpm run build:next` passes (incl. `tsc` declaration emit).
- `pnpm install --frozen-lockfile` passes.
- Verified in a real browser: `/api/graphql-playground` renders GraphiQL + Explorer with **zero console errors**, SRI passes, and a live authenticated query returns data (confirming `credentials: 'include'` sends the auth cookie end-to-end).

## Notes

This is a focused, non-breaking cleanup. A follow-up will separately explore making GraphQL fully opt-in (lazy imports + optional peer deps + scaffolding gating), which is breaking and warrants its own discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)