### PR TITLE
fix: safely validate SVG uploads with DOCTYPE declarations

### DIFF
--- a/packages/payload/src/uploads/checkFileRestrictions.spec.ts
+++ b/packages/payload/src/uploads/checkFileRestrictions.spec.ts
@@ -1,0 +1,356 @@
+import { randomUUID } from 'node:crypto'
+import fs from 'fs/promises'
+import os from 'os'
+import path from 'path'
+
+import type { CollectionConfig } from '../collections/config/types.js'
+import type { PayloadRequest } from '../types/index.js'
+import type { File } from './types.js'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { checkFileRestrictions } from './checkFileRestrictions.js'
+
+const svg11Doctype =
+  '<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">'
+
+const collection = {
+  fields: [],
+  slug: 'media',
+  upload: { mimeTypes: ['image/*'] },
+} as unknown as CollectionConfig
+
+const imageAndTextCollection = {
+  fields: [],
+  slug: 'media',
+  upload: { mimeTypes: ['image/*', 'text/plain'] },
+} as unknown as CollectionConfig
+
+const textOnlyCollection = {
+  fields: [],
+  slug: 'media',
+  upload: { mimeTypes: ['text/plain'] },
+} as unknown as CollectionConfig
+
+const req = {
+  payload: {
+    logger: {
+      error: vi.fn(),
+      warn: vi.fn(),
+    },
+  },
+} as unknown as PayloadRequest
+
+const createFile = ({
+  content,
+  mimetype = 'image/svg+xml',
+  name = 'image.svg',
+  tempFilePath,
+}: {
+  content: string
+  mimetype?: string
+  name?: string
+  tempFilePath?: string
+}): File => {
+  const data = Buffer.from(content)
+
+  return {
+    data: tempFilePath ? Buffer.alloc(0) : data,
+    mimetype,
+    name,
+    size: data.length,
+    tempFilePath,
+  }
+}
+
+describe('checkFileRestrictions SVG validation', () => {
+  const createdTempFiles: string[] = []
+
+  afterEach(async () => {
+    for (const tempFile of createdTempFiles) {
+      await fs.unlink(tempFile)
+    }
+    createdTempFiles.length = 0
+    vi.clearAllMocks()
+  })
+
+  it('should accept a valid SVG with an external SVG 1.1 DOCTYPE', async () => {
+    const content = `<?xml version="1.0" encoding="UTF-8"?>
+${svg11Doctype}
+<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10">
+  <rect width="10" height="10" />
+</svg>`
+
+    await expect(
+      checkFileRestrictions({ collection, file: createFile({ content }), req }),
+    ).resolves.toBeUndefined()
+  })
+
+  it('should accept a valid SVG when the external identifier contains a greater-than sign', async () => {
+    const content = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg SYSTEM "https://www.w3.org/Graphics/SVG/svg>11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10">
+  <rect width="10" height="10" />
+</svg>`
+
+    await expect(
+      checkFileRestrictions({ collection, file: createFile({ content }), req }),
+    ).resolves.toBeUndefined()
+  })
+
+  it('should accept a valid SVG with an external SVG 1.1 DOCTYPE from a temp file', async () => {
+    const content = `<?xml version="1.0" encoding="UTF-8"?>
+${svg11Doctype}
+<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10">
+  <rect width="10" height="10" />
+</svg>`
+    const tempFilePath = path.join(os.tmpdir(), `payload-svg-${randomUUID()}.svg`)
+    await fs.writeFile(tempFilePath, content)
+    createdTempFiles.push(tempFilePath)
+
+    await expect(
+      checkFileRestrictions({
+        collection,
+        file: createFile({ content, tempFilePath }),
+        req,
+      }),
+    ).resolves.toBeUndefined()
+  })
+
+  it.each([
+    {
+      content: `<?xml version="1.0"?>
+<!DOCTYPE svg [<!ENTITY xxe SYSTEM "file:///etc/passwd">]>
+<svg xmlns="http://www.w3.org/2000/svg"><text>&xxe;</text></svg>`,
+      name: 'an internal entity subset',
+    },
+    {
+      content: `<?xml version="1.0"?>
+${svg11Doctype}
+<svg xmlns="http://www.w3.org/2000/svg"><script>alert('xss')</script></svg>`,
+      name: 'a script after an external SVG DOCTYPE',
+    },
+    {
+      content: `<?xml version="1.0"?>
+${svg11Doctype}
+<svg xmlns="http://www.w3.org/2000/svg" onload="alert('xss')"></svg>`,
+      name: 'an event handler after an external SVG DOCTYPE',
+    },
+    {
+      content: `<?xml version="1.0"?>
+<!DOCTYPE html>
+<svg xmlns="http://www.w3.org/2000/svg"></svg>`,
+      name: 'an HTML DOCTYPE with an SVG root',
+    },
+    {
+      content: `<?xml version="1.0"?>
+<!DOCTYPE SVG>
+<svg xmlns="http://www.w3.org/2000/svg"></svg>`,
+      name: 'a case-mismatched SVG DOCTYPE root',
+    },
+    {
+      content: `<?xml version="1.0"?>
+<!DOCTYPE svg SYSTEM "><svg xmlns="http://www.w3.org/2000/svg"></svg>`,
+      name: 'an unterminated external identifier',
+    },
+    {
+      content: `${svg11Doctype}
+<html><body>not an SVG</body></html>`,
+      name: 'an SVG DOCTYPE with an HTML root',
+    },
+    {
+      content: '<!DOCTYPE html><html><body>not an SVG</body></html>',
+      name: 'an HTML document using an SVG extension',
+    },
+    {
+      content: `<?xml version="1.0"?>
+<!DOCTYPE note SYSTEM "note.dtd">
+<note xmlns="http://www.w3.org/2000/svg">not an SVG</note>`,
+      name: 'a non-SVG XML document using an SVG extension',
+    },
+    {
+      content: '<svg xmlns="urn:not-svg"><g xmlns="http://www.w3.org/2000/svg"></g></svg>',
+      name: 'an SVG namespace declared only on a descendant',
+    },
+    {
+      content: '<svg xmlns="urn:not-svg"><!-- xmlns="http://www.w3.org/2000/svg" --></svg>',
+      name: 'an SVG namespace declared only in a comment',
+    },
+    {
+      content:
+        '<svg data-description=\'xmlns="http://www.w3.org/2000/svg"\' xmlns="urn:not-svg"></svg>',
+      name: 'an SVG namespace present only inside another root attribute',
+    },
+    {
+      content:
+        '<!--ftypavif--><svg xmlns="http://www.w3.org/2000/svg"><script>alert(\'xss\')</script></svg>',
+      name: 'a scripted SVG colliding with an AVIF signature',
+    },
+    {
+      content: `<?xml version="1.0"?>
+${svg11Doctype}
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:s="http://www.w3.org/2000/svg">
+  <s:script>alert('xss')</s:script>
+</svg>`,
+      name: 'a namespace-prefixed script element',
+    },
+    {
+      content: `<?xml version="1.0"?>
+${svg11Doctype}
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:s="http://www.w3.org/2000/svg">
+  <s:foreignObject><div xmlns="http://www.w3.org/1999/xhtml">HTML</div></s:foreignObject>
+</svg>`,
+      name: 'a namespace-prefixed foreignObject element',
+    },
+    {
+      content: `<?xml version="1.0"?>
+${svg11Doctype}
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:s="http://www.w3.org/2000/svg">
+  <s:iframe src="https://example.com"></s:iframe>
+</svg>`,
+      name: 'a namespace-prefixed iframe element',
+    },
+    {
+      content: `<?xml version="1.0"?>
+${svg11Doctype}
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:s="http://www.w3.org/2000/svg">
+  <s:object data="https://example.com"></s:object>
+</svg>`,
+      name: 'a namespace-prefixed object element',
+    },
+    {
+      content: `<?xml version="1.0"?>
+${svg11Doctype}
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:s="http://www.w3.org/2000/svg">
+  <s:embed src="https://example.com"></s:embed>
+</svg>`,
+      name: 'a namespace-prefixed embed element',
+    },
+  ])('should reject $name', async ({ content }) => {
+    await expect(
+      checkFileRestrictions({ collection, file: createFile({ content }), req }),
+    ).rejects.toMatchObject({ name: 'ValidationError' })
+  })
+
+  it('should reject a detected XML SVG containing a script from a temp file', async () => {
+    const content = `<?xml version="1.0"?>
+<svg xmlns="http://www.w3.org/2000/svg"><script>alert('xss')</script></svg>`
+    const tempFilePath = path.join(os.tmpdir(), `payload-svg-${randomUUID()}.svg`)
+    await fs.writeFile(tempFilePath, content)
+    createdTempFiles.push(tempFilePath)
+
+    await expect(
+      checkFileRestrictions({
+        collection,
+        file: createFile({ content, tempFilePath }),
+        req,
+      }),
+    ).rejects.toMatchObject({ name: 'ValidationError' })
+  })
+
+  it('should reject a scripted SVG colliding with an AVIF signature from a temp file', async () => {
+    const content =
+      '<!--ftypavif--><svg xmlns="http://www.w3.org/2000/svg"><script>alert(\'xss\')</script></svg>'
+    const tempFilePath = path.join(os.tmpdir(), `payload-svg-${randomUUID()}.svg`)
+    await fs.writeFile(tempFilePath, content)
+    createdTempFiles.push(tempFilePath)
+
+    await expect(
+      checkFileRestrictions({
+        collection,
+        file: createFile({ content, tempFilePath }),
+        req,
+      }),
+    ).rejects.toMatchObject({ name: 'ValidationError' })
+  })
+
+  it('should reject a claimed SVG with a text extension when file detection has no result', async () => {
+    const content = '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(\'xss\')</script></svg>'
+
+    await expect(
+      checkFileRestrictions({
+        collection: imageAndTextCollection,
+        file: createFile({ content, name: 'image.txt' }),
+        req,
+      }),
+    ).rejects.toMatchObject({ name: 'ValidationError' })
+  })
+
+  it('should reject a claimed SVG with a text extension from a temp file', async () => {
+    const content = '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(\'xss\')</script></svg>'
+    const tempFilePath = path.join(os.tmpdir(), `payload-svg-${randomUUID()}.txt`)
+    await fs.writeFile(tempFilePath, content)
+    createdTempFiles.push(tempFilePath)
+
+    await expect(
+      checkFileRestrictions({
+        collection: imageAndTextCollection,
+        file: createFile({ content, name: 'image.txt', tempFilePath }),
+        req,
+      }),
+    ).rejects.toMatchObject({ name: 'ValidationError' })
+  })
+
+  it('should reject a parameterized SVG MIME claim containing a script', async () => {
+    const content = '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(\'xss\')</script></svg>'
+
+    await expect(
+      checkFileRestrictions({
+        collection: imageAndTextCollection,
+        file: createFile({
+          content,
+          mimetype: 'Image/SVG+XML; charset=UTF-8',
+          name: 'image.txt',
+        }),
+        req,
+      }),
+    ).rejects.toMatchObject({ name: 'ValidationError' })
+  })
+
+  it('should reject a parameterized SVG MIME claim containing a script from a temp file', async () => {
+    const content = '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(\'xss\')</script></svg>'
+    const tempFilePath = path.join(os.tmpdir(), `payload-svg-${randomUUID()}.txt`)
+    await fs.writeFile(tempFilePath, content)
+    createdTempFiles.push(tempFilePath)
+
+    await expect(
+      checkFileRestrictions({
+        collection: imageAndTextCollection,
+        file: createFile({
+          content,
+          mimetype: 'Image/SVG+XML; charset=UTF-8',
+          name: 'image.txt',
+          tempFilePath,
+        }),
+        req,
+      }),
+    ).rejects.toMatchObject({ name: 'ValidationError' })
+  })
+
+  it('should reject valid SVG content disguised as text when SVG MIME types are not allowed', async () => {
+    const content = '<svg xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10" /></svg>'
+
+    await expect(
+      checkFileRestrictions({
+        collection: textOnlyCollection,
+        file: createFile({ content, name: 'image.txt' }),
+        req,
+      }),
+    ).rejects.toMatchObject({ name: 'ValidationError' })
+  })
+
+  it('should reject valid SVG content disguised as a temp text file when SVG MIME types are not allowed', async () => {
+    const content = '<svg xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10" /></svg>'
+    const tempFilePath = path.join(os.tmpdir(), `payload-svg-${randomUUID()}.txt`)
+    await fs.writeFile(tempFilePath, content)
+    createdTempFiles.push(tempFilePath)
+
+    await expect(
+      checkFileRestrictions({
+        collection: textOnlyCollection,
+        file: createFile({ content, name: 'image.txt', tempFilePath }),
+        req,
+      }),
+    ).rejects.toMatchObject({ name: 'ValidationError' })
+  })
+})

