### PR TITLE
fix: account for conditional layout fields in generated types

### DIFF
--- a/packages/payload/src/fields/config/types.ts
+++ b/packages/payload/src/fields/config/types.ts
@@ -1775,7 +1775,10 @@ export type FlattenedJoinField = {
   targetField: RelationshipField | UploadField
 } & JoinField
 
-export type FlattenedField =
+export type FlattenedField = {
+  /** Whether a non-data layout ancestor has an admin condition. */
+  hasConditionalParent?: boolean
+} & (
   | CheckboxField
   | CodeField
   | DateField
@@ -1796,6 +1799,7 @@ export type FlattenedField =
   | TextareaField
   | TextField
   | UploadField
+)
 export type Field =
   | ArrayField
   | BlocksField

--- a/packages/payload/src/utilities/configToJSONSchema.spec.ts
+++ b/packages/payload/src/utilities/configToJSONSchema.spec.ts
@@ -65,6 +65,87 @@ describe('configToJSONSchema', () => {
     })
   })
 
+  it('should make required fields optional beneath conditional non-data layouts', () => {
+    // @ts-expect-error partial config
+    const config: Config = {
+      collections: [
+        {
+          slug: 'test',
+          fields: [
+            {
+              type: 'row',
+              admin: { condition: () => true },
+              fields: [{ name: 'rowField', type: 'text', required: true }],
+            },
+            {
+              type: 'collapsible',
+              label: 'Conditional collapsible',
+              admin: { condition: () => true },
+              fields: [{ name: 'collapsibleField', type: 'text', required: true }],
+            },
+            {
+              type: 'group',
+              admin: { condition: () => true },
+              fields: [{ name: 'groupField', type: 'text', required: true }],
+            },
+            {
+              type: 'tabs',
+              admin: { condition: () => true },
+              tabs: [
+                {
+                  label: 'Conditional tabs field',
+                  fields: [{ name: 'tabsField', type: 'text', required: true }],
+                },
+                {
+                  name: 'namedTab',
+                  label: 'Named tab beneath conditional tabs',
+                  fields: [{ name: 'namedTabField', type: 'text', required: true }],
+                },
+              ],
+            },
+            {
+              type: 'tabs',
+              tabs: [
+                {
+                  label: 'Conditional unnamed tab',
+                  admin: { condition: () => true },
+                  fields: [{ name: 'unnamedTabField', type: 'text', required: true }],
+                },
+                {
+                  name: 'conditionallyNamedTab',
+                  label: 'Conditional named tab',
+                  admin: { condition: () => true },
+                  fields: [{ name: 'conditionallyNamedTabField', type: 'text', required: true }],
+                },
+              ],
+            },
+          ],
+          timestamps: false,
+          versions: false,
+        },
+      ],
+    }
+
+    const sanitizedConfig = sanitizeConfig(config)
+    const { jsonSchema: schema } = configToJSONSchema(sanitizedConfig, 'text')
+    const testSchema = schema?.$defs?.test as JSONSchema4
+
+    expect(testSchema.required).toStrictEqual(['id'])
+    expect(testSchema.properties?.rowField).toStrictEqual({ type: ['string', 'null'] })
+    expect(testSchema.properties?.collapsibleField).toStrictEqual({ type: ['string', 'null'] })
+    expect(testSchema.properties?.groupField).toStrictEqual({ type: ['string', 'null'] })
+    expect(testSchema.properties?.tabsField).toStrictEqual({ type: ['string', 'null'] })
+    expect(testSchema.properties?.unnamedTabField).toStrictEqual({ type: ['string', 'null'] })
+    expect(testSchema.properties?.namedTab).toMatchObject({
+      required: ['namedTabField'],
+      type: 'object',
+    })
+    expect(testSchema.properties?.conditionallyNamedTab).toMatchObject({
+      required: ['conditionallyNamedTabField'],
+      type: 'object',
+    })
+  })
+
   it('should generate separate input types when generateInputTypes is enabled', () => {
     // @ts-expect-error partial config
     const config: Config = {

--- a/packages/payload/src/utilities/configToJSONSchema.ts
+++ b/packages/payload/src/utilities/configToJSONSchema.ts
@@ -25,7 +25,8 @@ const fieldIsInputExcluded = (field: FlattenedField): boolean =>
   field.type === 'join' || fieldIsVirtual(field)
 
 const fieldIsRequired = (field: FlattenedField): boolean => {
-  const isConditional = Boolean(field?.admin && field?.admin?.condition)
+  const isConditional =
+    field.hasConditionalParent || Boolean(field?.admin && field?.admin?.condition)
   if (isConditional) {
     return false
   }

--- a/packages/payload/src/utilities/flattenAllFields.ts
+++ b/packages/payload/src/utilities/flattenAllFields.ts
@@ -38,6 +38,16 @@ export const flattenAllFields = ({
     }
   }
 
+  return flattenFields({ fields, hasConditionalParent: false })
+}
+
+const flattenFields = ({
+  fields,
+  hasConditionalParent,
+}: {
+  fields: Field[]
+  hasConditionalParent: boolean
+}): FlattenedField[] => {
   const result: FlattenedField[] = []
 
   for (const field of fields) {
@@ -45,9 +55,23 @@ export const flattenAllFields = ({
       case 'array':
       case 'group': {
         if (fieldAffectsData(field)) {
-          result.push({ ...field, flattenedFields: flattenAllFields({ fields: field.fields }) })
+          result.push(
+            withConditionalParent({
+              field: {
+                ...field,
+                flattenedFields: flattenFields({
+                  fields: field.fields,
+                  hasConditionalParent: false,
+                }),
+              },
+              hasConditionalParent,
+            }),
+          )
         } else {
-          for (const nestedField of flattenAllFields({ fields: field.fields })) {
+          for (const nestedField of flattenFields({
+            fields: field.fields,
+            hasConditionalParent: hasConditionalParent || Boolean(field.admin?.condition),
+          })) {
             result.push(nestedField)
           }
         }
@@ -69,35 +93,53 @@ export const flattenAllFields = ({
           blocks,
         }
 
-        result.push(resultField)
+        result.push(withConditionalParent({ field: resultField, hasConditionalParent }))
         break
       }
 
       case 'collapsible':
       case 'row': {
-        for (const nestedField of flattenAllFields({ fields: field.fields })) {
+        for (const nestedField of flattenFields({
+          fields: field.fields,
+          hasConditionalParent: hasConditionalParent || Boolean(field.admin?.condition),
+        })) {
           result.push(nestedField)
         }
         break
       }
 
       case 'join': {
-        result.push(field as FlattenedJoinField)
+        result.push(
+          withConditionalParent({ field: field as FlattenedJoinField, hasConditionalParent }),
+        )
         break
       }
 
       case 'tabs': {
+        const tabsHaveConditionalParent = hasConditionalParent || Boolean(field.admin?.condition)
+
         for (const tab of field.tabs) {
           if (!tabHasName(tab)) {
-            for (const nestedField of flattenAllFields({ fields: tab.fields })) {
+            for (const nestedField of flattenFields({
+              fields: tab.fields,
+              hasConditionalParent: tabsHaveConditionalParent || Boolean(tab.admin?.condition),
+            })) {
               result.push(nestedField)
             }
           } else {
-            result.push({
-              ...tab,
-              type: 'tab',
-              flattenedFields: flattenAllFields({ fields: tab.fields }),
-            })
+            result.push(
+              withConditionalParent({
+                field: {
+                  ...tab,
+                  type: 'tab',
+                  flattenedFields: flattenFields({
+                    fields: tab.fields,
+                    hasConditionalParent: false,
+                  }),
+                },
+                hasConditionalParent: tabsHaveConditionalParent,
+              }),
+            )
           }
         }
         break
@@ -105,13 +147,29 @@ export const flattenAllFields = ({
 
       default: {
         if (field.type !== 'ui') {
-          result.push(field)
+          result.push(withConditionalParent({ field, hasConditionalParent }))
         }
       }
     }
   }
 
-  flattenedFieldsCache.set(fields, result)
+  if (!hasConditionalParent) {
+    flattenedFieldsCache.set(fields, result)
+  }
 
   return result
+}
+
+const withConditionalParent = <T extends FlattenedField>({
+  field,
+  hasConditionalParent,
+}: {
+  field: T
+  hasConditionalParent: boolean
+}): T => {
+  if (hasConditionalParent) {
+    return { ...field, hasConditionalParent }
+  }
+
+  return field
 }


### PR DESCRIPTION
### What?

Makes generated TypeScript properties optional when required fields are nested beneath conditional non-data layout fields.

### Why?

Non-data layout fields are removed by `flattenAllFields`. Their `admin.condition` was therefore lost before `fieldsToJSONSchema` determined whether nested fields were required.

At runtime, validation skips these nested fields when the parent condition is false, but the generated types incorrectly required them.

### How?

- Preserves whether a flattened field has a conditional non-data layout ancestor
- Includes inherited conditionality when determining generated-schema requiredness
- Stops propagation at data-bearing group and named-tab boundaries, keeping their required children required when the object is present
- Adds regression coverage for rows, collapsibles, unnamed groups, tabs containers, unnamed tabs, and named tabs

Fixes #17896
