### PR TITLE
perf: make bulk delete O(1) database queries instead of O(N)

### DIFF
--- a/packages/payload/src/collections/operations/delete.ts
+++ b/packages/payload/src/collections/operations/delete.ts
@@ -14,12 +14,16 @@ import { executeAccess } from '../../auth/executeAccess.js'
 import { combineQueries } from '../../database/combineQueries.js'
 import { validateQueryPaths } from '../../database/queryValidation/validateQueryPaths.js'
 import { sanitizeWhereQuery } from '../../database/sanitizeWhereQuery.js'
-import { APIError } from '../../errors/index.js'
+import { APIError, Locked } from '../../errors/index.js'
 import { afterRead } from '../../fields/hooks/afterRead/index.js'
 import { deleteUserPreferences } from '../../preferences/deleteUserPreferences.js'
 import { deleteAssociatedFiles } from '../../uploads/deleteAssociatedFiles.js'
 import { appendNonTrashedFilter } from '../../utilities/appendNonTrashedFilter.js'
-import { checkDocumentLockStatus } from '../../utilities/checkDocumentLockStatus.js'
+import {
+  checkDocumentLockStatus,
+  deleteDocumentLocks,
+  getLockedDocumentIds,
+} from '../../utilities/checkDocumentLockStatus.js'
 import { commitTransaction } from '../../utilities/commitTransaction.js'
 import { hasScheduledPublishEnabled } from '../../utilities/getVersionsConfig.js'
 import { initTransaction } from '../../utilities/initTransaction.js'
@@ -148,81 +152,134 @@ export const deleteOperation = async <
 
     const errors: BulkOperationResult<TSlug, TSelect>['errors'] = []
 
