### PR TITLE
fix(ui): default where-constrained permission to false

### DIFF
--- a/packages/payload/src/utilities/getEntityPermissions/getEntityPermissions.ts
+++ b/packages/payload/src/utilities/getEntityPermissions/getEntityPermissions.ts
@@ -299,10 +299,11 @@ const processWhereQuery = ({
       }),
     )
   } else {
-    // TODO: 4.0: Investigate defaulting to `false` here, if where query is returned but ignored as we don't
-    // have the document data available. This seems more secure.
-    // Alternatively, we could set permission to a third state, like 'unknown'.
-    // Even after calling sanitizePermissions, the permissions will still be true if the where query is returned but ignored as we don't have the document data available.
-    entityPermissions[operation] = { permission: true, where: accessResult } as Permission
+    // When no document data is available we cannot evaluate the where query
+    // against an actual document, so default to `false` (more secure) rather
+    // than claiming the caller may perform the operation on every document.
+    // The constraint is still returned so clients that opt into re-deriving
+    // access themselves can apply it.
+    entityPermissions[operation] = { permission: false, where: accessResult } as Permission
   }
 }

--- a/test/access-control/int.spec.ts
+++ b/test/access-control/int.spec.ts
@@ -995,6 +995,35 @@ describe('Access Control', () => {
       ).rejects.toThrow(Forbidden)
     })
   })
+
+  describe('conditional access (where query) without document data', () => {
+    it('reports permission: false when an access function returns a where constraint and no document data is available', async () => {
+      const anonymousReq = await createLocalReq({}, payload)
+
+      const permissions = await getEntityPermissions({
+        blockReferencesPermissions: {} as any,
+        entity: payload.collections[restrictedVersionsSlug].config,
+        entityType: 'collection',
+        operations: ['read', 'readVersions'],
+        fetchData: false,
+        req: anonymousReq,
+      })
+
+      // Without document data the returned where constraint cannot be
+      // evaluated against an actual document, so we must not report
+      // permission: true (the caller cannot act on every document). The
+      // constraint is still returned for clients that opt into re-deriving
+      // access themselves.
+      expect(permissions.read).toEqual({
+        permission: false,
+        where: { hidden: { not_equals: true } },
+      })
+      expect(permissions.readVersions).toEqual({
+        permission: false,
+        where: { 'version.hidden': { not_equals: true } },
+      })
+    })
+  })
 })
 
 async function createDoc<TSlug extends CollectionSlug = 'posts'>(


### PR DESCRIPTION
Fixes #17928

When an access function returns a where query constraint but no document data is available (`fetchData: false`, e.g. `GET /api/access`), the endpoint reported `permission: true` next to the constraint. A client reading the boolean alone concluded the caller could act on every document, while the `where` said otherwise.

## What changed
- In `processWhereQuery`'s no-data branch (`getEntityPermissions.ts`), default `permission` to `false` (more secure) instead of `true` — the direction already flagged in the source TODO. The constraint is still returned for clients that opt into re-deriving access themselves.
- Added an integration test in `test/access-control/int.spec.ts` covering `restricted-versions` read/readVersions with an anonymous request (which return where constraints), asserting `permission: false` + the constraint.

## Note
`fetchData: true` paths are unchanged: there the where query is evaluated against the actual document via `entityDocExists`, and the existing async-parent-permission tests keep passing.
