### PR TITLE
test: add reset and seed integration fixtures

### DIFF
--- a/test/__helpers/int/vitest.ts
+++ b/test/__helpers/int/vitest.ts
@@ -34,6 +34,7 @@ type IntegrationFixtures = {
     payloadInstance: Payload
     testConfig: TestConfig
     testCron: boolean
+    testDir: string
     testSuiteConfigured: boolean
   }
   $test: {
@@ -114,6 +115,13 @@ const testWithFixtures = vitestTest.extend<IntegrationFixtures>({
     // eslint-disable-next-line no-empty-pattern
     async ({}, use) => {
       await use(true)
+    },
+    { scope: 'file' },
+  ],
+  testDir: [
+    // eslint-disable-next-line no-empty-pattern
+    async ({}, use) => {
+      await use(getTestDirectory())
     },
     { scope: 'file' },
   ],

--- a/test/__helpers/int/vitest.ts
+++ b/test/__helpers/int/vitest.ts
@@ -7,6 +7,8 @@ import { expect, test as vitestTest } from 'vitest'
 import type { DatabaseAdapterType } from '../../dbAdapters.js'
 
 import { getCurrentDatabaseAdapter } from '../../dbAdapters.js'
+import { resetAndSeed } from '../shared/clearAndSeed/resetAndSeed.js'
+import { getTestDataConfig } from '../shared/clearAndSeed/testDataConfig.js'
 import { getSDK } from '../shared/getSDK.js'
 import { initPayloadInt } from '../shared/initPayloadInt.js'
 import { mongooseList } from '../shared/isMongoose.js'
@@ -18,14 +20,25 @@ type TestOptions = {
   db?: 'all' | 'drizzle' | 'mongo' | ((adapterType: DatabaseAdapterType) => boolean)
 }
 
+type TestSuiteOptions = {
+  config?: Promise<SanitizedConfig> | SanitizedConfig
+  cron?: boolean
+} & TestOptions
+
+type TestConfig = null | Promise<SanitizedConfig> | SanitizedConfig
+
 type IntegrationFixtures = {
   $file: {
     config: SanitizedConfig
-    payload: Payload
-    testDir: string
+    /** Raw file-scoped instance for suite hooks. Tests should use `payload`. */
+    payloadInstance: Payload
+    testConfig: TestConfig
+    testCron: boolean
+    testSuiteConfigured: boolean
   }
   $test: {
     cli: (input: Parameters<typeof runCLICommand>[0]) => ReturnType<typeof runCLICommand>
+    payload: Payload
     restClient: NextRESTClient
     sdk: ReturnType<typeof getSDK>
   }
@@ -43,19 +56,44 @@ const testWithFixtures = vitestTest.extend<IntegrationFixtures>({
     })
   },
   config: [
-    async ({ testDir }, use) => {
-      const { config } = await initPayloadInt(testDir, undefined, false)
+    async ({ testConfig, testSuiteConfigured }, use) => {
+      if (testSuiteConfigured && testConfig === null) {
+        throw new Error(
+          'This integration test requires Payload. Pass its config to test.suite({ config: testConfig })(...).',
+        )
+      }
+
+      const config =
+        testConfig !== null
+          ? await testConfig
+          : (await initPayloadInt(getTestDirectory(), undefined, false)).config
 
       await use(config)
     },
     { scope: 'file' },
   ],
-  payload: [
-    async ({ config }, use) => {
-      const payload = await getPayload({ config, cron: true })
+  payload: async ({ payloadInstance, testSuiteConfigured }, use) => {
+    if (testSuiteConfigured) {
+      const testDataConfig = getTestDataConfig(payloadInstance.config)
 
-      await use(payload)
-      await payload.destroy()
+      if (!testDataConfig) {
+        throw new Error('Test suite metadata was not registered by buildConfigWithDefaults.')
+      }
+
+      await resetAndSeed({ payload: payloadInstance, ...testDataConfig })
+    }
+
+    await use(payloadInstance)
+  },
+  payloadInstance: [
+    async ({ config, testCron }, use) => {
+      const payload = await getPayload({ config, cron: testCron })
+
+      try {
+        await use(payload)
+      } finally {
+        await payload.destroy()
+      }
     },
     { scope: 'file' },
   ],
@@ -65,30 +103,45 @@ const testWithFixtures = vitestTest.extend<IntegrationFixtures>({
   sdk: async ({ payload }, use) => {
     await use(getSDK(payload.config))
   },
-  testDir: [
+  testConfig: [
     // eslint-disable-next-line no-empty-pattern
     async ({}, use) => {
-      await use(getTestDirectory())
+      await use(null)
+    },
+    { scope: 'file' },
+  ],
+  testCron: [
+    // eslint-disable-next-line no-empty-pattern
+    async ({}, use) => {
+      await use(true)
+    },
+    { scope: 'file' },
+  ],
+  testSuiteConfigured: [
+    // eslint-disable-next-line no-empty-pattern
+    async ({}, use) => {
+      await use(false)
     },
     { scope: 'file' },
   ],
 })
 
 /**
- * Integration test API with Payload's shared fixtures and database filtering.
+ * Integration test API with Payload's shared lifecycle and database filtering.
  *
- * `config`, `payload`, and `testDir` are shared for the test file. `payload` is destroyed
- * automatically after the file finishes. Clients are new for every test so
- * authentication and other mutable state cannot leak into the next test.
- *
- * @example
- * test.options({ db: 'mongo' })('MongoDB only', async ({ payload }) => {
- *   await payload.find({ collection: 'posts' })
- * })
+ * Payload-backed test files supply their config to one root `test.suite`. Payload is initialized
+ * lazily, once per file, and destroyed afterward. Before every test that uses Payload, REST, or the
+ * SDK, the database and upload directories are reset and the suite's optional seed function is run.
+ * REST and SDK clients are recreated per test. Standalone integration tests use `test.suite({})` and
+ * do not initialize Payload.
  *
  * @example
- * test.options({ db: 'drizzle' }).describe('Drizzle only', () => {
- *   test('works', async ({ payload }) => { ... })
+ * import testConfig from './config.js'
+ *
+ * test.suite({ config: testConfig })('Posts', () => {
+ *   test('reads posts', async ({ payload }) => {
+ *     await payload.find({ collection: 'posts' })
+ *   })
  * })
  */
 export const test = Object.assign(testWithFixtures, {
@@ -99,7 +152,16 @@ export const test = Object.assign(testWithFixtures, {
       describe: testWithFixtures.describe.runIf(shouldRun),
     })
   },
+  suite: ({ config, cron = true, db }: TestSuiteOptions) => {
+    testWithFixtures.override('testConfig', config ?? null)
+    testWithFixtures.override('testCron', cron)
+    testWithFixtures.override('testSuiteConfigured', true)
+
+    return testWithFixtures.describe.runIf(matchesDatabase({ db }))
+  },
 })
+
+export const it = test
 
 const getTestDirectory = (): string => {
   const testPath = expect.getState().testPath

--- a/test/__helpers/shared/clearAndSeed/getUploadDirectories.ts
+++ b/test/__helpers/shared/clearAndSeed/getUploadDirectories.ts
@@ -1,0 +1,19 @@
+import type { Payload } from 'payload'
+
+import path from 'node:path'
+
+export const getUploadDirectories = ({ payload }: { payload: Payload }): string[] => {
+  const directories = payload.config.collections.flatMap((collection) => {
+    if (
+      !collection.upload ||
+      collection.upload.disableLocalStorage ||
+      !collection.upload.staticDir
+    ) {
+      return []
+    }
+
+    return [path.resolve(collection.upload.staticDir)]
+  })
+
+  return [...new Set(directories)]
+}

--- a/test/__helpers/shared/clearAndSeed/reInitEndpoint.ts
+++ b/test/__helpers/shared/clearAndSeed/reInitEndpoint.ts
@@ -3,10 +3,66 @@ import type { Endpoint, PayloadHandler } from 'payload'
 import { status as httpStatus } from 'http-status'
 import * as qs from 'qs-esm'
 
+import type { TestDataConfig } from './testDataConfig.js'
+
 import { path } from './reInitializeDB.js'
+import { resetAndSeed } from './resetAndSeed.js'
 import { seedDB } from './seed.js'
 
-const handler: PayloadHandler = async (req) => {
+export const createReInitEndpoint = ({ seed, suite }: TestDataConfig): Endpoint => {
+  let resetQueue = Promise.resolve()
+
+  const handler: PayloadHandler = async (req) => {
+    const { payload } = req
+
+    if (!req.url) {
+      throw new Error('Request URL is required')
+    }
+
+    const query: {
+      deleteOnly?: string
+    } = qs.parse(req.url.split('?')[1] ?? '', {
+      depth: 10,
+      ignoreQueryPrefix: true,
+    })
+
+    const reset = resetQueue.then(async () => {
+      await resetAndSeed({
+        deleteOnly: query.deleteOnly === 'true',
+        payload,
+        seed,
+        suite,
+      })
+    })
+    resetQueue = reset.catch(() => undefined)
+
+    try {
+      await reset
+
+      return Response.json(
+        {
+          message: 'Database reset and seed run successfully.',
+        },
+        {
+          status: httpStatus.OK,
+        },
+      )
+    } catch (err) {
+      payload.logger.error(err)
+      return Response.json(err, {
+        status: httpStatus.BAD_REQUEST,
+      })
+    }
+  }
+
+  return {
+    handler,
+    method: 'post',
+    path,
+  }
+}
+
+const legacyHandler: PayloadHandler = async (req) => {
   process.env.SEED_IN_CONFIG_ONINIT = 'true'
   const { payload } = req
 
@@ -23,7 +79,7 @@ const handler: PayloadHandler = async (req) => {
     ignoreQueryPrefix: true,
   })
 
-  let uploadsDir = query.uploadsDir as string | string[]
+  let uploadsDir = query.uploadsDir
   if (typeof uploadsDir === 'object') {
     uploadsDir = Object.values(uploadsDir)
   }
@@ -32,12 +88,10 @@ const handler: PayloadHandler = async (req) => {
     await seedDB({
       _payload: payload,
       collectionSlugs: payload.config.collections.map(({ slug }) => slug),
+      deleteOnly: query.deleteOnly === 'true',
       seedFunction: payload.config.onInit,
       snapshotKey: String(query.snapshotKey),
-      // uploadsDir can be string or stringlist
       uploadsDir,
-      // query value will be a string of 'true' or 'false'
-      deleteOnly: query.deleteOnly === 'true',
     })
 
     return Response.json(
@@ -56,8 +110,9 @@ const handler: PayloadHandler = async (req) => {
   }
 }
 
+/** @deprecated Migrate the config to `buildConfigWithDefaults({ config, seed, suite })`. */
 export const reInitEndpoint: Endpoint = {
-  path,
+  handler: legacyHandler,
   method: 'get',
-  handler,
+  path,
 }

--- a/test/__helpers/shared/clearAndSeed/reInitEndpoint.ts
+++ b/test/__helpers/shared/clearAndSeed/reInitEndpoint.ts
@@ -49,9 +49,7 @@ export const createReInitEndpoint = ({ seed, suite }: TestDataConfig): Endpoint 
       )
     } catch (err) {
       payload.logger.error(err)
-      return Response.json(err, {
-        status: httpStatus.BAD_REQUEST,
-      })
+      return createErrorResponse(err)
     }
   }
 
@@ -104,11 +102,19 @@ const legacyHandler: PayloadHandler = async (req) => {
     )
   } catch (err) {
     payload.logger.error(err)
-    return Response.json(err, {
-      status: httpStatus.BAD_REQUEST,
-    })
+    return createErrorResponse(err)
   }
 }
+
+const createErrorResponse = (error: unknown): Response =>
+  Response.json(
+    {
+      message: error instanceof Error ? error.message : String(error),
+    },
+    {
+      status: httpStatus.INTERNAL_SERVER_ERROR,
+    },
+  )
 
 /** @deprecated Migrate the config to `buildConfigWithDefaults({ config, seed, suite })`. */
 export const reInitEndpoint: Endpoint = {

--- a/test/__helpers/shared/clearAndSeed/reInitializeDB.ts
+++ b/test/__helpers/shared/clearAndSeed/reInitializeDB.ts
@@ -4,14 +4,16 @@ import * as qs from 'qs-esm'
 export const path = '/re-initialize'
 
 export const reInitializeDB = async ({
+  deleteOnly,
   serverURL,
   snapshotKey,
   uploadsDir,
-  deleteOnly,
 }: {
   deleteOnly?: boolean
   serverURL: string
-  snapshotKey: string
+  /** @deprecated Supplied only by configs that have not migrated to the fixture yet. */
+  snapshotKey?: string
+  /** @deprecated Upload directories are inferred by migrated configs. */
   uploadsDir?: string | string[]
 }) => {
   const maxAttempts = 50
@@ -24,9 +26,9 @@ export const reInitializeDB = async ({
 
       const queryParams = qs.stringify(
         {
+          deleteOnly,
           snapshotKey,
           uploadsDir,
-          deleteOnly,
         },
         {
           addQueryPrefix: true,
@@ -36,10 +38,10 @@ export const reInitializeDB = async ({
       const response = await fetch(
         formatAdminURL({ apiRoute: '/api', path: `${path}${queryParams}`, serverURL }),
         {
-          method: 'get',
           headers: {
             'Content-Type': 'application/json',
           },
+          method: snapshotKey === undefined && uploadsDir === undefined ? 'post' : 'get',
         },
       )
 

--- a/test/__helpers/shared/clearAndSeed/reInitializeDB.ts
+++ b/test/__helpers/shared/clearAndSeed/reInitializeDB.ts
@@ -46,7 +46,9 @@ export const reInitializeDB = async ({
       )
 
       if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`)
+        const message = await getErrorMessage(response)
+
+        throw new Error(`HTTP error! status: ${response.status}${message ? `; ${message}` : ''}`)
       }
 
       const timeTaken = Date.now() - startTime
@@ -65,4 +67,23 @@ export const reInitializeDB = async ({
       attempt++
     }
   }
+}
+
+const getErrorMessage = async (response: Response): Promise<string | undefined> => {
+  try {
+    const body: unknown = await response.json()
+
+    if (
+      body !== null &&
+      typeof body === 'object' &&
+      'message' in body &&
+      typeof body.message === 'string'
+    ) {
+      return body.message
+    }
+  } catch {
+    // The response may not be JSON if the application server itself failed.
+  }
+
+  return undefined
 }

--- a/test/__helpers/shared/clearAndSeed/reInitializeDB.ts
+++ b/test/__helpers/shared/clearAndSeed/reInitializeDB.ts
@@ -21,21 +21,23 @@ export const reInitializeDB = async ({
   const startTime = Date.now()
 
   while (attempt <= maxAttempts) {
+    console.log(`Attempting to reinitialize DB (attempt ${attempt}/${maxAttempts})...`)
+
+    const queryParams = qs.stringify(
+      {
+        deleteOnly,
+        snapshotKey,
+        uploadsDir,
+      },
+      {
+        addQueryPrefix: true,
+      },
+    )
+
+    let response: Response
+
     try {
-      console.log(`Attempting to reinitialize DB (attempt ${attempt}/${maxAttempts})...`)
-
-      const queryParams = qs.stringify(
-        {
-          deleteOnly,
-          snapshotKey,
-          uploadsDir,
-        },
-        {
-          addQueryPrefix: true,
-        },
-      )
-
-      const response = await fetch(
+      response = await fetch(
         formatAdminURL({ apiRoute: '/api', path: `${path}${queryParams}`, serverURL }),
         {
           headers: {
@@ -44,16 +46,6 @@ export const reInitializeDB = async ({
           method: snapshotKey === undefined && uploadsDir === undefined ? 'post' : 'get',
         },
       )
-
-      if (!response.ok) {
-        const message = await getErrorMessage(response)
-
-        throw new Error(`HTTP error! status: ${response.status}${message ? `; ${message}` : ''}`)
-      }
-
-      const timeTaken = Date.now() - startTime
-      console.log(`Successfully reinitialized DB (took ${timeTaken}ms)`)
-      return
     } catch (error) {
       console.error(`Failed to reinitialize DB`, error)
 
@@ -65,7 +57,18 @@ export const reInitializeDB = async ({
       console.log('Retrying in 3 seconds...')
       await new Promise((resolve) => setTimeout(resolve, 3000))
       attempt++
+      continue
     }
+
+    if (!response.ok) {
+      const message = await getErrorMessage(response)
+
+      throw new Error(`HTTP error! status: ${response.status}${message ? `; ${message}` : ''}`)
+    }
+
+    const timeTaken = Date.now() - startTime
+    console.log(`Successfully reinitialized DB (took ${timeTaken}ms)`)
+    return
   }
 }
 

--- a/test/__helpers/shared/clearAndSeed/reset.ts
+++ b/test/__helpers/shared/clearAndSeed/reset.ts
@@ -23,26 +23,43 @@ export async function resetDB(_payload: Payload, collectionSlugs: string[]) {
     }
   } else if ('drizzle' in _payload.db) {
     const db = _payload.db as unknown as DrizzleAdapter
+    // Fixture writes must target the primary when the adapter has read replicas.
+    const drizzle = db.primaryDrizzle ?? db.drizzle
 
-    // Alternative to: await db.drizzle.execute(sql`drop schema public cascade; create schema public;`)
-
-    // Deleting the schema causes issues when restoring the database from a snapshot later on. That's why we only delete the table data here,
-    // To avoid having to re-create any table schemas / indexes / whatever
-    const schema = db.drizzle._.schema
-    if (!schema) {
+    // Preserve the schema so cached snapshots can be restored without rebuilding tables or indexes.
+    const tableNames = Object.keys(db.tables)
+    if (!tableNames.length) {
       return
     }
 
-    const queries = Object.values(schema)
-      .map((table: any) => {
-        return `DELETE FROM ${db.schemaName ? db.schemaName + '.' : ''}${table.dbName};`
-      })
-      .join('')
+    const schemaPrefix = db.schemaName ? `"${db.schemaName.replaceAll('"', '""')}".` : ''
+    const tableReferences = tableNames.map((tableName) => {
+      const escapedTableName = tableName.replaceAll('"', '""')
 
-    await db.execute({
-      drizzle: db.drizzle,
-      raw: queries,
+      return `${schemaPrefix}"${escapedTableName}"`
     })
+
+    if (db.name === 'postgres') {
+      await db.execute({
+        drizzle,
+        raw: `TRUNCATE TABLE ${tableReferences.join(',')} CONTINUE IDENTITY CASCADE;`,
+      })
+    } else {
+      await db.execute({ drizzle, raw: 'PRAGMA foreign_keys = off' })
+
+      try {
+        for (const tableReference of tableReferences) {
+          await db.execute({ drizzle, raw: `DELETE FROM ${tableReference};` })
+        }
+      } finally {
+        await db.execute({ drizzle, raw: 'PRAGMA foreign_keys = on' })
+      }
+    }
+
+    if (db.primaryDrizzle) {
+      // Keep subsequent test reads on the primary until the replica catches up.
+      db.lastWriteTimestamp = Date.now()
+    }
   } else if (
     'clearDatabase' in _payload.db &&
     typeof (_payload.db as any).clearDatabase === 'function'

--- a/test/__helpers/shared/clearAndSeed/resetAndSeed.ts
+++ b/test/__helpers/shared/clearAndSeed/resetAndSeed.ts
@@ -1,0 +1,28 @@
+import type { Payload } from 'payload'
+
+import type { TestDataConfig } from './testDataConfig.js'
+
+import { getUploadDirectories } from './getUploadDirectories.js'
+import { seedDB } from './seed.js'
+
+export const resetAndSeed = async ({
+  alwaysSeed,
+  deleteOnly,
+  payload,
+  seed,
+  suite,
+}: {
+  alwaysSeed?: boolean
+  deleteOnly?: boolean
+  payload: Payload
+} & TestDataConfig): Promise<void> => {
+  await seedDB({
+    _payload: payload,
+    alwaysSeed,
+    collectionSlugs: payload.config.collections.map(({ slug }) => slug),
+    deleteOnly,
+    seedFunction: seed,
+    snapshotKey: suite,
+    uploadsDir: getUploadDirectories({ payload }),
+  })
+}

--- a/test/__helpers/shared/clearAndSeed/seed.ts
+++ b/test/__helpers/shared/clearAndSeed/seed.ts
@@ -3,11 +3,11 @@ import * as os from 'node:os'
 import path from 'path'
 import { type Payload } from 'payload'
 
+import type { SeedFunction } from './testDataConfig.js'
+
 import { isErrorWithCode } from '../isErrorWithCode.js'
 import { resetDB } from './reset.js'
 import { createSnapshot, dbSnapshot, restoreFromSnapshot, uploadsDirCache } from './snapshot.js'
-
-type SeedFunction = (_payload: Payload) => Promise<void> | void
 
 export async function seedDB({
   _payload,
@@ -25,20 +25,53 @@ export async function seedDB({
   alwaysSeed?: boolean
   collectionSlugs: string[]
   deleteOnly?: boolean
-  seedFunction: SeedFunction
+  seedFunction?: SeedFunction
   /**
    * Key to uniquely identify the kind of snapshot. Each test suite should pass in a unique key
    */
   snapshotKey: string
   uploadsDir?: string | string[]
 }) {
+  const invalidateSnapshot = () => {
+    delete dbSnapshot[snapshotKey]
+    delete uploadsDirCache[snapshotKey]
+  }
+
+  const resetDatabase = async (): Promise<boolean> => {
+    try {
+      await resetDB(_payload, collectionSlugs)
+      return false
+    } catch (initialResetError) {
+      // Some database integration tests intentionally mutate or drop their schema.
+      // Reinitialize it once and retry so the next test still starts from a known-clean state.
+      if (!('drizzle' in _payload.db)) {
+        throw initialResetError
+      }
+
+      const previousForcePush = process.env.PAYLOAD_FORCE_DRIZZLE_PUSH
+      process.env.PAYLOAD_FORCE_DRIZZLE_PUSH = 'true'
+
+      try {
+        await _payload.db.init()
+        await _payload.db.connect()
+      } finally {
+        if (previousForcePush === undefined) {
+          delete process.env.PAYLOAD_FORCE_DRIZZLE_PUSH
+        } else {
+          process.env.PAYLOAD_FORCE_DRIZZLE_PUSH = previousForcePush
+        }
+      }
+
+      await resetDB(_payload, collectionSlugs)
+      return true
+    }
+  }
+
   /**
    * Reset database
    */
-  try {
-    await resetDB(_payload, collectionSlugs)
-  } catch (error) {
-    console.error('Error in operation (resetting database):', error)
+  if (await resetDatabase()) {
+    invalidateSnapshot()
   }
   /**
    * Delete uploads directory if it exists
@@ -70,7 +103,7 @@ export async function seedDB({
    * Mongoose & Postgres: Restore snapshot of old data if available
    *
    * Note for postgres: For postgres, this needs to happen AFTER the tables were created.
-   * This does not work if I run payload.db.init or payload.db.connect anywhere. Thus, when resetting the database, we are not dropping the schema, but are instead only deleting the table values
+   * The reset preserves the schema so the cached rows can be restored without rebuilding it.
    */
   let restored = false
   if (
@@ -79,25 +112,27 @@ export async function seedDB({
     Object.keys(dbSnapshot[snapshotKey]).length &&
     !deleteOnly
   ) {
-    await restoreFromSnapshot(_payload, snapshotKey, collectionSlugs)
+    try {
+      await restoreFromSnapshot(_payload, snapshotKey, collectionSlugs)
 
-    /**
-     * Restore uploads dir if it exists
-     */
-    if (uploadsDirCache[snapshotKey]) {
-      for (const cache of uploadsDirCache[snapshotKey]) {
-        if (cache.originalDir && fs.existsSync(cache.cacheDir)) {
-          try {
+      /**
+       * Restore uploads dir if it exists
+       */
+      if (uploadsDirCache[snapshotKey]) {
+        for (const cache of uploadsDirCache[snapshotKey]) {
+          if (cache.originalDir && fs.existsSync(cache.cacheDir)) {
             fs.cpSync(cache.cacheDir, cache.originalDir, { recursive: true })
-          } catch (err) {
-            console.error('Error in operation (restoring uploads dir):', err)
-            throw err
           }
         }
       }
-    }
 
-    restored = true
+      restored = true
+    } catch {
+      // Snapshots are only a test-speed optimization. If a test changed the schema or adapter
+      // state, discard the stale cache and rebuild the canonical state with the seed function.
+      invalidateSnapshot()
+      await resetDatabase()
+    }
   }
 
   /**

--- a/test/__helpers/shared/clearAndSeed/seedCommand.ts
+++ b/test/__helpers/shared/clearAndSeed/seedCommand.ts
@@ -1,0 +1,26 @@
+import { strictObject } from 'payload'
+import { defineCLICommand } from 'payload/cli'
+
+import type { TestDataConfig } from './testDataConfig.js'
+
+import { resetAndSeed } from './resetAndSeed.js'
+
+export const createSeedCommand = ({ seed, suite }: TestDataConfig) =>
+  defineCLICommand({
+    description: `${seed ? 'Reset and seed' : 'Reset'} the ${suite} test suite database.`,
+    handler: async ({ getPayload }) => {
+      const payload = await getPayload()
+
+      await resetAndSeed({
+        alwaysSeed: true,
+        payload,
+        seed,
+        suite,
+      })
+
+      payload.logger.info(
+        `${seed ? 'Reset and seeded' : 'Reset'} the ${suite} test suite database.`,
+      )
+    },
+    input: strictObject({}),
+  })

--- a/test/__helpers/shared/clearAndSeed/snapshot.ts
+++ b/test/__helpers/shared/clearAndSeed/snapshot.ts
@@ -1,10 +1,6 @@
 import type { PostgresAdapter } from '@payloadcms/db-postgres'
 import type { SQLiteAdapter } from '@payloadcms/db-sqlite'
-import type { PgTable } from 'drizzle-orm/pg-core'
-import type { SQLiteTable } from 'drizzle-orm/sqlite-core'
 import type { Payload } from 'payload'
-
-import { sql } from 'drizzle-orm'
 
 import { isMongoose } from '../isMongoose.js'
 
@@ -46,15 +42,15 @@ async function restoreFromMongooseSnapshot(collectionsObj, snapshotKey: string) 
 
 async function createDrizzleSnapshot(db: PostgresAdapter | SQLiteAdapter, snapshotKey: string) {
   const snapshot = {}
+  // Capture the freshly seeded primary state instead of a potentially stale replica.
+  const drizzle = db.primaryDrizzle ?? db.drizzle
 
-  const schema: Record<string, PgTable | SQLiteTable> = db.drizzle._.schema
-  if (!schema) {
+  if (!Object.keys(db.tables).length) {
     return
   }
 
-  for (const tableName in schema) {
-    const table = db.drizzle.query[tableName]['fullSchema'][tableName] //db.drizzle._.schema[tableName]
-    const records = await db.drizzle.select().from(table).execute()
+  for (const [tableName, table] of Object.entries(db.tables)) {
+    const records = await drizzle.select().from(table).execute()
     snapshot[tableName] = records
   }
 
@@ -69,6 +65,7 @@ async function restoreFromDrizzleSnapshot(
     throw new Error('No snapshot found to restore from.')
   }
   const db = adapter.name === 'postgres' ? (adapter as PostgresAdapter) : (adapter as SQLiteAdapter)
+  const drizzle = db.primaryDrizzle ?? db.drizzle
   let disableFKConstraintChecksQuery
   let enableFKConstraintChecksQuery
 
@@ -84,29 +81,27 @@ async function restoreFromDrizzleSnapshot(
   // Temporarily disable foreign key constraint checks
   try {
     await db.execute({
-      drizzle: db.drizzle,
+      drizzle,
       raw: disableFKConstraintChecksQuery,
     })
     for (const tableName in dbSnapshot[snapshotKey]) {
-      const table = db.drizzle.query[tableName]['fullSchema'][tableName]
-      await db.execute({
-        drizzle: db.drizzle,
-        sql: sql`DELETE FROM ${table}`,
-      }) // This deletes all records from the table. Probably not necessary, as I'm deleting the table before restoring anyways
-
+      const table = db.tables[tableName]
       const records = dbSnapshot[snapshotKey][tableName]
       if (records.length > 0) {
-        await db.drizzle.insert(table).values(records).execute()
+        await drizzle.insert(table).values(records).execute()
       }
     }
-  } catch (e) {
-    console.error(e)
   } finally {
     // Re-enable foreign key constraint checks
     await db.execute({
-      drizzle: db.drizzle,
+      drizzle,
       raw: enableFKConstraintChecksQuery,
     })
+  }
+
+  if (db.primaryDrizzle) {
+    // Keep subsequent test reads on the primary until the replica catches up.
+    db.lastWriteTimestamp = Date.now()
   }
 }
 

--- a/test/__helpers/shared/clearAndSeed/testDataConfig.ts
+++ b/test/__helpers/shared/clearAndSeed/testDataConfig.ts
@@ -1,0 +1,18 @@
+import type { Payload, SanitizedConfig } from 'payload'
+
+export type SeedFunction = (payload: Payload) => Promise<void> | void
+
+export type TestDataConfig = {
+  seed?: SeedFunction
+  suite: string
+}
+
+export const testDataConfigSymbol: unique symbol = Symbol('testDataConfig')
+
+type ConfigWithTestData = {
+  [testDataConfigSymbol]?: TestDataConfig
+} & SanitizedConfig
+
+export const getTestDataConfig = (config: SanitizedConfig): TestDataConfig | undefined => {
+  return (config as ConfigWithTestData)[testDataConfigSymbol]
+}

--- a/test/buildConfigWithDefaults.ts
+++ b/test/buildConfigWithDefaults.ts
@@ -31,7 +31,15 @@ import { en } from 'payload/i18n/en'
 import { es } from 'payload/i18n/es'
 import sharp from 'sharp'
 
-import { reInitEndpoint } from './__helpers/shared/clearAndSeed/reInitEndpoint.js'
+import {
+  createReInitEndpoint,
+  reInitEndpoint,
+} from './__helpers/shared/clearAndSeed/reInitEndpoint.js'
+import { createSeedCommand } from './__helpers/shared/clearAndSeed/seedCommand.js'
+import {
+  type SeedFunction,
+  testDataConfigSymbol,
+} from './__helpers/shared/clearAndSeed/testDataConfig.js'
 import { localAPIEndpoint } from './__helpers/shared/sdk/endpoint.js'
 import { databaseAdapter } from './databaseAdapter.js'
 import { testEmailAdapter } from './testEmailAdapter.js'
@@ -40,12 +48,35 @@ import { testEmailAdapter } from './testEmailAdapter.js'
 // process.env.PAYLOAD_DATABASE = 'postgres'
 // process.env.PAYLOAD_DATABASE = 'sqlite'
 
-export async function buildConfigWithDefaults(
+type BuildConfigWithDefaultsArgs = {
+  config: Partial<Config>
+  disableAutoLogin?: boolean
+  seed?: SeedFunction
+  suite: string
+}
+
+type LegacyBuildConfigWithDefaultsOptions = {
+  disableAutoLogin?: boolean
+}
+
+export function buildConfigWithDefaults(args: BuildConfigWithDefaultsArgs): Promise<SanitizedConfig>
+/** @deprecated Use `buildConfigWithDefaults({ config, disableAutoLogin, seed, suite })`. */
+export function buildConfigWithDefaults(
   testConfig?: Partial<Config>,
-  options?: {
-    disableAutoLogin?: boolean
-  },
+  options?: LegacyBuildConfigWithDefaultsOptions,
+): Promise<SanitizedConfig>
+export async function buildConfigWithDefaults(
+  argsOrConfig: BuildConfigWithDefaultsArgs | Partial<Config> = {},
+  legacyOptions: LegacyBuildConfigWithDefaultsOptions = {},
 ): Promise<SanitizedConfig> {
+  const usesTestDataConfig = 'config' in argsOrConfig && 'suite' in argsOrConfig
+  const testConfig = usesTestDataConfig ? argsOrConfig.config : argsOrConfig
+  const disableAutoLogin = usesTestDataConfig
+    ? argsOrConfig.disableAutoLogin
+    : legacyOptions.disableAutoLogin
+  const testDataConfig = usesTestDataConfig
+    ? { seed: argsOrConfig.seed, suite: argsOrConfig.suite }
+    : undefined
   const config: Config = {
     db: databaseAdapter,
     editor: lexicalEditor({
@@ -135,7 +166,11 @@ export async function buildConfigWithDefaults(
     sharp,
     telemetry: false,
     ...testConfig,
-    endpoints: [localAPIEndpoint, reInitEndpoint, ...(testConfig?.endpoints || [])],
+    endpoints: [
+      localAPIEndpoint,
+      testDataConfig ? createReInitEndpoint(testDataConfig) : reInitEndpoint,
+      ...(testConfig?.endpoints || []),
+    ],
     i18n: {
       supportedLanguages: {
         de,
@@ -160,7 +195,7 @@ export async function buildConfigWithDefaults(
 
   if (config.admin.autoLogin === undefined) {
     config.admin.autoLogin =
-      process.env.PAYLOAD_PUBLIC_DISABLE_AUTO_LOGIN === 'true' || options?.disableAutoLogin
+      process.env.PAYLOAD_PUBLIC_DISABLE_AUTO_LOGIN === 'true' || disableAutoLogin
         ? false
         : {
             email: 'dev@payloadcms.com',
@@ -181,5 +216,24 @@ export async function buildConfigWithDefaults(
     config.plugins = [...(config.plugins ?? []), mcpPlugin({})]
   }
 
-  return await buildConfig(config)
+  if (config.cli !== false && testDataConfig) {
+    config.cli = {
+      ...config.cli,
+      commands: {
+        ...config.cli?.commands,
+        seed: createSeedCommand(testDataConfig),
+      },
+    }
+  }
+
+  const sanitizedConfig = await buildConfig(config)
+
+  if (testDataConfig) {
+    Object.defineProperty(sanitizedConfig, testDataConfigSymbol, {
+      enumerable: false,
+      value: testDataConfig,
+    })
+  }
+
+  return sanitizedConfig
 }

--- a/test/dev.ts
+++ b/test/dev.ts
@@ -35,7 +35,10 @@ const {
 } = minimist(process.argv.slice(2), {
   // Treat framework flags as boolean so a trailing suite positional
   // (e.g. `--framework-tanstack-start admin`) isn't consumed as the flag's value.
-  boolean: ['framework-next', 'framework-tanstack-start'],
+  boolean: ['framework-next', 'framework-tanstack-start', 'seed'],
+  default: {
+    seed: true,
+  },
 })
 
 let testSuiteArg: string | undefined
@@ -162,6 +165,18 @@ if (args.o) {
 }
 
 process.env.PAYLOAD_DROP_DATABASE = process.env.PAYLOAD_DROP_DATABASE === 'false' ? 'false' : 'true'
+
+if (args.seed !== false) {
+  const response = await fetch(`http://localhost:${serverResult.port}/api/re-initialize`, {
+    method: 'POST',
+  })
+
+  if (response.ok) {
+    console.log(`✓ Seeded ${testSuiteArg}`)
+  } else if (response.status !== 404) {
+    throw new Error(`Failed to seed ${testSuiteArg}: ${response.status} ${await response.text()}`)
+  }
+}
 
 void fetch(`http://localhost:${serverResult.port}${serverResult.adminRoute}`).catch(() => {})
 void fetch(`http://localhost:${serverResult.port}/api/access`).catch(() => {})

--- a/test/eslint.config.js
+++ b/test/eslint.config.js
@@ -42,7 +42,7 @@ export const testEslintConfig = [
         // Ensures the eslint plugin recognizes our custom `it`/`test` wrappers:
         // - `test/__helpers/int/vitest.ts` (db-aware wrapper)
         // - any suite-local `helpers/**/*Fixtures.ts` re-exporting an `it` extended via `test.extend()`
-        vitestImports: [/helpers\/int\/vitest/, /helpers\/.*Fixtures/],
+        vitestImports: [/int\/vitest/, /helpers\/.*Fixtures/],
       },
     },
     rules: {

--- a/test/runE2E.ts
+++ b/test/runE2E.ts
@@ -191,6 +191,7 @@ async function executePlaywright({
   if (!turbo) {
     spawnDevArgs.push('--no-turbo')
   }
+  spawnDevArgs.push('--no-seed')
 
   process.env.START_MEMORY_DB = 'true'
 
@@ -228,6 +229,8 @@ async function executePlaywright({
   if (prodServer && !portInUse) {
     await waitForServer(e2ePort)
   }
+
+  await resetServer(e2ePort)
 
   const shardFlag = shardArg ? ` --shard=${shardArg}` : ''
   const fullyParallelFlag = fullyParallelArg ? ' --fully-parallel' : ''
@@ -321,4 +324,26 @@ async function waitForServer(port: number, timeoutMs = 8 * 60 * 1000): Promise<v
   }
 
   throw new Error(`Prod server did not start within ${timeoutMs / 1000}s`)
+}
+
+async function resetServer(port: number, timeoutMs = 8 * 60 * 1000): Promise<void> {
+  const url = `http://localhost:${port}/api/re-initialize`
+  const start = Date.now()
+  console.log(`Waiting to reset test data at ${url} …`)
+
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const response = await fetch(url, { method: 'POST' })
+
+      if (response.ok || response.status === 404) {
+        return
+      }
+
+      throw new Error(`${response.status} ${await response.text()}`)
+    } catch {
+      await new Promise((resolve) => setTimeout(resolve, 1000))
+    }
+  }
+
+  throw new Error(`Timed out waiting to reset test data at ${url}`)
 }

--- a/test/runE2E.ts
+++ b/test/runE2E.ts
@@ -329,21 +329,29 @@ async function waitForServer(port: number, timeoutMs = 8 * 60 * 1000): Promise<v
 async function resetServer(port: number, timeoutMs = 8 * 60 * 1000): Promise<void> {
   const url = `http://localhost:${port}/api/re-initialize`
   const start = Date.now()
+  let lastConnectionError: unknown
   console.log(`Waiting to reset test data at ${url} …`)
 
   while (Date.now() - start < timeoutMs) {
+    let response: Response
+
     try {
-      const response = await fetch(url, { method: 'POST' })
-
-      if (response.ok || response.status === 404) {
-        return
-      }
-
-      throw new Error(`${response.status} ${await response.text()}`)
-    } catch {
+      response = await fetch(url, { method: 'POST' })
+    } catch (error) {
+      lastConnectionError = error
       await new Promise((resolve) => setTimeout(resolve, 1000))
+      continue
     }
+
+    if (response.ok || response.status === 404) {
+      return
+    }
+
+    throw new Error(`Failed to reset test data: ${response.status} ${await response.text()}`)
   }
 
-  throw new Error(`Timed out waiting to reset test data at ${url}`)
+  const connectionError =
+    lastConnectionError instanceof Error ? `: ${lastConnectionError.message}` : ''
+
+  throw new Error(`Timed out waiting to reset test data at ${url}${connectionError}`)
 }


### PR DESCRIPTION
## What?

Moves integration-test setup out of Payload config `onInit` hooks and into explicit Vitest fixtures.

This introduces `test.suite({ config, db?, cron? })` as the root wrapper for an integration test file. The wrapper supplies the Payload config to every test inside it and preserves the existing database filtering API.

It also adds the object form of `buildConfigWithDefaults`:

```ts
buildConfigWithDefaults({
  suite: 'posts',
  config: { collections: [Posts] },
  seed,
})
```

The built config stores its reset/seed metadata, infers upload directories from configured upload collections, and registers both the `/api/re-initialize` endpoint and `seed` CLI command. Dev and E2E startup use the same reset-and-seed operation.

### Before

A representative seeded suite had to coordinate its config and test hooks manually:

```ts
// config.ts
export default buildConfigWithDefaults({
  collections: [Posts],
  onInit: async (payload) => {
    if (process.env.SEED_IN_CONFIG_ONINIT !== 'false') {
      await seed(payload)
    }
  },
})

// int.spec.ts
let payload: Payload
let restClient: NextRESTClient

describe('posts', () => {
  beforeAll(async () => {
    process.env.SEED_IN_CONFIG_ONINIT = 'false'
    ;({ payload, restClient } = await initPayloadInt(dirname))
  })

  beforeEach(async () => {
    await clearAndSeedEverything(payload)
  })

  afterAll(async () => {
    await payload.destroy()
  })

  it('lists seeded posts', async () => {
    // Uses the module-scoped Payload and REST client.
  })
})
```

### After

```ts
// config.ts
export default buildConfigWithDefaults({
  suite: 'posts',
  config: { collections: [Posts] },
  seed,
})

// int.spec.ts
import testConfig from './config.js'

test.suite({ config: testConfig })('posts', () => {
  test('lists seeded posts', async ({ payload, restClient }) => {
    // Reset and seed run exactly once before this test.
  })
})
```

### Lifecycle

| Scope | Responsibility |
| --- | --- |
| File | Lazily create one Payload instance |
| Test | Reset the database and uploads, then run the optional seed before using Payload |
| File teardown | Destroy the Payload instance |

```text
payloadInstance // file-scoped
  getPayload()
  └─ destroy after the file finishes

payload // test-scoped
  resetAndSeed(payloadInstance)
  └─ return payloadInstance

restClient -> payload
sdk        -> payload
```

Vitest resolves the test-scoped `payload` fixture once per test, so requesting both `payload` and `restClient` does not reset twice. A test that does not use `payload`, `restClient`, or `sdk` does not initialize or reset Payload.

The legacy fixture and config-builder paths remain available in this PR so existing integration suites continue to run while they are migrated.

## Why?

Seeding through `onInit` is not idempotent: it can fail when Payload starts twice against the same database and requires environment-variable opt-outs for suites that must skip it. Manual setup hooks also make test isolation inconsistent.

This lifecycle gives every Payload-backed test the same reset guarantee, including suites without a seed function and tests that create their own data.

Part 1 of stack #17993.
