### PR TITLE
fix: allow disabling joins for collections without join fields

### DIFF
--- a/packages/payload/src/types/index.ts
+++ b/packages/payload/src/types/index.ts
@@ -171,21 +171,20 @@ export type DefaultValue =
  * Applies pagination for join fields for including collection relationships
  */
 export type JoinQuery<TSlug extends CollectionSlug = string> =
-  TypedCollectionJoins[TSlug] extends Record<string, string>
-    ?
-        | false
-        | Partial<{
-            [K in keyof TypedCollectionJoins[TSlug]]:
-              | {
-                  count?: boolean
-                  limit?: number
-                  page?: number
-                  sort?: string
-                  where?: Where
-                }
-              | false
-          }>
-    : never
+  | false
+  | (TypedCollectionJoins[TSlug] extends Record<string, string>
+      ? Partial<{
+          [K in keyof TypedCollectionJoins[TSlug]]:
+            | {
+                count?: boolean
+                limit?: number
+                page?: number
+                sort?: string
+                where?: Where
+              }
+            | false
+        }>
+      : never)
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type Document = any

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -76,15 +76,14 @@ export type RequiredDataFromCollectionSlug<
 > = RequiredDataFromCollection<T['collections'][TSlug]>
 
 export type JoinQuery<T extends PayloadTypesShape, TSlug extends CollectionSlug<T>> =
-  T['collectionsJoins'][TSlug] extends Record<string, string>
-    ?
-        | false
-        | Partial<{
-            [K in keyof T['collectionsJoins'][TSlug]]:
-              | { count?: boolean; limit?: number; page?: number; sort?: Sort; where?: Where }
-              | false
-          }>
-    : never
+  | false
+  | (T['collectionsJoins'][TSlug] extends Record<string, string>
+      ? Partial<{
+          [K in keyof T['collectionsJoins'][TSlug]]:
+            | { count?: boolean; limit?: number; page?: number; sort?: Sort; where?: Where }
+            | false
+        }>
+      : never)
 
 export type PopulateType<T extends PayloadTypesShape> = Partial<T['collectionsSelect']>
 

--- a/test/types/types.spec.ts
+++ b/test/types/types.spec.ts
@@ -194,8 +194,11 @@ describe('Types testing', () => {
   })
 
   describe('joins', () => {
-    test('join query for pages should have type never as pages does not define any joins', () => {
-      expect<JoinQuery<'pages'>>().type.toBe<never>()
+    test('should allow disabling joins for pages even though it does not define any joins', () => {
+      expect<JoinQuery<'pages'>>().type.toBe<false>()
+      expect(payload.find({ collection: 'pages', joins: false })).type.toBe<
+        Promise<PaginatedDocs<Page>>
+      >()
     })
 
     test('join query for pages-categories should be defined with the relatedPages key', () => {
@@ -1224,6 +1227,13 @@ describe('Types testing', () => {
         | 'posts'
         | 'users'
       >()
+    })
+
+    test('should allow disabling joins for collections without joins', () => {
+      expect<PayloadSDK<LocalConfig>['find']>().type.toBeCallableWith({
+        collection: 'pages',
+        joins: false,
+      })
     })
 
     test('ensure SDK with explicit generic uses has correct data for collection in create', async () => {


### PR DESCRIPTION
### What?
Allow `joins: false` for collections without generated join fields.

### Why?
It was rejected by the type definition despite being supported at runtime.

### How?
Keep `false` outside the conditional type and cover local API and SDK typing.

Fixes #17904