### PR TITLE
fix(ui): restore modified on any failed submit, not just draft submits

### DIFF
--- a/packages/ui/src/forms/Form/index.tsx
+++ b/packages/ui/src/forms/Form/index.tsx
@@ -460,15 +460,16 @@ export const Form: React.FC<FormProps> = (props) => {
           setProcessing(false)
           setSubmitted(true)
 
-          // When there was an error submitting a draft,
-          // set the form state to unsubmitted, to not trigger visible form validation on changes after the failed submit.
-          // Also keep the form as modified so the save button remains enabled for retry.
-          if (overridesFromArgs['_status'] === 'draft') {
-            setModified(true)
+          // The submit failed — the document was not persisted and the form still holds unsaved
+          // changes. Always restore modified so that Save draft / Publish / Save remains enabled
+          // for a retry. (Previously only draft submits restored it, leaving a failed publish
+          // with Save draft greyed-out and no way to park the in-progress work.)
+          setModified(true)
 
-            if (!validateDrafts) {
-              setSubmitted(false)
-            }
+          // When there was an error submitting a draft, additionally clear the submitted flag so
+          // that visible field-validation errors are not triggered on subsequent edits.
+          if (overridesFromArgs['_status'] === 'draft' && !validateDrafts) {
+            setSubmitted(false)
           }
 
           contextRef.current = { ...contextRef.current } // triggers rerender of all components that subscribe to form


### PR DESCRIPTION
## What?

A failed **Publish** leaves **Save draft** (and Save / Publish) permanently disabled. The only escape is making an arbitrary edit to flip the form back to modified. Navigating away or reloading loses all unsaved work. Fixes #17517.

## Root cause

`setModified(false)` runs unconditionally after every completed request (before the status is checked). The error branch then called `setModified(true)` only when the submit carried `_status === 'draft'`. A failed publish carries no `_status`, so `modified` was never restored to `true` — leaving every save button grey.

(The `_status === 'draft'` scope came from #14584 fixing #14227, which was correct at the time but only patched the draft-submit case.)

## Fix

Move `setModified(true)` to the top of the error branch so it fires for **any** failed submit — publish, regular save, or draft. The `setSubmitted(false)` call stays scoped to draft submits only; that clause suppresses visible field-validation errors on subsequent edits, which is draft-specific behaviour.

```diff
- if (overridesFromArgs['_status'] === 'draft') {
-   setModified(true)
-
-   if (!validateDrafts) {
-     setSubmitted(false)
-   }
- }
+ setModified(true)
+
+ if (overridesFromArgs['_status'] === 'draft' && !validateDrafts) {
+   setSubmitted(false)
+ }
```

## How to test

1. Create a collection with `versions: { drafts: true }` and a `required` text field.
2. Open a new document, leave the required field blank, fill in something else.
3. Click **Publish changes**.
4. Server returns 400 (required-field validation error).
5. **Before**: Save draft is greyed-out. Navigating away loses the work.
6. **After**: Save draft is still enabled. User can park the work as a draft and fix the required field later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)