### PR TITLE
test: add shared Payload integration fixtures

### DIFF
--- a/test/__helpers/int/vitest.ts
+++ b/test/__helpers/int/vitest.ts
@@ -1,115 +1,121 @@
-import type { SuiteFactory, TestFunction } from 'vitest'
+import type { Payload, SanitizedConfig } from 'payload'
 
-import { describe as vitestDescribe, it as vitestIt } from 'vitest'
+import path from 'node:path'
+import { getPayload } from 'payload'
+import { expect, test as vitestTest } from 'vitest'
 
-import { type DatabaseAdapterType, getCurrentDatabaseAdapter } from '../../dbAdapters.js'
+import type { DatabaseAdapterType } from '../../dbAdapters.js'
+
+import { getCurrentDatabaseAdapter } from '../../dbAdapters.js'
+import { getSDK } from '../shared/getSDK.js'
+import { initPayloadInt } from '../shared/initPayloadInt.js'
 import { mongooseList } from '../shared/isMongoose.js'
+import { NextRESTClient } from '../shared/NextRESTClient.js'
 
-type ItOptions = {
-  /**
-   * Specify which database(s) the test should run on.
-   * - 'all': Run on all databases (default)
-   * - 'drizzle': Run only on Drizzle (Postgres/SQLite)
-   * - 'mongo': Run only on MongoDB
-   * - function: Custom function that receives the current adapter type and returns a boolean indicating whether to run the test.
-   */
+type TestOptions = {
+  /** Limits the test or suite to the selected database adapters. */
   db?: 'all' | 'drizzle' | 'mongo' | ((adapterType: DatabaseAdapterType) => boolean)
+}
+
+type IntegrationFixtures = {
+  $file: {
+    config: SanitizedConfig
+    payload: Payload
+    testDir: string
+  }
+  $test: {
+    restClient: NextRESTClient
+    sdk: ReturnType<typeof getSDK>
+  }
+}
+
+// Keep all fixtures in one extension so Vitest can trace test calls back to their source lines.
+const testWithFixtures = vitestTest.extend<IntegrationFixtures>({
+  config: [
+    async ({ testDir }, use) => {
+      const { config } = await initPayloadInt(testDir, undefined, false)
+
+      await use(config)
+    },
+    { scope: 'file' },
+  ],
+  payload: [
+    async ({ config }, use) => {
+      const payload = await getPayload({ config, cron: true })
+
+      await use(payload)
+      await payload.destroy()
+    },
+    { scope: 'file' },
+  ],
+  restClient: async ({ payload }, use) => {
+    await use(new NextRESTClient(payload.config))
+  },
+  sdk: async ({ payload }, use) => {
+    await use(getSDK(payload.config))
+  },
+  testDir: [
+    // eslint-disable-next-line no-empty-pattern
+    async ({}, use) => {
+      await use(getTestDirectory())
+    },
+    { scope: 'file' },
+  ],
+})
+
+/**
+ * Integration test API with Payload's shared fixtures and database filtering.
+ *
+ * `config`, `payload`, and `testDir` are shared for the test file. `payload` is destroyed
+ * automatically after the file finishes. Clients are new for every test so
+ * authentication and other mutable state cannot leak into the next test.
+ *
+ * @example
+ * test.options({ db: 'mongo' })('MongoDB only', async ({ payload }) => {
+ *   await payload.find({ collection: 'posts' })
+ * })
+ *
+ * @example
+ * test.options({ db: 'drizzle' }).describe('Drizzle only', () => {
+ *   test('works', async ({ payload }) => { ... })
+ * })
+ */
+export const test = Object.assign(testWithFixtures, {
+  options: (options: TestOptions) => {
+    const shouldRun = matchesDatabase(options)
+
+    return Object.assign(testWithFixtures.runIf(shouldRun), {
+      describe: testWithFixtures.describe.runIf(shouldRun),
+    })
+  },
+})
+
+const getTestDirectory = (): string => {
+  const testPath = expect.getState().testPath
+
+  if (!testPath) {
+    throw new Error('Could not determine the integration test file path.')
+  }
+
+  return path.dirname(testPath)
 }
 
 const isMongo = mongooseList.includes(process.env.PAYLOAD_DATABASE!)
 
-/**
- * Custom `it` wrapper that supports database-specific test execution.
- *
- * @example
- * // Run only on Drizzle (Postgres/SQLite)
- * it('drizzle-specific test', { db: 'drizzle' }, async () => { ... })
- *
- * // Run only on MongoDB
- * it('mongo-specific test', { db: 'mongo' }, async () => { ... })
- *
- * // Run on all databases (default)
- * it('universal test', async () => { ... })
- */
-const itWithOptions = (
-  name: string,
-  optionsOrFn?: ItOptions | TestFunction,
-  fn?: TestFunction,
-): ReturnType<typeof vitestIt> => {
-  // Handle overloads: it(name, fn) or it(name, options, fn)
-  const options: ItOptions | undefined = typeof optionsOrFn === 'object' ? optionsOrFn : undefined
-  const testFn: TestFunction | undefined = typeof optionsOrFn === 'function' ? optionsOrFn : fn
-
-  const db = options?.db ?? 'all'
-
+const matchesDatabase = ({ db = 'all' }: TestOptions = {}): boolean => {
   if (typeof db === 'function') {
-    if (!db(getCurrentDatabaseAdapter())) {
-      return vitestIt.skip(name, testFn)
-    }
-
-    return vitestIt(name, testFn)
+    return db(getCurrentDatabaseAdapter())
   }
 
-  if (db === 'drizzle' && isMongo) {
-    return vitestIt.skip(name, testFn)
+  if (db === 'mongo') {
+    return isMongo
   }
-  if (db === 'mongo' && !isMongo) {
-    return vitestIt.skip(name, testFn)
+
+  if (db === 'drizzle') {
+    return !isMongo
   }
-  return vitestIt(name, testFn)
+
+  return true
 }
 
-// Add skip property for compatibility
-itWithOptions.skip = vitestIt.skip
-
-// Needs to be called `it` for the vitest vs code extension to recognize it as a test function
-export const it = itWithOptions
-
-/**
- * Custom `describe` wrapper that supports database-specific suite execution.
- *
- * @example
- * // Run only on Drizzle (Postgres/SQLite)
- * describe('drizzle-specific suite', { db: 'drizzle' }, () => { ... })
- *
- * // Run only on MongoDB
- * describe('mongo-specific suite', { db: 'mongo' }, () => { ... })
- *
- * // Run on all databases (default)
- * describe('universal suite', () => { ... })
- */
-const describeWithOptions = (
-  name: string,
-  optionsOrFn?: ItOptions | SuiteFactory,
-  fn?: SuiteFactory,
-): ReturnType<typeof vitestDescribe> => {
-  // Handle overloads: describe(name, fn) or describe(name, options, fn)
-  const options: ItOptions | undefined = typeof optionsOrFn === 'object' ? optionsOrFn : undefined
-  const suiteFn: SuiteFactory | undefined = typeof optionsOrFn === 'function' ? optionsOrFn : fn
-
-  const db = options?.db ?? 'all'
-
-  if (typeof db === 'function') {
-    if (!db(getCurrentDatabaseAdapter())) {
-      return vitestDescribe.skip(name, suiteFn)
-    }
-    return vitestDescribe(name, suiteFn)
-  }
-
-  if (db === 'drizzle' && isMongo) {
-    return vitestDescribe.skip(name, suiteFn)
-  }
-  if (db === 'mongo' && !isMongo) {
-    return vitestDescribe.skip(name, suiteFn)
-  }
-  return vitestDescribe(name, suiteFn)
-}
-
-// Add skip property for compatibility
-describeWithOptions.skip = vitestDescribe.skip
-
-// Needs to be called `describe` for the vitest vs code extension to recognize it
-export const describe = describeWithOptions
-
-// Re-export for convenience
 export { isMongo }

--- a/test/database/int.spec.ts
+++ b/test/database/int.spec.ts
@@ -29,13 +29,13 @@ import {
 } from 'payload'
 import { assert } from 'ts-essentials'
 import { fileURLToPath } from 'url'
-import { afterAll, afterEach, beforeAll, beforeEach, expect } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 
 import type { NextRESTClient } from '../__helpers/shared/NextRESTClient.js'
 import type { Global2, Post } from './payload-types.js'
 
 import { sanitizeQueryValue } from '../../packages/db-mongodb/src/queries/sanitizeQueryValue.js'
-import { describe, it } from '../__helpers/int/vitest.js'
+import { test } from '../__helpers/int/vitest.js'
 import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
 import { removeFiles } from '../__helpers/shared/removeFiles.js'
 import { devUser } from '../credentials.js'
@@ -90,10 +90,11 @@ describe('database', () => {
     await payload.destroy()
   })
 
-  describe(
-    'connection pool',
-    { db: (adapter) => adapter.startsWith('postgres') || adapter === 'supabase' },
-    () => {
+  test
+    .options({
+      db: (adapter) => adapter.startsWith('postgres') || adapter === 'supabase',
+    })
+    .describe('connection pool', () => {
       it('should not leave a client checked out after connecting', async () => {
         const { pool } = payload.db as unknown as PostgresAdapter
 
@@ -108,8 +109,7 @@ describe('database', () => {
         // the process, so `pool.end()` never drains after `payload.destroy()`.
         expect(pool.totalCount - pool.idleCount).toBe(0)
       })
-    },
-  )
+    })
 
   describe('id type', () => {
     it('should sanitize incoming IDs if ID type is number', async () => {
@@ -788,10 +788,8 @@ describe('database', () => {
       await noTimestampsTestDB(true)
     })
 
-    // eslint-disable-next-line vitest/expect-expect
-    it(
+    test.options({ db: 'mongo' })(
       'ensure timestamps are not created in update or create when timestamps are disabled even with allowAdditionalKeys true',
-      { db: 'mongo' },
       async () => {
         const originalAllowAdditionalKeys = payload.db.allowAdditionalKeys
         payload.db.allowAdditionalKeys = true
@@ -800,10 +798,8 @@ describe('database', () => {
       },
     )
 
-    // eslint-disable-next-line vitest/expect-expect
-    it(
+    test.options({ db: 'mongo' })(
       'ensure timestamps are not created in db adapter update or create when timestamps are disabled even with allowAdditionalKeys true',
-      { db: 'mongo' },
       async () => {
         const originalAllowAdditionalKeys = payload.db.allowAdditionalKeys
         payload.db.allowAdditionalKeys = true
@@ -1892,7 +1888,7 @@ describe('database', () => {
     })
 
     // known drizzle issue: https://github.com/payloadcms/payload/issues/4597
-    it('should run migrate:down', { db: 'mongo' }, async () => {
+    test.options({ db: 'mongo' })('should run migrate:down', async () => {
       // migrate existing if there any
       await payload.db.migrate()
 
@@ -1926,7 +1922,7 @@ describe('database', () => {
     })
 
     // known drizzle issue: https://github.com/payloadcms/payload/issues/4597
-    it('should run migrate:refresh', { db: 'mongo' }, async () => {
+    test.options({ db: 'mongo' })('should run migrate:refresh', async () => {
       let error
       try {
         await payload.db.migrateRefresh()
@@ -1944,7 +1940,7 @@ describe('database', () => {
   })
 
   // known drizzle issue: https://github.com/payloadcms/payload/issues/4597
-  it('should run migrate:reset', { db: 'mongo' }, async () => {
+  test.options({ db: 'mongo' })('should run migrate:reset', async () => {
     let error
     try {
       await payload.db.migrateReset()
@@ -2398,48 +2394,42 @@ describe('database', () => {
         })
       }
 
-      it(
-        'should throw error when beginTransaction fails to connect (drizzle)',
-        { db: (adapter) => adapter.startsWith('postgres') || adapter === 'supabase' },
-        async () => {
-          const db = payload.db as unknown as Record<string, unknown>
-          const originalDrizzle = db.drizzle
-          try {
-            db.drizzle = {
-              transaction: () => Promise.reject(new Error('connection refused')),
-            }
-
-            await expect(() => payload.db.beginTransaction()).rejects.toThrow(/connection refused/)
-          } finally {
-            db.drizzle = originalDrizzle
+      test.options({
+        db: (adapter) => adapter.startsWith('postgres') || adapter === 'supabase',
+      })('should throw error when beginTransaction fails to connect (drizzle)', async () => {
+        const db = payload.db as unknown as Record<string, unknown>
+        const originalDrizzle = db.drizzle
+        try {
+          db.drizzle = {
+            transaction: () => Promise.reject(new Error('connection refused')),
           }
-        },
-      )
 
-      it(
-        'should throw error when beginTransaction fails to connect (mongo)',
-        {
-          db: (adapter) =>
-            adapter === 'mongodb' || adapter === 'mongodb-atlas' || adapter === 'documentdb',
-        },
-        async () => {
-          const db = payload.db as unknown as Record<string, unknown>
-          const originalConnection = db.connection
-          try {
-            db.connection = {
-              getClient: () => ({
-                startSession: () => {
-                  throw new Error('connection refused')
-                },
-              }),
-            }
+          await expect(() => payload.db.beginTransaction()).rejects.toThrow(/connection refused/)
+        } finally {
+          db.drizzle = originalDrizzle
+        }
+      })
 
-            await expect(() => payload.db.beginTransaction()).rejects.toThrow(/connection refused/)
-          } finally {
-            db.connection = originalConnection
+      test.options({
+        db: (adapter) =>
+          adapter === 'mongodb' || adapter === 'mongodb-atlas' || adapter === 'documentdb',
+      })('should throw error when beginTransaction fails to connect (mongo)', async () => {
+        const db = payload.db as unknown as Record<string, unknown>
+        const originalConnection = db.connection
+        try {
+          db.connection = {
+            getClient: () => ({
+              startSession: () => {
+                throw new Error('connection refused')
+              },
+            }),
           }
-        },
-      )
+
+          await expect(() => payload.db.beginTransaction()).rejects.toThrow(/connection refused/)
+        } finally {
+          db.connection = originalConnection
+        }
+      })
 
       describe('disableTransaction', () => {
         let disabledTransactionPost
@@ -3244,7 +3234,7 @@ describe('database', () => {
     })
   })
 
-  describe('Schema generation', { db: 'drizzle' }, () => {
+  test.options({ db: 'drizzle' }).describe('Schema generation', () => {
     it('should generate Drizzle Postgres schema', async () => {
       const generatedAdapterName = process.env.PAYLOAD_DATABASE
       if (!generatedAdapterName?.includes('postgres') && generatedAdapterName !== 'supabase') {
@@ -5952,7 +5942,7 @@ describe('database', () => {
     await payload.db.connect()
   })
 
-  it('ensure mongodb query sanitization does not duplicate IDs', { db: 'mongo' }, () => {
+  test.options({ db: 'mongo' })('ensure mongodb query sanitization does not duplicate IDs', () => {
     const res: any = sanitizeQueryValue({
       field: {
         name: '_id',
@@ -5971,9 +5961,8 @@ describe('database', () => {
     expect(JSON.parse(JSON.stringify(res)).val[0]).toEqual('68378b649ca45274fb10126f')
   })
 
-  it(
+  test.options({ db: 'mongo' })(
     'ensure mongodb respects collation when using collection in the config',
-    { db: 'mongo' },
     async () => {
       // Clear any existing documents
       await payload.delete({ collection: 'simple', where: {} })
@@ -6023,9 +6012,8 @@ describe('database', () => {
     },
   )
 
-  it(
+  test.options({ db: 'mongo' })(
     'ensure mongodb collation works with draft pagination without sort',
-    { db: 'mongo' },
     async () => {
       // Clear any existing documents
       await payload.delete({ collection: 'categories', where: {} })

--- a/test/database/migrate-to-blocks-as-json/int.spec.ts
+++ b/test/database/migrate-to-blocks-as-json/int.spec.ts
@@ -8,7 +8,7 @@ import path from 'path'
 import { getPayload } from 'payload'
 import { expect, it } from 'vitest'
 
-import { describe } from '../../__helpers/int/vitest.js'
+import { test } from '../../__helpers/int/vitest.js'
 import config from './config.js'
 
 const filename = fileURLToPath(import.meta.url)
@@ -17,7 +17,7 @@ const dirname = path.dirname(filename)
 // path for temp config created after initial migration which should have blocks as json enabled
 const tempConfigPath = path.resolve(dirname, 'GENERATED_after_migration.config.ts')
 
-describe('migrateToBlocksAsJSON', { db: 'drizzle' }, () => {
+test.options({ db: 'drizzle' }).describe('migrateToBlocksAsJSON', () => {
   it('should migrate to blocks as json', async () => {
     // seed initital data
     const payload = await getPayload({ config })

--- a/test/database/migrations-cli.int.spec.ts
+++ b/test/database/migrations-cli.int.spec.ts
@@ -9,10 +9,10 @@ import fs from 'fs'
 import path from 'path'
 import { migrateCLI } from 'payload'
 import { fileURLToPath } from 'url'
-import { afterEach, beforeEach, expect } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
+import { test } from '../__helpers/int/vitest.js'
 import { removeFiles } from '../__helpers/shared/removeFiles.js'
-import { describe, it } from '../__helpers/int/vitest.js'
 import configPromise from './config.js'
 
 const filename = fileURLToPath(import.meta.url)
@@ -66,9 +66,8 @@ describe('migrations CLI', () => {
     expect(migrationContent).toContain("import { sql } from 'drizzle-orm'")
   })
 
-  it(
+  test.options({ db: 'mongo' })(
     'should create migration from @payloadcms/db-* adapter predefinedMigrations folder',
-    { db: 'mongo' },
     async () => {
       // Tests: Path 1 in getPredefinedMigration.ts - @payloadcms/db-* prefix handling
       // These load directly from adapter's predefinedMigrations folder WITHOUT package.json exports

--- a/test/database/sqlite-bound-parameters-limit.int.spec.ts
+++ b/test/database/sqlite-bound-parameters-limit.int.spec.ts
@@ -4,18 +4,17 @@ import path from 'path'
 import { fileURLToPath } from 'url'
 import { afterAll, beforeAll, expect, it } from 'vitest'
 
+import { test } from '../__helpers/int/vitest.js'
 import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
-import { describe } from '../__helpers/int/vitest.js'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
 let payload: Payload
 
-describe(
-  'database - sqlite bound parameters limit',
-  { db: (type) => type.startsWith('sqlite') },
-  () => {
+test
+  .options({ db: (type) => type.startsWith('sqlite') })
+  .describe('database - sqlite bound parameters limit', () => {
     beforeAll(async () => {
       ;({ payload } = await initPayloadInt(dirname))
     })
@@ -127,5 +126,4 @@ describe(
       expect(res.docs[0].id).toBe(simpleLocalizedDoc.id)
       expect(res.docs[0].text).toBe('Test')
     })
-  },
-)
+  })

--- a/test/eslint.config.js
+++ b/test/eslint.config.js
@@ -47,6 +47,12 @@ export const testEslintConfig = [
     },
     rules: {
       '@typescript-eslint/no-explicit-any': 'off',
+      'vitest/no-standalone-expect': [
+        'error',
+        {
+          additionalTestBlockFunctions: ['it.options', 'test.options', 'describe.options'],
+        },
+      ],
     },
   },
   {

--- a/test/fields/int.spec.ts
+++ b/test/fields/int.spec.ts
@@ -6,12 +6,12 @@ import { slugifyHandler } from '@payloadcms/ui/utilities/slugify'
 import path from 'path'
 import { createLocalReq, reload } from 'payload'
 import { fileURLToPath } from 'url'
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 
 import type { NextRESTClient } from '../__helpers/shared/NextRESTClient.js'
 import type { BlockField, GroupField } from './payload-types.js'
 
-import { it } from '../__helpers/int/vitest.js'
+import { test } from '../__helpers/int/vitest.js'
 import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
 import { isMongoose } from '../__helpers/shared/isMongoose.js'
 import { devUser } from '../credentials.js'
@@ -3178,7 +3178,7 @@ describe('Fields', () => {
       expect((idFields[0].admin?.disabled as { filter?: boolean })?.filter).toBe(true)
     })
 
-    it('should query exists true', { db: 'mongo' }, async () => {
+    test.options({ db: 'mongo' })('should query exists true', async () => {
       await payload.delete({ collection: 'array-fields', where: {} })
 
       const withoutCollapsed = await payload.create({
@@ -3226,7 +3226,7 @@ describe('Fields', () => {
       expect(res.docs[0].id).toBe(withCollapsed.id)
     })
 
-    it('should query exists false', { db: 'mongo' }, async () => {
+    test.options({ db: 'mongo' })('should query exists false', async () => {
       await payload.delete({ collection: 'array-fields', where: {} })
 
       const withoutCollapsed = await payload.create({
@@ -3927,9 +3927,8 @@ describe('Fields', () => {
 
     // TODO: re-enable on sqlite once the drizzle sqlite adapter's createJSONQuery supports
     // lexical's `{root: {children: [...]}}` shape
-    it(
+    test.options({ db: (adapter) => adapter.startsWith('sqlite') === false })(
       'should query based on richtext data within a block',
-      { db: (adapter) => adapter.startsWith('sqlite') === false },
       async () => {
         const blockFieldsSuccess = await payload.find({
           collection: 'block-fields',
@@ -3956,9 +3955,8 @@ describe('Fields', () => {
     )
 
     // TODO: re-enable on sqlite — see note above.
-    it(
+    test.options({ db: (adapter) => adapter.startsWith('sqlite') === false })(
       'should query based on richtext data within a localized block, specifying locale',
-      { db: (adapter) => adapter.startsWith('sqlite') === false },
       async () => {
         const blockFieldsSuccess = await payload.find({
           collection: 'block-fields',
@@ -3985,9 +3983,8 @@ describe('Fields', () => {
     )
 
     // TODO: re-enable on sqlite — see note above.
-    it(
+    test.options({ db: (adapter) => adapter.startsWith('sqlite') === false })(
       'should query based on richtext data within a localized block, without specifying locale',
-      { db: (adapter) => adapter.startsWith('sqlite') === false },
       async () => {
         const blockFieldsSuccess = await payload.find({
           collection: 'block-fields',
@@ -4745,7 +4742,7 @@ describe('Fields', () => {
         ).rejects.toBeTruthy()
       })
 
-      it('should disallow unsafe query values', { db: 'drizzle' }, async () => {
+      test.options({ db: 'drizzle' })('should disallow unsafe query values', async () => {
         await expect(
           payload.find({
             collection: 'json-fields',

--- a/test/joins/buildJoinAggregation.int.spec.ts
+++ b/test/joins/buildJoinAggregation.int.spec.ts
@@ -9,12 +9,11 @@ import { expect, it } from 'vitest'
 
 import { buildJoinAggregation } from '../../packages/db-mongodb/src/utilities/buildJoinAggregation.js'
 import { buildProjectionFromSelect } from '../../packages/db-mongodb/src/utilities/buildProjectionFromSelect.js'
-import { describe } from '../__helpers/int/vitest.js'
+import { test } from '../__helpers/int/vitest.js'
 
-describe(
-  'buildJoinAggregation',
-  { db: (adapter) => adapter === 'mongodb' || adapter === 'mongodb-atlas' },
-  () => {
+test
+  .options({ db: (adapter) => adapter === 'mongodb' || adapter === 'mongodb-atlas' })
+  .describe('buildJoinAggregation', () => {
     const getAdapter = async (): Promise<MongooseAdapter> => {
       const payload = await getPayload({
         key: '_buildJoinAggregation',
@@ -339,5 +338,4 @@ describe(
       expect(aggregation).toBeInstanceOf(Array)
       expect(aggregation).toHaveLength(0)
     })
-  },
-)
+  })

--- a/test/joins/queryPath.int.spec.ts
+++ b/test/joins/queryPath.int.spec.ts
@@ -3,12 +3,11 @@ import { type MongooseAdapter } from '@payloadcms/db-mongodb'
 import { buildConfig, getPayload } from 'payload'
 import { afterEach, expect, it, vi } from 'vitest'
 
-import { describe } from '../__helpers/int/vitest.js'
+import { test } from '../__helpers/int/vitest.js'
 
-describe(
-  'mongodb read path selection',
-  { db: (adapter) => adapter === 'mongodb' || adapter === 'mongodb-atlas' },
-  () => {
+test
+  .options({ db: (adapter) => adapter === 'mongodb' || adapter === 'mongodb-atlas' })
+  .describe('mongodb read path selection', () => {
     const createdIDs: (number | string)[] = []
 
     const getPayloadInstance = async () =>
@@ -147,5 +146,4 @@ describe(
       expect(aggregateSpy).toHaveBeenCalledTimes(1)
       expect(paginateSpy).not.toHaveBeenCalled()
     })
-  },
-)
+  })

--- a/test/lexical/lexical.int.spec.ts
+++ b/test/lexical/lexical.int.spec.ts
@@ -2,14 +2,14 @@ import type {
   SerializedEditorState,
   SerializedParagraphNode,
 } from '@payloadcms/richtext-lexical/lexical'
-import type { Block, BlocksField, BlockSlug, Config, PaginatedDocs, Payload } from 'payload'
+import type { Block, BlocksField, BlockSlug, Config, PaginatedDocs } from 'payload'
 
 import {
   BlocksFeature,
   buildEditorState,
   type DefaultNodeTypes,
-  type LexicalRichTextAdapter,
   lexicalEditor,
+  type LexicalRichTextAdapter,
   LinkFeature,
   type SerializedBlockNode,
   type SerializedLinkNode,
@@ -17,12 +17,10 @@ import {
   type SerializedUploadNode,
   UploadFeature,
 } from '@payloadcms/richtext-lexical'
-import path from 'path'
 import { configToJSONSchema, sanitizeConfig } from 'payload'
 import { generateTypes } from 'payload/node'
 import { sanitizeUrl } from 'payload/shared'
-import { fileURLToPath } from 'url'
-import { beforeAll, beforeEach, describe, expect, it as vitestIt } from 'vitest'
+import { expect } from 'vitest'
 
 import type { LexicalField, RichTextField } from './payload-types.js'
 
@@ -48,9 +46,7 @@ import {
 
 // Diff converter
 import { LinkDiffHTMLConverterAsync } from '../../packages/richtext-lexical/src/field/Diff/converters/link.js'
-import { it } from '../__helpers/int/vitest.js'
-import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
-import { NextRESTClient } from '../__helpers/shared/NextRESTClient.js'
+import { test } from '../__helpers/int/vitest.js'
 import { devUser } from '../credentials.js'
 import { lexicalDocData } from './collections/Lexical/data.js'
 import { generateLexicalLocalizedRichText } from './collections/LexicalLocalized/generateLexicalRichText.js'
@@ -67,26 +63,18 @@ import {
   uploadsSlug,
 } from './slugs.js'
 
-let payload: Payload
-let restClient: NextRESTClient
-
 let createdArrayDocID: number | string = null
 let createdJPGDocID: number | string = null
 let createdTextDocID: number | string = null
 let createdRichTextDocID: number | string = null
 
-const filename = fileURLToPath(import.meta.url)
-const dirname = path.dirname(filename)
-
-describe('Lexical', () => {
-  beforeAll(async () => {
+test.describe('Lexical', () => {
+  test.beforeAll(() => {
     process.env.SEED_IN_CONFIG_ONINIT = 'false' // Makes it so the payload config onInit seed is not run. Otherwise, the seed would be run unnecessarily twice for the initial test run - once for beforeEach and once for onInit
-    ;({ payload, restClient } = await initPayloadInt(dirname))
   })
 
-  beforeEach(async () => {
+  test.beforeEach(async ({ payload, restClient }) => {
     await clearAndSeedEverything(payload)
-    restClient = new NextRESTClient(payload.config)
     await restClient.login({
       slug: 'users',
       credentials: devUser,
@@ -141,8 +129,8 @@ describe('Lexical', () => {
     ).docs[0].id
   })
 
-  describe('basic', () => {
-    it('should allow querying on lexical content', async () => {
+  test.describe('basic', () => {
+    test('should allow querying on lexical content', async ({ payload }) => {
       const richTextDoc: RichTextField = (
         await payload.find({
           collection: richTextFieldsSlug,
@@ -178,7 +166,9 @@ describe('Lexical', () => {
       )
     })
 
-    it('should populate respect depth parameter and populate link node relationship', async () => {
+    test('should populate respect depth parameter and populate link node relationship', async ({
+      payload,
+    }) => {
       const richTextDoc: RichTextField = (
         await payload.find({
           collection: richTextFieldsSlug,
@@ -218,7 +208,7 @@ describe('Lexical', () => {
       expect(linkNode.fields.doc.value.text).toStrictEqual(textDoc.text)
     })
 
-    it('should populate relationship node', async () => {
+    test('should populate relationship node', async ({ payload }) => {
       const richTextDoc: RichTextField = (
         await payload.find({
           collection: richTextFieldsSlug,
@@ -239,7 +229,9 @@ describe('Lexical', () => {
       expect(relationshipNode.value.text).toStrictEqual(textDoc.text)
     })
 
-    it('should respect GraphQL rich text depth parameter and populate upload node', async () => {
+    test('should respect GraphQL rich text depth parameter and populate upload node', async ({
+      restClient,
+    }) => {
       const query = `query {
         RichTextFields {
           docs {
@@ -265,7 +257,7 @@ describe('Lexical', () => {
     })
   })
 
-  it('ensure link nodes convert to markdown', async () => {
+  test('ensure link nodes convert to markdown', async ({ payload }) => {
     const newLexicalDoc = await payload.create({
       collection: lexicalFieldsSlug,
       depth: 0,
@@ -321,8 +313,8 @@ describe('Lexical', () => {
     )
   })
 
-  describe('upload markdown: Lexical → Markdown (export)', () => {
-    it('exports upload node to markdown placeholder when unpopulated', async () => {
+  test.describe('upload markdown: Lexical → Markdown (export)', () => {
+    test('exports upload node to markdown placeholder when unpopulated', async ({ payload }) => {
       const newLexicalDoc = await payload.create({
         collection: lexicalFieldsSlug,
         depth: 0,
@@ -353,7 +345,7 @@ describe('Lexical', () => {
       expect(newLexicalDoc.lexicalWithBlocks_markdown).toEqual(`![uploads:${createdJPGDocID}]()`)
     })
 
-    it('exported markdown contains upload placeholder in seeded doc', async () => {
+    test('exported markdown contains upload placeholder in seeded doc', async ({ payload }) => {
       const lexicalDoc = await payload.find({
         collection: lexicalFieldsSlug,
         depth: 0,
@@ -366,8 +358,8 @@ describe('Lexical', () => {
     })
   })
 
-  describe('advanced - blocks', () => {
-    it('should not populate relationships in blocks if depth is 0', async () => {
+  test.describe('advanced - blocks', () => {
+    test('should not populate relationships in blocks if depth is 0', async ({ payload }) => {
       const lexicalDoc: LexicalField = (
         await payload.find({
           collection: lexicalFieldsSlug,
@@ -391,7 +383,7 @@ describe('Lexical', () => {
       expect(relationshipBlockNode.fields.rel).toStrictEqual(createdJPGDocID)
     })
 
-    it('should populate relationships in blocks with depth=1', async () => {
+    test('should populate relationships in blocks with depth=1', async ({ payload }) => {
       const lexicalDoc: LexicalField = (
         await payload.find({
           collection: lexicalFieldsSlug,
@@ -415,7 +407,9 @@ describe('Lexical', () => {
       expect(relationshipBlockNode.fields.rel.filename).toStrictEqual('payload.jpg')
     })
 
-    it('should correctly populate polymorphic hasMany relationships in blocks with depth=0', async () => {
+    test('should correctly populate polymorphic hasMany relationships in blocks with depth=0', async ({
+      payload,
+    }) => {
       const lexicalDoc: LexicalField = (
         await payload.find({
           collection: lexicalFieldsSlug,
@@ -445,7 +439,9 @@ describe('Lexical', () => {
       expect(relationshipBlockNode.fields.rel[1].value).toStrictEqual(createdJPGDocID)
     })
 
-    it('should correctly populate polymorphic hasMany relationships in blocks with depth=1', async () => {
+    test('should correctly populate polymorphic hasMany relationships in blocks with depth=1', async ({
+      payload,
+    }) => {
       // Related issue: https://github.com/payloadcms/payload/issues/4277
       const lexicalDoc: LexicalField = (
         await payload.find({
@@ -482,7 +478,9 @@ describe('Lexical', () => {
       expect(relationshipBlockNode.fields.rel[1].value.filename).toStrictEqual('payload.jpg')
     })
 
-    it('should not populate relationship nodes inside of a sub-editor from a blocks node with 0 depth', async () => {
+    test('should not populate relationship nodes inside of a sub-editor from a blocks node with 0 depth', async ({
+      payload,
+    }) => {
       const lexicalDoc: LexicalField = (
         await payload.find({
           collection: lexicalFieldsSlug,
@@ -514,7 +512,9 @@ describe('Lexical', () => {
       expect(typeof subEditorRelationshipNode.value).not.toStrictEqual('object')
     })
 
-    it('should populate relationship nodes inside of a sub-editor from a blocks node with 1 depth', async () => {
+    test('should populate relationship nodes inside of a sub-editor from a blocks node with 1 depth', async ({
+      payload,
+    }) => {
       const lexicalDoc: LexicalField = (
         await payload.find({
           collection: lexicalFieldsSlug,
@@ -561,7 +561,9 @@ describe('Lexical', () => {
       expect(populatedDocEditorRelationshipNode.value).not.toStrictEqual('object')
     })
 
-    it('should populate relationship nodes inside of a sub-editor from a blocks node with depth 2', async () => {
+    test('should populate relationship nodes inside of a sub-editor from a blocks node with depth 2', async ({
+      payload,
+    }) => {
       const lexicalDoc: LexicalField = (
         await payload.find({
           collection: lexicalFieldsSlug,
@@ -607,8 +609,8 @@ describe('Lexical', () => {
     })
   })
 
-  describe('Localization', () => {
-    it('ensure localized lexical field is different across locales', async () => {
+  test.describe('Localization', () => {
+    test('ensure localized lexical field is different across locales', async ({ payload }) => {
       const lexicalDocEN = await payload.find({
         collection: 'lexical-localized-fields',
         locale: 'en',
@@ -634,7 +636,9 @@ describe('Lexical', () => {
       )
     })
 
-    it('ensure localized text field within blocks field within unlocalized lexical field is different across locales', async () => {
+    test('ensure localized text field within blocks field within unlocalized lexical field is different across locales', async ({
+      payload,
+    }) => {
       const lexicalDocEN = await payload.find({
         collection: 'lexical-localized-fields',
         locale: 'en',
@@ -670,8 +674,8 @@ describe('Lexical', () => {
     })
   })
 
-  describe('Hooks', () => {
-    it('ensure hook within number field within lexical block runs', async () => {
+  test.describe('Hooks', () => {
+    test('ensure hook within number field within lexical block runs', async ({ payload }) => {
       const lexicalDocEN = await payload.create({
         collection: 'lexical-localized-fields',
         locale: 'en',
@@ -703,8 +707,10 @@ describe('Lexical', () => {
     })
   })
 
-  describe('Autosave', () => {
-    it('should populate previousValue in afterChange hooks for fields inside lexical', async () => {
+  test.describe('Autosave', () => {
+    test('should populate previousValue in afterChange hooks for fields inside lexical', async ({
+      payload,
+    }) => {
       const { autosaveHookLog, clearAutosaveHookLog } = await import(
         './collections/LexicalAutosave/index.js'
       )
@@ -792,8 +798,8 @@ describe('Lexical', () => {
     })
   })
 
-  describe('sanitizeUrl', () => {
-    vitestIt.each([
+  test.describe('sanitizeUrl', () => {
+    test.each([
       ['http://example.com', 'http://example.com'],
       ['https://example.com/page', 'https://example.com/page'],
       ['mailto:user@example.com', 'mailto:user@example.com'],
@@ -808,7 +814,7 @@ describe('Lexical', () => {
       expect(sanitizeUrl(input)).toBe(expected)
     })
 
-    vitestIt.each([
+    test.each([
       ['javascript:alert(1)', '#'],
       ['JavaScript:alert(document.cookie)', '#'],
       ['JAVASCRIPT:void(0)', '#'],
@@ -819,7 +825,7 @@ describe('Lexical', () => {
       expect(sanitizeUrl(input)).toBe(expected)
     })
 
-    vitestIt('trims whitespace', () => {
+    test('trims whitespace', () => {
       expect(sanitizeUrl('  https://example.com  ')).toBe('https://example.com')
     })
   })
@@ -859,10 +865,10 @@ describe('Lexical', () => {
   ] as const
 
   for (const variant of converterVariants) {
-    describe(`HTML Converters (${variant.label})`, () => {
+    test.describe(`HTML Converters (${variant.label})`, () => {
       // ── Text ──
-      describe('TextHTMLConverter', () => {
-        vitestIt('escapes script tags in text content', async () => {
+      test.describe('TextHTMLConverter', () => {
+        test('escapes script tags in text content', async () => {
           const result = await variant.text.text!({
             ...converterBaseArgs,
             node: { format: 0, text: '<script>alert("xss")</script>' } as any,
@@ -872,7 +878,7 @@ describe('Lexical', () => {
           expect(result).toContain('&lt;script&gt;')
         })
 
-        vitestIt('escapes HTML entities in bold text', async () => {
+        test('escapes HTML entities in bold text', async () => {
           const result = await variant.text.text!({
             ...converterBaseArgs,
             node: { format: 1, text: '<img src=x onerror=alert(1)>' } as any,
@@ -883,7 +889,7 @@ describe('Lexical', () => {
           expect(result).toContain('&lt;img')
         })
 
-        vitestIt('preserves normal text with formatting', async () => {
+        test('preserves normal text with formatting', async () => {
           const result = await variant.text.text!({
             ...converterBaseArgs,
             node: { format: 1, text: 'Hello World' } as any,
@@ -892,7 +898,7 @@ describe('Lexical', () => {
           expect(result).toBe('<strong>Hello World</strong>')
         })
 
-        vitestIt('properly encodes ampersands', async () => {
+        test('properly encodes ampersands', async () => {
           const result = await variant.text.text!({
             ...converterBaseArgs,
             node: { format: 0, text: 'Tom & Jerry' } as any,
@@ -903,8 +909,8 @@ describe('Lexical', () => {
       })
 
       // ── Link ──
-      describe('LinkHTMLConverter', () => {
-        vitestIt('blocks javascript: protocol in autolink', async () => {
+      test.describe('LinkHTMLConverter', () => {
+        test('blocks javascript: protocol in autolink', async () => {
           const result = await variant.link.autolink!({
             ...converterBaseArgs,
             node: {
@@ -917,7 +923,7 @@ describe('Lexical', () => {
           expect(result).toContain('href="#"')
         })
 
-        vitestIt('blocks data: protocol in link', async () => {
+        test('blocks data: protocol in link', async () => {
           const result = await variant.link.link!({
             ...converterBaseArgs,
             node: {
@@ -934,7 +940,7 @@ describe('Lexical', () => {
           expect(result).toContain('href="#"')
         })
 
-        vitestIt('escapes HTML entities in href attribute', async () => {
+        test('escapes HTML entities in href attribute', async () => {
           const result = await variant.link.autolink!({
             ...converterBaseArgs,
             node: {
@@ -950,7 +956,7 @@ describe('Lexical', () => {
           expect(result).toContain('&amp;')
         })
 
-        vitestIt('allows safe https URLs', async () => {
+        test('allows safe https URLs', async () => {
           const result = await variant.link.autolink!({
             ...converterBaseArgs,
             node: {
@@ -962,7 +968,7 @@ describe('Lexical', () => {
           expect(result).toContain('href="https://example.com/safe-page"')
         })
 
-        vitestIt('preserves query params with proper encoding', async () => {
+        test('preserves query params with proper encoding', async () => {
           const result = await variant.link.autolink!({
             ...converterBaseArgs,
             node: {
@@ -976,7 +982,7 @@ describe('Lexical', () => {
       })
 
       // ── Upload ──
-      describe('UploadHTMLConverter', () => {
+      test.describe('UploadHTMLConverter', () => {
         const baseUploadNode = {
           fields: {},
           relationTo: 'uploads',
@@ -991,7 +997,7 @@ describe('Lexical', () => {
           },
         }
 
-        vitestIt('escapes HTML in non-image filename', async () => {
+        test('escapes HTML in non-image filename', async () => {
           const result = await variant.upload.upload!({
             ...converterBaseArgs,
             node: {
@@ -1008,7 +1014,7 @@ describe('Lexical', () => {
           expect(result).toContain('</a>')
         })
 
-        vitestIt('escapes HTML in alt attribute', async () => {
+        test('escapes HTML in alt attribute', async () => {
           const result = await variant.upload.upload!({
             ...converterBaseArgs,
             node: {
@@ -1022,7 +1028,7 @@ describe('Lexical', () => {
           expect(result).toContain('&quot;')
         })
 
-        vitestIt('escapes HTML in image URL', async () => {
+        test('escapes HTML in image URL', async () => {
           const result = await variant.upload.upload!({
             ...converterBaseArgs,
             node: {
@@ -1038,7 +1044,7 @@ describe('Lexical', () => {
           expect(result).not.toContain('<script>')
         })
 
-        vitestIt('renders normal image with correct attributes', async () => {
+        test('renders normal image with correct attributes', async () => {
           const result = await variant.upload.upload!({
             ...converterBaseArgs,
             node: {
@@ -1064,8 +1070,8 @@ describe('Lexical', () => {
       })
 
       // ── Heading ──
-      describe('HeadingHTMLConverter', () => {
-        vitestIt.each(['h1', 'h2', 'h3', 'h4', 'h5', 'h6'])('allows valid tag: %s', async (tag) => {
+      test.describe('HeadingHTMLConverter', () => {
+        test.each(['h1', 'h2', 'h3', 'h4', 'h5', 'h6'])('allows valid tag: %s', async (tag) => {
           const result = await variant.heading.heading!({
             ...converterBaseArgs,
             node: { children: [], tag } as any,
@@ -1075,7 +1081,7 @@ describe('Lexical', () => {
           expect(result).toContain(`</${tag}>`)
         })
 
-        vitestIt('rejects arbitrary tag names and defaults to h1', async () => {
+        test('rejects arbitrary tag names and defaults to h1', async () => {
           const result = await variant.heading.heading!({
             ...converterBaseArgs,
             node: { children: [], tag: 'script' } as any,
@@ -1087,8 +1093,8 @@ describe('Lexical', () => {
       })
 
       // ── List ──
-      describe('ListHTMLConverter', () => {
-        vitestIt.each(['ol', 'ul'])('allows valid list tag: %s', async (tag) => {
+      test.describe('ListHTMLConverter', () => {
+        test.each(['ol', 'ul'])('allows valid list tag: %s', async (tag) => {
           const result = await variant.list.list!({
             ...converterBaseArgs,
             node: { children: [], listType: 'bullet', tag } as any,
@@ -1098,7 +1104,7 @@ describe('Lexical', () => {
           expect(result).toContain(`</${tag}>`)
         })
 
-        vitestIt('rejects arbitrary tag names and defaults to ul', async () => {
+        test('rejects arbitrary tag names and defaults to ul', async () => {
           const result = await variant.list.list!({
             ...converterBaseArgs,
             node: { children: [], listType: 'bullet', tag: 'img' } as any,
@@ -1108,7 +1114,7 @@ describe('Lexical', () => {
           expect(result).toContain('<ul')
         })
 
-        vitestIt('validates listType against allowlist', async () => {
+        test('validates listType against allowlist', async () => {
           const result = await variant.list.list!({
             ...converterBaseArgs,
             node: { children: [], listType: 'evil"><script>', tag: 'ul' } as any,
@@ -1120,8 +1126,8 @@ describe('Lexical', () => {
       })
 
       // ── Table ──
-      describe('TableHTMLConverter', () => {
-        vitestIt.each([
+      test.describe('TableHTMLConverter', () => {
+        test.each([
           ['hex', '#ff0000'],
           ['named', 'steelblue'],
           ['rgb()', 'rgb(255, 0, 0)'],
@@ -1141,7 +1147,7 @@ describe('Lexical', () => {
           expect(result).toContain(`background-color: ${color};`)
         })
 
-        vitestIt('rejects invalid backgroundColor values', async () => {
+        test('rejects invalid backgroundColor values', async () => {
           const result = await variant.table.tablecell!({
             ...converterBaseArgs,
             node: {
@@ -1157,7 +1163,7 @@ describe('Lexical', () => {
           expect(result).not.toContain('background-color:')
         })
 
-        vitestIt('renders th for header cells with correct attributes', async () => {
+        test('renders th for header cells with correct attributes', async () => {
           const result = await variant.table.tablecell!({
             ...converterBaseArgs,
             node: {
@@ -1178,8 +1184,8 @@ describe('Lexical', () => {
     })
   }
 
-  describe('UploadHTMLConverter — picture/source path', () => {
-    vitestIt('escapes HTML in source srcset and type attributes', () => {
+  test.describe('UploadHTMLConverter — picture/source path', () => {
+    test('escapes HTML in source srcset and type attributes', () => {
       const result = UploadHTMLConverter.upload!({
         ...converterBaseArgs,
         node: {
@@ -1214,10 +1220,10 @@ describe('Lexical', () => {
     })
   })
 
-  describe('Diff View Link Converter', () => {
+  test.describe('Diff View Link Converter', () => {
     const diffLinkConverter = LinkDiffHTMLConverterAsync({})
 
-    vitestIt('blocks disallowed protocols in autolink', async () => {
+    test('blocks disallowed protocols in autolink', async () => {
       const result = await diffLinkConverter.autolink!({
         ...converterBaseArgs,
         node: {
@@ -1230,7 +1236,7 @@ describe('Lexical', () => {
       expect(result).toContain('href="#"')
     })
 
-    vitestIt('blocks disallowed protocols in link', async () => {
+    test('blocks disallowed protocols in link', async () => {
       const result = await diffLinkConverter.link!({
         ...converterBaseArgs,
         node: {
@@ -1247,7 +1253,7 @@ describe('Lexical', () => {
       expect(result).toContain('href="#"')
     })
 
-    vitestIt('properly encodes special characters in href', async () => {
+    test('properly encodes special characters in href', async () => {
       const result = await diffLinkConverter.autolink!({
         ...converterBaseArgs,
         node: {
@@ -1260,7 +1266,7 @@ describe('Lexical', () => {
       expect(result).toContain('&quot;')
     })
 
-    vitestIt('allows safe URLs and includes fields hash', async () => {
+    test('allows safe URLs and includes fields hash', async () => {
       const result = await diffLinkConverter.autolink!({
         ...converterBaseArgs,
         node: {
@@ -1275,8 +1281,8 @@ describe('Lexical', () => {
   })
 })
 
-describe('Lexical root editor sanitization', () => {
-  vitestIt('should resolve referenced blocks after their fields are sanitized', () => {
+test.describe('Lexical root editor sanitization', () => {
+  test('should resolve referenced blocks after their fields are sanitized', () => {
     const config = {
       blocks: [
         {
@@ -1311,107 +1317,101 @@ describe('Lexical root editor sanitization', () => {
   })
 })
 
-describe('Lexical block interface generation', () => {
+test.describe('Lexical block interface generation', () => {
   // A lexical block's interface is named after its slug (PascalCase) or its `interfaceName`.
   // When two differently-shaped blocks resolve to the same name, each must get its own
   // interface — the first keeps the clean name, the second gets a content-hash suffix — so
   // neither is silently mistyped. This mirrors payload core's `registerBlockInterface`.
-  vitestIt(
-    'content-hashes a colliding lexical block instead of silently overwriting it',
-    async () => {
-      const heroEditor = (fieldName: string, fieldType: 'number' | 'text') =>
-        lexicalEditor({
-          features: [
-            BlocksFeature({
-              blocks: [{ slug: 'hero', fields: [{ name: fieldName, type: fieldType }] }],
-            }),
-          ],
-        })
-
-      // Two richText fields each define a `hero` block with DIFFERENT fields, so both
-      // resolve to the `Hero` interface name.
-      const config = {
-        collections: [
-          {
-            slug: 'collisionTest',
-            fields: [
-              { name: 'rt1', type: 'richText', editor: heroEditor('title', 'text') },
-              { name: 'rt2', type: 'richText', editor: heroEditor('subtitle', 'number') },
-            ],
-          },
+  test('content-hashes a colliding lexical block instead of silently overwriting it', () => {
+    const heroEditor = (fieldName: string, fieldType: 'number' | 'text') =>
+      lexicalEditor({
+        features: [
+          BlocksFeature({
+            blocks: [{ slug: 'hero', fields: [{ name: fieldName, type: fieldType }] }],
+          }),
         ],
-      } as unknown as Config
+      })
 
-      const sanitizedConfig = sanitizeConfig(config)
-      const { jsonSchema } = configToJSONSchema(sanitizedConfig, 'text')
-      const defs = jsonSchema.$defs!
+    // Two richText fields each define a `hero` block with DIFFERENT fields, so both
+    // resolve to the `Hero` interface name.
+    const config = {
+      collections: [
+        {
+          slug: 'collisionTest',
+          fields: [
+            { name: 'rt1', type: 'richText', editor: heroEditor('title', 'text') },
+            { name: 'rt2', type: 'richText', editor: heroEditor('subtitle', 'number') },
+          ],
+        },
+      ],
+    } as unknown as Config
 
-      // Each differently-shaped `hero` gets its own interface (one clean, one hashed).
-      const heroNames = Object.keys(defs).filter((k) => /^Hero(?:_[0-9A-F]{8})?$/.test(k))
-      expect(heroNames).toHaveLength(2)
+    const sanitizedConfig = sanitizeConfig(config)
+    const { jsonSchema } = configToJSONSchema(sanitizedConfig, 'text')
+    const defs = jsonSchema.$defs!
 
-      // ...and they carry distinct field shapes (not a silent overwrite).
-      const shapeOf = (name: string): string =>
-        Object.keys((defs[name] as { properties: Record<string, unknown> }).properties)
-          .sort()
-          .join(',')
-      expect(shapeOf(heroNames[0]!)).not.toBe(shapeOf(heroNames[1]!))
-    },
-  )
+    // Each differently-shaped `hero` gets its own interface (one clean, one hashed).
+    const heroNames = Object.keys(defs).filter((k) => /^Hero(?:_[0-9A-F]{8})?$/.test(k))
+    expect(heroNames).toHaveLength(2)
+
+    // ...and they carry distinct field shapes (not a silent overwrite).
+    const shapeOf = (name: string): string =>
+      Object.keys((defs[name] as { properties: Record<string, unknown> }).properties)
+        .sort()
+        .join(',')
+    expect(shapeOf(heroNames[0]!)).not.toBe(shapeOf(heroNames[1]!))
+  })
 })
 
-describe('Lexical link fields interface generation', () => {
+test.describe('Lexical link fields interface generation', () => {
   // The node-union name is a content hash of the editor's nodes. A link node only carries a `$ref`
   // to its `LexicalLinkFields_<hash>` interface, whose *content* lives separately — so two editors
   // with identical nodes but different custom LinkFeature fields must not hash the same, or one
   // `LexicalLinkFields_<hash>` would overwrite the other and mistype a field.
-  vitestIt(
-    'gives editors with identical nodes but different custom link fields distinct interfaces',
-    async () => {
-      const linkEditor = (fieldName: string) =>
-        lexicalEditor({
-          features: [
-            LinkFeature({
-              fields: ({ defaultFields }) => [...defaultFields, { name: fieldName, type: 'text' }],
-            }),
-          ],
-        })
-
-      // Two richText fields with the same nodes, differing only in their custom link field.
-      const config = {
-        collections: [
-          {
-            slug: 'linkCollisionTest',
-            fields: [
-              { name: 'rt1', type: 'richText', editor: linkEditor('label') },
-              { name: 'rt2', type: 'richText', editor: linkEditor('trackingId') },
-            ],
-          },
+  test('gives editors with identical nodes but different custom link fields distinct interfaces', () => {
+    const linkEditor = (fieldName: string) =>
+      lexicalEditor({
+        features: [
+          LinkFeature({
+            fields: ({ defaultFields }) => [...defaultFields, { name: fieldName, type: 'text' }],
+          }),
         ],
-      } as unknown as Config
+      })
 
-      const sanitizedConfig = sanitizeConfig(config)
-      const { jsonSchema } = configToJSONSchema(sanitizedConfig, 'text')
-      const defs = jsonSchema.$defs!
+    // Two richText fields with the same nodes, differing only in their custom link field.
+    const config = {
+      collections: [
+        {
+          slug: 'linkCollisionTest',
+          fields: [
+            { name: 'rt1', type: 'richText', editor: linkEditor('label') },
+            { name: 'rt2', type: 'richText', editor: linkEditor('trackingId') },
+          ],
+        },
+      ],
+    } as unknown as Config
 
-      // Each editor gets its own custom-link-fields interface (not a single shared, overwritten one).
-      const linkFieldsNames = Object.keys(defs).filter((k) =>
-        /^LexicalLinkFields_[0-9A-F]{8}$/.test(k),
-      )
-      expect(linkFieldsNames).toHaveLength(2)
+    const sanitizedConfig = sanitizeConfig(config)
+    const { jsonSchema } = configToJSONSchema(sanitizedConfig, 'text')
+    const defs = jsonSchema.$defs!
 
-      // ...and each carries its own custom field (`label` vs `trackingId`), not a silent overwrite.
-      const propsOf = (name: string): string[] =>
-        Object.keys((defs[name] as { properties: Record<string, unknown> }).properties).sort()
-      expect(propsOf(linkFieldsNames[0]!)).not.toEqual(propsOf(linkFieldsNames[1]!))
-    },
-  )
+    // Each editor gets its own custom-link-fields interface (not a single shared, overwritten one).
+    const linkFieldsNames = Object.keys(defs).filter((k) =>
+      /^LexicalLinkFields_[0-9A-F]{8}$/.test(k),
+    )
+    expect(linkFieldsNames).toHaveLength(2)
+
+    // ...and each carries its own custom field (`label` vs `trackingId`), not a silent overwrite.
+    const propsOf = (name: string): string[] =>
+      Object.keys((defs[name] as { properties: Record<string, unknown> }).properties).sort()
+    expect(propsOf(linkFieldsNames[0]!)).not.toEqual(propsOf(linkFieldsNames[1]!))
+  })
 })
 
-describe('Lexical upload node type generation', () => {
+test.describe('Lexical upload node type generation', () => {
   // The upload node's JSON Schema validates configured extra fields strictly, so the generated
   // TypeScript must expose them too - not erase them to `{ [k: string]: unknown }`.
-  vitestIt('reflects UploadFeature extra fields in the generated upload node type', async () => {
+  test('reflects UploadFeature extra fields in the generated upload node type', async () => {
     const config = {
       collections: [
         { slug: 'media', fields: [], upload: true },
@@ -1448,10 +1448,10 @@ describe('Lexical upload node type generation', () => {
   })
 })
 
-describe('Lexical inline block node type generation', () => {
+test.describe('Lexical inline block node type generation', () => {
   // A `BlocksFeature` with `blocks` but no `inlineBlocks` should not make the generated node union
   // claim the field can contain inline-block nodes - the editor can never produce one.
-  vitestIt('omits the inline-block node type when no inline blocks are configured', async () => {
+  test('omits the inline-block node type when no inline blocks are configured', async () => {
     const config = {
       collections: [
         {

--- a/test/queues/int.spec.ts
+++ b/test/queues/int.spec.ts
@@ -11,11 +11,11 @@ import {
 } from 'payload'
 import { wait } from 'payload/shared'
 import { fileURLToPath } from 'url'
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 
 import type { NextRESTClient } from '../__helpers/shared/NextRESTClient.js'
 
-import { it } from '../__helpers/int/vitest.js'
+import { test } from '../__helpers/int/vitest.js'
 import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
 import { devUser } from '../credentials.js'
 import { clearAndSeedEverything } from './seed.js'
@@ -1244,9 +1244,8 @@ describe('Queues - Payload', () => {
 
   describe('worker recovery', () => {
     // The child process can share the file-backed SQLite test database.
-    it(
+    test.options({ db: (type) => type.startsWith('sqlite') })(
       'should recover a job after its worker process is killed',
-      { db: (type) => type.startsWith('sqlite') },
       async () => {
         _internal_jobSystemGlobals.shouldAutoRun = false
         payload.config.jobs.deleteJobOnComplete = false

--- a/test/relationships/int.spec.ts
+++ b/test/relationships/int.spec.ts
@@ -4,7 +4,7 @@ import { randomBytes, randomUUID } from 'crypto'
 import { Types } from 'mongoose'
 import path from 'path'
 import { fileURLToPath } from 'url'
-import { afterAll, beforeAll, beforeEach, describe, expect } from 'vitest'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 
 import type { NextRESTClient } from '../__helpers/shared/NextRESTClient.js'
 import type {
@@ -17,9 +17,8 @@ import type {
   Relation,
 } from './payload-types.js'
 
-import { it } from '../__helpers/int/vitest.js'
+import { test } from '../__helpers/int/vitest.js'
 import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
-import { mongooseList } from '../__helpers/shared/isMongoose.js'
 import { devUser } from '../credentials.js'
 import { clearAndSeedEverything } from './seed.js'
 import {
@@ -42,8 +41,6 @@ const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
 type EasierChained = { id: string; relation: EasierChained }
-
-const mongoIt = mongooseList.includes(process.env.PAYLOAD_DATABASE || '') ? it : it.skip
 
 describe('Relationships', () => {
   beforeAll(async () => {
@@ -503,34 +500,36 @@ describe('Relationships', () => {
 
       // MongoDB dedupes $in at execution, so the bug is only visible in the
       // filter Payload hands to Mongoose — not in the returned docs.
-      mongoIt('should not duplicate IDs in $in when querying through a relationship', async () => {
-        const movie = await payload.create({
-          collection: 'movies',
-          data: { name: 'dup_test_movie' },
-        })
-
-        const Model = (payload.db as any).collections.directors
-        const originalPaginate = Model.paginate.bind(Model)
-        let capturedQuery: any
-        Model.paginate = (query: any, ...rest: any[]) => {
-          capturedQuery = query
-          return originalPaginate(query, ...rest)
-        }
-
-        try {
-          await payload.find({
-            collection: 'directors',
-            where: { 'movie.name': { equals: 'dup_test_movie' } },
+      test.options({ db: 'mongo' })(
+        'should not duplicate IDs in $in when querying through a relationship',
+        async () => {
+          const movie = await payload.create({
+            collection: 'movies',
+            data: { name: 'dup_test_movie' },
           })
-        } finally {
-          Model.paginate = originalPaginate
-        }
 
-        // eslint-disable-next-line vitest/no-standalone-expect
-        expect(capturedQuery.$and[0].movie.$in).toHaveLength(1)
+          const Model = (payload.db as any).collections.directors
+          const originalPaginate = Model.paginate.bind(Model)
+          let capturedQuery: any
+          Model.paginate = (query: any, ...rest: any[]) => {
+            capturedQuery = query
+            return originalPaginate(query, ...rest)
+          }
 
-        await payload.delete({ collection: 'movies', id: movie.id })
-      })
+          try {
+            await payload.find({
+              collection: 'directors',
+              where: { 'movie.name': { equals: 'dup_test_movie' } },
+            })
+          } finally {
+            Model.paginate = originalPaginate
+          }
+
+          expect(capturedQuery.$and[0].movie.$in).toHaveLength(1)
+
+          await payload.delete({ collection: 'movies', id: movie.id })
+        },
+      )
 
       describe('hasMany relationships', () => {
         describe('has-many relationship operators', () => {
@@ -744,9 +743,8 @@ describe('Relationships', () => {
           })
 
           // `near` on a point field is not implemented by the drizzle sqlite adapter
-          it(
+          test.options({ db: (adapter) => !adapter.startsWith('sqlite') })(
             'should support equals with a geospatial nested query',
-            { db: (adapter) => adapter.startsWith('sqlite') === false },
             async () => {
               const nearbyMovie = await payload.create({
                 collection: 'movies',
@@ -942,7 +940,7 @@ describe('Relationships', () => {
           expect(query2.totalDocs).toStrictEqual(2)
         })
 
-        mongoIt('should treat an ObjectId as a relationship ID', async () => {
+        test.options({ db: 'mongo' })('should treat an ObjectId as a relationship ID', async () => {
           const movie = await payload.create({ collection: 'movies', data: {} })
 
           const director = await payload.create({
@@ -967,45 +965,47 @@ describe('Relationships', () => {
         })
 
         // all operator is not supported in Postgres yet for any fields
-        mongoIt('should query using "all" by hasMany relationship field', async () => {
-          const movie1 = await payload.create({
-            collection: 'movies',
-            data: {},
-          })
-          const movie2 = await payload.create({
-            collection: 'movies',
-            data: {},
-          })
+        test.options({ db: 'mongo' })(
+          'should query using "all" by hasMany relationship field',
+          async () => {
+            const movie1 = await payload.create({
+              collection: 'movies',
+              data: {},
+            })
+            const movie2 = await payload.create({
+              collection: 'movies',
+              data: {},
+            })
 
-          await payload.create({
-            collection: 'directors',
-            data: {
-              name: 'Quentin Tarantino',
-              movies: [movie2.id, movie1.id],
-            },
-          })
-
-          await payload.create({
-            collection: 'directors',
-            data: {
-              name: 'Quentin Tarantino',
-              movies: [movie2.id],
-            },
-          })
-
-          const query1 = await payload.find({
-            collection: 'directors',
-            depth: 0,
-            where: {
-              movies: {
-                all: [movie1.id],
+            await payload.create({
+              collection: 'directors',
+              data: {
+                name: 'Quentin Tarantino',
+                movies: [movie2.id, movie1.id],
               },
-            },
-          })
+            })
 
-          // eslint-disable-next-line vitest/no-standalone-expect
-          expect(query1.totalDocs).toStrictEqual(1)
-        })
+            await payload.create({
+              collection: 'directors',
+              data: {
+                name: 'Quentin Tarantino',
+                movies: [movie2.id],
+              },
+            })
+
+            const query1 = await payload.find({
+              collection: 'directors',
+              depth: 0,
+              where: {
+                movies: {
+                  all: [movie1.id],
+                },
+              },
+            })
+
+            expect(query1.totalDocs).toStrictEqual(1)
+          },
+        )
 
         it('should query using "in" by hasMany relationship field', async () => {
           const tree1 = await payload.create({
@@ -2107,38 +2107,40 @@ describe('Relationships', () => {
     })
 
     // all operator is not supported in Postgres yet for any fields
-    mongoIt('should allow REST all querying on polymorphic relationships', async () => {
-      const movie = await payload.create({
-        collection: 'movies',
-        data: {
-          name: 'Pulp Fiction 2',
-        },
-      })
-      await payload.create({
-        collection: polymorphicRelationshipsSlug,
-        data: {
-          polymorphic: {
-            relationTo: 'movies',
-            value: movie.id,
+    test.options({ db: 'mongo' })(
+      'should allow REST all querying on polymorphic relationships',
+      async () => {
+        const movie = await payload.create({
+          collection: 'movies',
+          data: {
+            name: 'Pulp Fiction 2',
           },
-        },
-      })
-
-      const queryOne = await restClient
-        .GET(`/${polymorphicRelationshipsSlug}`, {
-          query: {
-            where: {
-              'polymorphic.value': {
-                all: [movie.id],
-              },
+        })
+        await payload.create({
+          collection: polymorphicRelationshipsSlug,
+          data: {
+            polymorphic: {
+              relationTo: 'movies',
+              value: movie.id,
             },
           },
         })
-        .then((res) => res.json())
 
-      // eslint-disable-next-line vitest/no-standalone-expect
-      expect(queryOne.docs).toHaveLength(1)
-    })
+        const queryOne = await restClient
+          .GET(`/${polymorphicRelationshipsSlug}`, {
+            query: {
+              where: {
+                'polymorphic.value': {
+                  all: [movie.id],
+                },
+              },
+            },
+          })
+          .then((res) => res.json())
+
+        expect(queryOne.docs).toHaveLength(1)
+      },
+    )
 
     it('should allow querying on polymorphic relationships with an object syntax', async () => {
       const movie = await payload.create({


### PR DESCRIPTION
This PR moves Payload's integration test setup into shared Vitest fixtures. Integration suites can receive the initialized config, Payload instance, REST client, and SDK directly, and Payload is shut down automatically after the file finishes.

## Before

Each integration suite had to create the same variables and repeat its setup and cleanup:

```ts
let payload: Payload
let restClient: NextRESTClient

beforeAll(async () => {
  ;({ payload, restClient } = await initPayloadInt(dirname))
})

afterAll(async () => {
  await payload.destroy()
})
```

Database-specific tests also used separate wrappers, which made the available fixtures and filtering behavior harder to discover.

## After

The shared `test` export provides the common integration resources through Vitest's normal test context:

```ts
import { test } from '../__helpers/int/vitest.js'

test('should create a document', async ({ payload, restClient, sdk }) => {
  // Use the initialized Payload instance and clients directly.
})
```

`config`, `payload`, and `testDir` are shared for the test file. The REST client and SDK are created for each test so their mutable state does not leak, and the fixture destroys Payload after the file finishes.

Database filtering now uses the same API:

```ts
test.options({ db: 'mongo' })('should run with MongoDB', async ({ payload }) => {
  // ...
})

test.options({ db: 'drizzle' }).describe('Drizzle adapters', () => {
  test('should run with SQL adapters', async ({ payload }) => {
    // ...
  })
})
```

The affected Lexical, relationships, fields, joins, queues, and database suites now use these fixtures instead of keeping their own setup and teardown code.