-    const promises = docs.map(async (doc) => {
-      let result
+    type Doc = DataFromCollectionSlug<TSlug>
+    type ResultDoc = BulkOperationResult<TSlug, TSelect>['docs'][number]
 
-      const { id } = doc
+    const pushError = (id: number | string, error: unknown) => {
+      errors.push({
+        id,
+        isPublic: error instanceof Error ? isErrorPublic(error, config) : false,
+        message: error instanceof Error ? error.message : 'Unknown error',
+      })
+    }
 
-      try {
-        // Each document gets its own transaction when singleTransaction is enabled
-        let docShouldCommit = false
-        if (req.payload.db.bulkOperationsSingleTransaction) {
-          docShouldCommit = await initTransaction(req)
+    // /////////////////////////////////////
+    // beforeDelete - Collection, and associated files
+    // /////////////////////////////////////
+
+    const runBeforeDeleteWork = async (doc: Doc) => {
+      if (collectionConfig.hooks?.beforeDelete?.length) {
+        for (const hook of collectionConfig.hooks.beforeDelete) {
+          await hook({
+            id: doc.id,
+            collection: collectionConfig,
+            context: req.context,
+            req,
+          })
         }
+      }
 
-        // /////////////////////////////////////
-        // Handle potentially locked documents
-        // /////////////////////////////////////
+      await deleteAssociatedFiles({
+        collectionConfig,
+        config,
+        doc,
+        overrideDelete: true,
+        req,
+      })
+    }
+
+    // /////////////////////////////////////
+    // afterRead - Fields, afterRead - Collection, afterDelete - Collection
+    // /////////////////////////////////////
+
+    const runAfterDeleteWork = async (doc: Doc): Promise<ResultDoc> => {
+      let result = await afterRead({
+        collection: collectionConfig,
+        context: req.context,
+        depth: depth!,
+        doc,
+        // @ts-expect-error - vestiges of when tsconfig was not strict. Feel free to improve
+        draft: undefined,
+        fallbackLocale: fallbackLocale!,
+        global: null,
+        locale: locale!,
+        overrideAccess: overrideAccess!,
+        populate,
+        req,
+        select,
+        showHiddenFields: showHiddenFields!,
+      })
+
+      // Add collection property for auth collections
+      if (collectionConfig.auth) {
+        result = { ...result, collection: collectionConfig.slug }
+      }
+
+      if (collectionConfig.hooks?.afterRead?.length) {
+        for (const hook of collectionConfig.hooks.afterRead) {
+          result =
+            (await hook({
+              collection: collectionConfig,
+              context: req.context,
+              doc: result || doc,
+              overrideAccess,
+              req,
+            })) || result
+        }
+      }
+
+      if (collectionConfig.hooks?.afterDelete?.length) {
+        for (const hook of collectionConfig.hooks.afterDelete) {
+          result =
+            (await hook({
+              id: doc.id,
+              collection: collectionConfig,
+              context: req.context,
+              doc: result,
+              req,
+            })) || result
+        }
+      }
+
+      return result as ResultDoc
+    }
+
+    /**
+     * One transaction and one set of database calls per document. Only used when
+     * `bulkOperationsSingleTransaction` is enabled, which requires each document to be committed
+     * on its own and therefore cannot share a batched write with the rest of the operation.
+     */
+    const deleteDocumentIndividually = async (doc: Doc): Promise<null | ResultDoc> => {
+      try {
+        const docShouldCommit = await initTransaction(req)
 
         await checkDocumentLockStatus({
-          id,
+          id: doc.id,
           collectionSlug: collectionConfig.slug,
-          lockErrorMessage: `Document with ID ${id} is currently locked and cannot be deleted.`,
+          lockErrorMessage: `Document with ID ${doc.id} is currently locked and cannot be deleted.`,
           overrideLock,
           req,
         })
 
-        // /////////////////////////////////////
-        // beforeDelete - Collection
-        // /////////////////////////////////////
-
-        if (collectionConfig.hooks?.beforeDelete?.length) {
-          for (const hook of collectionConfig.hooks.beforeDelete) {
-            await hook({
-              id,
-              collection: collectionConfig,
-              context: req.context,
-              req,
-            })
-          }
-        }
-
-        await deleteAssociatedFiles({
-          collectionConfig,
-          config,
-          doc,
-          overrideDelete: true,
-          req,
-        })
-
-        // /////////////////////////////////////
-        // Delete versions
-        // /////////////////////////////////////
+        await runBeforeDeleteWork(doc)
 
         if (collectionConfig.versions) {
           await deleteCollectionVersions({
-            id,
+            id: doc.id,
             slug: collectionConfig.slug,
             payload,
             req,
           })
         }
 
-        // /////////////////////////////////////
-        // Delete scheduled posts
-        // /////////////////////////////////////
         if (hasScheduledPublishEnabled(collectionConfig)) {
           await deleteScheduledPublishJobs({
-            id,
+            id: doc.id,
             slug: collectionConfig.slug,
             payload,
             req,
           })
         }
-
-        // /////////////////////////////////////
-        // Delete document
-        // /////////////////////////////////////
 
         await payload.db.deleteOne({
           collection: collectionConfig.slug,
@@ -230,107 +287,158 @@ export const deleteOperation = async <
           returning: false,
           where: {
             id: {
-              equals: id,
+              equals: doc.id,
             },
           },
         })
 
-        // /////////////////////////////////////
-        // afterRead - Fields
-        // /////////////////////////////////////
+        const result = await runAfterDeleteWork(doc)
 
-        result = await afterRead({
-          collection: collectionConfig,
-          context: req.context,
-          depth: depth!,
-          doc: result || doc,
-          // @ts-expect-error - vestiges of when tsconfig was not strict. Feel free to improve
-          draft: undefined,
-          fallbackLocale: fallbackLocale!,
-          global: null,
-          locale: locale!,
-          overrideAccess: overrideAccess!,
-          populate,
-          req,
-          select,
-          showHiddenFields: showHiddenFields!,
-        })
-
-        // /////////////////////////////////////
-        // Add collection property for auth collections
-        // /////////////////////////////////////
-
-        if (collectionConfig.auth) {
-          result = { ...result, collection: collectionConfig.slug }
-        }
-
-        // /////////////////////////////////////
-        // afterRead - Collection
-        // /////////////////////////////////////
-
-        if (collectionConfig.hooks?.afterRead?.length) {
-          for (const hook of collectionConfig.hooks.afterRead) {
-            result =
-              (await hook({
-                collection: collectionConfig,
-                context: req.context,
-                doc: result || doc,
-                overrideAccess,
-                req,
-              })) || result
-          }
-        }
-
-        // /////////////////////////////////////
-        // afterDelete - Collection
-        // /////////////////////////////////////
-
-        if (collectionConfig.hooks?.afterDelete?.length) {
-          for (const hook of collectionConfig.hooks.afterDelete) {
-            result =
-              (await hook({
-                id,
-                collection: collectionConfig,
-                context: req.context,
-                doc: result,
-                req,
-              })) || result
-          }
-        }
-
-        // /////////////////////////////////////
-        // 8. Return results
-        // /////////////////////////////////////
         if (docShouldCommit) {
           await commitTransaction(req)
         }
 
         return result
       } catch (error) {
-        const isPublic = error instanceof Error ? isErrorPublic(error, config) : false
+        await killTransaction(req)
+        pushError(doc.id, error)
 
-        if (req.payload.db.bulkOperationsSingleTransaction) {
-          await killTransaction(req)
+        return null
+      }
+    }
+
+    /**
+     * Deletes the whole batch using a constant number of database calls, independent of how many
+     * documents matched. Hooks still run per document, they just no longer each carry a write.
+     */
+    const deleteDocumentsInBulk = async (): Promise<(null | ResultDoc)[]> => {
+      const results: (null | ResultDoc)[] = new Array(docs.length).fill(null)
+
+      // /////////////////////////////////////
+      // Handle potentially locked documents
+      // /////////////////////////////////////
+
+      const lockedIds = await getLockedDocumentIds({
+        collectionSlug: collectionConfig.slug,
+        ids: docs.map(({ id }) => id),
+        overrideLock,
+        req,
+      })
+
+      const unlocked: { doc: Doc; index: number }[] = []
+
+      docs.forEach((doc, index) => {
+        if (lockedIds.has(String(doc.id))) {
+          pushError(
+            doc.id,
+            new Locked(`Document with ID ${doc.id} is currently locked and cannot be deleted.`),
+          )
+
+          return
         }
-        errors.push({
-          id: doc.id,
-          isPublic,
-          message: error instanceof Error ? error.message : 'Unknown error',
+
+        unlocked.push({ doc, index })
+      })
+
+      await deleteDocumentLocks({
+        collectionSlug: collectionConfig.slug,
+        ids: unlocked.map(({ doc }) => doc.id),
+        req,
+      })
+
+      const deletable: { doc: Doc; index: number }[] = []
+
+      await Promise.all(
+        unlocked.map(async (entry) => {
+          try {
+            await runBeforeDeleteWork(entry.doc)
+            deletable.push(entry)
+          } catch (error) {
+            pushError(entry.doc.id, error)
+          }
+        }),
+      )
+
+      if (!deletable.length) {
+        return results
+      }
+
+      const ids = deletable.map(({ doc }) => doc.id)
+
+      // /////////////////////////////////////
+      // Delete versions
+      // /////////////////////////////////////
+
+      if (collectionConfig.versions) {
+        await deleteCollectionVersions({
+          slug: collectionConfig.slug,
+          ids,
+          payload,
+          req,
         })
       }
-      return null
-    })
 
-    // Process sequentially when using single transaction mode to avoid shared state issues
-    // Process in parallel when using one transaction for better performance
-    let awaitedDocs
+      // /////////////////////////////////////
+      // Delete scheduled posts
+      // /////////////////////////////////////
+
+      if (hasScheduledPublishEnabled(collectionConfig)) {
+        await deleteScheduledPublishJobs({
+          slug: collectionConfig.slug,
+          ids,
+          payload,
+          req,
+        })
+      }
+
+      // /////////////////////////////////////
+      // Delete documents
+      // /////////////////////////////////////
+
+      try {
+        await payload.db.deleteMany({
+          collection: collectionConfig.slug,
+          req,
+          where: {
+            id: {
+              in: ids,
+            },
+          },
+        })
+      } catch (error) {
+        // A batched delete either lands for every id or for none, so it cannot be attributed to a
+        // single document the way a per-document delete could.
+        for (const { doc } of deletable) {
+          pushError(doc.id, error)
+        }
+
+        return results
+      }
+
+      await Promise.all(
+        deletable.map(async (entry) => {
+          try {
+            results[entry.index] = await runAfterDeleteWork(entry.doc)
+          } catch (error) {
+            pushError(entry.doc.id, error)
+          }
+        }),
+      )
+
+      return results
+    }
+
+    let awaitedDocs: (null | ResultDoc)[]
+
     if (req.payload.db.bulkOperationsSingleTransaction) {
+      // Process sequentially so that each document's transaction is isolated from the next
       awaitedDocs = []
-      for (const promise of promises) {
-        awaitedDocs.push(await promise)
+
+      for (const doc of docs) {
+        awaitedDocs.push(await deleteDocumentIndividually(doc))
       }
     } else {
-      awaitedDocs = await Promise.all(promises)
+      awaitedDocs = await deleteDocumentsInBulk()
     }
 
     // /////////////////////////////////////
@@ -345,7 +453,7 @@ export const deleteOperation = async <
     })
 
     let result = {
-      docs: awaitedDocs.filter(Boolean),
+      docs: awaitedDocs.filter((doc): doc is ResultDoc => Boolean(doc)),
       errors,
     }
 

--- a/packages/payload/src/collections/operations/delete.ts
+++ b/packages/payload/src/collections/operations/delete.ts
@@ -62,7 +62,10 @@ export const deleteOperation = async <
   }
 
   try {
-    const shouldCommit = !args.disableTransaction && (await initTransaction(args.req))
+    const shouldCommit =
+      !args.disableTransaction &&
+      !args.req.payload.db.bulkOperationsSingleTransaction &&
+      (await initTransaction(args.req))
     // /////////////////////////////////////
     // beforeOperation - Collection
     // /////////////////////////////////////

--- a/packages/payload/src/collections/operations/delete.ts
+++ b/packages/payload/src/collections/operations/delete.ts
@@ -155,11 +155,11 @@ export const deleteOperation = async <
     type Doc = DataFromCollectionSlug<TSlug>
     type ResultDoc = BulkOperationResult<TSlug, TSelect>['docs'][number]
 
-    const pushError = (id: number | string, error: unknown) => {
+    const pushError = (id: number | string, error: unknown, message?: string) => {
       errors.push({
         id,
         isPublic: error instanceof Error ? isErrorPublic(error, config) : false,
-        message: error instanceof Error ? error.message : 'Unknown error',
+        message: message ?? (error instanceof Error ? error.message : 'Unknown error'),
       })
     }
 
@@ -406,10 +406,15 @@ export const deleteOperation = async <
           },
         })
       } catch (error) {
-        // A batched delete either lands for every id or for none, so it cannot be attributed to a
-        // single document the way a per-document delete could.
+        // The delete covers the whole batch, so a failure here belongs to the batch rather than to
+        // any single document. Say so explicitly, otherwise one batch failure reads as N unrelated
+        // per-document failures.
+        const message = `Bulk delete failed for this batch of ${deletable.length} documents: ${
+          error instanceof Error ? error.message : 'Unknown error'
+        }`
+
         for (const { doc } of deletable) {
-          pushError(doc.id, error)
+          pushError(doc.id, error, message)
         }
 
         return results

--- a/packages/payload/src/collections/operations/delete.ts
+++ b/packages/payload/src/collections/operations/delete.ts
@@ -154,6 +154,7 @@ export const deleteOperation = async <
     })
 
     const errors: BulkOperationResult<TSlug, TSelect>['errors'] = []
