### PR TITLE
fix: "No client field found for ..." 500 error in version diff

### DIFF
--- a/packages/ui/src/views/Version/RenderFieldsToDiff/DiffCollapser/index.tsx
+++ b/packages/ui/src/views/Version/RenderFieldsToDiff/DiffCollapser/index.tsx
@@ -14,6 +14,7 @@ import { countChangedFields, countChangedFieldsInRows } from '../utilities/count
 const baseClass = 'diff-collapser'
 
 type Props = {
+  changeCount?: number
   hideGutter?: boolean
   initCollapsed?: boolean
   Label: React.ReactNode
@@ -40,6 +41,7 @@ type Props = {
 )
 
 export const DiffCollapser: React.FC<Props> = ({
+  changeCount: changeCountFromProps,
   children,
   field,
   fields,
@@ -56,9 +58,11 @@ export const DiffCollapser: React.FC<Props> = ({
   const [isCollapsed, setIsCollapsed] = useState(initCollapsed)
   const { config } = useConfig()
 
-  let changeCount = 0
+  let changeCount: number
 
-  if (isIterable) {
+  if (typeof changeCountFromProps === 'number') {
+    changeCount = changeCountFromProps
+  } else if (isIterable) {
     if (!fieldIsArrayType(field) && !fieldIsBlockType(field)) {
       throw new Error(
         'DiffCollapser: field must be an array or blocks field when isIterable is true',

--- a/packages/ui/src/views/Version/RenderFieldsToDiff/buildVersionFields.spec.ts
+++ b/packages/ui/src/views/Version/RenderFieldsToDiff/buildVersionFields.spec.ts
@@ -1,0 +1,75 @@
+import type { ClientFieldSchemaMap, Field, SanitizedFieldsPermissions } from 'payload'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import { buildVersionFields, type BuildVersionFieldsArgs } from './buildVersionFields.js'
+
+vi.mock('../../../elements/RenderServerComponent/index.js', () => ({
+  RenderServerComponent: () => null,
+}))
+
+describe('buildVersionFields', () => {
+  it('should use the source block permissions when a block is replaced', () => {
+    const sourceBlock = {
+      fields: [{ name: 'shared', type: 'text' }],
+      slug: 'source',
+    } satisfies { fields: Field[]; slug: string }
+    const replacementBlock = {
+      fields: [{ name: 'shared', type: 'text' }],
+      slug: 'replacement',
+    } satisfies { fields: Field[]; slug: string }
+    const blocksField = {
+      blocks: [sourceBlock, replacementBlock],
+      name: 'blocks',
+      type: 'blocks',
+    } satisfies Field
+    const clientSchemaMap = new Map([
+      ['pages.blocks', blocksField],
+      ['pages.blocks.source.shared', sourceBlock.fields[0]],
+      ['pages.blocks.replacement.shared', replacementBlock.fields[0]],
+    ]) as ClientFieldSchemaMap
+    const fieldsPermissions = {
+      blocks: {
+        blocks: {
+          replacement: { fields: {} },
+          source: { fields: { shared: true } },
+        },
+        read: true,
+      },
+    } as SanitizedFieldsPermissions
+
+    const { versionFields } = buildVersionFields({
+      clientSchemaMap,
+      customDiffComponents: {},
+      entitySlug: 'pages',
+      fields: [blocksField],
+      fieldsPermissions,
+      i18n: { t: (key: string) => key },
+      modifiedOnly: true,
+      parentIndexPath: '',
+      parentIsLocalized: false,
+      parentPath: '',
+      parentSchemaPath: '',
+      req: {
+        payload: {
+          blocks: {},
+          importMap: {},
+          logger: { error: vi.fn() },
+        },
+      },
+      selectedLocales: [],
+      versionFromSiblingData: {
+        blocks: [{ blockType: 'source', shared: 'readable source value' }],
+      },
+      versionToSiblingData: {
+        blocks: [{ blockType: 'replacement' }],
+      },
+    } as BuildVersionFieldsArgs)
+
+    const rowFields = versionFields[0]?.field?.rows?.[0]
+
+    expect(rowFields).toHaveLength(1)
+    expect(rowFields?.[0]?.field?.path).toBe('blocks.0.shared')
+    expect(rowFields?.[0]?.field?.schemaPath).toBe('blocks.source.shared')
+  })
+})

--- a/packages/ui/src/views/Version/RenderFieldsToDiff/buildVersionFields.spec.ts
+++ b/packages/ui/src/views/Version/RenderFieldsToDiff/buildVersionFields.spec.ts
@@ -1,5 +1,12 @@
-import type { ClientFieldSchemaMap, Field, SanitizedFieldsPermissions } from 'payload'
+import type {
+  ClientField,
+  ClientFieldSchemaMap,
+  Field,
+  SanitizedFieldsPermissions,
+  VersionField,
+} from 'payload'
 
+import { getFieldPaths } from 'payload/shared'
 import { describe, expect, it, vi } from 'vitest'
 
 import { buildVersionFields, type BuildVersionFieldsArgs } from './buildVersionFields.js'
@@ -9,6 +16,122 @@ vi.mock('../../../elements/RenderServerComponent/index.js', () => ({
 }))
 
 describe('buildVersionFields', () => {
+  it('should render version diffs when a block with unnamed row and collapsible fields is replaced', () => {
+    const linkButtonBlock = {
+      fields: [
+        {
+          fields: [{ name: 'variant', type: 'text' }],
+          name: 'appearance',
+          type: 'group',
+        },
+        {
+          fields: [{ name: 'label', type: 'text' }],
+          type: 'row',
+        },
+        {
+          fields: [{ name: 'eventTag', type: 'text' }],
+          label: 'Tracking',
+          type: 'collapsible',
+        },
+      ],
+      slug: 'link-button',
+    } satisfies { fields: Field[]; slug: string }
+    const signInButtonBlock = {
+      fields: [
+        {
+          fields: [{ name: 'variant', type: 'text' }],
+          name: 'appearance',
+          type: 'group',
+        },
+        {
+          fields: [{ name: 'label', type: 'text' }],
+          type: 'row',
+        },
+        { name: 'isSignup', type: 'checkbox' },
+        {
+          fields: [{ name: 'eventTag', type: 'text' }],
+          label: 'Tracking',
+          type: 'collapsible',
+        },
+      ],
+      slug: 'sign-in-button',
+    } satisfies { fields: Field[]; slug: string }
+    const blocksField = {
+      blocks: [linkButtonBlock, signInButtonBlock],
+      name: 'ctas',
+      type: 'blocks',
+    } satisfies Field
+    const clientSchemaMap = new Map([['pages.ctas', blocksField]]) as ClientFieldSchemaMap
+
+    addFieldsToClientSchemaMap({
+      clientSchemaMap,
+      entitySlug: 'pages',
+      fields: linkButtonBlock.fields,
+      parentSchemaPath: 'ctas.link-button',
+    })
+    addFieldsToClientSchemaMap({
+      clientSchemaMap,
+      entitySlug: 'pages',
+      fields: signInButtonBlock.fields,
+      parentSchemaPath: 'ctas.sign-in-button',
+    })
+
+    const { versionFields } = buildVersionFields({
+      clientSchemaMap,
+      customDiffComponents: {},
+      entitySlug: 'pages',
+      fields: [blocksField],
+      fieldsPermissions: { ctas: true } as SanitizedFieldsPermissions,
+      i18n: { t: (key: string) => key },
+      modifiedOnly: true,
+      parentIndexPath: '',
+      parentIsLocalized: false,
+      parentPath: '',
+      parentSchemaPath: '',
+      req: {
+        payload: {
+          blocks: {},
+          importMap: {},
+          logger: { error: vi.fn() },
+        },
+      },
+      selectedLocales: [],
+      versionFromSiblingData: {
+        ctas: [
+          {
+            appearance: { variant: 'primary' },
+            blockType: 'sign-in-button',
+            eventTag: 'sign-in tracking',
+            isSignup: true,
+            label: 'Sign in',
+          },
+        ],
+      },
+      versionToSiblingData: {
+        ctas: [
+          {
+            appearance: { variant: 'secondary' },
+            blockType: 'link-button',
+            eventTag: 'link tracking',
+            label: 'Learn more',
+          },
+        ],
+      },
+    } as BuildVersionFieldsArgs)
+
+    const rowFields = versionFields[0]?.field?.rows?.[0] ?? []
+    const schemaPaths = getSchemaPaths(rowFields)
+
+    expect(schemaPaths).toEqual(
+      expect.arrayContaining([
+        'ctas.sign-in-button._index-1.label',
+        'ctas.sign-in-button._index-3.eventTag',
+        'ctas.link-button._index-1.label',
+        'ctas.link-button._index-2.eventTag',
+      ]),
+    )
+  })
+
   it('should use the source block permissions when a block is replaced', () => {
     const sourceBlock = {
       fields: [{ name: 'shared', type: 'text' }],
@@ -73,3 +196,63 @@ describe('buildVersionFields', () => {
     expect(rowFields?.[0]?.field?.schemaPath).toBe('blocks.source.shared')
   })
 })
+
+function addFieldsToClientSchemaMap({
+  clientSchemaMap,
+  entitySlug,
+  fields,
+  parentIndexPath = '',
+  parentSchemaPath,
+}: {
+  clientSchemaMap: ClientFieldSchemaMap
+  entitySlug: string
+  fields: Field[]
+  parentIndexPath?: string
+  parentSchemaPath: string
+}): void {
+  fields.forEach((field, index) => {
+    const { indexPath, schemaPath } = getFieldPaths({
+      field,
+      index,
+      parentIndexPath,
+      parentSchemaPath,
+    })
+
+    clientSchemaMap.set(`${entitySlug}.${schemaPath}`, field as ClientField)
+
+    if (field.type === 'collapsible' || field.type === 'row') {
+      addFieldsToClientSchemaMap({
+        clientSchemaMap,
+        entitySlug,
+        fields: field.fields,
+        parentIndexPath: indexPath,
+        parentSchemaPath: schemaPath,
+      })
+    } else if (field.type === 'group') {
+      addFieldsToClientSchemaMap({
+        clientSchemaMap,
+        entitySlug,
+        fields: field.fields,
+        parentIndexPath: 'name' in field ? '' : indexPath,
+        parentSchemaPath: schemaPath,
+      })
+    }
+  })
+}
+
+function getSchemaPaths(versionFields: VersionField[]): string[] {
+  return versionFields.flatMap((versionField) => {
+    const field = versionField.field
+
+    if (!field) {
+      return []
+    }
+
+    return [
+      field.schemaPath,
+      ...getSchemaPaths(field.fields),
+      ...(field.rows?.flatMap((row) => getSchemaPaths(row)) ?? []),
+      ...(field.tabs?.flatMap((tab) => getSchemaPaths(tab.fields)) ?? []),
+    ]
+  })
+}

--- a/packages/ui/src/views/Version/RenderFieldsToDiff/buildVersionFields.tsx
+++ b/packages/ui/src/views/Version/RenderFieldsToDiff/buildVersionFields.tsx
@@ -460,21 +460,10 @@ const buildVersionField = ({
         }
       }
 
-      let blockFieldsPermissions: SanitizedFieldsPermissions = undefined
-
-      // fieldPermissions will be set here, as the blocks field has a name
-      if (typeof fieldPermissions === 'boolean') {
-        blockFieldsPermissions = fieldPermissions
-      } else if (typeof fieldPermissions?.blocks === 'boolean') {
-        blockFieldsPermissions = fieldPermissions.blocks
-      } else {
-        const permissionsBlockSpecific = fieldPermissions?.blocks?.[blockSlugToMatch]
-        if (typeof permissionsBlockSpecific === 'boolean') {
-          blockFieldsPermissions = permissionsBlockSpecific
-        } else {
-          blockFieldsPermissions = permissionsBlockSpecific?.fields
-        }
-      }
+      const blockFieldsPermissions = getBlockFieldsPermissions({
+        blockSlug: blockSlugToMatch,
+        fieldPermissions,
+      })
 
       const blockDiffArgs = {
         clientSchemaMap,
@@ -495,6 +484,10 @@ const buildVersionField = ({
         ? buildVersionFields({
             ...blockDiffArgs,
             fields: replacedBlock.fields,
+            fieldsPermissions: getBlockFieldsPermissions({
+              blockSlug: replacedBlock.slug,
+              fieldPermissions,
+            }),
             parentSchemaPath: schemaPath + '.' + replacedBlock.slug,
             versionFromSiblingData: fromRow,
             versionToSiblingData: {},
@@ -568,4 +561,24 @@ const buildVersionField = ({
   })
 
   return baseVersionField
+}
+
+const getBlockFieldsPermissions = ({
+  blockSlug,
+  fieldPermissions,
+}: {
+  blockSlug: string
+  fieldPermissions: SanitizedFieldPermissions | undefined
+}): SanitizedFieldsPermissions => {
+  if (typeof fieldPermissions === 'boolean') {
+    return fieldPermissions
+  }
+
+  if (typeof fieldPermissions?.blocks === 'boolean') {
+    return fieldPermissions.blocks
+  }
+
+  const blockPermissions = fieldPermissions?.blocks?.[blockSlug]
+
+  return typeof blockPermissions === 'boolean' ? blockPermissions : blockPermissions?.fields
 }

--- a/packages/ui/src/views/Version/RenderFieldsToDiff/buildVersionFields.tsx
+++ b/packages/ui/src/views/Version/RenderFieldsToDiff/buildVersionFields.tsx
@@ -17,13 +17,7 @@ import {
   type SanitizedFieldsPermissions,
   type VersionField,
 } from 'payload'
-import {
-  fieldIsID,
-  fieldShouldBeLocalized,
-  getFieldPaths,
-  getUniqueListBy,
-  tabHasName,
-} from 'payload/shared'
+import { fieldIsID, fieldShouldBeLocalized, getFieldPaths, tabHasName } from 'payload/shared'
 
 import { RenderServerComponent } from '../../../elements/RenderServerComponent/index.js'
 import { diffComponents } from './fields/index.js'
@@ -450,11 +444,9 @@ const buildVersionField = ({
           (block) => typeof block !== 'string' && block.slug === blockSlugToMatch,
         ) as FlattenedBlock | undefined)
 
-      let fields = []
+      let replacedBlock: FlattenedBlock | undefined = undefined
 
-      if (toRow.blockType === fromRow.blockType) {
-        fields = toBlock.fields
-      } else {
+      if (toRow.blockType !== fromRow.blockType) {
         const fromBlockSlugToMatch: string = fromRow?.blockType ?? toRow?.blockType
 
         const fromBlock =
@@ -463,10 +455,8 @@ const buildVersionField = ({
             (block) => typeof block !== 'string' && block.slug === fromBlockSlugToMatch,
           ) as FlattenedBlock | undefined)
 
-        if (fromBlock) {
-          fields = getUniqueListBy<Field>([...toBlock.fields, ...fromBlock.fields], 'name')
-        } else {
-          fields = toBlock.fields
+        if (fromBlock && fromBlock.slug !== toBlock.slug) {
+          replacedBlock = fromBlock
         }
       }
 
@@ -486,11 +476,10 @@ const buildVersionField = ({
         }
       }
 
-      const versionFields = buildVersionFields({
+      const blockDiffArgs = {
         clientSchemaMap,
         customDiffComponents,
         entitySlug,
-        fields,
         fieldsPermissions: blockFieldsPermissions,
         i18n,
         modifiedOnly,
@@ -498,12 +487,29 @@ const buildVersionField = ({
         parentIndexPath: 'name' in field ? '' : indexPath,
         parentIsLocalized: parentIsLocalized || ('localized' in field && field.localized),
         parentPath: ('name' in field ? path : parentPath) + '.' + i,
-        parentSchemaPath: schemaPath + '.' + toBlock.slug,
         req,
         selectedLocales,
-        versionFromSiblingData: fromRow,
+      }
+
+      const oldBlockFields = replacedBlock
+        ? buildVersionFields({
+            ...blockDiffArgs,
+            fields: replacedBlock.fields,
+            parentSchemaPath: schemaPath + '.' + replacedBlock.slug,
+            versionFromSiblingData: fromRow,
+            versionToSiblingData: {},
+          }).versionFields
+        : []
+
+      const newBlockFields = buildVersionFields({
+        ...blockDiffArgs,
+        fields: toBlock.fields,
+        parentSchemaPath: schemaPath + '.' + toBlock.slug,
+        versionFromSiblingData: replacedBlock ? {} : fromRow,
         versionToSiblingData: toRow,
       }).versionFields
+
+      const versionFields = [...oldBlockFields, ...newBlockFields]
 
       if (versionFields?.length) {
         baseVersionField.rows[i] = versionFields

--- a/packages/ui/src/views/Version/RenderFieldsToDiff/fields/Iterable/index.tsx
+++ b/packages/ui/src/views/Version/RenderFieldsToDiff/fields/Iterable/index.tsx
@@ -12,6 +12,7 @@ import { useTranslation } from '../../../../../providers/Translation/index.js'
 import { useSelectedLocales } from '../../../Default/SelectedLocalesContext.js'
 import { DiffCollapser } from '../../DiffCollapser/index.js'
 import { RenderVersionFieldsToDiff } from '../../RenderVersionFieldsToDiff.js'
+import { countChangedFieldsInRows } from '../../utilities/countChangedFields.js'
 import { getFieldsForRowComparison } from '../../utilities/getFieldsForRowComparison.js'
 
 const baseClass = 'iterable-diff'
@@ -70,6 +71,14 @@ export const Iterable: React.FC<FieldDiffClientProps> = ({
                 valueFromRow,
                 valueToRow,
               })
+              const changeCount = countChangedFieldsInRows({
+                config,
+                field,
+                locales: selectedLocales,
+                parentIsLocalized: parentIsLocalized || field.localized,
+                valueFromRows: [valueFromRow],
+                valueToRows: [valueToRow],
+              })
 
               if (!versionFields?.length) {
                 // Rows without a diff create "holes" in the baseVersionField.rows (=versionFields) array - this is to maintain the correct row indexes.
@@ -85,6 +94,7 @@ export const Iterable: React.FC<FieldDiffClientProps> = ({
               return (
                 <div className={`${baseClass}__row`} key={i}>
                   <DiffCollapser
+                    changeCount={changeCount}
                     fields={fields}
                     hideGutter={true}
                     Label={

--- a/packages/ui/src/views/Version/RenderFieldsToDiff/utilities/countChangedFields.spec.ts
+++ b/packages/ui/src/views/Version/RenderFieldsToDiff/utilities/countChangedFields.spec.ts
@@ -278,7 +278,7 @@ describe('countChangedFields', () => {
     expect(result).toBe(5)
   })
 
-  it('should count changed fields between blocks with different slugs', () => {
+  it('should count source and replacement fields between blocks with different slugs', () => {
     const fields: ClientField[] = [
       {
         name: 'blocks',
@@ -311,7 +311,7 @@ describe('countChangedFields', () => {
     }
 
     const result = countChangedFields({ valueFrom, fields, valueTo, locales })
-    expect(result).toBe(3)
+    expect(result).toBe(6)
   })
 
   describe('localized fields', () => {
@@ -536,5 +536,59 @@ describe('countChangedFieldsInRows', () => {
       valueToRows,
     })
     expect(result).toBe(2)
+  })
+
+  it('should count source and replacement block fields separately', () => {
+    const field: ClientField = {
+      name: 'myBlocks',
+      type: 'blocks',
+      blocks: [
+        {
+          slug: 'source',
+          fields: [
+            {
+              type: 'row',
+              fields: [{ name: 'sourceRow', type: 'text' }],
+            },
+            {
+              type: 'collapsible',
+              label: 'Source details',
+              fields: [{ name: 'sourceDetails', type: 'text' }],
+            },
+          ],
+        },
+        {
+          slug: 'replacement',
+          fields: [
+            {
+              type: 'row',
+              fields: [{ name: 'replacementRow', type: 'text' }],
+            },
+            {
+              type: 'collapsible',
+              label: 'Replacement details',
+              fields: [{ name: 'replacementDetails', type: 'text' }],
+            },
+          ],
+        },
+      ],
+    }
+
+    const result = countChangedFieldsInRows({
+      field,
+      locales: undefined,
+      valueFromRows: [
+        { blockType: 'source', sourceDetails: 'original details', sourceRow: 'original row' },
+      ],
+      valueToRows: [
+        {
+          blockType: 'replacement',
+          replacementDetails: 'replacement details',
+          replacementRow: 'replacement row',
+        },
+      ],
+    })
+
+    expect(result).toBe(4)
   })
 })

--- a/packages/ui/src/views/Version/RenderFieldsToDiff/utilities/countChangedFields.ts
+++ b/packages/ui/src/views/Version/RenderFieldsToDiff/utilities/countChangedFields.ts
@@ -3,7 +3,7 @@ import type { ArrayFieldClient, BlocksFieldClient, ClientConfig, ClientField } f
 import { fieldShouldBeLocalized, groupHasName } from 'payload/shared'
 
 import { fieldHasChanges } from './fieldHasChanges.js'
-import { getFieldsForRowComparison } from './getFieldsForRowComparison.js'
+import { getBlockFields, getFieldsForRowComparison } from './getFieldsForRowComparison.js'
 
 type Args = {
   config: ClientConfig
@@ -231,6 +231,33 @@ export function countChangedFieldsInRows({
   while (valueFromRows[i] || valueToRows[i]) {
     const valueFromRow = valueFromRows?.[i] || {}
     const valueToRow = valueToRows?.[i] || {}
+
+    if (field.type === 'blocks') {
+      const blockTypeFrom = (valueFromRow as { blockType?: string }).blockType
+      const blockTypeTo = (valueToRow as { blockType?: string }).blockType
+
+      if (blockTypeFrom !== blockTypeTo) {
+        count += countChangedFields({
+          config,
+          fields: getBlockFields({ blockSlug: blockTypeFrom, config, field }),
+          locales,
+          parentIsLocalized: parentIsLocalized || field.localized,
+          valueFrom: valueFromRow,
+          valueTo: {},
+        })
+        count += countChangedFields({
+          config,
+          fields: getBlockFields({ blockSlug: blockTypeTo, config, field }),
+          locales,
+          parentIsLocalized: parentIsLocalized || field.localized,
+          valueFrom: {},
+          valueTo: valueToRow,
+        })
+
+        i++
+        continue
+      }
+    }
 
     const { fields: rowFields } = getFieldsForRowComparison({
       baseVersionField: { type: 'text', fields: [], path: '', schemaPath: '' }, // Doesn't matter, as we don't need the versionFields output here

--- a/packages/ui/src/views/Version/RenderFieldsToDiff/utilities/getFieldsForRowComparison.spec.ts
+++ b/packages/ui/src/views/Version/RenderFieldsToDiff/utilities/getFieldsForRowComparison.spec.ts
@@ -31,7 +31,7 @@ describe('getFieldsForRowComparison', () => {
   })
 
   describe('blocks fields', () => {
-    it('should return combined fields when block types match', () => {
+    it('should return the matching block fields when block types match', () => {
       const blockAFields: ClientField[] = [
         { name: 'a', type: 'text' },
         { name: 'b', type: 'text' },
@@ -63,7 +63,7 @@ describe('getFieldsForRowComparison', () => {
       expect(fields).toEqual(blockAFields)
     })
 
-    it('should return unique combined fields when block types differ', () => {
+    it('should not merge fields when block types differ', () => {
       const field: BlocksFieldClient = {
         type: 'blocks',
         name: 'myBlocks',
@@ -97,12 +97,7 @@ describe('getFieldsForRowComparison', () => {
         config: {} as any,
       })
 
-      // Should contain all unique fields from both blocks
-      expect(fields).toEqual([
-        { name: 'a', type: 'text' },
-        { name: 'b', type: 'text' },
-        { name: 'c', type: 'text' },
-      ])
+      expect(fields).toEqual([])
     })
   })
 })

--- a/packages/ui/src/views/Version/RenderFieldsToDiff/utilities/getFieldsForRowComparison.ts
+++ b/packages/ui/src/views/Version/RenderFieldsToDiff/utilities/getFieldsForRowComparison.ts
@@ -2,19 +2,17 @@ import type {
   ArrayFieldClient,
   BaseVersionField,
   BlocksFieldClient,
-  ClientBlock,
   ClientConfig,
   ClientField,
   VersionField,
 } from 'payload'
 
-import { getUniqueListBy } from 'payload/shared'
-
 /**
  * Get the fields for a row in an iterable field for comparison.
  * - Array fields: the fields of the array field, because the fields are the same for each row.
- * - Blocks fields: the union of fields from the comparison and version row,
- *   because the fields from the version and comparison rows may differ.
+ * - Blocks fields: the fields of the matching block when the block types are the same.
+ *   Replaced blocks intentionally return no shared field list because each block schema must be
+ *   compared independently.
  */
 export function getFieldsForRowComparison({
   baseVersionField,
@@ -41,46 +39,33 @@ export function getFieldsForRowComparison({
       : baseVersionField.fields
   } else if (field.type === 'blocks') {
     if (valueToRow?.blockType === valueFromRow?.blockType) {
-      const matchedBlock: ClientBlock =
-        config?.blocksMap?.[valueToRow?.blockType] ??
-        ((field.blocks.find(
-          (block) => typeof block !== 'string' && block.slug === valueToRow?.blockType,
-        ) || {
-          fields: [],
-        }) as ClientBlock)
-
-      fields = matchedBlock.fields
-      versionFields = baseVersionField.rows?.length
-        ? baseVersionField.rows[row]
-        : baseVersionField.fields
-    } else {
-      const matchedVersionBlock =
-        config?.blocksMap?.[valueToRow?.blockType] ??
-        ((field.blocks.find(
-          (block) => typeof block !== 'string' && block.slug === valueToRow?.blockType,
-        ) || {
-          fields: [],
-        }) as ClientBlock)
-
-      const matchedComparisonBlock =
-        config?.blocksMap?.[valueFromRow?.blockType] ??
-        ((field.blocks.find(
-          (block) => typeof block !== 'string' && block.slug === valueFromRow?.blockType,
-        ) || {
-          fields: [],
-        }) as ClientBlock)
-
-      fields = getUniqueListBy<ClientField>(
-        [...matchedVersionBlock.fields, ...matchedComparisonBlock.fields],
-        'name',
-      )
-
-      // buildVersionFields already merged the fields of the version and comparison rows together
-      versionFields = baseVersionField.rows?.length
-        ? baseVersionField.rows[row]
-        : baseVersionField.fields
+      fields = getBlockFields({
+        blockSlug: valueToRow?.blockType,
+        config,
+        field,
+      })
     }
+
+    versionFields = baseVersionField.rows?.length
+      ? baseVersionField.rows[row]
+      : baseVersionField.fields
   }
 
   return { fields, versionFields }
+}
+
+export function getBlockFields({
+  blockSlug,
+  config,
+  field,
+}: {
+  blockSlug: string | undefined
+  config: ClientConfig
+  field: BlocksFieldClient
+}): ClientField[] {
+  const matchedBlock =
+    (blockSlug && config?.blocksMap?.[blockSlug]) ||
+    field.blocks.find((block) => typeof block !== 'string' && block.slug === blockSlug)
+
+  return typeof matchedBlock === 'string' ? [] : (matchedBlock?.fields ?? [])
 }

--- a/test/versions/e2e.spec.ts
+++ b/test/versions/e2e.spec.ts
@@ -2508,6 +2508,67 @@ describe('Versions', () => {
       )
     })
 
+    test('should render a replaced block when both block schemas contain unnamed layouts', async () => {
+      await payload.update({
+        id: diffID,
+        collection: diffCollectionSlug,
+        data: {
+          blocks: diffDoc.blocks?.map((block, i) => {
+            if (i === 1) {
+              return {
+                blockType: 'TabsBlock',
+                namedTab1InBlock: {
+                  textInNamedTab1InBlock: 'replacement named tab',
+                },
+                textInRowInUnnamedTab2InBlock: 'replacement row',
+                textInUnnamedTab2InBlock: 'replacement unnamed tab',
+              }
+            }
+
+            return block
+          }),
+        },
+      })
+
+      const latestVersionDiff = (
+        await payload.findVersions({
+          collection: diffCollectionSlug,
+          depth: 0,
+          limit: 1,
+          where: {
+            parent: { equals: diffID },
+          },
+        })
+      ).docs[0] as Diff
+
+      await navigateToDiffVersionView(latestVersionDiff.id)
+
+      const sourceField = page.locator('[data-field-path="blocks.1.textInRowInCollapsibleBlock"]')
+      await expect(sourceField.locator('.html-diff__diff-old')).toHaveText(
+        'textInRowInCollapsibleBlock2',
+      )
+
+      const replacementField = page.locator(
+        '[data-field-path="blocks.1.textInRowInUnnamedTab2InBlock"]',
+      )
+      await expect(replacementField.locator('.html-diff__diff-new')).toHaveText('replacement row')
+
+      const blocks = page.locator('[data-field-path="blocks"]')
+      await blocks.locator('.diff-collapser__toggle-button').first().click()
+      await expect(blocks.locator('.diff-collapser__field-change-count').first()).toHaveText(
+        '5 changed fields',
+      )
+
+      await blocks.locator('.diff-collapser__toggle-button').first().click()
+      const changedRow = blocks.locator('.iterable-diff__row', {
+        has: page.getByText('Block 02', { exact: true }),
+      })
+      await changedRow.locator('.diff-collapser__toggle-button').first().click()
+      await expect(changedRow.locator('.diff-collapser__field-change-count')).toHaveText(
+        '5 changed fields',
+      )
+    })
+
     test('correctly renders diff for named tabs within block fields', async () => {
       await navigateToDiffVersionView()
 


### PR DESCRIPTION

## Which branch should this PR target?

- **`main`** — It was fixed for main but the issue was first noticed on 3.88.0

### What?

Fixes a 500 in the version diff view (`/admin/collections/:slug/:id/versions/:versionId`) when a row in a `blocks` field has a **different `blockType`** in the two compared versions and either block contains an unnamed presentational field (`row`, `collapsible`, `tabs`).

## The error:

```
ERROR: No client field found for pages._index-3-0.sections.hero.ctas.link-button._index-1.eventTag
    clientFieldKey: "pages._index-3-0.sections.hero.ctas.link-button._index-1.eventTag"
    parentPath: "sections.0.ctas.0"
    parentSchemaPath: "_index-3-0.sections.hero.ctas.link-button._index-1"
    path: "sections.0.ctas.0.eventTag"
    schemaPath: "_index-3-0.sections.hero.ctas.link-button._index-1.eventTag"
 ⨯ Error: No client field found for pages._index-3-0.sections.hero.ctas.link-button._index-1.eventTag
 GET /admin/collections/pages/<id>/versions/<versionId> 500
```

```
 [13:43:13] ERROR: No client field  found for pages._index-3-0.sections.hero.ctas.link-button._index-1.eventTag
  clientFieldKey: "pages._index-3-0.sections.hero.ctas.link-button._index-1.eventTag"
  clientSchemaMapKeys: [
    "pages",
    "pages.title",
    "pages._index-1",
    "pages._index-1.logoStyle",
     "pages._index-1.shouldDefaultToTransparent",
     "pages._index-1.iconColorInTransparentHeader",
     "pages._index-2",
...
...
     "pages.id"
     ]
   parentPath: "sections.0.ctas.0"
   parentSchemaPath: "_index-3-0.sections.hero.ctas.link-button._index-1"
   path: "sections.0.ctas.0.eventTag"
   schemaPath: "_index-3-0.sections.hero.ctas.link-button._index-1.eventTag"
  GET /admin/collections/pages/696fb2a113d9189706fd8a58/versions/6a8d4e0df5f005b920168ce5 500 in 4.0s (compile: 7ms, render: 3.9s)
...
## Cause

`buildVersionFields.tsx`, blocks branch — when the block type changed, both blocks' field lists are merged:

```ts
fields = getUniqueListBy<Field>([...toBlock.fields, ...fromBlock.fields], 'name')
```

`getUniqueListBy` is a `Map` keyed by the given property:

```ts
export function getUniqueListBy(arr, key) {
  return [...new Map(arr.map((item) => [item[key], item])).values()]
}
```

Unnamed fields (`row`, `collapsible`, `tabs`) have no `name`, so **every one of them collapses onto the single `undefined` key**. A `Map` keeps the first insertion *position* but the last *value*, so the surviving entry sits where the first unnamed field was and holds the last unnamed field.

## Reproduction

1. A collection with a `blocks` field containing at least two block types, each with an unnamed field:

```ts
{
  name: 'ctas',
  type: 'blocks',
  blocks: [
    {
      slug: 'link-button',
      fields: [
        { name: 'appearance', type: 'group', fields: [{ name: 'variant', type: 'text' }] },
        { type: 'row', fields: [{ name: 'label', type: 'text' }] },
        { type: 'collapsible', label: 'Tracking', fields: [{ name: 'eventTag', type: 'text' }] },
      ],
    },
    {
      slug: 'sign-in-button',
      fields: [
        { name: 'appearance', type: 'group', fields: [{ name: 'variant', type: 'text' }] },
        { type: 'row', fields: [{ name: 'label', type: 'text' }] },
        { name: 'isSignup', type: 'checkbox' },
        { type: 'collapsible', label: 'Tracking', fields: [{ name: 'eventTag', type: 'text' }] },
      ],
    },
  ],
}
```

2. Save a document with one `sign-in-button` row, with `eventTag` filled in.
3. Change that row to a `link-button` and save again.
4. Open the version view comparing those two versions → 500.

Same block type on both sides works fine; the crash requires the type to change.


## Fix

Diff each block against its own schema instead of merging the two field lists: the block that was replaced renders as fully removed, the block that replaced it as fully added. Every schema path then resolves under the slug it belongs to.