--- a/packages/payload/src/uploads/checkFileRestrictions.ts
+++ b/packages/payload/src/uploads/checkFileRestrictions.ts
@@ -131,6 +131,12 @@ export const checkFileRestrictions = async ({
     }
   }
 
+  const isValidSvgFile = async (): Promise<boolean> => {
+    const buffer = await getFileBuffer()
+
+    return detectSvgFromXml(buffer) && validateSvg(buffer)
+  }
+
   // Secondary mimetype check to assess file type from buffer
   if (configMimeTypes.length > 0) {
     let detected
@@ -168,14 +174,6 @@ export const checkFileRestrictions = async ({
           `File type ${mimeTypeFromExtension} (from extension ${typeFromExtension}) is not allowed.`,
         )
       } else {
-        // SVG security check (text-based files not detectable by buffer)
-        if (typeFromExtension.toLowerCase() === 'svg') {
-          const isSafeSvg = validateSvg(await getFileBuffer())
-          if (!isSafeSvg) {
-            errors.push('SVG file contains potentially harmful content.')
-          }
-        }
-
         // PDF validation
         if (mimeTypeFromExtension === 'application/pdf') {
           const isValidPDF = validatePDF(await getFileBuffer())
@@ -189,6 +187,20 @@ export const checkFileRestrictions = async ({
         req.payload.logger.warn(
           `File buffer returned no detectable MIME type for ${file.name}. Falling back to extension-based validation.`,
         )
+      }
+    }
+
+    const claimedMimeType = file.mimetype.split(';', 1)[0]?.trim().toLowerCase()
+    const shouldValidateAsSvg =
+      detected?.mime === 'image/svg+xml' ||
+      typeFromExtension.toLowerCase() === 'svg' ||
+      claimedMimeType === 'image/svg+xml'
+
+    if (shouldValidateAsSvg) {
+      if (await isValidSvgFile()) {
+        detected = { ext: 'svg', mime: 'image/svg+xml' }
+      } else {
+        errors.push('SVG file is invalid or contains potentially harmful content.')
       }
     }
 

--- a/packages/payload/src/uploads/detectSvgFromXml.ts
+++ b/packages/payload/src/uploads/detectSvgFromXml.ts
@@ -17,11 +17,49 @@ export function detectSvgFromXml(buffer: Buffer): boolean {
     }
 
     // Remove XML declarations, comments, and processing instructions
-    const cleanContent = content
+    let cleanContent = content
       .replace(/<\?xml[^>]*\?>/gi, '')
       .replace(/<!--[\s\S]*?-->/g, '')
       .replace(/<\?[^>]*\?>/g, '')
       .trim()
+
+    // Only allow a well-formed DOCTYPE for the SVG root without an internal subset.
+    if (cleanContent.startsWith('<!DOCTYPE')) {
+      let doctypeEndIndex = -1
+      let hasInternalSubset = false
+      let quoteCharacter: "'" | '"' | undefined
+
+      for (let index = 0; index < cleanContent.length; index++) {
+        const character = cleanContent[index]
+
+        if (quoteCharacter) {
+          if (character === quoteCharacter) {
+            quoteCharacter = undefined
+          }
+          continue
+        }
+
+        if (character === '"' || character === "'") {
+          quoteCharacter = character
+        } else if (character === '[') {
+          hasInternalSubset = true
+        } else if (character === '>') {
+          doctypeEndIndex = index
+          break
+        }
+      }
+
+      if (doctypeEndIndex === -1 || hasInternalSubset) {
+        return false
+      }
+
+      const doctypeDeclaration = cleanContent.slice(0, doctypeEndIndex + 1)
+      if (!isSupportedSvgDoctype({ declaration: doctypeDeclaration })) {
+        return false
+      }
+
+      cleanContent = cleanContent.slice(doctypeEndIndex + 1).trim()
+    }
 
     // Find the first actual element (root element)
     const rootElementMatch = cleanContent.match(/^<(\w+)(?:\s|>)/)
@@ -29,15 +67,13 @@ export function detectSvgFromXml(buffer: Buffer): boolean {
       return false
     }
 
-    // Validate SVG namespace - must be present for valid SVG
-    const svgNamespaceRegex = /xmlns=["']http:\/\/www\.w3\.org\/2000\/svg["']/
-    if (!svgNamespaceRegex.test(content)) {
+    const rootTagEndIndex = findUnquotedClosingBracket({ value: cleanContent })
+    if (rootTagEndIndex === -1) {
       return false
     }
 
-    // Additional validation: ensure it's not malformed
-    const svgOpenTag = content.match(/<svg[\s>]/)
-    if (!svgOpenTag) {
+    const rootTag = cleanContent.slice(0, rootTagEndIndex + 1)
+    if (!hasSvgNamespaceDeclaration({ rootTag })) {
       return false
     }
 
@@ -46,4 +82,147 @@ export function detectSvgFromXml(buffer: Buffer): boolean {
     // If any error occurs during parsing, treat as not SVG
     return false
   }
+}
+
+function findUnquotedClosingBracket({ value }: { value: string }): number {
+  let quoteCharacter: "'" | '"' | undefined
+
+  for (let index = 0; index < value.length; index++) {
+    const character = value[index]
+
+    if (quoteCharacter) {
+      if (character === quoteCharacter) {
+        quoteCharacter = undefined
+      }
+      continue
+    }
+
+    if (character === '"' || character === "'") {
+      quoteCharacter = character
+    } else if (character === '>') {
+      return index
+    }
+  }
+
+  return -1
+}
+
+function hasSvgNamespaceDeclaration({ rootTag }: { rootTag: string }): boolean {
+  const xmlWhitespaceRegex = /[\t\n\r ]/
+  let hasSvgNamespace = false
+  let index = '<svg'.length
+
+  while (index < rootTag.length) {
+    while (xmlWhitespaceRegex.test(rootTag[index] ?? '')) {
+      index++
+    }
+
+    if (rootTag[index] === '>') {
+      return hasSvgNamespace
+    }
+
+    if (rootTag[index] === '/' && rootTag[index + 1] === '>') {
+      return hasSvgNamespace
+    }
+
+    const attributeNameStart = index
+    while (index < rootTag.length && !/[\t\n\r =/>]/.test(rootTag[index] ?? '')) {
+      index++
+    }
+
+    if (attributeNameStart === index) {
+      return false
+    }
+
+    const attributeName = rootTag.slice(attributeNameStart, index)
+
+    while (xmlWhitespaceRegex.test(rootTag[index] ?? '')) {
+      index++
+    }
+
+    if (rootTag[index] !== '=') {
+      return false
+    }
+
+    index++
+    while (xmlWhitespaceRegex.test(rootTag[index] ?? '')) {
+      index++
+    }
+
+    const quoteCharacter = rootTag[index]
+    if (quoteCharacter !== '"' && quoteCharacter !== "'") {
+      return false
+    }
+
+    const attributeValueStart = ++index
+    while (index < rootTag.length && rootTag[index] !== quoteCharacter) {
+      index++
+    }
+
+    if (index >= rootTag.length) {
+      return false
+    }
+
+    const attributeValue = rootTag.slice(attributeValueStart, index)
+    index++
+
+    if (attributeName === 'xmlns') {
+      if (hasSvgNamespace || attributeValue !== 'http://www.w3.org/2000/svg') {
+        return false
+      }
+
+      hasSvgNamespace = true
+    }
+  }
+
+  return false
+}
+
+function isSupportedSvgDoctype({ declaration }: { declaration: string }): boolean {
+  const declarationBody = declaration.slice('<!DOCTYPE'.length, -1).trim()
+  if (declarationBody === 'svg') {
+    return true
+  }
+
+  if (!/^svg\s/.test(declarationBody)) {
+    return false
+  }
+
+  const externalIdentifier = declarationBody.slice('svg'.length).trimStart()
+  if (/^SYSTEM\s/.test(externalIdentifier)) {
+    const remaining = consumeQuotedLiteral({ value: externalIdentifier.slice('SYSTEM'.length) })
+
+    return remaining !== undefined && remaining.trim() === ''
+  }
+
+  if (/^PUBLIC\s/.test(externalIdentifier)) {
+    const afterPublicIdentifier = consumeQuotedLiteral({
+      value: externalIdentifier.slice('PUBLIC'.length),
+    })
+    if (afterPublicIdentifier === undefined || !/^\s/.test(afterPublicIdentifier)) {
+      return false
+    }
+
+    const remaining = consumeQuotedLiteral({ value: afterPublicIdentifier })
+
+    return remaining !== undefined && remaining.trim() === ''
+  }
+
+  return false
+}
+
+function consumeQuotedLiteral({ value }: { value: string }): string | undefined {
+  const trimmedValue = value.trimStart()
+  const quoteCharacter = trimmedValue[0]
+
+  if (quoteCharacter !== '"' && quoteCharacter !== "'") {
+    return undefined
+  }
+
+  const closingQuoteIndex = trimmedValue.indexOf(quoteCharacter, 1)
+  if (closingQuoteIndex === -1) {
+    return undefined
+  }
+
+  return trimmedValue.slice(closingQuoteIndex + 1)
 }

--- a/packages/payload/src/uploads/validateSvg.ts
+++ b/packages/payload/src/uploads/validateSvg.ts
@@ -8,8 +8,8 @@ export function validateSvg(buffer: Buffer): boolean {
 
     const dangerousPatterns = [
       // Script tags
-      /<script[\s>]/i,
-      /<\/script>/i,
+      /<(?:[^<>\s/:]+:)?script[\s>]/i,
+      /<\/(?:[^<>\s/:]+:)?script\s*>/i,
 
       // Event handlers (onclick, onload, onerror, etc.)
       /\son\w+\s*=/i,
@@ -19,14 +19,14 @@ export function validateSvg(buffer: Buffer): boolean {
       /data:text\/html/i,
 
       // Foreign objects (can embed HTML)
-      /<foreignObject[\s>]/i,
+      /<(?:[^<>\s/:]+:)?foreignObject[\s>]/i,
 
       // Embedded iframes
-      /<iframe[\s>]/i,
+      /<(?:[^<>\s/:]+:)?iframe[\s>]/i,
 
       // Embedded objects and embeds
-      /<object[\s>]/i,
-      /<embed[\s>]/i,
+      /<(?:[^<>\s/:]+:)?object[\s>]/i,
+      /<(?:[^<>\s/:]+:)?embed[\s>]/i,
 
       // Base64 encoded scripts (common obfuscation technique)
       /data:image\/svg\+xml;base64,[\w+/]*PHNjcmlwdA/i, // <script in base64


### PR DESCRIPTION
## Description

- accept valid SVG documents with strict external SVG DOCTYPE declarations
- reject internal subsets, mismatched DOCTYPE roots, HTML/XML pretenders, and malformed external identifiers
- validate SVG structure and harmful content across detected MIME, extension, claimed MIME, buffered uploads, and temp-file uploads
- normalize validated SVG content to `image/svg+xml` before applying configured MIME restrictions
- reject namespace-prefixed active elements and MIME/signature collision bypasses

Fixes #17958
Supersedes #17961

## Testing

- `pnpm test:unit packages/payload/src/uploads` (184 passed)
- `pnpm test:int:sqlite test/uploads/int.spec.ts -t "useTempFiles MIME type bypass"` (5 passed, 108 skipped)
- `pnpm --dir packages/payload build:types`
- ESLint, Prettier, and `git diff --check`
