### PR TITLE
fix(rest-api): handle ?joins=false query param without iterating string characters

### DIFF
--- a/packages/payload/src/utilities/parseParams/index.spec.ts
+++ b/packages/payload/src/utilities/parseParams/index.spec.ts
@@ -188,6 +188,16 @@ describe('parseParams', () => {
       expect(result).toHaveProperty('joins')
       // Note: actual sanitization logic is tested in sanitizeJoinParams tests
     })
+
+    it('should handle ?joins=false (string) from REST API without iterating characters', () => {
+      const result = parseParams({ joins: 'false' as any })
+      expect(result.joins).toBe(false)
+    })
+
+    it('should handle joins=false (boolean) from local API', () => {
+      const result = parseParams({ joins: false })
+      expect(result.joins).toBe(false)
+    })
   })
 
   describe('selectedLocales parameter', () => {

--- a/packages/payload/src/utilities/sanitizeJoinParams.ts
+++ b/packages/payload/src/utilities/sanitizeJoinParams.ts
@@ -19,6 +19,11 @@ export type JoinParams =
  * @param joins
  */
 export const sanitizeJoinParams = (_joins: JoinParams = {}): JoinQuery => {
+  // Handle top-level `?joins=false` (REST API sends it as the string "false")
+  if (_joins === false || (_joins as unknown) === 'false') {
+    return false
+  }
+
   const joinQuery: Record<string, any> = {}
   const joins = _joins as Record<string, any>
 


### PR DESCRIPTION
## Description
Fixes an issue where passing `?joins=false` in the REST API parsed the query string `"false"` into character indices (`"0"`, `"1"`, `"2"`, etc.) via `Object.keys()`. `sanitizeJoinParams` now checks for top-level `false` / `"false"` values before iterating properties and returns `false` directly.

Fixes #17929
