### PR TITLE
chore: add nathanlentz to payloadTeamUsernames

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -48,6 +48,7 @@ jobs:
               'paulpopus',
               'r1tsuu',
               'GermanJablo',
+              'nathanlentz',
             ];
 
             const type = context.payload.pull_request ? 'pull_request' : 'issue';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What?

Adds `nathanlentz` to the `payloadTeamUsernames` list in the `triage` workflow.

### Why?

Issues and PRs opened by `nathanlentz` were not being recognized as coming from the Payload team, so they missed the `created-by: Payload team` label and the stale-bot exemption that label provides.

### How?

One entry appended to the `payloadTeamUsernames` array in `.github/workflows/triage.yml`. The comparison is already case-insensitive, so no other changes are needed
