### PR TITLE
fix(uploads): detect SVG files with DOCTYPE declaration as image/svg+xml

### DIFF
--- a/packages/payload/src/uploads/checkFileRestrictions.ts
+++ b/packages/payload/src/uploads/checkFileRestrictions.ts
@@ -146,9 +146,9 @@ export const checkFileRestrictions = async ({
     }
     const typeFromExtension = file.name.split('.').pop() || ''
 
-    // Handle SVG files that are detected as XML due to <?xml declarations
+    // Handle SVG files that are detected as XML or HTML due to <?xml or <!DOCTYPE declarations
     if (
-      detected?.mime === 'application/xml' &&
+      (detected?.mime === 'application/xml' || detected?.mime === 'text/html') &&
       configMimeTypes.some(
         (type) => type.includes('image/') && (type.includes('svg') || type === 'image/*'),
       )

--- a/packages/payload/src/uploads/detectSvgFromXml.spec.ts
+++ b/packages/payload/src/uploads/detectSvgFromXml.spec.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+
+import { detectSvgFromXml } from './detectSvgFromXml.js'
+
+describe('detectSvgFromXml', () => {
+  it('detects a basic SVG with XML declaration', () => {
+    const svgContent = `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <circle cx="50" cy="50" r="40"/>
+</svg>`
+    expect(detectSvgFromXml(Buffer.from(svgContent))).toBe(true)
+  })
+
+  it('detects an SVG with a DOCTYPE declaration (the reported bug)', () => {
+    const svgContent = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <circle cx="50" cy="50" r="40"/>
+</svg>`
+    expect(detectSvgFromXml(Buffer.from(svgContent))).toBe(true)
+  })
+
+  it('detects a plain SVG without XML declaration or DOCTYPE', () => {
+    const svgContent = `<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <rect width="100" height="100"/>
+</svg>`
+    expect(detectSvgFromXml(Buffer.from(svgContent))).toBe(true)
+  })
+
+  it('returns false for an HTML file', () => {
+    const htmlContent = `<!DOCTYPE html>
+<html>
+  <body><p>Hello</p></body>
+</html>`
+    expect(detectSvgFromXml(Buffer.from(htmlContent))).toBe(false)
+  })
+
+  it('returns false for an XML file that is not SVG', () => {
+    const xmlContent = `<?xml version="1.0"?>
+<root xmlns="http://example.com">
+  <item>test</item>
+</root>`
+    expect(detectSvgFromXml(Buffer.from(xmlContent))).toBe(false)
+  })
+
+  it('returns false for an SVG without the required namespace', () => {
+    const svgContent = `<svg width="100" height="100">
+  <circle cx="50" cy="50" r="40"/>
+</svg>`
+    expect(detectSvgFromXml(Buffer.from(svgContent))).toBe(false)
+  })
+
+  it('returns false for an empty buffer', () => {
+    expect(detectSvgFromXml(Buffer.from(''))).toBe(false)
+  })
+})

--- a/packages/payload/src/uploads/detectSvgFromXml.ts
+++ b/packages/payload/src/uploads/detectSvgFromXml.ts
@@ -16,11 +16,12 @@ export function detectSvgFromXml(buffer: Buffer): boolean {
       return false
     }
 
-    // Remove XML declarations, comments, and processing instructions
+    // Remove XML declarations, comments, processing instructions, and DOCTYPE declarations
     const cleanContent = content
       .replace(/<\?xml[^>]*\?>/gi, '')
       .replace(/<!--[\s\S]*?-->/g, '')
       .replace(/<\?[^>]*\?>/g, '')
+      .replace(/<!DOCTYPE[^[>]*(?:\[[\s\S]*?\])?>/gi, '')
       .trim()
 
     // Find the first actual element (root element)


### PR DESCRIPTION
## Description
Fixes an issue where uploaded SVG files containing a \<!DOCTYPE>\ declaration were classified as \	ext/html\ or rejected during MIME type verification. \detectSvgFromXml\ now strips \<!DOCTYPE>\ declarations before root element matching, and \checkFileRestrictions\ checks for SVG XML structures when \	ext/html\ is initially detected.

Fixes #17958