### PR TITLE
fix(ui): translate document drawer labels

### DIFF
--- a/packages/ui/src/elements/DocumentDrawer/index.tsx
+++ b/packages/ui/src/elements/DocumentDrawer/index.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { useModal } from '@faceless-ui/modal'
+import { getTranslation } from '@payloadcms/translations'
 import React, { useCallback, useId, useMemo, useRef } from 'react'
 
 import type {
@@ -40,13 +41,13 @@ export const DocumentDrawerToggler: React.FC<DocumentTogglerProps> = ({
   operation,
   ...rest
 }) => {
-  const { t } = useTranslation()
+  const { i18n, t } = useTranslation()
   const [collectionConfig] = useRelatedCollections(collectionSlug)
 
   return (
     <DrawerToggler
       aria-label={t(operation === 'create' ? 'fields:addNewLabel' : 'general:editLabel', {
-        label: collectionConfig?.labels.singular,
+        label: getTranslation(collectionConfig?.labels.singular, i18n),
       })}
       buttonStyle={buttonStyle}
       className={[className, `${documentDrawerBaseClass}__toggler`].filter(Boolean).join(' ')}

--- a/test/fields-relationship/collections/Relation1/index.ts
+++ b/test/fields-relationship/collections/Relation1/index.ts
@@ -4,7 +4,15 @@ import { baseRelationshipFields } from '../../baseFields.js'
 import { relationOneSlug } from '../../slugs.js'
 
 export const Relation1: CollectionConfig = {
-  fields: baseRelationshipFields,
   slug: relationOneSlug,
+  fields: baseRelationshipFields,
+  labels: {
+    plural: {
+      en: 'Relation Ones',
+    },
+    singular: {
+      en: 'Relation One',
+    },
+  },
   versions: false,
 }

--- a/test/fields-relationship/e2e.spec.ts
+++ b/test/fields-relationship/e2e.spec.ts
@@ -634,6 +634,16 @@ describe('Relationship Field', () => {
     await expect(documentDrawer).toBeVisible()
   })
 
+  test('should translate localized labels for create document drawer togglers', async () => {
+    await loadCreatePage()
+
+    const createDrawerTrigger = page.locator(
+      '#field-relationship .relationship-add-new__add-button',
+    )
+
+    await expect(createDrawerTrigger).toHaveAttribute('aria-label', 'Add new Relation One')
+  })
+
   test('should open document from drawer by clicking on ID Label', async () => {
     const relatedDoc = await payload.create({
       collection: relationOneSlug,


### PR DESCRIPTION
### What?

Translate localized collection labels before interpolating them into `DocumentDrawerToggler` accessible names.

Add an E2E regression using a localized singular label and verify that the relationship add-new button exposes `Add new Relation One` instead of `Add new [object Object]`.

### Why?

`DocumentDrawerToggler` passes `collectionConfig.labels.singular` directly to i18next. When the label is a localized object, the generated `aria-label` contains `[object Object]`. The accessible name then overrides the correctly translated visible button text for screen-reader users.

This addresses the additional `DocumentDrawerToggler` occurrence reported in #17069. The original `CollectionCards` occurrence remains separate.

### How?

Resolve the collection label with `getTranslation` and the active i18n instance before calling `t`. The relationship fixture now uses a localized label so the Playwright assertion exercises the real configuration shape.

Validation:

- focused Playwright regression test against SQLite and system Chrome
- focused ESLint (no errors; pre-existing warnings only)
- Prettier
- `git diff --check`