### PR TITLE
fix(plugin-ecommerce): allow callers to override the Stripe PaymentIntent amount

### DIFF
--- a/packages/plugin-ecommerce/src/endpoints/initiatePayment.ts
+++ b/packages/plugin-ecommerce/src/endpoints/initiatePayment.ts
@@ -312,10 +312,24 @@ export const initiatePaymentHandler: InitiatePayment =
       }
     }
 
+    // Extract well-known fields; any remaining fields in req.data are forwarded verbatim so that
+    // adapters can receive caller-supplied values such as `amount` (to include shipping costs or
+    // apply discounts) without the endpoint needing to be modified.
+    const {
+      billingAddress: _billingAddress,
+      cartID: _cartID,
+      currency: _currency,
+      customerEmail: _customerEmail,
+      secret: _secret,
+      shippingAddress: _shippingAddress,
+      ...extraData
+    } = (data as Record<string, unknown>) ?? {}
+
     try {
       const paymentResponse = await paymentMethod.initiatePayment({
         customersSlug,
         data: {
+          ...extraData,
           billingAddress,
           cart,
           currency,

--- a/packages/plugin-ecommerce/src/payments/adapters/stripe/initiatePayment.ts
+++ b/packages/plugin-ecommerce/src/payments/adapters/stripe/initiatePayment.ts
@@ -18,7 +18,9 @@ export const initiatePayment: (props: Props) => NonNullable<PaymentAdapter>['ini
     const customerEmail = data.customerEmail
     const currency = data.currency
     const cart = data.cart
-    const amount = cart.subtotal
+    // data.amount lets callers override cart.subtotal — useful for adding shipping fees,
+    // applying gift-card discounts, or any surcharge that is not a cart line item.
+    const amount = typeof data.amount === 'number' ? data.amount : cart.subtotal
     const billingAddressFromData = data.billingAddress
     const shippingAddressFromData = data.shippingAddress
 

--- a/packages/plugin-ecommerce/src/types/index.ts
+++ b/packages/plugin-ecommerce/src/types/index.ts
@@ -70,6 +70,18 @@ type InitiatePayment = (args: {
   customersSlug?: string
   data: {
     /**
+     * Any additional fields forwarded from the request body.
+     */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    [key: string]: any
+    /**
+     * Override the amount charged to the customer, in the currency's smallest unit (e.g. cents).
+     * When omitted the adapter falls back to `cart.subtotal`.
+     * Pass this to include shipping fees, apply gift-card discounts, or add surcharges that are
+     * not represented as cart line items.
+     */
+    amount?: number
+    /**
      * Billing address for the payment.
      */
     billingAddress: TypedCollection['addresses']


### PR DESCRIPTION
## What?

The Stripe payment adapter hardcodes the PaymentIntent amount to `cart.subtotal`. There is no way to include shipping fees, apply gift-card discounts, or add any surcharge that is not a cart line item — callers are forced to fork the entire adapter just to change one line. Fixes #15784.

## Why?

```ts
// packages/plugin-ecommerce/src/payments/adapters/stripe/initiatePayment.ts
const amount = cart.subtotal  // no override possible
```

The endpoint handler also constructs a fixed `data` object from well-known fields only; any extra fields the caller sends in the request body are dropped before the adapter receives them.

## How?

Three small, backwards-compatible changes:

**1. `types/index.ts`** — add `amount?: number` and `[key: string]: any` to the `InitiatePayment` data type so adapters can receive caller-supplied overrides.

**2. `endpoints/initiatePayment.ts`** — destructure the well-known fields, then spread the remaining `req.data` keys into the `data` object forwarded to the adapter. No caller-supplied field is silently dropped.

**3. `adapters/stripe/initiatePayment.ts`** — use `data.amount` when it is a number; fall back to `cart.subtotal` when it is absent.

## Usage

```ts
// Charge subtotal + $4.99 shipping
await fetch('/api/payments/stripe/initiate', {
  method: 'POST',
  body: JSON.stringify({
    cartID: 'abc123',
    amount: 5499,  // 54.99 USD in cents: subtotal 50.00 + shipping 4.99
  }),
})
```

```ts
// Apply a gift-card discount — pass the already-reduced total
await fetch('/api/payments/stripe/initiate', {
  method: 'POST',
  body: JSON.stringify({
    cartID: 'abc123',
    amount: Math.max(0, cart.subtotal - giftCard.balance),
  }),
})
```

Custom adapters benefit automatically from the forwarded extra fields — no endpoint changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)