### PR TITLE
fix: respect read access in slug uniqueness probes

### DIFF
--- a/packages/payload/src/collections/operations/create.ts
+++ b/packages/payload/src/collections/operations/create.ts
@@ -283,7 +283,12 @@ export const createOperation = async <
     // Fill every locale of a localized slug so switching locales never lands on an empty slug. The
     // slug field hook only sees the active locale, so the rest are seeded here on create.
     if (config.localization) {
-      await fillEmptyLocalizedSlugs({ collection: collectionConfig, data: dataWithLocales, req })
+      await fillEmptyLocalizedSlugs({
+        collection: collectionConfig,
+        data: dataWithLocales,
+        overrideAccess,
+        req,
+      })
     }
 
     // /////////////////////////////////////

--- a/packages/payload/src/fields/baseFields/slug/fillEmptyLocalizedSlugs.ts
+++ b/packages/payload/src/fields/baseFields/slug/fillEmptyLocalizedSlugs.ts
@@ -30,7 +30,7 @@ type Args = {
 export const fillEmptyLocalizedSlugs = async ({
   collection,
   data,
-  overrideAccess = true,
+  overrideAccess = false,
   req,
 }: Args): Promise<JsonObject> => {
   const { localization } = req.payload.config

--- a/packages/payload/src/fields/baseFields/slug/fillEmptyLocalizedSlugs.ts
+++ b/packages/payload/src/fields/baseFields/slug/fillEmptyLocalizedSlugs.ts
@@ -12,6 +12,7 @@ type Args = {
   collection: SanitizedCollectionConfig
   /** The post-`beforeChange` data, with localized fields already keyed by locale. */
   data: JsonObject
+  overrideAccess?: boolean
   req: PayloadRequest
 }
 
@@ -29,6 +30,7 @@ type Args = {
 export const fillEmptyLocalizedSlugs = async ({
   collection,
   data,
+  overrideAccess = true,
   req,
 }: Args): Promise<JsonObject> => {
   const { localization } = req.payload.config
@@ -77,10 +79,18 @@ export const fillEmptyLocalizedSlugs = async ({
             draftsEnabled,
             field: field.name,
             locale,
+            overrideAccess,
             req,
             value: derived as string,
           })
-        : await getSlugFallbackValue({ collection, field: field.name, locale, req, slugify })
+        : await getSlugFallbackValue({
+            collection,
+            field: field.name,
+            locale,
+            overrideAccess,
+            req,
+            slugify,
+          })
     }
 
     data[field.name] = localeValues

--- a/packages/payload/src/fields/baseFields/slug/generateSlug.ts
+++ b/packages/payload/src/fields/baseFields/slug/generateSlug.ts
@@ -33,7 +33,16 @@ type Args = {
  */
 export const generateSlug =
   ({ name, localized, slugify: customSlugify, useAsSlug }: Args): FieldHook =>
-  async ({ collection, context, data, operation, originalDoc, overrideAccess, req, value }) => {
+  async ({
+    collection,
+    context,
+    data,
+    operation,
+    originalDoc,
+    overrideAccess = false,
+    req,
+    value,
+  }) => {
     const slugify = (valueToSlugify: unknown) =>
       customSlugify
         ? customSlugify({ data: (data ?? {}) as TypeWithID, req, valueToSlugify })

--- a/packages/payload/src/fields/baseFields/slug/generateSlug.ts
+++ b/packages/payload/src/fields/baseFields/slug/generateSlug.ts
@@ -33,7 +33,7 @@ type Args = {
  */
 export const generateSlug =
   ({ name, localized, slugify: customSlugify, useAsSlug }: Args): FieldHook =>
-  async ({ collection, context, data, operation, originalDoc, req, value }) => {
+  async ({ collection, context, data, operation, originalDoc, overrideAccess, req, value }) => {
     const slugify = (valueToSlugify: unknown) =>
       customSlugify
         ? customSlugify({ data: (data ?? {}) as TypeWithID, req, valueToSlugify })
@@ -47,7 +47,14 @@ export const generateSlug =
     //  - Takes a fresh `<singular>-<N>` fallback — not the original's slug, not a source-derived one
     //  - Skips the explicit-collision check below (see generateSlugBeforeDuplicate).
     if (collection && consumeSlugDuplicateFallback(context, name)) {
-      return await getSlugFallbackValue({ collection, field: name, locale, req, slugify })
+      return await getSlugFallbackValue({
+        collection,
+        field: name,
+        locale,
+        overrideAccess,
+        req,
+        slugify,
+      })
     }
 
     const storedSlug = originalDoc?.[name]
@@ -77,6 +84,7 @@ export const generateSlug =
             draftsEnabled: hasDraftsEnabled(collection),
             field: name,
             locale,
+            overrideAccess,
             req,
             value: slugified,
           }))
@@ -113,6 +121,7 @@ export const generateSlug =
         draftsEnabled: hasDraftsEnabled(collection),
         field: name,
         locale,
+        overrideAccess,
         req,
         value: derived as string,
       })
@@ -127,5 +136,12 @@ export const generateSlug =
       return undefined
     }
 
-    return await getSlugFallbackValue({ collection, field: name, locale, req, slugify })
+    return await getSlugFallbackValue({
+      collection,
+      field: name,
+      locale,
+      overrideAccess,
+      req,
+      slugify,
+    })
   }

--- a/packages/payload/src/fields/baseFields/slug/getSlugFallbackValue.ts
+++ b/packages/payload/src/fields/baseFields/slug/getSlugFallbackValue.ts
@@ -12,6 +12,7 @@ type Args = {
   id?: DefaultDocumentIDType
   /** Locale to scope the uniqueness check to, for a localized slug. */
   locale?: Locale['code']
+  overrideAccess?: boolean
   req: PayloadRequest
   slugify: (value: unknown) => Promise<string | undefined> | string | undefined
 }
@@ -27,6 +28,7 @@ export const getSlugFallbackValue = async ({
   collection,
   field,
   locale,
+  overrideAccess = true,
   req,
   slugify,
 }: Args): Promise<string> => {
@@ -39,6 +41,7 @@ export const getSlugFallbackValue = async ({
     draftsEnabled: hasDraftsEnabled(collection),
     field,
     locale,
+    overrideAccess,
     req,
     startIndex: 1,
     value: (await slugify(base)) || collection.slug,

--- a/packages/payload/src/fields/baseFields/slug/getSlugFallbackValue.ts
+++ b/packages/payload/src/fields/baseFields/slug/getSlugFallbackValue.ts
@@ -28,7 +28,7 @@ export const getSlugFallbackValue = async ({
   collection,
   field,
   locale,
-  overrideAccess = true,
+  overrideAccess = false,
   req,
   slugify,
 }: Args): Promise<string> => {

--- a/packages/payload/src/fields/hooks/beforeChange/promise.ts
+++ b/packages/payload/src/fields/hooks/beforeChange/promise.ts
@@ -144,6 +144,7 @@ export const promise = async ({
           indexPath: indexPathSegments,
           operation,
           originalDoc: doc,
+          overrideAccess,
           path: pathSegments,
           previousSiblingDoc: siblingDoc,
           previousValue: siblingDoc[field.name],

--- a/packages/payload/src/utilities/fieldValueExists.ts
+++ b/packages/payload/src/utilities/fieldValueExists.ts
@@ -1,6 +1,8 @@
 import type { DefaultDocumentIDType, Locale } from '../index.js'
 import type { PayloadRequest } from '../types/index.js'
 
+import { isolateObjectProperty } from './isolateObjectProperty.js'
+
 type Args = {
   collection: string
   /**
@@ -13,6 +15,7 @@ type Args = {
   /** Exclude this document, so a doc doesn't conflict with itself on update. */
   id?: DefaultDocumentIDType
   locale?: Locale['code']
+  overrideAccess?: boolean
   req: PayloadRequest
   value: unknown
 }
@@ -20,11 +23,10 @@ type Args = {
 /**
  * Whether another document in `collection` already uses `value` for `field`.
  *
- * Runs the `find` operation without threading `req`, so it queries outside the caller's transaction:
- * a committed read is what a uniqueness check wants (other documents are committed, the document
- * being written is excluded by `id`), and it avoids the "cursor on a session with a transaction in
- * progress" error that a transactional read from inside a hook would hit. `draft` includes slugs
- * that only exist in a draft version.
+ * Runs the `find` operation outside the caller's transaction while preserving the rest of the
+ * request. A committed read is what a uniqueness check wants, and isolating the transaction avoids
+ * the "cursor on a session with a transaction in progress" error from a hook. `draft` includes
+ * slugs that only exist in a draft version.
  */
 export const fieldValueExists = async ({
   id,
@@ -32,17 +34,24 @@ export const fieldValueExists = async ({
   draftsEnabled,
   field,
   locale,
+  overrideAccess = true,
   req,
   value,
 }: Args): Promise<boolean> => {
+  const queryReq = isolateObjectProperty(req, ['query', 'transactionID'])
+  queryReq.query = { ...req.query }
+  delete queryReq.transactionID
+
   const { docs } = await req.payload.find({
     collection,
     depth: 0,
+    disableErrors: true,
     draft: Boolean(draftsEnabled),
     limit: 2,
     locale: locale as Parameters<typeof req.payload.find>[0]['locale'],
-    overrideAccess: true,
+    overrideAccess,
     pagination: false,
+    req: queryReq,
     where: { [field]: { equals: value } },
   })
 

--- a/packages/payload/src/utilities/fieldValueExists.ts
+++ b/packages/payload/src/utilities/fieldValueExists.ts
@@ -34,7 +34,7 @@ export const fieldValueExists = async ({
   draftsEnabled,
   field,
   locale,
-  overrideAccess = true,
+  overrideAccess = false,
   req,
   value,
 }: Args): Promise<boolean> => {

--- a/packages/payload/src/utilities/getUniqueFieldValue.ts
+++ b/packages/payload/src/utilities/getUniqueFieldValue.ts
@@ -36,7 +36,7 @@ export const getUniqueFieldValue = async ({
   draftsEnabled,
   field,
   locale,
-  overrideAccess = true,
+  overrideAccess = false,
   req,
   startIndex = 0,
   value,

--- a/packages/payload/src/utilities/getUniqueFieldValue.ts
+++ b/packages/payload/src/utilities/getUniqueFieldValue.ts
@@ -13,6 +13,7 @@ type Args = {
   id?: DefaultDocumentIDType
   /** Locale to scope the check to, for localized fields. */
   locale?: Locale['code']
+  overrideAccess?: boolean
   req: PayloadRequest
   /**
    * Index the search starts from. `0` (default) tries the bare `value` first, then `value-1`, …
@@ -35,6 +36,7 @@ export const getUniqueFieldValue = async ({
   draftsEnabled,
   field,
   locale,
+  overrideAccess = true,
   req,
   startIndex = 0,
   value,
@@ -48,6 +50,7 @@ export const getUniqueFieldValue = async ({
       draftsEnabled,
       field,
       locale,
+      overrideAccess,
       req,
       value: candidate,
     })

--- a/packages/ui/src/utilities/slugify.ts
+++ b/packages/ui/src/utilities/slugify.ts
@@ -97,6 +97,7 @@ export const slugifyHandler: ServerFunction<
       draftsEnabled: hasDraftsEnabled(collectionConfig),
       field: field.name,
       locale: localeToScope,
+      overrideAccess: true,
       req,
       value: result,
     })
@@ -107,6 +108,7 @@ export const slugifyHandler: ServerFunction<
     collection: collectionConfig,
     field: field.name,
     locale: localeToScope,
+    overrideAccess: true,
     req,
     slugify,
   })

--- a/test/fields/baseConfig.ts
+++ b/test/fields/baseConfig.ts
@@ -29,6 +29,7 @@ import RowFields from './collections/Row/index.js'
 import SelectFields from './collections/Select/index.js'
 import SelectVersionsFields from './collections/SelectVersions/index.js'
 import SlugField from './collections/SlugField/index.js'
+import { SlugFieldAccess } from './collections/SlugFieldAccess/index.js'
 import { SlugFieldAutosave } from './collections/SlugFieldAutosave/index.js'
 import TabsFields from './collections/Tabs/index.js'
 import { TabsFields2 } from './collections/Tabs2/index.js'
@@ -82,6 +83,7 @@ export const collections: CollectionConfig[] = [
   RelationshipFields,
   SelectFields,
   SlugField,
+  SlugFieldAccess,
   SlugFieldAutosave,
   TabsFields2,
   TabsFields,

--- a/test/fields/collections/SlugFieldAccess/index.ts
+++ b/test/fields/collections/SlugFieldAccess/index.ts
@@ -1,0 +1,25 @@
+import type { CollectionConfig } from 'payload'
+
+export const slugFieldAccessSlug = 'slug-field-access'
+
+export const SlugFieldAccess: CollectionConfig = {
+  slug: slugFieldAccessSlug,
+  access: {
+    create: () => true,
+    read: () => false,
+    update: () => true,
+  },
+  fields: [
+    { name: 'title', type: 'text' },
+    { name: 'slug', type: 'slug', unique: false, useAsSlug: 'title' },
+    { name: 'localizedTitle', type: 'text', localized: true },
+    {
+      name: 'localizedSlug',
+      type: 'slug',
+      localized: true,
+      unique: false,
+      useAsSlug: 'localizedTitle',
+    },
+    { name: 'sourcelessSlug', type: 'slug', unique: false },
+  ],
+}

--- a/test/fields/int.spec.ts
+++ b/test/fields/int.spec.ts
@@ -840,6 +840,131 @@ describe('Fields', () => {
     })
   })
 
+  describe('slug field read access', () => {
+    const collection = 'slug-field-access'
+    const created: (number | string)[] = []
+
+    afterEach(async () => {
+      for (const id of created) {
+        await payload.delete({ collection, id })
+      }
+      created.length = 0
+    })
+
+    it('should apply read access when checking a generated slug during create', async () => {
+      const hidden = await payload.create({
+        collection,
+        data: { title: 'Shared title' },
+      })
+      created.push(hidden.id)
+
+      const req = await createLocalReq({ user: user.user }, payload)
+      const createdWithAccess = await payload.create({
+        collection,
+        data: { title: 'Shared title' },
+        overrideAccess: false,
+        req,
+      })
+      created.push(createdWithAccess.id)
+
+      expect(createdWithAccess.slug).toBe('shared-title')
+    })
+
+    it('should apply read access when checking an explicit slug during update', async () => {
+      const hidden = await payload.create({
+        collection,
+        data: { slug: 'shared-slug', title: 'Hidden' },
+      })
+      const editable = await payload.create({
+        collection,
+        data: { slug: 'editable-slug', title: 'Editable' },
+      })
+      created.push(hidden.id, editable.id)
+
+      const req = await createLocalReq({ user: user.user }, payload)
+      const updated = await payload.update({
+        collection,
+        id: editable.id,
+        data: { slug: 'shared-slug' },
+        overrideAccess: false,
+        req,
+      })
+
+      expect(updated.slug).toBe('shared-slug')
+    })
+
+    it('should apply read access while filling localized slugs', async () => {
+      const hidden = await payload.create({
+        collection,
+        data: { localizedTitle: 'Localized title', title: 'Hidden' },
+        locale: 'en',
+      })
+      created.push(hidden.id)
+
+      const req = await createLocalReq({ user: user.user }, payload)
+      const createdWithAccess = await payload.create({
+        collection,
+        data: { localizedTitle: 'Localized title', title: 'Visible' },
+        locale: 'en',
+        overrideAccess: false,
+        req,
+      })
+      created.push(createdWithAccess.id)
+
+      const allLocales = await payload.findByID({
+        collection,
+        id: createdWithAccess.id,
+        locale: 'all',
+      })
+      const hiddenLocales = await payload.findByID({
+        collection,
+        id: hidden.id,
+        locale: 'all',
+      })
+      const localizedSlug = allLocales.localizedSlug as unknown as Record<string, string>
+      const hiddenLocalizedSlug = hiddenLocales.localizedSlug as unknown as Record<string, string>
+
+      expect(localizedSlug.en).toBe('localized-title')
+      expect(localizedSlug.es).toBe(hiddenLocalizedSlug.es)
+    })
+
+    it('should apply read access when choosing a source-less fallback', async () => {
+      const hidden = await payload.create({
+        collection,
+        data: { title: 'Hidden' },
+      })
+      created.push(hidden.id)
+
+      const req = await createLocalReq({ user: user.user }, payload)
+      const createdWithAccess = await payload.create({
+        collection,
+        data: { title: 'Visible' },
+        overrideAccess: false,
+        req,
+      })
+      created.push(createdWithAccess.id)
+
+      expect(createdWithAccess.sourcelessSlug).toBe(hidden.sourcelessSlug)
+    })
+
+    it('should retain elevated slug probes for explicitly elevated Local API creates', async () => {
+      const hidden = await payload.create({
+        collection,
+        data: { title: 'Shared title' },
+      })
+      created.push(hidden.id)
+
+      const elevated = await payload.create({
+        collection,
+        data: { title: 'Shared title' },
+        overrideAccess: true,
+      })
+      created.push(elevated.id)
+
+      expect(elevated.slug).toBe('shared-title-1')
+    })
+  })
+
   describe('text', () => {
     let doc
     const text = 'text field'

--- a/test/fields/int.spec.ts
+++ b/test/fields/int.spec.ts
@@ -851,6 +851,23 @@ describe('Fields', () => {
       created.length = 0
     })
 
+    it('should apply read access when a REST create omits overrideAccess', async () => {
+      const hidden = await payload.create({
+        collection,
+        data: { title: 'REST shared title' },
+      })
+      created.push(hidden.id)
+
+      const response = await restClient.POST(`/${collection}`, {
+        body: JSON.stringify({ title: 'REST shared title' }),
+      })
+      const { doc } = await response.json()
+      created.push(doc.id)
+
+      expect(response.status).toBe(201)
+      expect(doc.slug).toBe('rest-shared-title')
+    })
+
     it('should apply read access when checking a generated slug during create', async () => {
       const hidden = await payload.create({
         collection,

--- a/test/fields/payload-types.ts
+++ b/test/fields/payload-types.ts
@@ -213,6 +213,7 @@ export interface Config {
     'relationship-fields': RelationshipField;
     'select-fields': SelectField;
     'slug-fields': SlugField;
+    'slug-field-access': SlugFieldAccess;
     'slug-autosave': SlugAutosave;
     'tabs-fields-2': TabsFields2;
     'tabs-fields': TabsField;
@@ -257,6 +258,7 @@ export interface Config {
     'relationship-fields': RelationshipFieldsSelect<false> | RelationshipFieldsSelect<true>;
     'select-fields': SelectFieldsSelect<false> | SelectFieldsSelect<true>;
     'slug-fields': SlugFieldsSelect<false> | SlugFieldsSelect<true>;
+    'slug-field-access': SlugFieldAccessSelect<false> | SlugFieldAccessSelect<true>;
     'slug-autosave': SlugAutosaveSelect<false> | SlugAutosaveSelect<true>;
     'tabs-fields-2': TabsFields2Select<false> | TabsFields2Select<true>;
     'tabs-fields': TabsFieldsSelect<false> | TabsFieldsSelect<true>;
@@ -1750,6 +1752,20 @@ export interface SlugField {
   readOnlySlug?: string | null;
   sourcelessSlug?: string | null;
   test?: string | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "slug-field-access".
+ */
+export interface SlugFieldAccess {
+  id: string;
+  title?: string | null;
+  slug: string;
+  localizedTitle?: string | null;
+  localizedSlug: string;
+  sourcelessSlug: string;
   updatedAt: string;
   createdAt: string;
 }
@@ -3538,6 +3554,19 @@ export interface SlugFieldsSelect<T extends boolean = true> {
   readOnlySlug?: T;
   sourcelessSlug?: T;
   test?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "slug-field-access_select".
+ */
+export interface SlugFieldAccessSelect<T extends boolean = true> {
+  title?: T;
+  slug?: T;
+  localizedTitle?: T;
+  localizedSlug?: T;
+  sourcelessSlug?: T;
   updatedAt?: T;
   createdAt?: T;
 }


### PR DESCRIPTION
A caller with create or update access but no collection read access could probe candidate slug values. Validation failures and generated suffixes differed when a matching inaccessible document existed, allowing the caller to infer whether that slug was already in use.

1. `fieldValueExists` always enabled `overrideAccess`.
2. Slug generation did not receive the operation’s access setting, including localized and source-less fallback paths.

The fix threads the caller’s access setting through each probe while keeping reads outside the active transaction. Explicitly elevated Local API operations retain their existing unrestricted behavior.