+    let didBatchDeleteFail = false
 
     type Doc = DataFromCollectionSlug<TSlug>
     type ResultDoc = BulkOperationResult<TSlug, TSelect>['docs'][number]
@@ -409,6 +410,12 @@ export const deleteOperation = async <
           },
         })
       } catch (error) {
+        didBatchDeleteFail = true
+
+        if (shouldCommit) {
+          await killTransaction(req)
+        }
+
         // The delete covers the whole batch, so a failure here belongs to the batch rather than to
         // any single document. Say so explicitly, otherwise one batch failure reads as N unrelated
         // per-document failures.
@@ -453,12 +460,14 @@ export const deleteOperation = async <
     // Delete Preferences
     // /////////////////////////////////////
 
-    await deleteUserPreferences({
-      collectionConfig,
-      ids: docs.map(({ id }) => id),
-      payload,
-      req,
-    })
+    if (!didBatchDeleteFail) {
+      await deleteUserPreferences({
+        collectionConfig,
+        ids: docs.map(({ id }) => id),
+        payload,
+        req,
+      })
+    }
 
     let result = {
       docs: awaitedDocs.filter((doc): doc is ResultDoc => Boolean(doc)),
@@ -477,7 +486,7 @@ export const deleteOperation = async <
       result,
     })
 
