### PR TITLE
fix: isolate context for nested Local API calls

### DIFF
--- a/packages/payload/src/utilities/createLocalReq.spec.ts
+++ b/packages/payload/src/utilities/createLocalReq.spec.ts
@@ -4,7 +4,7 @@ import type { Payload } from '../index.js'
 
 import { createLocalReq } from './createLocalReq.js'
 
-describe('createLocalReq - URL construction', () => {
+describe('createLocalReq', () => {
   const mockPayload = {
     config: {
       serverURL: undefined,
@@ -19,6 +19,27 @@ describe('createLocalReq - URL construction', () => {
       error: vi.fn(),
     },
   } as unknown as Payload
+
+  it('should isolate context passed to nested Local API calls', async () => {
+    const req = await createLocalReq({}, mockPayload)
+
+    const nestedReq = await createLocalReq({ context: { value: 5 }, req }, mockPayload)
+    const siblingReq = await createLocalReq({ req }, mockPayload)
+
+    expect(nestedReq.context).toEqual({ value: 5 })
+    expect(req.context).toEqual({})
+    expect(siblingReq.context).toEqual({})
+  })
+
+  it('should inherit parent context without sharing its object', async () => {
+    const req = await createLocalReq({ context: { parentValue: 1 } }, mockPayload)
+
+    const nestedReq = await createLocalReq({ context: { nestedValue: 2 }, req }, mockPayload)
+
+    expect(nestedReq.context).toEqual({ nestedValue: 2, parentValue: 1 })
+    expect(nestedReq.context).not.toBe(req.context)
+    expect(req.context).toEqual({ parentValue: 1 })
+  })
 
   it('should use req.url when provided and serverURL is undefined', async () => {
     const req = {

--- a/packages/payload/src/utilities/createLocalReq.spec.ts
+++ b/packages/payload/src/utilities/createLocalReq.spec.ts
@@ -41,6 +41,17 @@ describe('createLocalReq', () => {
     expect(req.context).toEqual({ parentValue: 1 })
   })
 
+  it('should share context when nested Local API calls do not pass context', async () => {
+    const req = await createLocalReq({ context: { parentValue: 1 } }, mockPayload)
+
+    const nestedReq = await createLocalReq({ req }, mockPayload)
+    nestedReq.context.nestedValue = 2
+
+    expect(nestedReq).toBe(req)
+    expect(nestedReq.context).toBe(req.context)
+    expect(req.context).toEqual({ nestedValue: 2, parentValue: 1 })
+  })
+
   it('should use req.url when provided and serverURL is undefined', async () => {
     const req = {
       url: 'http://example.com/api/test',

--- a/packages/payload/src/utilities/createLocalReq.ts
+++ b/packages/payload/src/utilities/createLocalReq.ts
@@ -4,6 +4,7 @@ import type { PayloadRequest } from '../types/index.js'
 import { getDataLoader } from '../collections/dataloader.js'
 import { getLocalI18n } from '../translations/getLocalI18n.js'
 import { sanitizeFallbackLocale } from '../utilities/sanitizeFallbackLocale.js'
+import { isolateObjectProperty } from './isolateObjectProperty.js'
 
 function getRequestContext(
   req: Partial<PayloadRequest> = { context: null } as unknown as PayloadRequest,
@@ -136,6 +137,7 @@ export const createLocalReq: CreateLocalReq = async (
     req.headers = new Headers()
   }
 
+  req = isolateObjectProperty(req, 'context')
   req.context = getRequestContext(req, context)
   req.payloadAPI = req?.payloadAPI || 'local'
   req.payload = payload

--- a/packages/payload/src/utilities/createLocalReq.ts
+++ b/packages/payload/src/utilities/createLocalReq.ts
@@ -137,7 +137,9 @@ export const createLocalReq: CreateLocalReq = async (
     req.headers = new Headers()
   }
 
-  req = isolateObjectProperty(req, 'context')
+  if (typeof context !== 'undefined') {
+    req = isolateObjectProperty(req, 'context')
+  }
   req.context = getRequestContext(req, context)
   req.payloadAPI = req?.payloadAPI || 'local'
   req.payload = payload


### PR DESCRIPTION
### What?

Isolate `req.context` when a nested Local API operation explicitly supplies `context`, while preserving parent context values for that nested operation.

Calls that pass only `req` retain the existing shared operation context. This is required by recursive operations such as hierarchy path computation and its request-scoped ancestor cache.

This adds regression coverage for:

- the sibling-call leak reported in #10250
- parent-to-child context inheritance without sharing the context object when child context is explicit
- intentional context sharing when a nested call reuses `req` without supplying context

### Why?

`createLocalReq` currently assigns an explicitly merged context directly to the provided request. A nested Local API call with its own context therefore mutates the request owned by its parent operation. Later or concurrently running sibling hooks can then observe values that belong only to the nested call.

The initial patch isolated every nested call. Full CI showed that this was too broad: Payload's hierarchy recursion passes `req` without a new context and intentionally shares cache updates within the operation. The corrected condition preserves that established behavior while isolating explicitly supplied child context.

### How?

Use the existing `isolateObjectProperty` proxy only when the Local API caller supplies `context`. Other request state remains shared, including transaction state. Explicit child context values are shallowly merged over inherited parent values without rebinding the caller's context property.

Validated with:

- `pnpm exec vitest run --project unit packages/payload/src/utilities/createLocalReq.spec.ts` — 9 tests passed
- `PAYLOAD_DATABASE=sqlite pnpm run test:int hierarchy` — 35 tests passed
- `pnpm --filter payload build:types`
- focused ESLint and Prettier checks
- `git diff --check`

Fixes #10250
