### PR TITLE
fix: preserve Cloudflare request context for multipart parsing

### DIFF
--- a/packages/payload/src/uploads/fetchAPI-multipart/process-multipart.spec.ts
+++ b/packages/payload/src/uploads/fetchAPI-multipart/process-multipart.spec.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { processMultipartFormdata } from './index.js'
+
+describe('processMultipartFormdata', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('should avoid stream reader context loss in Cloudflare Workers', async () => {
+    vi.stubGlobal('navigator', { userAgent: 'Cloudflare-Workers' })
+    expect(navigator.userAgent).toBe('Cloudflare-Workers')
+
+    const formData = new FormData()
+    formData.set('email', 'admin@example.com')
+    const request = new Request('https://example.com/api/users/login', {
+      body: formData,
+      method: 'POST',
+    })
+    const bufferedBody = await request.clone().arrayBuffer()
+    const body = request.body
+
+    expect(body).not.toBeNull()
+    if (!body) {
+      throw new Error('Expected a multipart request body.')
+    }
+
+    const getReader = vi.spyOn(body, 'getReader').mockImplementation(() => {
+      throw new Error('The stream reader resumed outside the active request context.')
+    })
+    const arrayBuffer = vi.spyOn(request, 'arrayBuffer').mockResolvedValue(bufferedBody)
+
+    await expect(processMultipartFormdata({ request })).resolves.toMatchObject({
+      fields: { email: 'admin@example.com' },
+    })
+    expect(getReader).not.toHaveBeenCalled()
+    expect(arrayBuffer).toHaveBeenCalledOnce()
+  })
+
+  it('should preserve multipart streaming outside Cloudflare Workers', async () => {
+    vi.stubGlobal('navigator', { userAgent: 'Node.js/24' })
+
+    const formData = new FormData()
+    formData.set('email', 'admin@example.com')
+    const request = new Request('https://example.com/api/users/login', {
+      body: formData,
+      method: 'POST',
+    })
+    const arrayBuffer = vi
+      .spyOn(request, 'arrayBuffer')
+      .mockRejectedValue(new Error('Expected Payload to stream this request.'))
+
+    await expect(processMultipartFormdata({ request })).resolves.toMatchObject({
+      fields: { email: 'admin@example.com' },
+    })
+    expect(arrayBuffer).not.toHaveBeenCalled()
+  })
+
+  it('should preserve multipart file size limits in Cloudflare Workers', async () => {
+    vi.stubGlobal('navigator', { userAgent: 'Cloudflare-Workers' })
+
+    const formData = new FormData()
+    formData.set('file', new Blob(['too large']), 'oversized.txt')
+    const request = new Request('https://example.com/api/media', {
+      body: formData,
+      method: 'POST',
+    })
+
+    await expect(
+      processMultipartFormdata({
+        options: {
+          abortOnLimit: true,
+          limits: { fileSize: 1 },
+          responseOnLimit: 'Test file is too large',
+        },
+        request,
+      }),
+    ).rejects.toMatchObject({
+      message: 'Test file is too large',
+      status: 413,
+    })
+  })
+})

--- a/packages/payload/src/uploads/fetchAPI-multipart/processMultipart.ts
+++ b/packages/payload/src/uploads/fetchAPI-multipart/processMultipart.ts
@@ -26,8 +26,6 @@ type ProcessMultipart = (args: {
   request: Request
 }) => Promise<FetchAPIFileUploadResponse>
 export const processMultipart: ProcessMultipart = async ({ options, request }) => {
-  let parsingRequest = true
-
   let shouldAbortProccessing = false
   let fileCount = 0
   let filesCompleted = 0
@@ -61,8 +59,6 @@ export const processMultipart: ProcessMultipart = async ({ options, request }) =
   request.headers.forEach((value, name) => {
     headersObject[name] = value
   })
-
-  const reader = request.body?.getReader()
 
   const busboy = Busboy({ ...options, headers: headersObject })
 
@@ -224,16 +220,25 @@ export const processMultipart: ProcessMultipart = async ({ options, request }) =
     },
   )
 
-  while (parsingRequest) {
-    const { done, value } = await reader!.read()
+  if (isCloudflareWorker()) {
+    // workerd stream reader promises can resume in the context where the body was created,
+    // losing a request scope established before multipart parsing begins.
+    busboy.end(new Uint8Array(await request.arrayBuffer()))
+  } else {
+    const reader = request.body?.getReader()
+    let isParsingRequest = true
 
-    if (done) {
-      parsingRequest = false
-      busboy.end()
-    }
+    while (isParsingRequest) {
+      const { done, value } = await reader!.read()
 
-    if (value && !shouldAbortProccessing) {
-      busboy.write(value)
+      if (done) {
+        isParsingRequest = false
+        busboy.end()
+      }
+
+      if (value && !shouldAbortProccessing) {
+        busboy.write(value)
+      }
     }
   }
 
@@ -246,4 +251,8 @@ export const processMultipart: ProcessMultipart = async ({ options, request }) =
   await busboyFinished
 
   return result
+}
+
+function isCloudflareWorker(): boolean {
+  return typeof navigator !== 'undefined' && navigator.userAgent === 'Cloudflare-Workers'
 }


### PR DESCRIPTION
### What?

Use the Fetch Body promise to consume multipart request bodies in Cloudflare Workers before passing them to Busboy.
Keep the existing stream-reader implementation for every other runtime.

Add focused regression coverage for the Cloudflare path, non-Cloudflare streaming, and multipart file-size limits.

### Why?

Native workerd stream-reader promises can resume outside the `AsyncLocalStorage` frame established for the active request.
When a database adapter scopes its client to that frame, multipart authentication and collection requests can reach the transaction layer without an active Worker request and return HTTP 500.

`Request.arrayBuffer()` retains the active request context in the affected runtime.
The runtime-specific branch avoids removing multipart streaming from Node and other runtimes.

### How?

Cloudflare Workers expose `navigator.userAgent === 'Cloudflare-Workers'`.
For that runtime only, the parser awaits `request.arrayBuffer()` and ends Busboy with the resulting bytes.
Other runtimes continue reading and writing body chunks as before.

The file-limit regression verifies that Busboy still rejects an oversized file with HTTP 413 on the buffered path.

### Verification

- `pnpm test:unit packages/payload/src/uploads/fetchAPI-multipart/process-multipart.spec.ts`
- `pnpm --filter payload lint` (0 errors)
- `pnpm build:payload`

Fixes #17935