-    if (shouldCommit) {
+    if (shouldCommit && !didBatchDeleteFail) {
       await commitTransaction(req)
     }
 

--- a/packages/payload/src/utilities/checkDocumentLockStatus.ts
+++ b/packages/payload/src/utilities/checkDocumentLockStatus.ts
@@ -1,6 +1,6 @@
 import type { TypeWithID } from '../collections/config/types.js'
 import type { PaginatedDocs } from '../database/types.js'
-import type { JsonObject, PayloadRequest } from '../types/index.js'
+import type { JsonObject, PayloadRequest, Where } from '../types/index.js'
 
 import { Locked } from '../errors/index.js'
 import { lockedDocumentsCollectionSlug } from '../locked-documents/config.js'
@@ -102,5 +102,111 @@ export const checkDocumentLockStatus = async ({
     // Not passing req fails on postgres
     req: payload.db.name === 'mongoose' ? undefined : req,
     where: lockedDocumentQuery,
+  })
+}
+
+type BulkLockArgs = {
+  collectionSlug: string
+  ids: (number | string)[]
+  req: PayloadRequest
+}
+
+const buildBulkLockedDocumentQuery = (collectionSlug: string, ids: (number | string)[]): Where => ({
+  and: [{ 'document.relationTo': { equals: collectionSlug } }, { 'document.value': { in: ids } }],
+})
+
+const isLockingAvailable = (collectionSlug: string, req: PayloadRequest): boolean => {
+  const { payload } = req
+
+  if (!payload.collections?.[lockedDocumentsCollectionSlug]) {
+    return false
+  }
+
+  return payload.collections?.[collectionSlug]?.config?.lockDocuments !== false
+}
+
+/**
+ * Batched counterpart to `checkDocumentLockStatus`. Resolves the lock state of every id with a
+ * single query instead of one per document, and returns the ids that are locked by another user.
+ * Callers are expected to report those ids as errors and leave them alone.
+ */
+export const getLockedDocumentIds = async ({
+  collectionSlug,
+  ids,
+  lockDurationDefault = 300, // Default 5 minutes in seconds
+  overrideLock = true,
+  req,
+}: {
+  lockDurationDefault?: number
+  overrideLock?: boolean
+} & BulkLockArgs): Promise<Set<string>> => {
+  const lockedIds = new Set<string>()
+
+  if (overrideLock || !ids.length || !isLockingAvailable(collectionSlug, req)) {
+    return lockedIds
+  }
+
+  const { payload } = req
+  const lockDocumentsProp = payload.collections?.[collectionSlug]?.config?.lockDocuments
+
+  const lockedDocumentResult: PaginatedDocs<JsonObject & TypeWithID> = await payload.db.find({
+    collection: lockedDocumentsCollectionSlug,
+    limit: 0,
+    pagination: false,
+    sort: '-updatedAt',
+    where: buildBulkLockedDocumentQuery(collectionSlug, ids),
+  })
+
+  const lockDuration =
+    typeof lockDocumentsProp === 'object' ? lockDocumentsProp.duration : lockDurationDefault
+
+  const lockDurationInMilliseconds = lockDuration * 1000
+  const currentUserId = req.user?.id
+  const now = new Date().getTime()
+  const resolved = new Set<string>()
+
+  for (const lockedDoc of lockedDocumentResult?.docs ?? []) {
+    const documentId = String(lockedDoc.document?.value)
+
+    // Sorted by -updatedAt, so the first row seen for an id is its most recent lock
+    if (resolved.has(documentId)) {
+      continue
+    }
+    resolved.add(documentId)
+
+    const lastEditedAt = new Date(lockedDoc?.updatedAt).getTime()
+
+    // document is locked by another user and the lock hasn't expired
+    if (
+      lockedDoc.user?.value !== currentUserId &&
+      now - lastEditedAt <= lockDurationInMilliseconds
+    ) {
+      lockedIds.add(documentId)
+    }
+  }
+
+  return lockedIds
+}
+
+/**
+ * Batched counterpart to the lock cleanup `checkDocumentLockStatus` performs, so that bulk
+ * operations release every lock in one query instead of one per document.
+ */
+export const deleteDocumentLocks = async ({
+  collectionSlug,
+  ids,
+  req,
+}: BulkLockArgs): Promise<void> => {
+  const { payload } = req
+
+  if (!ids.length || !isLockingAvailable(collectionSlug, req)) {
+    return
+  }
+
+  await payload.db.deleteMany({
+    collection: lockedDocumentsCollectionSlug,
+    // Not passing req fails on postgres
+    req: payload.db.name === 'mongoose' ? undefined : req,
+    where: buildBulkLockedDocumentQuery(collectionSlug, ids),
   })
 }

