### PR TITLE
fix(drizzle): preserve omitted hasMany selects

### DIFF
--- a/packages/drizzle/src/transform/write/traverseFields.ts
+++ b/packages/drizzle/src/transform/write/traverseFields.ts
@@ -696,6 +696,10 @@ export const traverseFields = ({
     }
 
     if (field.type === 'select' && field.hasMany) {
+      if (fieldData === undefined) {
+        return
+      }
+
       const selectTableName = adapter.tableNameMap.get(`${parentTableName}_${columnName}`)
       if (!selects[selectTableName]) {
         selects[selectTableName] = []

--- a/test/database/int.spec.ts
+++ b/test/database/int.spec.ts
@@ -42,6 +42,7 @@ import { devUser } from '../credentials.js'
 import { seed } from './seed.js'
 import {
   customIDsSlug,
+  customSchemaSlug,
   defaultValuesSlug,
   errorOnUnnamedFieldsSlug,
   fieldsPersistanceSlug,
@@ -2161,6 +2162,66 @@ describe('database', () => {
       expect(doc.array[0].localizedText).toStrictEqual('goodbye')
       expect(doc.blocks[0].text).toStrictEqual('hello')
       expect(doc.blocks[0].localizedText).toStrictEqual('goodbye')
+    })
+
+    it('should preserve omitted hasMany selects when updating an array with db.updateOne', async () => {
+      const doc = await payload.create({
+        collection: customSchemaSlug,
+        data: {
+          array: [{ text: 'array row' }],
+          select: ['a', 'b'],
+        },
+      })
+
+      await payload.db.updateOne({
+        collection: customSchemaSlug,
+        id: doc.id,
+        data: {
+          array: [],
+        },
+      })
+
+      const updated = await payload.findByID({
+        collection: customSchemaSlug,
+        id: doc.id,
+      })
+
+      expect(updated.array).toHaveLength(0)
+      expect(updated.select).toStrictEqual(['a', 'b'])
+
+      await payload.delete({
+        collection: customSchemaSlug,
+        id: doc.id,
+      })
+    })
+
+    it('should clear hasMany selects when provided as an empty array to db.updateOne', async () => {
+      const doc = await payload.create({
+        collection: customSchemaSlug,
+        data: {
+          select: ['a', 'b'],
+        },
+      })
+
+      await payload.db.updateOne({
+        collection: customSchemaSlug,
+        id: doc.id,
+        data: {
+          select: [],
+        },
+      })
+
+      const updated = await payload.findByID({
+        collection: customSchemaSlug,
+        id: doc.id,
+      })
+
+      expect(updated.select).toHaveLength(0)
+
+      await payload.delete({
+        collection: customSchemaSlug,
+        id: doc.id,
+      })
     })
 
     it('arrays should work with both long field names and dbName', async () => {


### PR DESCRIPTION
## Summary

- preserve existing Postgres has-many select rows when a low-level partial `db.updateOne` omits that field
- retain explicit `select: []` behavior so callers can still clear the rows
- add integration coverage for both preservation and explicit clearing through the full upsert path

## Root cause

When another array field forced the non-optimized upsert path, write traversal created an empty select-table bucket even for an omitted has-many select. The upsert then treated that bucket as an instruction to delete all existing rows.

## Verification

- `pnpm test:int:postgres test/database/int.spec.ts -t schema` — 9 passed
- `pnpm test:int:postgres test/database/int.spec.ts --reporter=dot` — 159 passed, 17 skipped
- `pnpm --filter @payloadcms/drizzle build:types` — passed
- `pnpm --filter @payloadcms/drizzle lint` — passed (pre-existing warnings only)
- Prettier check — passed

Fixes #17922

Linear: https://linear.app/figma/issue/POSS-168
