### PR TITLE
fix(ui): show image thumbnails in folder list view

### DIFF
--- a/packages/ui/src/elements/FolderView/FolderFileTable/index.scss
+++ b/packages/ui/src/elements/FolderView/FolderFileTable/index.scss
@@ -7,5 +7,19 @@
       grid-template-columns: auto 1fr;
       gap: calc(var(--base) / 2);
     }
+
+    &__thumbnail {
+      align-self: center;
+      width: var(--base);
+      height: var(--base);
+      overflow: hidden;
+
+      img,
+      svg {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+      }
+    }
   }
 }

--- a/packages/ui/src/elements/FolderView/FolderFileTable/index.tsx
+++ b/packages/ui/src/elements/FolderView/FolderFileTable/index.tsx
@@ -9,6 +9,7 @@ import { useConfig } from '../../../providers/Config/index.js'
 import { useFolder } from '../../../providers/Folders/index.js'
 import { useTranslation } from '../../../providers/Translation/index.js'
 import { formatDate } from '../../../utilities/formatDocTitle/formatDateTitle.js'
+import { Thumbnail } from '../../Thumbnail/index.js'
 import { ColoredFolderIcon } from '../ColoredFolderIcon/index.js'
 import { DraggableTableRow } from '../DraggableTableRow/index.js'
 import { SimpleTable, TableHeader } from '../SimpleTable/index.js'
@@ -184,7 +185,16 @@ export function FolderFileTable({ showRelationCell = true }: Props) {
                 if (index === 0) {
                   return (
                     <span className={`${baseClass}__cell-with-icon`} key={`${itemKey}-${name}`}>
-                      <DocumentIcon />
+                      {value.url ? (
+                        <Thumbnail
+                          className={`${baseClass}__thumbnail`}
+                          doc={value}
+                          fileSrc={value.url}
+                          size="none"
+                        />
+                      ) : (
+                        <DocumentIcon />
+                      )}
                       {cellValue}
                     </span>
                   )

--- a/test/folders/e2e.spec.ts
+++ b/test/folders/e2e.spec.ts
@@ -45,6 +45,10 @@ test.describe('Folders', () => {
   let OmittedFromBrowseBy: AdminUrlUtil
   let serverURL: string
   let adminRoute: string
+  const createdRecords: {
+    collection: 'media' | 'payload-folders'
+    id: string
+  }[] = []
 
   test.beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
@@ -73,6 +77,13 @@ test.describe('Folders', () => {
       serverURL,
       snapshotKey: 'foldersTest',
     })
+  })
+
+  test.afterEach(async () => {
+    for (const { id, collection } of createdRecords.slice().reverse()) {
+      await payload.delete({ id, collection, overrideAccess: true })
+    }
+    createdRecords.length = 0
   })
 
   test.describe('No folders', () => {
@@ -401,6 +412,37 @@ test.describe('Folders', () => {
       await gridViewButton.click()
       const gridView = page.locator('.item-card-grid')
       await expect(gridView).toBeVisible()
+    })
+
+    test('should show image thumbnails in list view', async () => {
+      const folder = await payload.create({
+        collection: 'payload-folders',
+        data: {
+          name: 'Media Folder',
+          folderType: ['media'],
+        },
+        overrideAccess: true,
+      })
+      createdRecords.push({ id: String(folder.id), collection: 'payload-folders' })
+
+      const media = await payload.create({
+        collection: 'media',
+        data: {
+          folder: folder.id,
+        },
+        filePath: path.resolve(dirname, '../uploads/image.png'),
+        overrideAccess: true,
+      })
+      createdRecords.push({ id: String(media.id), collection: 'media' })
+
+      const mediaURL = new AdminUrlUtil(serverURL, 'media')
+      await page.goto(mediaURL.byFolder)
+      await clickFolderCard({ doubleClick: true, folderName: 'Media Folder', page })
+      await page.locator('.folder-view-toggle-button').nth(1).click()
+
+      const thumbnail = page.locator('.folder-file-table__thumbnail img')
+      await expect(thumbnail).toBeVisible()
+      await expect(thumbnail).toHaveAttribute('src', /image\.png/)
     })
 
     test('should sort folders', async () => {


### PR DESCRIPTION
## Description

- Render existing upload previews in `FolderFileTable` when a thumbnail URL is available
- Retain the generic document icon for non-previewable documents
- Keep thumbnail sizing compact and local to folder list rows
- Add an E2E regression test using a real image upload

This is a bounded fix for Payload 3.x. Equivalent thumbnail behavior already exists in the current hierarchy list implementation.

Closes #17964  
Linear: [POSS-177](https://linear.app/figma/issue/POSS-177/folder-list-view-folderfiletable-show-image-thumbnails-instead-of-the)