--- a/packages/payload/src/versions/deleteCollectionVersions.ts
+++ b/packages/payload/src/versions/deleteCollectionVersions.ts
@@ -4,26 +4,36 @@ import { type Payload } from '../index.js'
 
 type Args = {
   id?: number | string
+  /**
+   * Delete the versions of many parent documents at once. Takes precedence over `id`.
+   */
+  ids?: (number | string)[]
   payload: Payload
   req?: PayloadRequest
   slug: string
 }
 
-export const deleteCollectionVersions = async ({ id, slug, payload, req }: Args): Promise<void> => {
+export const deleteCollectionVersions = async ({
+  id,
+  slug,
+  ids,
+  payload,
+  req,
+}: Args): Promise<void> => {
   try {
     await payload.db.deleteVersions({
       collection: slug,
       req,
       where: {
-        parent: {
-          equals: id,
-        },
+        parent: ids ? { in: ids } : { equals: id },
       },
     })
   } catch (err) {
     payload.logger.error({
       err,
-      msg: `There was an error removing versions for the deleted ${slug} document with ID ${id}.`,
+      msg: ids
+        ? `There was an error removing versions for ${ids.length} deleted ${slug} documents.`
+        : `There was an error removing versions for the deleted ${slug} document with ID ${id}.`,
     })
   }
 }

--- a/packages/payload/src/versions/deleteCollectionVersions.ts
+++ b/packages/payload/src/versions/deleteCollectionVersions.ts
@@ -13,6 +13,12 @@ type Args = {
   slug: string
 }
 
+/**
+ * Deletes every version belonging to one parent document, or to many at once via `ids`.
+ *
+ * @internal - this may break or be removed at any time. It is exported from the package root only
+ * so that Payload 2.x `payload/versions` imports keep resolving, not as an API to build on.
+ */
 export const deleteCollectionVersions = async ({
   id,
   slug,

--- a/packages/payload/src/versions/deleteScheduledPublishJobs.ts
+++ b/packages/payload/src/versions/deleteScheduledPublishJobs.ts
@@ -5,6 +5,10 @@ import { jobsCollectionSlug } from '../queues/config/collection.js'
 
 type Args = {
   id?: number | string
+  /**
+   * Delete the scheduled publish jobs of many documents at once. Takes precedence over `id`.
+   */
+  ids?: (number | string)[]
   payload: Payload
   req?: PayloadRequest
   slug: string
@@ -13,6 +17,7 @@ type Args = {
 export const deleteScheduledPublishJobs = async ({
   id,
   slug,
+  ids,
   payload,
   req,
 }: Args): Promise<void> => {
@@ -34,9 +39,7 @@ export const deleteScheduledPublishJobs = async ({
             },
           },
           {
-            'input.doc.value': {
-              equals: id,
-            },
+            'input.doc.value': ids ? { in: ids } : { equals: id },
           },
           {
             'input.doc.relationTo': {
@@ -55,7 +58,9 @@ export const deleteScheduledPublishJobs = async ({
   } catch (err) {
     payload.logger.error({
       err,
-      msg: `There was an error deleting scheduled publish jobs from the queue for ${slug} document with ID ${id}.`,
+      msg: ids
+        ? `There was an error deleting scheduled publish jobs from the queue for ${ids.length} ${slug} documents.`
+        : `There was an error deleting scheduled publish jobs from the queue for ${slug} document with ID ${id}.`,
     })
   }
 }

--- a/packages/payload/src/versions/deleteScheduledPublishJobs.ts
+++ b/packages/payload/src/versions/deleteScheduledPublishJobs.ts
@@ -38,9 +38,19 @@ export const deleteScheduledPublishJobs = async ({
               exists: false,
             },
           },
-          {
-            'input.doc.value': ids ? { in: ids } : { equals: id },
-          },
+          ids
+            ? {
+                or: ids.map((id) => ({
+                  'input.doc.value': {
+                    equals: id,
+                  },
+                })),
+              }
+            : {
+                'input.doc.value': {
+                  equals: id,
+                },
+              },
           {
             'input.doc.relationTo': {
               equals: slug,

--- a/test/collections-rest/bulk-delete-rollback.int.spec.ts
+++ b/test/collections-rest/bulk-delete-rollback.int.spec.ts
@@ -1,0 +1,81 @@
+import type { Payload } from 'payload'
+
+import path from 'path'
+import { fileURLToPath } from 'url'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+
+import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
+import { postsSlug } from './config.js'
+
+const filename = fileURLToPath(import.meta.url)
+const dirname = path.dirname(filename)
+
+let payload: Payload
+
+describe('Collections REST - bulk delete rollback', () => {
+  beforeAll(async () => {
+    ;({ payload } = await initPayloadInt(dirname))
+  })
+
+  afterAll(async () => {
+    await payload.destroy()
+  })
+
+  it.skipIf(
+    process.env.PAYLOAD_DATABASE === 'cosmosdb' || process.env.PAYLOAD_DATABASE === 'documentdb',
+  )('should roll back when the batched deleteMany fails', async () => {
+    const title = 'bulk-delete-failure'
+
+    await payload.create({
+      collection: postsSlug,
+      data: { title },
+    })
+    await payload.create({
+      collection: postsSlug,
+      data: { title },
+    })
+
+    const originalDeleteMany = payload.db.deleteMany.bind(payload.db)
+    const deleteManySpy = vi.spyOn(payload.db, 'deleteMany').mockImplementation(async (args) => {
+      if (args.collection === postsSlug) {
+        throw new Error('database connection lost')
+      }
+
+      return originalDeleteMany(args)
+    })
+    const beginSpy = vi.spyOn(payload.db, 'beginTransaction')
+    const commitSpy = vi.spyOn(payload.db, 'commitTransaction')
+    const rollbackSpy = vi.spyOn(payload.db, 'rollbackTransaction')
+
+    const result = await payload.delete({
+      collection: postsSlug,
+      where: { title: { equals: title } },
+    })
+
+    const deletedCollections = deleteManySpy.mock.calls.map(([args]) => args.collection)
+    const transactionID = await beginSpy.mock.results[0]?.value
+    const commitCalls = commitSpy.mock.calls.length
+    const rollbackCalls = rollbackSpy.mock.calls.length
+
+    deleteManySpy.mockRestore()
+    beginSpy.mockRestore()
+    commitSpy.mockRestore()
+    rollbackSpy.mockRestore()
+
+    expect(result.docs).toHaveLength(0)
+    expect(result.errors).toHaveLength(2)
+    expect(result.errors.every(({ message }) => message.startsWith('Bulk delete failed'))).toBe(
+      true,
+    )
+    expect(commitCalls).toBe(0)
+    expect(rollbackCalls).toBe(transactionID ? 1 : 0)
+    expect(deletedCollections).not.toContain('payload-preferences')
+
+    const remainingDocs = await payload.find({
+      collection: postsSlug,
+      where: { title: { equals: title } },
+    })
+
+    expect(remainingDocs.docs).toHaveLength(2)
+  })
+})

--- a/test/collections-rest/int.spec.ts
+++ b/test/collections-rest/int.spec.ts
@@ -5,7 +5,7 @@ import { serialize } from 'object-to-formdata'
 import path from 'path'
 import { APIError, NotFound } from 'payload'
 import { fileURLToPath } from 'url'
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { NextRESTClient } from '../__helpers/shared/NextRESTClient.js'
 import type { Relation } from './config.js'
@@ -364,6 +364,42 @@ describe('collections-rest', () => {
         expect(response.status).toEqual(200)
         expect(docs[0].title).toEqual('title') // Check was not modified
         expect(docs).toHaveLength(count)
+      })
+
+      it('should not scale database delete calls with the number of documents', async () => {
+        const deleteOneSpy = vi.spyOn(payload.db, 'deleteOne')
+        const deleteManySpy = vi.spyOn(payload.db, 'deleteMany')
+
+        const countDeleteCalls = async (count: number) => {
+          await createPosts(count)
+
+          deleteOneSpy.mockClear()
+          deleteManySpy.mockClear()
+
+          const { docs, errors } = await payload.delete({
+            collection: postsSlug,
+            where: { title: { equals: 'title' } },
+          })
+
+          expect(errors).toHaveLength(0)
+          expect(docs).toHaveLength(count)
+
+          return {
+            deleteMany: deleteManySpy.mock.calls.length,
+            deleteOne: deleteOneSpy.mock.calls.length,
+          }
+        }
+
+        const few = await countDeleteCalls(2)
+        const many = await countDeleteCalls(20)
+
+        // Deleting ten times as many documents must not cost ten times as many queries
+        expect(few.deleteOne).toBe(0)
+        expect(many.deleteOne).toBe(0)
+        expect(many.deleteMany).toBe(few.deleteMany)
+
+        deleteOneSpy.mockRestore()
+        deleteManySpy.mockRestore()
       })
 
       it('should return formatted errors for bulk deletes', async () => {

--- a/test/collections-rest/int.spec.ts
+++ b/test/collections-rest/int.spec.ts
@@ -366,7 +366,7 @@ describe('collections-rest', () => {
         expect(docs).toHaveLength(count)
       })
 
-      it('should not scale database delete calls with the number of documents', async () => {
+      it('should use the configured bulk delete strategy', async () => {
         const deleteOneSpy = vi.spyOn(payload.db, 'deleteOne')
         const deleteManySpy = vi.spyOn(payload.db, 'deleteMany')
 
@@ -393,13 +393,16 @@ describe('collections-rest', () => {
         const few = await countDeleteCalls(2)
         const many = await countDeleteCalls(20)
 
-        // Deleting ten times as many documents must not cost ten times as many queries
-        expect(few.deleteOne).toBe(0)
-        expect(many.deleteOne).toBe(0)
-        expect(many.deleteMany).toBe(few.deleteMany)
-
         deleteOneSpy.mockRestore()
         deleteManySpy.mockRestore()
+
+        const isPerDocument = payload.db.bulkOperationsSingleTransaction
+
+        expect(few.deleteOne).toBe(isPerDocument ? 2 : 0)
+        expect(many.deleteOne).toBe(isPerDocument ? 20 : 0)
+        // When batched writes are enabled, deleting ten times as many documents must not cost ten
+        // times as many deleteMany calls.
+        expect(isPerDocument || many.deleteMany === few.deleteMany).toBe(true)
       })
 
       it('should return formatted errors for bulk deletes', async () => {

--- a/test/database/postgres-logs.int.spec.ts
+++ b/test/database/postgres-logs.int.spec.ts
@@ -175,6 +175,42 @@ describePostgres('database - postgres logs', () => {
     expect(allPosts.docs[0]?.id).toEqual(doc1.id)
   })
 
+  it('ensure bulk delete uses a constant number of db queries regardless of how many documents match', async () => {
+    const countQueriesForBulkDelete = async (documentCount: number) => {
+      for (let i = 0; i < documentCount; i++) {
+        await payload.create({
+          collection: 'simple',
+          data: {
+            text: 'bulk-delete',
+            number: i,
+          },
+        })
+      }
+
+      // Count every console log
+      const consoleCount = vitest.spyOn(console, 'log').mockImplementation(() => {})
+
+      const { docs, errors } = await payload.delete({
+        collection: 'simple',
+        where: {
+          text: { equals: 'bulk-delete' },
+        },
+      })
+
+      const queryCount = consoleCount.mock.calls.length
+      consoleCount.mockRestore()
+
+      expect(errors).toHaveLength(0)
+      expect(docs).toHaveLength(documentCount)
+
+      return queryCount
+    }
+
+    // Deleting ten times as many documents must not cost ten times as many queries. Before
+    // batching this was 4 queries per document, so 13 vs 85 rather than 8 vs 8.
+    expect(await countQueriesForBulkDelete(20)).toBe(await countQueriesForBulkDelete(2))
+  })
+
   it('ensure array update using $push is done in single db call', async () => {
     const post = await payload.create({
       collection: 'posts',

--- a/test/locked-documents/bulk-delete.int.spec.ts
+++ b/test/locked-documents/bulk-delete.int.spec.ts
@@ -1,0 +1,133 @@
+import type { Payload } from 'payload'
+
+import path from 'path'
+import { NotFound } from 'payload'
+import { fileURLToPath } from 'url'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import type { User } from './payload-types.js'
+
+import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
+import { postsSlug } from './slugs.js'
+
+const lockedDocumentCollection = 'payload-locked-documents'
+
+let payload: Payload
+
+const filename = fileURLToPath(import.meta.url)
+const dirname = path.dirname(filename)
+
+describe('Locked documents - bulk delete', () => {
+  let deletingUser: User
+  let otherUser: User
+
+  beforeAll(async () => {
+    ;({ payload } = await initPayloadInt(dirname))
+
+    deletingUser = await payload.create({
+      collection: 'users',
+      data: {
+        email: 'bulk-delete-owner@payloadcms.com',
+        password: 'test',
+      },
+    })
+
+    otherUser = await payload.create({
+      collection: 'users',
+      data: {
+        email: 'bulk-delete-other@payloadcms.com',
+        password: 'test',
+      },
+    })
+  })
+
+  afterAll(async () => {
+    await payload.destroy()
+  })
+
+  // Bulk delete resolves the lock state of the whole batch in a single query, rather than one
+  // query per document like deleting a single document does
+  it('should skip locked documents but delete the unlocked ones', async () => {
+    const lockedPost = await payload.create({
+      collection: postsSlug,
+      data: {
+        text: 'bulk delete locked post',
+      },
+    })
+
+    const unlockedPost = await payload.create({
+      collection: postsSlug,
+      data: {
+        text: 'bulk delete unlocked post',
+      },
+    })
+
+    // Give locking ownership of one of the two documents to another user
+    await payload.create({
+      collection: lockedDocumentCollection,
+      data: {
+        document: {
+          relationTo: 'posts',
+          value: lockedPost.id,
+        },
+        globalSlug: undefined,
+        user: {
+          relationTo: 'users',
+          value: otherUser.id,
+        },
+      },
+    })
+
+    // The other document is locked by the user performing the delete, so it is not blocked. It
+    // also lets us assert that its lock is released.
+    const ownLock = await payload.create({
+      collection: lockedDocumentCollection,
+      data: {
+        document: {
+          relationTo: 'posts',
+          value: unlockedPost.id,
+        },
+        globalSlug: undefined,
+        user: {
+          relationTo: 'users',
+          value: deletingUser.id,
+        },
+      },
+    })
+
+    const { docs, errors } = await payload.delete({
+      collection: postsSlug,
+      overrideLock: false, // necessary to trigger the lock check
+      user: deletingUser,
+      where: {
+        id: { in: [lockedPost.id, unlockedPost.id] },
+      },
+    })
+
+    expect(docs).toHaveLength(1)
+    expect(docs[0]?.id).toStrictEqual(unlockedPost.id)
+
+    expect(errors).toHaveLength(1)
+    expect(errors[0]?.id).toStrictEqual(lockedPost.id)
+    expect(errors[0]?.message).toMatch(/currently locked and cannot be deleted/)
+
+    // The locked document must survive
+    const remainingPosts = await payload.find({
+      collection: postsSlug,
+      where: {
+        id: { in: [lockedPost.id, unlockedPost.id] },
+      },
+    })
+
+    expect(remainingPosts.docs).toHaveLength(1)
+    expect(remainingPosts.docs[0]?.id).toStrictEqual(lockedPost.id)
+
+    // The lock of the deleted document must be released
+    await expect(
+      payload.findByID({
+        id: ownLock.id,
+        collection: lockedDocumentCollection,
+      }),
+    ).rejects.toBeInstanceOf(NotFound)
+  })
+})


### PR DESCRIPTION
## Problem

`payload.delete({ where })` loads the matching documents, then issues four writes *per document*: a lock cleanup, a version delete, a scheduled-job delete and a `deleteOne`. Query count grows linearly with N, which is what exhausts connection pools on large deletes, and turns one call into hundreds of requests on HTTP-backed adapters. The `deleteOne` also re-reads a row `db.find()` already loaded, for a result nobody uses (`returning: false`).

## Change

Those writes are batched behind an `id in [...]` filter, so query count no longer depends on N. `delete.ts` becomes three phases: per-document pre-work (locks, `beforeDelete`, file cleanup), batched writes, per-document post-work (`afterRead`, `afterDelete`). Hooks and per-document error reporting still run per document; the result shape is unchanged.

`deleteCollectionVersions` and `deleteScheduledPublishJobs` gain an optional plural `ids`. Two batched lock helpers sit beside `checkDocumentLockStatus`, which is itself untouched, so `update`, `deleteByID` and globals are unaffected. `bulkOperationsSingleTransaction` (`n: true`) keeps the per-document path.

## Measured

Query counts from the logger already used by `test/database/postgres-logs.int.spec.ts`:

| documents | before | after |
| --- | --- | --- |
| 2 | 13 | 8 |
| 20 | 85 | 8 |
| 200 | 805 | 8 |

## Error attribution

Unchanged for every framework-level failure: locks, `beforeDelete`, file cleanup, `afterRead` and `afterDelete` all still report the exact document. Access control never produced per-document errors here, since `access.delete` is merged into the query before `db.find()`, so a denied document never enters the batch.

Only the collection delete changes: it covers every id at once, so a failure is reported against the batch with a message saying so, instead of repeating a driver error against each id as though each failed independently.

Related: #13618, #15517