### PR TITLE
docs(plugin-nested-docs): clarify runtime config access

### DIFF
--- a/docs/plugins/build-your-own.mdx
+++ b/docs/plugins/build-your-own.mdx
@@ -54,6 +54,16 @@ The initialization process goes in the following order:
 4. Sanitization cleans and validates data
 5. Final config gets initialized
 
+<Banner type="warning">
+  A plugin receives the config as it exists at that point in the plugin
+  sequence. Later plugins can return new config, collection, or global objects,
+  so references captured during plugin execution are not guaranteed to match the
+  final runtime config. Hooks and other delayed callbacks should resolve final
+  state from their runtime arguments instead of closing over plugin-time config
+  objects. In hooks, use the runtime `collection` or `global` argument, or read
+  `req.payload.config`.
+</Banner>
+
 ## Plugin Template
 
 In the [Payload Plugin Template](https://github.com/payloadcms/payload/tree/main/templates/plugin), you will see a common file structure that is used across plugins:

--- a/docs/plugins/plugin-api.mdx
+++ b/docs/plugins/plugin-api.mdx
@@ -74,6 +74,16 @@ The result of `definePlugin` is a factory function — call it with your options
 plugins: [seoPlugin({ collections: ['pages', 'posts'] })]
 ```
 
+<Banner type="warning">
+  The `config` passed to `definePlugin` is the value produced by earlier
+  plugins, not the final runtime config. Execution order controls when a plugin
+  transforms that value, but later plugins can still replace config, collection,
+  or global objects. Hooks and other delayed callbacks should resolve final
+  state from their runtime arguments instead of closing over plugin-time config
+  objects. In hooks, use the runtime `collection` or `global` argument, or read
+  `req.payload.config`.
+</Banner>
+
 ## Execution ordering with `order`
 
 By default, plugins execute in the order they appear in the `plugins` array. Setting `order` lets you declare execution order explicitly, regardless of array position.

--- a/test/plugin-nested-docs/config.ts
+++ b/test/plugin-nested-docs/config.ts
@@ -3,6 +3,7 @@ import path from 'path'
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 import { nestedDocsPlugin } from '@payloadcms/plugin-nested-docs'
+import { definePlugin } from 'payload'
 
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
 import { devUser } from '../credentials.js'
@@ -10,6 +11,42 @@ import { Categories } from './collections/Categories.js'
 import { Pages } from './collections/Pages.js'
 import { Users } from './collections/Users.js'
 import { seed } from './seed/index.js'
+
+const disableDraftsBeforeNestedDocs = definePlugin({
+  slug: 'disable-drafts-before-nested-docs',
+  order: -10,
+  plugin: ({ config }) => ({
+    ...config,
+    collections: (config.collections || []).map((collection) =>
+      collection.slug === Pages.slug
+        ? {
+            ...collection,
+            versions: false,
+          }
+        : collection,
+    ),
+  }),
+})
+
+const enableDraftsAfterNestedDocs = definePlugin({
+  slug: 'enable-drafts-after-nested-docs',
+  order: 10,
+  plugin: ({ config }) => ({
+    ...config,
+    collections: (config.collections || []).map((collection) =>
+      collection.slug === Pages.slug
+        ? {
+            ...collection,
+            versions: {
+              drafts: {
+                schedulePublish: true,
+              },
+            },
+          }
+        : collection,
+    ),
+  }),
+})
 
 export default buildConfigWithDefaults({
   admin: {
@@ -35,6 +72,7 @@ export default buildConfigWithDefaults({
     await seed(payload)
   },
   plugins: [
+    disableDraftsBeforeNestedDocs(),
     nestedDocsPlugin({
       collections: ['pages'],
       generateLabel: (_, doc) => doc.title as string,
@@ -47,6 +85,7 @@ export default buildConfigWithDefaults({
       generateURL: (docs) => docs.reduce((url, doc) => `${url}/${doc.name}`, ''),
       parentFieldSlug: 'owner',
     }),
+    enableDraftsAfterNestedDocs(),
   ],
   typescript: {
     outputFile: path.resolve(dirname, 'payload-types.ts'),

--- a/test/plugin-nested-docs/int.spec.ts
+++ b/test/plugin-nested-docs/int.spec.ts
@@ -204,6 +204,28 @@ describe('@payloadcms/plugin-nested-docs', () => {
       createdPageIDs.length = 0
     })
 
+    it('should resave incomplete drafts when a later plugin enables drafts', async () => {
+      const draftPage = await payload.create({
+        collection: 'pages',
+        data: {
+          slug: 'later-plugin-draft',
+          _status: 'draft',
+          title: '',
+        },
+        draft: true,
+      })
+      createdPageIDs.push(draftPage.id)
+
+      const savedDraft = await payload.findByID({
+        id: draftPage.id,
+        collection: 'pages',
+        draft: true,
+      })
+
+      expect(savedDraft._status).toBe('draft')
+      expect(savedDraft.breadcrumbs?.at(-1)?.doc).toBe(draftPage.id)
+    })
+
     it('should preserve published version of child when parent is saved and child has unpublished draft', async () => {
       // Step 1: Create parent page and publish it
       const parentDoc = await payload.create({


### PR DESCRIPTION
### What?

Document that plugin callbacks receive an intermediate config and should resolve final runtime state from hook and callback arguments.

Add a nested-docs integration regression where an earlier plugin disables drafts and a later plugin enables them after nested-docs initializes.

### Why?

Plugins execute sequentially. A plugin-time config, collection, or global reference can become stale when a later plugin returns replacement objects. Capturing those references in hooks causes difficult runtime failures.

The nested-docs regression creates an incomplete draft. Its automatic breadcrumb resave must use the final runtime collection so it runs in draft mode and stores the new document ID instead of failing required-field validation.

### How?

Add warnings to the basic and advanced plugin-authoring guides. Configure the test collection so nested-docs initializes without drafts and a later plugin restores the draft config, then assert the incomplete draft is resaved correctly.

A possible follow-up is to add this check to Payload's bundled agent skill. An agent can trace values through helper factories and surrounding lifecycle context more reliably than a general ESLint rule. Payload's ESLint plugin could still enforce a narrower direct-capture rule.

Related to #10008

### Validation

- Focused regression red/green verification
- SQLite nested-docs integration suite (13 passed)
- Prettier
- `git diff --check`
