### PR TITLE
docs: add RepoCloud as a one-click deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,13 +65,19 @@ All-in-one on Vercel — one click to deploy Payload with a **Next.js** front en
 
 [![Deploy with Vercel](https://vercel.com/button)](https://dub.sh/payload-vercel)
 
+### Deploy on RepoCloud
+
+One-click cloud deployment with competitive pricing for open-source applications.
+
+[![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/Payload/)
+
 ## One-click templates
 
 Jumpstart your next project with a ready-to-go template. These are **production-ready, end-to-end solutions** designed to get you to market fast. Build any kind of **website**, **ecommerce store**, **blog**, or **portfolio** — complete with a modern front end built using **React Server Components** and **Tailwind**.
 
 #### 🌐 [Website](https://github.com/payloadcms/payload/tree/main/templates/website)
 
-#### 🛍️ [Ecommerce](https://github.com/payloadcms/payload/tree/main/templates/ecommerce) 🎉 _**NEW**_ 🎉
+#### 🛒️ [Ecommerce](https://github.com/payloadcms/payload/tree/main/templates/ecommerce) 🎉 _**NEW**_ 🎉
 
 We're constantly adding more templates to our [**Templates Directory**](https://github.com/payloadcms/payload/tree/main/templates).
 If you maintain your own, add the `payload-template` topic to your GitHub repo so others can discover it.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ All-in-one on Vercel — one click to deploy Payload with a **Next.js** front en
 
 ### Deploy on RepoCloud
 
-One-click cloud deployment with competitive pricing for open-source applications.
+One click to deploy Payload on RepoCloud with managed hosting for open-source applications.
 
 [![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/Payload/)
 
@@ -77,7 +77,7 @@ Jumpstart your next project with a ready-to-go template. These are **production-
 
 #### 🌐 [Website](https://github.com/payloadcms/payload/tree/main/templates/website)
 
-#### 🛒️ [Ecommerce](https://github.com/payloadcms/payload/tree/main/templates/ecommerce) 🎉 _**NEW**_ 🎉
+#### 🛍️ [Ecommerce](https://github.com/payloadcms/payload/tree/main/templates/ecommerce) 🎉 _**NEW**_ 🎉
 
 We're constantly adding more templates to our [**Templates Directory**](https://github.com/payloadcms/payload/tree/main/templates).
 If you maintain your own, add the `payload-template` topic to your GitHub repo so others can discover it.


### PR DESCRIPTION
Adds [RepoCloud](https://repocloud.io) as a one-click deployment option alongside
Cloudflare and Vercel in the "One-click deployment options" section.

RepoCloud provides managed cloud hosting for open-source applications with one-click deployment.

- Adds new "Deploy on RepoCloud" subsection to `README.md`
- Uses the same format as existing Cloudflare and Vercel deploy buttons (markdown image link, no explicit height)
- Links to: https://repocloud.io/details/Payload/