### PR TITLE
test: migrate integration suites (2/5)

### DIFF
--- a/test/__helpers/int/configImport.config.ts
+++ b/test/__helpers/int/configImport.config.ts
@@ -1,0 +1,5 @@
+import type { SanitizedConfig } from 'payload'
+
+process.env.PAYLOAD_TEST_CONFIG_IMPORTED = 'true'
+
+export default Promise.resolve({} as SanitizedConfig)

--- a/test/__helpers/int/configImport.int.spec.ts
+++ b/test/__helpers/int/configImport.int.spec.ts
@@ -1,0 +1,17 @@
+import { expect } from 'vitest'
+
+import { test } from './vitest.js'
+
+test.suite({ config: './configImport.config.ts' })('integration config fixture', () => {
+  test.beforeAll(() => {
+    expect(process.env.PAYLOAD_TEST_CONFIG_IMPORTED).toBe('true')
+  })
+
+  test.afterAll(() => {
+    delete process.env.PAYLOAD_TEST_CONFIG_IMPORTED
+  })
+
+  test('keeps the automatically imported config available to tests', () => {
+    expect(process.env.PAYLOAD_TEST_CONFIG_IMPORTED).toBe('true')
+  })
+})

--- a/test/__helpers/int/vitest.ts
+++ b/test/__helpers/int/vitest.ts
@@ -31,6 +31,8 @@ type IntegrationFixtures = {
     configPath: null | string
     /** Raw file-scoped instance for suite hooks. Tests should use `payload`. */
     payloadInstance: Payload
+    /** Config supplied to `test.suite`, imported automatically before file hooks run. */
+    resolvedConfig: null | SanitizedConfig
     testCron: boolean
     testDir: string
     testSuiteConfigured: boolean
@@ -65,7 +67,7 @@ const testWithFixtures = vitestTest.extend<IntegrationFixtures>({
     }
   },
   config: [
-    async ({ configPath, testDir, testSuiteConfigured }, use) => {
+    async ({ resolvedConfig, testDir, testSuiteConfigured }, use) => {
       if (!testSuiteConfigured) {
         const { config } = await initPayloadInt(testDir, undefined, false)
 
@@ -73,17 +75,13 @@ const testWithFixtures = vitestTest.extend<IntegrationFixtures>({
         return
       }
 
-      if (configPath === null) {
+      if (resolvedConfig === null) {
         throw new Error(
           "This integration test requires Payload. Pass its config path to test.suite({ config: './config.ts' })(...).",
         )
       }
 
-      const { default: config } = (await import(configPath)) as {
-        default: Promise<SanitizedConfig> | SanitizedConfig
-      }
-
-      await use(await config)
+      await use(resolvedConfig)
     },
     { scope: 'file' },
   ],
@@ -122,6 +120,21 @@ const testWithFixtures = vitestTest.extend<IntegrationFixtures>({
   restClient: async ({ payload }, use) => {
     await use(new NextRESTClient(payload.config))
   },
+  resolvedConfig: [
+    async ({ configPath }, use) => {
+      if (configPath === null) {
+        await use(null)
+        return
+      }
+
+      const { default: config } = (await import(configPath)) as {
+        default: Promise<SanitizedConfig> | SanitizedConfig
+      }
+
+      await use(await config)
+    },
+    { auto: true, scope: 'file' },
+  ],
   sdk: async ({ payload }, use) => {
     await use(getSDK(payload.config))
   },
@@ -151,11 +164,12 @@ const testWithFixtures = vitestTest.extend<IntegrationFixtures>({
 /**
  * Integration test API with Payload's shared lifecycle and database filtering.
  *
- * Payload-backed test files supply their config to one root `test.suite`. Payload is initialized
- * lazily, once per file, and destroyed afterward. Before every test that uses Payload, REST, or the
- * SDK, the database and upload directories are reset and the suite's optional seed function is run.
- * REST and SDK clients are recreated per test. Standalone integration tests use `test.suite({})` and
- * do not initialize Payload.
+ * Payload-backed test files supply their config to one root `test.suite`. The config module is
+ * imported once before file hooks run. Payload is initialized lazily, once per file, and destroyed
+ * afterward. Before every test that uses Payload, REST, or the SDK, the database and upload
+ * directories are reset and the suite's optional seed function is run. REST and SDK clients are
+ * recreated per test. Standalone integration tests use `test.suite({})` and do not initialize
+ * Payload.
  *
  * @example
  * test.suite({ config: './config.ts' })('Posts', () => {

--- a/test/group-by/config.ts
+++ b/test/group-by/config.ts
@@ -15,26 +15,25 @@ const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
 export default buildConfigWithDefaults({
-  collections: [
-    PagesCollection,
-    PostsCollection,
-    CategoriesCollection,
-    MediaCollection,
-    RelationshipsCollection,
-    NoGroupableCollection,
-  ],
-  admin: {
-    importMap: {
-      baseDir: path.resolve(dirname),
+  suite: 'group-by',
+  config: {
+    admin: {
+      importMap: {
+        baseDir: path.resolve(dirname),
+      },
+    },
+    collections: [
+      PagesCollection,
+      PostsCollection,
+      CategoriesCollection,
+      MediaCollection,
+      RelationshipsCollection,
+      NoGroupableCollection,
+    ],
+    editor: lexicalEditor({}),
+    typescript: {
+      outputFile: path.resolve(dirname, 'payload-types.ts'),
     },
   },
-  editor: lexicalEditor({}),
-  onInit: async (payload) => {
-    if (process.env.SEED_IN_CONFIG_ONINIT !== 'false') {
-      await seed(payload)
-    }
-  },
-  typescript: {
-    outputFile: path.resolve(dirname, 'payload-types.ts'),
-  },
+  seed,
 })

--- a/test/group-by/e2e.spec.ts
+++ b/test/group-by/e2e.spec.ts
@@ -77,7 +77,6 @@ test.describe('Group By', () => {
 
     await reInitializeDB({
       serverURL,
-      snapshotKey: 'groupByTests',
     })
 
     await ensureCompilationIsDone({ page, serverURL })

--- a/test/i18n/config.ts
+++ b/test/i18n/config.ts
@@ -31,88 +31,94 @@ export type CustomTranslationsObject = typeof customTranslationsObject.en
 export type CustomTranslationsKeys = NestedKeysStripped<CustomTranslationsObject>
 
 export default buildConfigWithDefaults({
-  admin: {
-    importMap: {
-      baseDir: path.resolve(dirname),
-    },
-    components: {
-      afterDashboard: [
-        '/ComponentWithDefaultI18n.js#ComponentWithDefaultI18n',
-        '/ComponentWithCustomI18n.js#ComponentWithCustomI18n',
-      ],
-    },
-  },
-  collections: [
-    {
-      slug: 'collection1',
-      labels: {
-        singular: {
-          en: 'EN Collection 1',
-          es: 'ES Collection 1',
-        },
-        plural: {
-          en: 'EN Collection 1s',
-          es: 'ES Collection 1s',
-        },
+  suite: 'i18n',
+  config: {
+    admin: {
+      components: {
+        afterDashboard: [
+          '/ComponentWithDefaultI18n.js#ComponentWithDefaultI18n',
+          '/ComponentWithCustomI18n.js#ComponentWithCustomI18n',
+        ],
       },
-      fields: [
-        {
-          name: 'i18nFieldLabel',
-          type: 'text',
-          label: {
-            en: 'en-label',
-            es: 'es-label',
+      importMap: {
+        baseDir: path.resolve(dirname),
+      },
+    },
+    collections: [
+      {
+        slug: 'collection1',
+        fields: [
+          {
+            name: 'i18nFieldLabel',
+            type: 'text',
+            label: {
+              en: 'en-label',
+              es: 'es-label',
+            },
+          },
+          {
+            name: 'fieldDefaultI18nValid',
+            type: 'text',
+            label: ({ t }) => t('fields:addLabel'),
+          },
+          {
+            name: 'fieldDefaultI18nInvalid',
+            type: 'text',
+            // @ts-expect-error // Keep the ts-expect-error comment. This NEEDS to throw an error
+            label: ({ t }) => t('fields:addLabel2'),
+          },
+          {
+            name: 'fieldCustomI18nValidDefault',
+            type: 'text',
+            label: ({ t }: { t: TFunction<CustomTranslationsKeys | DefaultTranslationKeys> }) =>
+              t('fields:addLabel'),
+          },
+          {
+            name: 'fieldCustomI18nValidCustom',
+            type: 'text',
+            label: ({ t }: { t: TFunction<CustomTranslationsKeys | DefaultTranslationKeys> }) =>
+              t('general:test'),
+          },
+          {
+            name: 'fieldCustomI18nInvalid',
+            type: 'text',
+            label: ({ t }: { t: TFunction<CustomTranslationsKeys | DefaultTranslationKeys> }) =>
+              // @ts-expect-error // Keep the ts-expect-error comment. This NEEDS to throw an error
+              t('fields:addLabel2'),
+          },
+        ],
+        labels: {
+          plural: {
+            en: 'EN Collection 1s',
+            es: 'ES Collection 1s',
+          },
+          singular: {
+            en: 'EN Collection 1',
+            es: 'ES Collection 1',
           },
         },
-        {
-          name: 'fieldDefaultI18nValid',
-          type: 'text',
-          label: ({ t }) => t('fields:addLabel'),
-        },
-        {
-          name: 'fieldDefaultI18nInvalid',
-          type: 'text',
-          // @ts-expect-error // Keep the ts-expect-error comment. This NEEDS to throw an error
-          label: ({ t }) => t('fields:addLabel2'),
-        },
-        {
-          name: 'fieldCustomI18nValidDefault',
-          type: 'text',
-          label: ({ t }: { t: TFunction<CustomTranslationsKeys | DefaultTranslationKeys> }) =>
-            t('fields:addLabel'),
-        },
-        {
-          name: 'fieldCustomI18nValidCustom',
-          type: 'text',
-          label: ({ t }: { t: TFunction<CustomTranslationsKeys | DefaultTranslationKeys> }) =>
-            t('general:test'),
-        },
-        {
-          name: 'fieldCustomI18nInvalid',
-          type: 'text',
-          label: ({ t }: { t: TFunction<CustomTranslationsKeys | DefaultTranslationKeys> }) =>
-            // @ts-expect-error // Keep the ts-expect-error comment. This NEEDS to throw an error
-            t('fields:addLabel2'),
-        },
-      ],
-      versions: false,
-    },
-  ],
-  globals: [
-    {
-      slug: 'global',
-      label: {
-        en: 'EN Global',
-        es: 'ES Global',
+        versions: false,
       },
-      fields: [{ name: 'text', type: 'text' }],
-      versions: false,
+    ],
+    globals: [
+      {
+        slug: 'global',
+        fields: [{ name: 'text', type: 'text' }],
+        label: {
+          en: 'EN Global',
+          es: 'ES Global',
+        },
+        versions: false,
+      },
+    ],
+    i18n: {
+      translations: customTranslationsObject,
     },
-  ],
-  i18n: {
-    translations: customTranslationsObject,
+    typescript: {
+      outputFile: path.resolve(dirname, 'payload-types.ts'),
+    },
   },
-  onInit: async (payload) => {
+  seed: async (payload) => {
     await payload.create({
       collection: 'users',
       data: {
@@ -120,8 +126,5 @@ export default buildConfigWithDefaults({
         password: devUser.password,
       },
     })
-  },
-  typescript: {
-    outputFile: path.resolve(dirname, 'payload-types.ts'),
   },
 })

--- a/test/i18n/e2e.spec.ts
+++ b/test/i18n/e2e.spec.ts
@@ -37,8 +37,6 @@ describe('i18n', () => {
     const prebuild = false // Boolean(process.env.CI)
 
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
-
-    process.env.SEED_IN_CONFIG_ONINIT = 'false' // Makes it so the payload config onInit seed is not run. Otherwise, the seed would be run unnecessarily twice for the initial test run - once for beforeEach and once for onInit
     ;({ payload, serverURL } = await initPayloadE2ENoConfig<Config>({
       dirname,
       prebuild,
@@ -52,7 +50,6 @@ describe('i18n', () => {
   beforeEach(async () => {
     await reInitializeDB({
       serverURL,
-      snapshotKey: 'i18nTests',
     })
 
     await ensureCompilationIsDone({ page, serverURL })

--- a/test/joins/buildJoinAggregation.int.spec.ts
+++ b/test/joins/buildJoinAggregation.int.spec.ts
@@ -5,15 +5,15 @@ import type { SanitizedCollectionConfig } from 'payload'
 // @ts-ignore
 import { type MongooseAdapter } from '@payloadcms/db-mongodb'
 import { buildConfig, buildVersionCollectionFields, getPayload } from 'payload'
-import { expect, it } from 'vitest'
+import { expect } from 'vitest'
 
 import { buildJoinAggregation } from '../../packages/db-mongodb/src/utilities/buildJoinAggregation.js'
 import { buildProjectionFromSelect } from '../../packages/db-mongodb/src/utilities/buildProjectionFromSelect.js'
 import { test } from '../__helpers/int/vitest.js'
 
-test
-  .options({ db: (adapter) => adapter === 'mongodb' || adapter === 'mongodb-atlas' })
-  .describe('buildJoinAggregation', () => {
+test.suite({ db: (adapter) => adapter === 'mongodb' || adapter === 'mongodb-atlas' })(
+  'buildJoinAggregation',
+  () => {
     const getAdapter = async (): Promise<MongooseAdapter> => {
       const payload = await getPayload({
         key: '_buildJoinAggregation',
@@ -112,7 +112,7 @@ test
     const getLookups = (aggregation: mongoose.PipelineStage[]) =>
       aggregation.filter((each) => '$lookup' in each).map((each) => each.$lookup)
 
-    it('should add all the joins to the aggregation', async () => {
+    test('should add all the joins to the aggregation', async () => {
       const adapter = await getAdapter()
 
       const aggregation = await buildJoinAggregation({
@@ -138,7 +138,7 @@ test
       expect(lookups[1]!.localField).toBe('_id')
     })
 
-    it('should add only 1 join because of the projection (include)', async () => {
+    test('should add only 1 join because of the projection (include)', async () => {
       const adapter = await getAdapter()
 
       const aggregation = await buildJoinAggregation({
@@ -165,7 +165,7 @@ test
       expect(lookups[0]!.localField).toBe('_id')
     })
 
-    it('should add only 1 join because of the projection (exclude)', async () => {
+    test('should add only 1 join because of the projection (exclude)', async () => {
       const adapter = await getAdapter()
 
       const aggregation = await buildJoinAggregation({
@@ -192,7 +192,7 @@ test
       expect(lookups[0]!.localField).toBe('_id')
     })
 
-    it('should not add any joins because of the projection', async () => {
+    test('should not add any joins because of the projection', async () => {
       const adapter = await getAdapter()
 
       const aggregation = await buildJoinAggregation({
@@ -212,7 +212,7 @@ test
       expect(aggregation).toHaveLength(0)
     })
 
-    it('should add all the joins to the aggregation with versions', async () => {
+    test('should add all the joins to the aggregation with versions', async () => {
       const adapter = await getAdapter()
 
       const aggregation = await buildJoinAggregation({
@@ -240,7 +240,7 @@ test
       expect(lookups[1]!.localField).toBe('parent')
     })
 
-    it('should add only 1 join because of the projection (include) with versions', async () => {
+    test('should add only 1 join because of the projection (include) with versions', async () => {
       const adapter = await getAdapter()
       const fields = buildVersionCollectionFields(
         adapter.payload.config,
@@ -276,7 +276,7 @@ test
       expect(lookups[0]!.localField).toBe('parent')
     })
 
-    it('should add only 1 join because of the projection (exclude) with versions', async () => {
+    test('should add only 1 join because of the projection (exclude) with versions', async () => {
       const adapter = await getAdapter()
       const fields = buildVersionCollectionFields(
         adapter.payload.config,
@@ -312,7 +312,7 @@ test
       expect(lookups[0]!.localField).toBe('parent')
     })
 
-    it('should not add any joins because of the projection with versions', async () => {
+    test('should not add any joins because of the projection with versions', async () => {
       const adapter = await getAdapter()
       const fields = buildVersionCollectionFields(
         adapter.payload.config,
@@ -338,4 +338,5 @@ test
       expect(aggregation).toBeInstanceOf(Array)
       expect(aggregation).toHaveLength(0)
     })
-  })
+  },
+)

--- a/test/joins/config.ts
+++ b/test/joins/config.ts
@@ -28,360 +28,359 @@ const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
 export default buildConfigWithDefaults({
-  admin: {
-    importMap: {
-      baseDir: path.resolve(dirname),
-    },
-    user: 'users',
-  },
-  collections: [
-    {
-      slug: 'users',
-      auth: true,
-      fields: [
-        {
-          type: 'join',
-          collection: 'posts',
-          on: 'author',
-          name: 'posts',
-        },
-      ],
-      versions: false,
-    },
-    Posts,
-    Categories,
-    HiddenPosts,
-    Uploads,
-    Versions,
-    CategoriesVersions,
-    Singular,
-    SelfJoins,
-    {
-      slug: localizedPostsSlug,
-      admin: {
-        useAsTitle: 'title',
+  suite: 'joins',
+  config: {
+    admin: {
+      importMap: {
+        baseDir: path.resolve(dirname),
       },
-      fields: [
-        {
-          name: 'title',
-          type: 'text',
-          localized: true,
-        },
-        {
-          name: 'category',
-          type: 'relationship',
-          localized: true,
-          relationTo: localizedCategoriesSlug,
-        },
-      ],
-      versions: false,
+      user: 'users',
     },
-    {
-      slug: localizedCategoriesSlug,
-      admin: {
-        useAsTitle: 'name',
+    collections: [
+      {
+        slug: 'users',
+        auth: true,
+        fields: [
+          {
+            name: 'posts',
+            type: 'join',
+            collection: 'posts',
+            on: 'author',
+          },
+        ],
+        versions: false,
       },
-      fields: [
-        {
-          name: 'name',
-          type: 'text',
+      Posts,
+      Categories,
+      HiddenPosts,
+      Uploads,
+      Versions,
+      CategoriesVersions,
+      Singular,
+      SelfJoins,
+      {
+        slug: localizedPostsSlug,
+        admin: {
+          useAsTitle: 'title',
         },
-        {
-          name: 'relatedPosts',
-          type: 'join',
-          collection: localizedPostsSlug,
-          on: 'category',
-          localized: true,
-        },
-      ],
-      versions: false,
-    },
-    {
-      slug: restrictedCategoriesSlug,
-      admin: {
-        useAsTitle: 'name',
+        fields: [
+          {
+            name: 'title',
+            type: 'text',
+            localized: true,
+          },
+          {
+            name: 'category',
+            type: 'relationship',
+            localized: true,
+            relationTo: localizedCategoriesSlug,
+          },
+        ],
+        versions: false,
       },
-      fields: [
-        {
-          name: 'name',
-          type: 'text',
+      {
+        slug: localizedCategoriesSlug,
+        admin: {
+          useAsTitle: 'name',
         },
-        {
-          // this field is misconfigured to have `where` constraint using a restricted field
-          name: 'restrictedPosts',
-          type: 'join',
-          collection: postsSlug,
-          on: 'category',
-          where: {
-            restrictedField: { equals: 'restricted' },
+        fields: [
+          {
+            name: 'name',
+            type: 'text',
+          },
+          {
+            name: 'relatedPosts',
+            type: 'join',
+            collection: localizedPostsSlug,
+            localized: true,
+            on: 'category',
+          },
+        ],
+        versions: false,
+      },
+      {
+        slug: restrictedCategoriesSlug,
+        admin: {
+          useAsTitle: 'name',
+        },
+        fields: [
+          {
+            name: 'name',
+            type: 'text',
+          },
+          {
+            // this field is misconfigured to have `where` constraint using a restricted field
+            name: 'restrictedPosts',
+            type: 'join',
+            collection: postsSlug,
+            on: 'category',
+            where: {
+              restrictedField: { equals: 'restricted' },
+            },
+          },
+        ],
+        versions: false,
+      },
+      {
+        slug: categoriesJoinRestrictedSlug,
+        admin: {
+          useAsTitle: 'name',
+        },
+        fields: [
+          {
+            name: 'name',
+            type: 'text',
+          },
+          {
+            // join collection with access.read: () => false which should not populate
+            name: 'collectionRestrictedJoin',
+            type: 'join',
+            collection: collectionRestrictedSlug,
+            on: 'category',
+          },
+        ],
+        versions: false,
+      },
+      {
+        slug: restrictedPostsSlug,
+        admin: {
+          useAsTitle: 'title',
+        },
+        fields: [
+          {
+            name: 'title',
+            type: 'text',
+          },
+          {
+            name: 'restrictedField',
+            type: 'text',
+            access: {
+              read: () => false,
+              update: () => false,
+            },
+          },
+          {
+            name: 'category',
+            type: 'relationship',
+            relationTo: restrictedCategoriesSlug,
+          },
+        ],
+        versions: false,
+      },
+      {
+        slug: collectionRestrictedSlug,
+        access: {
+          read: () => ({ canRead: { equals: true } }),
+        },
+        admin: {
+          useAsTitle: 'title',
+        },
+        fields: [
+          {
+            name: 'title',
+            type: 'text',
+          },
+          {
+            name: 'canRead',
+            type: 'checkbox',
+            defaultValue: false,
+          },
+          {
+            name: 'category',
+            type: 'relationship',
+            relationTo: categoriesJoinRestrictedSlug,
+          },
+        ],
+        versions: false,
+      },
+      {
+        slug: 'depth-joins-1',
+        fields: [
+          {
+            name: 'rel',
+            type: 'relationship',
+            relationTo: 'depth-joins-2',
+          },
+          {
+            name: 'joins',
+            type: 'join',
+            collection: 'depth-joins-3',
+            maxDepth: 2,
+            on: 'rel',
+          },
+        ],
+        versions: false,
+      },
+      {
+        slug: 'depth-joins-2',
+        fields: [
+          {
+            name: 'joins',
+            type: 'join',
+            collection: 'depth-joins-1',
+            maxDepth: 2,
+            on: 'rel',
+          },
+        ],
+        versions: false,
+      },
+      {
+        slug: 'depth-joins-3',
+        fields: [
+          {
+            name: 'rel',
+            type: 'relationship',
+            relationTo: 'depth-joins-1',
+          },
+        ],
+        versions: false,
+      },
+      {
+        slug: 'multiple-collections-parents',
+        access: { read: () => true },
+        fields: [
+          {
+            name: 'children',
+            type: 'join',
+            admin: {
+              defaultColumns: ['title', 'name', 'description'],
+            },
+            collection: ['multiple-collections-1', 'multiple-collections-2'],
+            on: 'parent',
+          },
+        ],
+        versions: false,
+      },
+      {
+        slug: 'multiple-collections-1',
+        access: { read: () => true },
+        admin: { useAsTitle: 'title' },
+        fields: [
+          {
+            name: 'parent',
+            type: 'relationship',
+            relationTo: 'multiple-collections-parents',
+          },
+          {
+            name: 'title',
+            type: 'text',
+          },
+          {
+            name: 'name',
+            type: 'text',
+          },
+        ],
+        versions: false,
+      },
+      {
+        slug: 'multiple-collections-2',
+        access: { read: () => true },
+        admin: { useAsTitle: 'title' },
+        fields: [
+          {
+            name: 'parent',
+            type: 'relationship',
+            relationTo: 'multiple-collections-parents',
+          },
+          {
+            name: 'title',
+            type: 'text',
+          },
+          {
+            name: 'description',
+            type: 'text',
+          },
+        ],
+        versions: false,
+      },
+      {
+        slug: foldersSlug,
+        admin: {
+          group: 'Joins Test',
+          useAsTitle: 'name',
+        },
+        fields: [
+          {
+            name: 'name',
+            type: 'text',
+          },
+        ],
+        folders: {
+          collectionSpecific: { fieldName: 'folderType' },
+          joinField: {
+            name: 'children',
+            admin: {
+              defaultColumns: ['title', 'name', 'description'],
+            },
           },
         },
-      ],
-      versions: false,
-    },
-    {
-      slug: categoriesJoinRestrictedSlug,
-      admin: {
-        useAsTitle: 'name',
+        versions: false,
       },
-      fields: [
-        {
-          name: 'name',
-          type: 'text',
-        },
-        {
-          // join collection with access.read: () => false which should not populate
-          name: 'collectionRestrictedJoin',
-          type: 'join',
-          collection: collectionRestrictedSlug,
-          on: 'category',
-        },
-      ],
-      versions: false,
-    },
-    {
-      slug: restrictedPostsSlug,
-      admin: {
-        useAsTitle: 'title',
-      },
-      fields: [
-        {
-          name: 'title',
-          type: 'text',
-        },
-        {
-          name: 'restrictedField',
-          type: 'text',
-          access: {
-            read: () => false,
-            update: () => false,
+      {
+        slug: 'example-pages',
+        admin: { useAsTitle: 'title' },
+        fields: [
+          createFolderField({ relationTo: foldersSlug }),
+          {
+            name: 'title',
+            type: 'text',
           },
-        },
-        {
-          name: 'category',
-          type: 'relationship',
-          relationTo: restrictedCategoriesSlug,
-        },
-      ],
-      versions: false,
-    },
-    {
-      slug: collectionRestrictedSlug,
-      admin: {
-        useAsTitle: 'title',
-      },
-      access: {
-        read: () => ({ canRead: { equals: true } }),
-      },
-      fields: [
-        {
-          name: 'title',
-          type: 'text',
-        },
-        {
-          name: 'canRead',
-          type: 'checkbox',
-          defaultValue: false,
-        },
-        {
-          name: 'category',
-          type: 'relationship',
-          relationTo: categoriesJoinRestrictedSlug,
-        },
-      ],
-      versions: false,
-    },
-    {
-      slug: 'depth-joins-1',
-      fields: [
-        {
-          name: 'rel',
-          type: 'relationship',
-          relationTo: 'depth-joins-2',
-        },
-        {
-          name: 'joins',
-          type: 'join',
-          collection: 'depth-joins-3',
-          on: 'rel',
-          maxDepth: 2,
-        },
-      ],
-      versions: false,
-    },
-    {
-      slug: 'depth-joins-2',
-      fields: [
-        {
-          name: 'joins',
-          type: 'join',
-          collection: 'depth-joins-1',
-          on: 'rel',
-          maxDepth: 2,
-        },
-      ],
-      versions: false,
-    },
-    {
-      slug: 'depth-joins-3',
-      fields: [
-        {
-          name: 'rel',
-          type: 'relationship',
-          relationTo: 'depth-joins-1',
-        },
-      ],
-      versions: false,
-    },
-    {
-      slug: 'multiple-collections-parents',
-      access: { read: () => true },
-      fields: [
-        {
-          type: 'join',
-          name: 'children',
-          collection: ['multiple-collections-1', 'multiple-collections-2'],
-          on: 'parent',
-          admin: {
-            defaultColumns: ['title', 'name', 'description'],
+          {
+            name: 'name',
+            type: 'text',
           },
-        },
-      ],
-      versions: false,
-    },
-    {
-      slug: 'multiple-collections-1',
-      access: { read: () => true },
-      admin: { useAsTitle: 'title' },
-      fields: [
-        {
-          type: 'relationship',
-          relationTo: 'multiple-collections-parents',
-          name: 'parent',
-        },
-        {
-          name: 'title',
-          type: 'text',
-        },
-        {
-          name: 'name',
-          type: 'text',
-        },
-      ],
-      versions: false,
-    },
-    {
-      slug: 'multiple-collections-2',
-      access: { read: () => true },
-      admin: { useAsTitle: 'title' },
-      fields: [
-        {
-          type: 'relationship',
-          relationTo: 'multiple-collections-parents',
-          name: 'parent',
-        },
-        {
-          name: 'title',
-          type: 'text',
-        },
-        {
-          name: 'description',
-          type: 'text',
-        },
-      ],
-      versions: false,
-    },
-    {
-      slug: foldersSlug,
-      admin: {
-        useAsTitle: 'name',
-        group: 'Joins Test',
+        ],
+        versions: false,
       },
-      folders: {
-        collectionSpecific: { fieldName: 'folderType' },
-        joinField: {
-          name: 'children',
-          admin: {
-            defaultColumns: ['title', 'name', 'description'],
+      {
+        slug: 'example-posts',
+        admin: { useAsTitle: 'title' },
+        fields: [
+          createFolderField({ relationTo: foldersSlug }),
+          {
+            name: 'title',
+            type: 'text',
           },
-        },
+          {
+            name: 'description',
+            type: 'text',
+          },
+        ],
+        versions: false,
       },
-      fields: [
-        {
-          name: 'name',
-          type: 'text',
-        },
-      ],
-      versions: false,
-    },
-    {
-      slug: 'example-pages',
-      admin: { useAsTitle: 'title' },
-      fields: [
-        createFolderField({ relationTo: foldersSlug }),
-        {
-          name: 'title',
-          type: 'text',
-        },
-        {
-          name: 'name',
-          type: 'text',
-        },
-      ],
-      versions: false,
-    },
-    {
-      slug: 'example-posts',
-      admin: { useAsTitle: 'title' },
-      fields: [
-        createFolderField({ relationTo: foldersSlug }),
-        {
-          name: 'title',
-          type: 'text',
-        },
-        {
-          name: 'description',
-          type: 'text',
-        },
-      ],
-      versions: false,
-    },
-    {
-      slug: 'folderPoly1',
-      fields: [
-        {
-          name: 'folderPoly1Title',
-          type: 'text',
-        },
-        createFolderField({ relationTo: foldersSlug }),
-      ],
-      versions: false,
-    },
-    {
-      slug: 'folderPoly2',
-      fields: [
-        {
-          name: 'folderPoly2Title',
-          type: 'text',
-        },
-        createFolderField({ relationTo: foldersSlug }),
-      ],
-      versions: false,
-    },
-  ],
-  localization: {
-    locales: [
-      { label: '(en)', code: 'en' },
-      { label: '(es)', code: 'es' },
+      {
+        slug: 'folderPoly1',
+        fields: [
+          {
+            name: 'folderPoly1Title',
+            type: 'text',
+          },
+          createFolderField({ relationTo: foldersSlug }),
+        ],
+        versions: false,
+      },
+      {
+        slug: 'folderPoly2',
+        fields: [
+          {
+            name: 'folderPoly2Title',
+            type: 'text',
+          },
+          createFolderField({ relationTo: foldersSlug }),
+        ],
+        versions: false,
+      },
     ],
-    defaultLocale: 'en',
+    localization: {
+      defaultLocale: 'en',
+      locales: [
+        { code: 'en', label: '(en)' },
+        { code: 'es', label: '(es)' },
+      ],
+    },
+    typescript: {
+      outputFile: path.resolve(dirname, 'payload-types.ts'),
+    },
   },
-  onInit: async (payload) => {
-    if (process.env.SEED_IN_CONFIG_ONINIT !== 'false') {
-      await seed(payload)
-    }
-  },
-  typescript: {
-    outputFile: path.resolve(dirname, 'payload-types.ts'),
-  },
+  seed,
 })

--- a/test/joins/e2e.spec.ts
+++ b/test/joins/e2e.spec.ts
@@ -53,7 +53,6 @@ describe('Join Field', () => {
 
   beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
-    process.env.SEED_IN_CONFIG_ONINIT = 'false' // Makes it so the payload config onInit seed is not run. Otherwise, the seed would be run unnecessarily twice for the initial test run - once for beforeEach and once for onInit
     ;({ payload, serverURL } = await initPayloadE2ENoConfig<Config>({
       dirname,
     }))
@@ -74,8 +73,6 @@ describe('Join Field', () => {
   beforeEach(async () => {
     await reInitializeDB({
       serverURL,
-      snapshotKey: 'joinsTest',
-      uploadsDir: [],
     })
 
     if (client) {

--- a/test/joins/int.spec.ts
+++ b/test/joins/int.spec.ts
@@ -10,7 +10,6 @@ import type { Category, Config, DepthJoins1, DepthJoins3, Post, Singular } from 
 import { test } from '../__helpers/int/vitest.js'
 import { idToString } from '../__helpers/shared/idToString.js'
 import { devUser } from '../credentials.js'
-import testConfig from './config.js'
 import {
   categoriesJoinRestrictedSlug,
   categoriesSlug,
@@ -26,7 +25,7 @@ let token: string
 
 const { email, password } = devUser
 
-test.suite({ config: testConfig })('Joins Field', () => {
+test.suite({ config: './config.ts' })('Joins Field', () => {
   let category: Category
   let otherCategory: Category
   let categoryID

--- a/test/joins/int.spec.ts
+++ b/test/joins/int.spec.ts
@@ -3,14 +3,14 @@ import type { Payload, TypeWithID } from 'payload'
 import path from 'path'
 import { getFileByPath } from 'payload'
 import { fileURLToPath } from 'url'
-import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { expect } from 'vitest'
 
-import type { NextRESTClient } from '../__helpers/shared/NextRESTClient.js'
 import type { Category, Config, DepthJoins1, DepthJoins3, Post, Singular } from './payload-types.js'
 
+import { test } from '../__helpers/int/vitest.js'
 import { idToString } from '../__helpers/shared/idToString.js'
-import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
 import { devUser } from '../credentials.js'
+import testConfig from './config.js'
 import {
   categoriesJoinRestrictedSlug,
   categoriesSlug,
@@ -22,14 +22,11 @@ import {
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
-
-let payload: Payload
 let token: string
-let restClient: NextRESTClient
 
 const { email, password } = devUser
 
-describe('Joins Field', () => {
+test.suite({ config: testConfig })('Joins Field', () => {
   let category: Category
   let otherCategory: Category
   let categoryID
@@ -37,9 +34,7 @@ describe('Joins Field', () => {
   // --__--__--__--__--__--__--__--__--__
   // Boilerplate test setup/teardown
   // --__--__--__--__--__--__--__--__--__
-  beforeAll(async () => {
-    ;({ payload, restClient } = await initPayloadInt(dirname))
-
+  test.beforeEach(async ({ payload, restClient }) => {
     const data = await restClient
       .POST('/users/login', {
         body: JSON.stringify({
@@ -85,49 +80,48 @@ describe('Joins Field', () => {
       if (i % 2 === 0) {
         categories = [category.id, otherCategory.id]
       }
-      await createPost({
-        title: `test ${i}`,
-        category: category.id,
-        upload: uploadedImage,
-        categories,
-        categoriesLocalized: categories,
-        polymorphic: {
-          relationTo: 'categories',
-          value: category.id,
-        },
-        polymorphics: [
-          {
-            relationTo: 'categories',
-            value: category.id,
-          },
-        ],
-        localizedPolymorphic: {
-          relationTo: 'categories',
-          value: category.id,
-        },
-        localizedPolymorphics: [
-          {
-            relationTo: 'categories',
-            value: category.id,
-          },
-        ],
-        group: {
+      await createPost(
+        { payload },
+        {
+          title: `test ${i}`,
           category: category.id,
-          camelCaseCategory: category.id,
+          upload: uploadedImage,
+          categories,
+          categoriesLocalized: categories,
+          polymorphic: {
+            relationTo: 'categories',
+            value: category.id,
+          },
+          polymorphics: [
+            {
+              relationTo: 'categories',
+              value: category.id,
+            },
+          ],
+          localizedPolymorphic: {
+            relationTo: 'categories',
+            value: category.id,
+          },
+          localizedPolymorphics: [
+            {
+              relationTo: 'categories',
+              value: category.id,
+            },
+          ],
+          group: {
+            category: category.id,
+            camelCaseCategory: category.id,
+          },
+          array: [{ category: category.id }],
+          arrayHasMany: [{ category: [category.id] }],
+          localizedArray: [{ category: category.id }],
+          blocks: [{ blockType: 'block', category: category.id }],
         },
-        array: [{ category: category.id }],
-        arrayHasMany: [{ category: [category.id] }],
-        localizedArray: [{ category: category.id }],
-        blocks: [{ blockType: 'block', category: category.id }],
-      })
+      )
     }
   })
 
-  afterAll(async () => {
-    await payload.destroy()
-  })
-
-  it('should populate joins using findByID', async () => {
+  test('should populate joins using findByID', async ({ payload }) => {
     const categoryWithPosts = await payload.findByID({
       id: category.id,
       joins: {
@@ -144,7 +138,7 @@ describe('Joins Field', () => {
     expect(categoryWithPosts.group.relatedPosts.docs[0].title).toStrictEqual('test 9')
   })
 
-  it('should not populate joins if not selected', async () => {
+  test('should not populate joins if not selected', async ({ payload }) => {
     const categoryWithPosts = await payload.findByID({
       id: category.id,
       joins: {
@@ -159,7 +153,7 @@ describe('Joins Field', () => {
     expect(Object.keys(categoryWithPosts)).toStrictEqual(['id'])
   })
 
-  it('should populate joins if selected', async () => {
+  test('should populate joins if selected', async ({ payload }) => {
     const categoryWithPosts = await payload.findByID({
       id: category.id,
       joins: {
@@ -186,7 +180,7 @@ describe('Joins Field', () => {
     expect(categoryWithPosts.group.relatedPosts.docs[0].title).toStrictEqual('test 9')
   })
 
-  it('should count joins', async () => {
+  test('should count joins', async ({ payload }) => {
     let categoryWithPosts = await payload.findByID({
       id: category.id,
       joins: {
@@ -216,7 +210,7 @@ describe('Joins Field', () => {
     expect(categoryWithPosts.group.relatedPosts?.totalDocs).toBe(15)
   })
 
-  it('should count hasMany relationship joins', async () => {
+  test('should count hasMany relationship joins', async ({ payload }) => {
     const res = await payload.findByID({
       id: category.id,
       collection: categoriesSlug,
@@ -228,7 +222,7 @@ describe('Joins Field', () => {
     expect(res.hasManyPosts?.totalDocs).toBe(15)
   })
 
-  it('should populate relationships in joins', async () => {
+  test('should populate relationships in joins', async ({ payload }) => {
     const { docs } = await payload.find({
       limit: 1,
       collection: postsSlug,
@@ -240,7 +234,7 @@ describe('Joins Field', () => {
     expect(docs[0].category.relatedPosts.docs).toHaveLength(5) // uses defaultLimit
   })
 
-  it('should populate relationships in joins with camelCase names', async () => {
+  test('should populate relationships in joins with camelCase names', async ({ payload }) => {
     const { docs } = await payload.find({
       limit: 1,
       collection: postsSlug,
@@ -251,7 +245,7 @@ describe('Joins Field', () => {
     expect(docs[0].group.camelCaseCategory.group.camelCasePosts.docs).toHaveLength(10)
   })
 
-  it('should populate joins with array relationships', async () => {
+  test('should populate joins with array relationships', async ({ payload }) => {
     const categoryWithPosts = await payload.findByID({
       id: category.id,
       collection: categoriesSlug,
@@ -261,7 +255,7 @@ describe('Joins Field', () => {
     expect(categoryWithPosts.arrayPosts.docs).toHaveLength(10)
   })
 
-  it('should populate joins with array hasMany relationships', async () => {
+  test('should populate joins with array hasMany relationships', async ({ payload }) => {
     const categoryWithPosts = await payload.findByID({
       id: category.id,
       collection: categoriesSlug,
@@ -271,7 +265,7 @@ describe('Joins Field', () => {
     expect(categoryWithPosts.arrayHasManyPosts.docs).toHaveLength(10)
   })
 
-  it('should populate joins with localized array relationships', async () => {
+  test('should populate joins with localized array relationships', async ({ payload }) => {
     const categoryWithPosts = await payload.findByID({
       id: category.id,
       collection: categoriesSlug,
@@ -281,7 +275,7 @@ describe('Joins Field', () => {
     expect(categoryWithPosts.localizedArrayPosts.docs).toHaveLength(10)
   })
 
-  it('should populate joins with blocks relationships', async () => {
+  test('should populate joins with blocks relationships', async ({ payload }) => {
     const categoryWithPosts = await payload.findByID({
       id: category.id,
       collection: categoriesSlug,
@@ -290,7 +284,7 @@ describe('Joins Field', () => {
     expect(categoryWithPosts.blocksPosts.docs).toBeDefined()
   })
 
-  it('should populate uploads in joins', async () => {
+  test('should populate uploads in joins', async ({ payload }) => {
     const { docs } = await payload.find({
       limit: 1,
       collection: postsSlug,
@@ -300,7 +294,7 @@ describe('Joins Field', () => {
     expect(docs[0].upload.relatedPosts.docs).toHaveLength(10)
   })
 
-  it('should join on polymorphic relationships', async () => {
+  test('should join on polymorphic relationships', async ({ payload }) => {
     const categoryWithPosts = await payload.findByID({
       collection: categoriesSlug,
       id: category.id,
@@ -311,7 +305,9 @@ describe('Joins Field', () => {
     expect(categoryWithPosts.localizedPolymorphics.docs[0]).toHaveProperty('id')
   })
 
-  it('should not throw a path validation error when querying joins with polymorphic relationships', async () => {
+  test('should not throw a path validation error when querying joins with polymorphic relationships', async ({
+    payload,
+  }) => {
     const folderDoc = await payload.create({
       collection: 'folders',
       data: {
@@ -369,7 +365,7 @@ describe('Joins Field', () => {
     expect(result.docs[0]?.children.docs).toHaveLength(1)
   })
 
-  it('should allow join where query on hasMany select fields', async () => {
+  test('should allow join where query on hasMany select fields', async ({ payload }) => {
     const folderDoc = await payload.create({
       collection: 'folders',
       data: {
@@ -419,7 +415,7 @@ describe('Joins Field', () => {
     expect(findFolder?.docs[0]?.children?.docs).toHaveLength(1)
   })
 
-  it('should query where with exists for hasMany select fields', async () => {
+  test('should query where with exists for hasMany select fields', async ({ payload }) => {
     await payload.delete({ collection: 'folders', where: {} })
     const folderDoc = await payload.create({
       collection: 'folders',
@@ -479,7 +475,7 @@ describe('Joins Field', () => {
     expect(findFolder?.docs[0]?.children?.docs).toHaveLength(1)
   })
 
-  it('should filter joins using where query', async () => {
+  test('should filter joins using where query', async ({ payload }) => {
     const categoryWithPosts = await payload.findByID({
       id: category.id,
       joins: {
@@ -499,7 +495,7 @@ describe('Joins Field', () => {
     expect(categoryWithPosts.relatedPosts.hasNextPage).toStrictEqual(false)
   })
 
-  it('should apply defaultSort when no sort is specified in join query', async () => {
+  test('should apply defaultSort when no sort is specified in join query', async ({ payload }) => {
     const categoryWithPosts = await payload.findByID({
       id: category.id,
       collection: categoriesSlug,
@@ -510,7 +506,7 @@ describe('Joins Field', () => {
     expect((categoryWithPosts.relatedPosts!.docs![0] as Post).title).toStrictEqual('test 9')
   })
 
-  it('should override defaultSort when sort is specified in join query', async () => {
+  test('should override defaultSort when sort is specified in join query', async ({ payload }) => {
     const categoryWithPosts = await payload.findByID({
       id: category.id,
       collection: categoriesSlug,
@@ -525,7 +521,7 @@ describe('Joins Field', () => {
     expect((categoryWithPosts.relatedPosts!.docs![0] as Post).title).toStrictEqual('test 0')
   })
 
-  it('should populate joins using find', async () => {
+  test('should populate joins using find', async ({ payload }) => {
     const result = await payload.find({
       collection: categoriesSlug,
       where: {
@@ -540,7 +536,7 @@ describe('Joins Field', () => {
     expect(categoryWithPosts.group.relatedPosts.docs[0].title).toBe('test 14')
   })
 
-  it('should populate joins using find with hasMany relationships', async () => {
+  test('should populate joins using find with hasMany relationships', async ({ payload }) => {
     const result = await payload.find({
       collection: categoriesSlug,
       where: {
@@ -565,8 +561,11 @@ describe('Joins Field', () => {
     expect(otherCategoryWithPosts.hasManyPosts.docs[0].title).toBe('test 14')
   })
 
-  it('should populate joins using find with hasMany localized relationships', async () => {
+  test('should populate joins using find with hasMany localized relationships', async ({
+    payload,
+  }) => {
     const post_1 = await createPost(
+      { payload },
       {
         title: `test es localized 1`,
         categoriesLocalized: [category.id],
@@ -579,6 +578,7 @@ describe('Joins Field', () => {
     )
 
     const post_2 = await createPost(
+      { payload },
       {
         title: `test es localized 2`,
         categoriesLocalized: [otherCategory.id],
@@ -648,7 +648,7 @@ describe('Joins Field', () => {
     })
   })
 
-  it('should not error when deleting documents with joins', async () => {
+  test('should not error when deleting documents with joins', async ({ payload }) => {
     const category = await payload.create({
       collection: categoriesSlug,
       data: {
@@ -656,9 +656,12 @@ describe('Joins Field', () => {
       },
     })
 
-    await createPost({
-      category: category.id,
-    })
+    await createPost(
+      { payload },
+      {
+        category: category.id,
+      },
+    )
 
     const result = await payload.delete({
       collection: categoriesSlug,
@@ -671,9 +674,9 @@ describe('Joins Field', () => {
     expect(result.docs[0].id).toStrictEqual(category.id)
   })
 
-  describe('`where` filters', () => {
+  test.describe('`where` filters', () => {
     let categoryWithFilteredPost
-    beforeAll(async () => {
+    test.beforeEach(async ({ payload }) => {
       categoryWithFilteredPost = await payload.create({
         collection: categoriesSlug,
         data: {
@@ -681,17 +684,23 @@ describe('Joins Field', () => {
         },
       })
 
-      await createPost({
-        title: 'filtered post',
-        category: categoryWithFilteredPost.id,
-        isFiltered: true,
-      })
+      await createPost(
+        { payload },
+        {
+          title: 'filtered post',
+          category: categoryWithFilteredPost.id,
+          isFiltered: true,
+        },
+      )
 
-      await createPost({
-        title: 'unfiltered post',
-        category: categoryWithFilteredPost.id,
-        isFiltered: false,
-      })
+      await createPost(
+        { payload },
+        {
+          title: 'unfiltered post',
+          category: categoryWithFilteredPost.id,
+          isFiltered: false,
+        },
+      )
 
       categoryWithFilteredPost = await payload.findByID({
         id: categoryWithFilteredPost.id,
@@ -699,11 +708,13 @@ describe('Joins Field', () => {
       })
     })
 
-    it('should filter joins using where from field config', () => {
+    test('should filter joins using where from field config', () => {
       expect(categoryWithFilteredPost.filtered.docs).toHaveLength(1)
     })
 
-    it('should filter joins using where from field config and the requested filter', async () => {
+    test('should filter joins using where from field config and the requested filter', async ({
+      payload,
+    }) => {
       categoryWithFilteredPost = await payload.findByID({
         id: categoryWithFilteredPost.id,
         collection: categoriesSlug,
@@ -720,10 +731,10 @@ describe('Joins Field', () => {
     })
   })
 
-  describe('Joins with localization', () => {
+  test.describe('Joins with localization', () => {
     let localizedCategory: Category
 
-    beforeAll(async () => {
+    test.beforeEach(async ({ payload }) => {
       localizedCategory = await payload.create({
         collection: 'localized-categories',
         locale: 'en',
@@ -758,7 +769,9 @@ describe('Joins Field', () => {
       })
     })
 
-    it('should populate joins using findByID with localization on the relationship', async () => {
+    test('should populate joins using findByID with localization on the relationship', async ({
+      payload,
+    }) => {
       const enCategory = await payload.findByID({
         id: localizedCategory.id,
         collection: 'localized-categories',
@@ -774,13 +787,13 @@ describe('Joins Field', () => {
     })
   })
 
-  describe('Joins with versions', () => {
-    afterEach(async () => {
+  test.describe('Joins with versions', () => {
+    test.afterEach(async ({ payload }) => {
       await payload.delete({ collection: 'versions', where: {} })
       await payload.delete({ collection: 'categories-versions', where: {} })
     })
 
-    it('should populate joins when versions on both sides draft false', async () => {
+    test('should populate joins when versions on both sides draft false', async ({ payload }) => {
       const category = await payload.create({ collection: 'categories-versions', data: {} })
 
       const version = await payload.create({
@@ -793,7 +806,9 @@ describe('Joins Field', () => {
       expect(res.docs[0].relatedVersions.docs[0].id).toBe(version.id)
     })
 
-    it('should populate joins with hasMany relationships when versions on both sides draft false', async () => {
+    test('should populate joins with hasMany relationships when versions on both sides draft false', async ({
+      payload,
+    }) => {
       const category = await payload.create({ collection: 'categories-versions', data: {} })
 
       const version = await payload.create({
@@ -806,7 +821,9 @@ describe('Joins Field', () => {
       expect(res.docs[0].relatedVersionsMany.docs[0].id).toBe(version.id)
     })
 
-    it('should populate joins with hasMany relationships when versions on both sides draft true payload.db.queryDrafts', async () => {
+    test('should populate joins with hasMany relationships when versions on both sides draft true payload.db.queryDrafts', async ({
+      payload,
+    }) => {
       const category = await payload.create({ collection: 'categories-versions', data: {} })
 
       const version = await payload.create({
@@ -822,7 +839,9 @@ describe('Joins Field', () => {
       expect(res.docs[0].relatedVersions.docs[0].id).toBe(version.id)
     })
 
-    it('should populate joins with hasMany when on both sides documents are in draft', async () => {
+    test('should populate joins with hasMany when on both sides documents are in draft', async ({
+      payload,
+    }) => {
       const category = await payload.create({
         collection: 'categories-versions',
         data: { _status: 'draft' },
@@ -851,7 +870,9 @@ describe('Joins Field', () => {
       expect(res.docs[0].relatedVersions.docs[0].title).toBe('updated-title')
     })
 
-    it('should populate joins when versions on both sides draft true payload.db.queryDrafts', async () => {
+    test('should populate joins when versions on both sides draft true payload.db.queryDrafts', async ({
+      payload,
+    }) => {
       const category = await payload.create({ collection: 'categories-versions', data: {} })
 
       const version = await payload.create({
@@ -868,8 +889,8 @@ describe('Joins Field', () => {
     })
   })
 
-  describe('REST', () => {
-    it('should have simple paginate for joins', async () => {
+  test.describe('REST', () => {
+    test('should have simple paginate for joins', async ({ restClient }) => {
       const query = {
         depth: 1,
         where: {
@@ -896,7 +917,7 @@ describe('Joins Field', () => {
       expect(unlimited.docs[0].relatedPosts.hasNextPage).toStrictEqual(false)
     })
 
-    it('should have simple paginate with page for joins', async () => {
+    test('should have simple paginate with page for joins', async ({ restClient }) => {
       const query = {
         depth: 1,
         where: {
@@ -936,7 +957,7 @@ describe('Joins Field', () => {
       )
     })
 
-    it('should respect access control for join collections', async () => {
+    test('should respect access control for join collections', async ({ payload }) => {
       const { docs } = await payload.find({
         collection: categoriesJoinRestrictedSlug,
         where: {
@@ -952,7 +973,7 @@ describe('Joins Field', () => {
       )
     })
 
-    it('should respect access control for join request `where` queries', async () => {
+    test('should respect access control for join request `where` queries', async ({ payload }) => {
       await expect(
         payload.findByID({
           id: category.id,
@@ -970,20 +991,25 @@ describe('Joins Field', () => {
       ).rejects.toThrow('The following path cannot be queried: restrictedField')
     })
 
-    it('should respect access control of join field configured `where` queries', async () => {
+    test('should respect access control of join field configured `where` queries', async ({
+      payload,
+    }) => {
       const restrictedCategory = await payload.create({
         collection: restrictedCategoriesSlug,
         data: {
           name: 'restricted category',
         },
       })
-      await createPost({
-        collection: restrictedPostsSlug,
-        data: {
-          title: 'restricted post',
-          category: restrictedCategory.id,
+      await createPost(
+        { payload },
+        {
+          collection: restrictedPostsSlug,
+          data: {
+            title: 'restricted post',
+            category: restrictedCategory.id,
+          },
         },
-      })
+      )
       await expect(
         payload.findByID({
           id: category.id,
@@ -994,14 +1020,14 @@ describe('Joins Field', () => {
       ).rejects.toThrow('The following path cannot be queried: restrictedField')
     })
 
-    it('should sort joins', async () => {
+    test('should sort joins', async ({ restClient }) => {
       const response = await restClient
         .GET(`/categories/${category.id}?joins[relatedPosts][sort]=-title`)
         .then((res) => res.json())
       expect(response.relatedPosts.docs[0].title).toStrictEqual('test 9')
     })
 
-    it('should query in on collections with joins', async () => {
+    test('should query in on collections with joins', async ({ restClient }) => {
       const response = await restClient
         .GET(`/categories?where[id][in]=${category.id}`)
         .then((res) => res.json())
@@ -1009,8 +1035,8 @@ describe('Joins Field', () => {
     })
   })
 
-  describe('GraphQL', () => {
-    it('should have simple paginate for joins', async () => {
+  test.describe('GraphQL', () => {
+    test('should have simple paginate for joins', async ({ restClient }) => {
       const queryWithLimit = `query {
     Categories(where: {
             name: { equals: "paginate example" }
@@ -1068,7 +1094,7 @@ describe('Joins Field', () => {
       expect(unlimited.data.Categories.docs[0].relatedPosts.hasNextPage).toStrictEqual(false)
     })
 
-    it('should return totalDocs with count: true', async () => {
+    test('should return totalDocs with count: true', async ({ restClient }) => {
       const queryWithLimit = `query {
     Categories(where: {
             name: { equals: "paginate example" }
@@ -1099,7 +1125,7 @@ describe('Joins Field', () => {
       expect(pageWithLimit.data.Categories.docs[0].relatedPosts.totalDocs).toStrictEqual(15)
     })
 
-    it('should have simple paginate with page for joins', async () => {
+    test('should have simple paginate with page for joins', async ({ restClient }) => {
       let queryWithLimit = `query {
     Categories(where: {
             name: { equals: "paginate example" }
@@ -1187,7 +1213,7 @@ describe('Joins Field', () => {
       )
     })
 
-    it('should have simple paginate with page for joins polymorphic', async () => {
+    test('should have simple paginate with page for joins polymorphic', async ({ restClient }) => {
       let queryWithLimit = `query {
     Categories(where: {
             name: { equals: "paginate example" }
@@ -1275,7 +1301,10 @@ describe('Joins Field', () => {
       )
     })
 
-    it('should populate joins with hasMany when on both sides documents are in draft', async () => {
+    test('should populate joins with hasMany when on both sides documents are in draft', async ({
+      payload,
+      restClient,
+    }) => {
       const category = await payload.create({
         collection: 'categories-versions',
         data: { _status: 'draft' },
@@ -1321,7 +1350,7 @@ describe('Joins Field', () => {
       )
     })
 
-    it('should have simple paginate for joins inside groups', async () => {
+    test('should have simple paginate for joins inside groups', async ({ restClient }) => {
       const queryWithLimit = `query {
     Categories(where: {
             name: { equals: "paginate example" }
@@ -1386,7 +1415,7 @@ describe('Joins Field', () => {
       expect(unlimited.data.Categories.docs[0].group.relatedPosts.hasNextPage).toStrictEqual(false)
     })
 
-    it('should sort joins', async () => {
+    test('should sort joins', async ({ restClient }) => {
       const query = `query {
         Category(id: ${categoryID}) {
           relatedPosts(
@@ -1405,7 +1434,7 @@ describe('Joins Field', () => {
       expect(response.data.Category.relatedPosts.docs[0].title).toStrictEqual('test 9')
     })
 
-    it('should query in on collections with joins', async () => {
+    test('should query in on collections with joins', async ({ restClient }) => {
       const query = `query {
          Category(id: ${categoryID}) {
           relatedPosts(
@@ -1428,7 +1457,7 @@ describe('Joins Field', () => {
       expect(response.data.Category.relatedPosts.docs[0].title).toStrictEqual('test 3')
     })
 
-    it('should respect access control for join collections', async () => {
+    test('should respect access control for join collections', async ({ restClient }) => {
       const query = `query {
         CategoriesJoinRestricteds {
           docs {
@@ -1454,7 +1483,10 @@ describe('Joins Field', () => {
     })
   })
 
-  it('should work id.in command delimited querying with joins', async () => {
+  test('should work id.in command delimited querying with joins', async ({
+    payload,
+    restClient,
+  }) => {
     const allCategories = await payload.find({ collection: categoriesSlug, pagination: false })
 
     const allCategoriesByIds = await restClient
@@ -1472,7 +1504,7 @@ describe('Joins Field', () => {
     expect(allCategories.totalDocs).toBe(allCategoriesByIds.totalDocs)
   })
 
-  it('should join with singular collection name', async () => {
+  test('should join with singular collection name', async ({ payload }) => {
     const {
       docs: [category],
     } = await payload.find({ collection: categoriesSlug, limit: 1, depth: 0 })
@@ -1490,7 +1522,9 @@ describe('Joins Field', () => {
     expect((categoryWithJoins.singulars.docs[0] as Singular).id).toBe(singular.id)
   })
 
-  it('local API should not populate individual join by providing schemaPath=false', async () => {
+  test('local API should not populate individual join by providing schemaPath=false', async ({
+    payload,
+  }) => {
     const {
       docs: [res],
     } = await payload.find({
@@ -1512,7 +1546,9 @@ describe('Joins Field', () => {
     expect(res.group.camelCasePosts.docs).toBeDefined()
   })
 
-  it('rEST API should not populate individual join by providing schemaPath=false', async () => {
+  test('rEST API should not populate individual join by providing schemaPath=false', async ({
+    restClient,
+  }) => {
     const {
       docs: [res],
     } = await restClient
@@ -1537,7 +1573,7 @@ describe('Joins Field', () => {
     expect(res.group.camelCasePosts.docs).toBeDefined()
   })
 
-  it('should have correct totalDocs', async () => {
+  test('should have correct totalDocs', async ({ payload }) => {
     for (let i = 0; i < 50; i++) {
       await payload.create({ collection: categoriesSlug, data: { name: 'totalDocs' } })
     }
@@ -1559,7 +1595,7 @@ describe('Joins Field', () => {
     await payload.delete({ collection: categoriesSlug, where: { name: { equals: 'totalDocs' } } })
   })
 
-  it('should self join', async () => {
+  test('should self join', async ({ payload }) => {
     const doc_1 = await payload.create({ collection: 'self-joins', data: {} })
     const doc_2 = await payload.create({ collection: 'self-joins', data: { rel: doc_1 }, depth: 0 })
 
@@ -1568,7 +1604,7 @@ describe('Joins Field', () => {
     expect((data.joins.docs[0] as TypeWithID).id).toBe(doc_2.id)
   })
 
-  it('should populate joins on depth 2', async () => {
+  test('should populate joins on depth 2', async ({ payload }) => {
     const depthJoin_2 = await payload.create({ collection: 'depth-joins-2', data: {}, depth: 0 })
     const depthJoin_1 = await payload.create({
       collection: 'depth-joins-1',
@@ -1597,8 +1633,8 @@ describe('Joins Field', () => {
     expect(joinedDoc2.id).toBe(depthJoin_3.id)
   })
 
-  describe('Array of collection', () => {
-    it('should join across multiple collections', async () => {
+  test.describe('Array of collection', () => {
+    test('should join across multiple collections', async ({ payload }) => {
       let parent = await payload.create({
         collection: 'multiple-collections-parents',
         depth: 0,
@@ -1795,7 +1831,7 @@ describe('Joins Field', () => {
     })
   })
 
-  it('should support where querying by a top level join field', async () => {
+  test('should support where querying by a top level join field', async ({ payload }) => {
     const category = await payload.create({ collection: 'categories', data: {} })
     await payload.create({
       collection: 'posts',
@@ -1810,7 +1846,7 @@ describe('Joins Field', () => {
     expect(found.docs[0].id).toBe(category.id)
   })
 
-  it('should support where querying by a join field as ID', async () => {
+  test('should support where querying by a join field as ID', async ({ payload }) => {
     const category = await payload.create({ collection: 'categories', data: {} })
     const post = await payload.create({
       collection: 'posts',
@@ -1835,7 +1871,9 @@ describe('Joins Field', () => {
     expect(found_2.docs[0].id).toBe(category.id)
   })
 
-  it('should support where querying by a join field with hasMany relationship', async () => {
+  test('should support where querying by a join field with hasMany relationship', async ({
+    payload,
+  }) => {
     const category = await payload.create({ collection: 'categories', data: {} })
     await payload.create({
       collection: 'posts',
@@ -1850,7 +1888,9 @@ describe('Joins Field', () => {
     expect(found.docs[0].id).toBe(category.id)
   })
 
-  it('should support where querying by a join field with relationship nested to a group', async () => {
+  test('should support where querying by a join field with relationship nested to a group', async ({
+    payload,
+  }) => {
     const category = await payload.create({ collection: 'categories', data: {} })
     await payload.create({
       collection: 'posts',
@@ -1865,7 +1905,9 @@ describe('Joins Field', () => {
     expect(found.docs[0].id).toBe(category.id)
   })
 
-  it('should support where querying by a join field with relationship nested to an array', async () => {
+  test('should support where querying by a join field with relationship nested to an array', async ({
+    payload,
+  }) => {
     const category = await payload.create({ collection: 'categories', data: {} })
     const post = await payload.create({
       collection: 'posts',
@@ -1883,7 +1925,7 @@ describe('Joins Field', () => {
     await payload.delete({ collection: 'categories', id: category.id })
   })
 
-  it('should support where querying by a join field multiple times', async () => {
+  test('should support where querying by a join field multiple times', async ({ payload }) => {
     const category = await payload.create({ collection: 'categories', data: {} })
     await payload.create({
       collection: 'posts',
@@ -1911,7 +1953,9 @@ describe('Joins Field', () => {
     expect(found.docs[0].id).toBe(category.id)
   })
 
-  it('should support where querying by a join field with hasMany relationship multiple times', async () => {
+  test('should support where querying by a join field with hasMany relationship multiple times', async ({
+    payload,
+  }) => {
     const category = await payload.create({ collection: 'categories', data: {} })
     await payload.create({
       collection: 'posts',
@@ -1938,31 +1982,34 @@ describe('Joins Field', () => {
     expect(found.docs[0].id).toBe(category.id)
   })
 
-  describe('Polymorphic join query validation', () => {
+  test.describe('Polymorphic join query validation', () => {
     const isPostgres = process.env.PAYLOAD_DATABASE === 'postgres'
 
-    it.skipIf(!isPostgres)('should reject unknown operators and not delay response', async () => {
-      const startTime = Date.now()
+    test.skipIf(!isPostgres)(
+      'should reject unknown operators and not delay response',
+      async ({ restClient }) => {
+        const startTime = Date.now()
 
-      const response = await restClient.GET('/categories', {
-        query: {
-          limit: 1,
-          joins: {
-            polymorphicJoin: {
-              limit: 1,
-              where: { x: { $raw: 'EXISTS(SELECT 1 FROM pg_sleep(3))' } },
+        const response = await restClient.GET('/categories', {
+          query: {
+            limit: 1,
+            joins: {
+              polymorphicJoin: {
+                limit: 1,
+                where: { x: { $raw: 'EXISTS(SELECT 1 FROM pg_sleep(3))' } },
+              },
             },
           },
-        },
-      })
+        })
 
-      const elapsedSeconds = (Date.now() - startTime) / 1000
+        const elapsedSeconds = (Date.now() - startTime) / 1000
 
-      expect(response.status).toBe(400)
-      expect(elapsedSeconds).toBeLessThan(1)
-    })
+        expect(response.status).toBe(400)
+        expect(elapsedSeconds).toBeLessThan(1)
+      },
+    )
 
-    it('should reject unknown operators in polymorphic join where', async () => {
+    test('should reject unknown operators in polymorphic join where', async ({ restClient }) => {
       const response = await restClient.GET('/categories', {
         query: {
           limit: 1,
@@ -1978,7 +2025,7 @@ describe('Joins Field', () => {
       expect(response.status).toBe(400)
     })
 
-    it('should allow valid operators in polymorphic join where', async () => {
+    test('should allow valid operators in polymorphic join where', async ({ restClient }) => {
       const response = await restClient.GET('/categories', {
         query: {
           limit: 1,
@@ -1994,7 +2041,7 @@ describe('Joins Field', () => {
       expect(response.status).toBe(200)
     })
 
-    it('should reject unknown operators regardless of value type', async () => {
+    test('should reject unknown operators regardless of value type', async ({ restClient }) => {
       const payloads = [
         { title: { bogus_operator: 'primitive' } },
         { title: { not_a_real_op: { nested: 'object' } } },
@@ -2018,7 +2065,7 @@ describe('Joins Field', () => {
       }
     })
 
-    it('should reject unknown operators when value is an array', async () => {
+    test('should reject unknown operators when value is an array', async ({ restClient }) => {
       // When qs parses [$raw][0]=value, the value becomes an array.
       // Arrays must be rejected the same as other value types.
       const response = await restClient.GET('/categories', {
@@ -2036,7 +2083,9 @@ describe('Joins Field', () => {
       expect(response.status).toBe(400)
     })
 
-    it('should reject disallowed characters in polymorphic join where paths', async () => {
+    test('should reject disallowed characters in polymorphic join where paths', async ({
+      restClient,
+    }) => {
       // Polymorphic joins suppress "field not found" errors so that
       // fields unique to one collection are accepted. But paths with
       // disallowed characters must always be rejected.
@@ -2066,7 +2115,7 @@ describe('Joins Field', () => {
       }
     })
 
-    it('should reject $raw in non-polymorphic join where clause', async () => {
+    test('should reject $raw in non-polymorphic join where clause', async ({ restClient }) => {
       // Non-polymorphic joins use the full parseParams pipeline, not
       // buildSQLWhere. The $raw operator must still be rejected.
       const response = await restClient.GET('/categories', {
@@ -2085,8 +2134,10 @@ describe('Joins Field', () => {
     })
   })
 
-  describe('Top-level query validation', () => {
-    it('should reject $raw operator on top-level collection queries via REST', async () => {
+  test.describe('Top-level query validation', () => {
+    test('should reject $raw operator on top-level collection queries via REST', async ({
+      restClient,
+    }) => {
       // $raw is an internal-only operator and must be rejected
       // at the top-level collection query as well as in joins.
       const response = await restClient.GET(`/${postsSlug}`, {
@@ -2099,7 +2150,7 @@ describe('Joins Field', () => {
       expect(response.status).toBe(400)
     })
 
-    it('should reject $raw operator via Local API', async () => {
+    test('should reject $raw operator via Local API', async ({ payload }) => {
       // The Local API goes through the same validateQueryPaths pipeline.
       await expect(
         payload.find({
@@ -2110,7 +2161,9 @@ describe('Joins Field', () => {
       ).rejects.toBeTruthy()
     })
 
-    it('should reject unknown operators on top-level collection queries', async () => {
+    test('should reject unknown operators on top-level collection queries', async ({
+      restClient,
+    }) => {
       const response = await restClient.GET(`/${postsSlug}`, {
         query: {
           limit: 1,
@@ -2121,7 +2174,7 @@ describe('Joins Field', () => {
       expect(response.status).toBe(400)
     })
 
-    it('should reject $raw nested inside AND combinator', async () => {
+    test('should reject $raw nested inside AND combinator', async ({ restClient }) => {
       // Unrecognized operators inside boolean combinators should
       // also be caught by recursive validation.
       const response = await restClient.GET(`/${postsSlug}`, {
@@ -2136,7 +2189,7 @@ describe('Joins Field', () => {
       expect(response.status).toBe(400)
     })
 
-    it('should reject $raw nested inside OR combinator', async () => {
+    test('should reject $raw nested inside OR combinator', async ({ restClient }) => {
       const response = await restClient.GET(`/${postsSlug}`, {
         query: {
           limit: 1,
@@ -2149,7 +2202,9 @@ describe('Joins Field', () => {
       expect(response.status).toBe(400)
     })
 
-    it('should reject $raw nested inside AND combinator in join where', async () => {
+    test('should reject $raw nested inside AND combinator in join where', async ({
+      restClient,
+    }) => {
       const response = await restClient.GET('/categories', {
         query: {
           limit: 1,
@@ -2169,7 +2224,11 @@ describe('Joins Field', () => {
   })
 })
 
-async function createPost(overrides?: Partial<Post>, locale?: Config['locale']) {
+async function createPost(
+  { payload }: { payload: Payload },
+  overrides?: Partial<Post>,
+  locale?: Config['locale'],
+) {
   return payload.create({
     collection: postsSlug,
     locale,

--- a/test/joins/queryPath.int.spec.ts
+++ b/test/joins/queryPath.int.spec.ts
@@ -1,13 +1,13 @@
 // @ts-ignore
 import { type MongooseAdapter } from '@payloadcms/db-mongodb'
 import { buildConfig, getPayload } from 'payload'
-import { afterEach, expect, it, vi } from 'vitest'
+import { expect, vi } from 'vitest'
 
 import { test } from '../__helpers/int/vitest.js'
 
-test
-  .options({ db: (adapter) => adapter === 'mongodb' || adapter === 'mongodb-atlas' })
-  .describe('mongodb read path selection', () => {
+test.suite({ db: (adapter) => adapter === 'mongodb' || adapter === 'mongodb-atlas' })(
+  'mongodb read path selection',
+  () => {
     const createdIDs: (number | string)[] = []
 
     const getPayloadInstance = async () =>
@@ -62,7 +62,7 @@ test
       }
     }
 
-    afterEach(async () => {
+    test.afterEach(async () => {
       vi.restoreAllMocks()
 
       const payload = await getPayloadInstance()
@@ -74,7 +74,7 @@ test
       createdIDs.length = 0
     })
 
-    it('should use Model.paginate when a select excludes every join field', async () => {
+    test('should use Model.paginate when a select excludes every join field', async () => {
       const { adapter, payload } = await seedCategory()
       const Model = adapter.collections.categories!
 
@@ -93,7 +93,7 @@ test
       expect(paginateSpy).toHaveBeenCalledTimes(1)
     })
 
-    it('should use Model.paginate when every join is disabled individually', async () => {
+    test('should use Model.paginate when every join is disabled individually', async () => {
       const { adapter, payload } = await seedCategory()
       const Model = adapter.collections.categories!
 
@@ -112,7 +112,7 @@ test
       expect(paginateSpy).toHaveBeenCalledTimes(1)
     })
 
-    it('should use Model.findOne for findByID when a select excludes every join field', async () => {
+    test('should use Model.findOne for findByID when a select excludes every join field', async () => {
       const { adapter, category, payload } = await seedCategory()
       const Model = adapter.collections.categories!
 
@@ -130,7 +130,7 @@ test
       expect(findOneSpy).toHaveBeenCalledTimes(1)
     })
 
-    it('should still use Model.aggregate when a join field is actually selected', async () => {
+    test('should still use Model.aggregate when a join field is actually selected', async () => {
       const { adapter, payload } = await seedCategory()
       const Model = adapter.collections.categories!
 
@@ -146,4 +146,5 @@ test
       expect(aggregateSpy).toHaveBeenCalledTimes(1)
       expect(paginateSpy).not.toHaveBeenCalled()
     })
-  })
+  },
+)

--- a/test/localization-rtl/config.ts
+++ b/test/localization-rtl/config.ts
@@ -14,43 +14,49 @@ import { Users } from './collections/users.js'
 import deepMerge from './deepMerge.js'
 
 export default buildConfigWithDefaults({
-  admin: {
-    importMap: {
-      baseDir: path.resolve(dirname),
+  suite: 'localization-rtl',
+  config: {
+    admin: {
+      importMap: {
+        baseDir: path.resolve(dirname),
+      },
     },
-  },
-  collections: [Users, Posts],
-  /*i18n: {
+    collections: [Users, Posts],
+    /*i18n: {
     fallbackLng: 'en', // default
     debug: false, // default
     resources: {
       ar: deepMerge(en, ar),
     },
   },*/
-  localization: {
-    locales: [
-      {
-        label: 'English',
-        code: 'en',
+    i18n: {
+      supportedLanguages: {
+        ar,
+        de,
+        en,
+        es,
       },
-      {
-        label: 'Arabic',
-        code: 'ar',
-        rtl: true,
-      },
-    ],
-    defaultLocale: 'en',
-    fallback: true,
-  },
-  i18n: {
-    supportedLanguages: {
-      ar,
-      en,
-      es,
-      de,
+    },
+    localization: {
+      defaultLocale: 'en',
+      fallback: true,
+      locales: [
+        {
+          code: 'en',
+          label: 'English',
+        },
+        {
+          code: 'ar',
+          label: 'Arabic',
+          rtl: true,
+        },
+      ],
+    },
+    typescript: {
+      outputFile: path.resolve(dirname, 'payload-types.ts'),
     },
   },
-  onInit: async (payload) => {
+  seed: async (payload) => {
     await payload.create({
       collection: 'users',
       data: {
@@ -58,8 +64,5 @@ export default buildConfigWithDefaults({
         password: devUser.password,
       },
     })
-  },
-  typescript: {
-    outputFile: path.resolve(dirname, 'payload-types.ts'),
   },
 })

--- a/test/localization/config.ts
+++ b/test/localization/config.ts
@@ -59,487 +59,493 @@ const openAccess: CollectionConfig['access'] = {
 }
 
 export default buildConfigWithDefaults({
-  admin: {
-    importMap: {
-      baseDir: path.resolve(dirname),
-    },
-  },
-  collections: [
-    RichTextCollection,
-    BlocksCollection,
-    NestedArray,
-    NestedFields,
-    LocalizedDrafts,
-    LocalizedDateFields,
-    AllFieldsLocalized,
-    {
-      admin: {
-        listSearchableFields: 'name',
-      },
-      auth: true,
-      fields: [
-        {
-          name: 'name',
-          label: { en: 'Full name' },
-          type: 'text',
-        },
-        {
-          name: 'relation',
-          relationTo: localizedPostsSlug,
-          type: 'relationship',
-        },
-      ],
-      slug: 'users',
-      versions: false,
-    },
-    {
-      slug: localizedPostsSlug,
-      access: openAccess,
-      admin: {
-        useAsTitle: 'title',
-      },
-      fields: [
-        {
-          name: 'title',
-          label: { en: 'Full title' },
-          index: true,
-          localized: true,
-          type: 'text',
-        },
-        {
-          name: 'description',
-          type: 'text',
-        },
-        {
-          name: 'localizedDescription',
-          localized: true,
-          type: 'text',
-        },
-        {
-          name: 'localizedCheckbox',
-          localized: true,
-          type: 'checkbox',
-        },
-        {
-          name: 'children',
-          hasMany: true,
-          relationTo: localizedPostsSlug,
-          type: 'relationship',
-        },
-        {
-          name: 'group',
-          fields: [
-            {
-              name: 'children',
-              type: 'text',
-            },
-          ],
-          type: 'group',
-        },
-        {
-          name: 'unique',
-          type: 'text',
-          localized: true,
-          unique: true,
-        },
-      ],
-      versions: false,
-    },
-    NoLocalizedFieldsCollection,
-    ArrayCollection,
-    {
-      fields: [
-        {
-          name: 'title',
-          localized: true,
-          required: true,
-          type: 'text',
-        },
-        {
-          type: 'tabs',
-          tabs: [
-            {
-              label: 'SEO',
-              fields: [
-                {
-                  name: 'seoTitle',
-                  type: 'text',
-                  localized: true,
-                  unique: true,
-                },
-              ],
-            },
-            {
-              label: 'Main Nav',
-              fields: [
-                {
-                  name: 'nav',
-                  type: 'group',
-                  fields: [
-                    {
-                      name: 'layout',
-                      blocks: [
-                        {
-                          fields: [
-                            {
-                              name: 'text',
-                              type: 'text',
-                            },
-                            {
-                              name: 'nestedArray',
-                              type: 'array',
-                              fields: [
-                                {
-                                  name: 'text',
-                                  type: 'text',
-                                },
-                                {
-                                  name: 'l2',
-                                  type: 'array',
-                                  fields: [
-                                    {
-                                      name: 'l3',
-                                      type: 'array',
-                                      fields: [
-                                        {
-                                          name: 'l4',
-                                          type: 'array',
-                                          fields: [
-                                            {
-                                              name: 'superNestedText',
-                                              type: 'text',
-                                            },
-                                          ],
-                                        },
-                                      ],
-                                    },
-                                  ],
-                                },
-                              ],
-                            },
-                          ],
-                          slug: 'text',
-                        },
-                        {
-                          fields: [
-                            {
-                              name: 'number',
-                              type: 'number',
-                            },
-                          ],
-                          slug: 'number',
-                        },
-                      ],
-                      localized: true,
-                      required: true,
-                      type: 'blocks',
-                    },
-                  ],
-                },
-              ],
-            },
-            {
-              name: 'myTab',
-              fields: [
-                {
-                  name: 'text',
-                  type: 'text',
-                },
-                {
-                  name: 'group',
-                  type: 'group',
-                  localized: true,
-                  fields: [
-                    {
-                      name: 'nestedArray2',
-                      type: 'array',
-                      fields: [
-                        {
-                          name: 'nestedText',
-                          type: 'text',
-                        },
-                      ],
-                    },
-                    {
-                      name: 'nestedText',
-                      type: 'text',
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
-        },
-      ],
-      slug: withRequiredLocalizedFields,
-      versions: false,
-    },
-    {
-      access: openAccess,
-      fields: [
-        // Relationship
-        {
-          name: 'localizedRelationship',
-          relationTo: localizedPostsSlug,
-          type: 'relationship',
-        },
-        // Relation hasMany
-        {
-          name: 'localizedRelationHasManyField',
-          hasMany: true,
-          relationTo: localizedPostsSlug,
-          type: 'relationship',
-        },
-        // Relation multiple relationTo
-        {
-          name: 'localizedRelationMultiRelationTo',
-          relationTo: [localizedPostsSlug, cannotCreateDefaultLocale],
-          type: 'relationship',
-        },
-        // Relation multiple relationTo hasMany
-        {
-          name: 'localizedRelationMultiRelationToHasMany',
-          hasMany: true,
-          relationTo: [localizedPostsSlug, cannotCreateDefaultLocale],
-          type: 'relationship',
-        },
-      ],
-      slug: withLocalizedRelSlug,
-      versions: false,
-    },
-    {
-      fields: [
-        {
-          name: 'relationship',
-          localized: true,
-          relationTo: localizedPostsSlug,
-          type: 'relationship',
-        },
-        {
-          name: 'relationshipHasMany',
-          hasMany: true,
-          localized: true,
-          relationTo: localizedPostsSlug,
-          type: 'relationship',
-        },
-        {
-          name: 'relationMultiRelationTo',
-          localized: true,
-          relationTo: [localizedPostsSlug, cannotCreateDefaultLocale],
-          type: 'relationship',
-        },
-        {
-          name: 'relationMultiRelationToHasMany',
-          hasMany: true,
-          localized: true,
-          relationTo: [localizedPostsSlug, cannotCreateDefaultLocale],
-          type: 'relationship',
-        },
-        {
-          name: 'arrayField',
-          fields: [
-            {
-              name: 'nestedRelation',
-              label: 'Nested Relation',
-              relationTo: localizedPostsSlug,
-              type: 'relationship',
-            },
-          ],
-          label: 'Array Field',
-          localized: true,
-          type: 'array',
-        },
-      ],
-      slug: relationshipLocalizedSlug,
-      versions: false,
-    },
-    {
-      access: {
-        ...openAccess,
-        create: ({ req }) => req.locale !== defaultLocale,
-      },
-      fields: [
-        {
-          name: 'name',
-          type: 'text',
-        },
-      ],
-      slug: cannotCreateDefaultLocale,
-      versions: false,
-    },
-    {
-      access: {
-        ...openAccess,
-        update: ({ req }) => req.locale === spanishLocale,
-      },
-      fields: [
-        {
-          name: 'title',
-          type: 'text',
-          localized: true,
-        },
-      ],
-      slug: localeRestrictedSlug,
-      versions: false,
-    },
-    NestedToArrayAndBlock,
-    Group,
-    Tab,
-    {
-      slug: localizedSortSlug,
-      access: openAccess,
-      fields: [
-        {
-          name: 'title',
-          index: true,
-          localized: true,
-          type: 'text',
-        },
-        {
-          name: 'date',
-          type: 'date',
-          localized: true,
-        },
-      ],
-      versions: false,
-    },
-    {
-      slug: blocksWithLocalizedSameName,
-      fields: [
-        {
-          type: 'blocks',
-          name: 'blocks',
-          blocks: [
-            {
-              slug: 'block_first',
-              fields: [
-                {
-                  name: 'title',
-                  type: 'text',
-                  localized: true,
-                },
-              ],
-            },
-            {
-              slug: 'block_second',
-              fields: [
-                {
-                  name: 'title',
-                  type: 'text',
-                  localized: true,
-                },
-              ],
-            },
-          ],
-        },
-      ],
-      versions: false,
-    },
-    LocalizedWithinLocalized,
-    ArrayWithFallbackCollection,
-  ],
-  globals: [
-    {
-      fields: [
-        {
-          name: 'array',
-          fields: [
-            {
-              name: 'text',
-              localized: true,
-              type: 'text',
-            },
-          ],
-          type: 'array',
-        },
-      ],
-      slug: 'global-array',
-      versions: false,
-    },
-    {
-      fields: [
-        {
-          name: 'text',
-          localized: true,
-          type: 'text',
-        },
-      ],
-      slug: 'global-text',
-      versions: false,
-    },
-    {
-      fields: [
-        {
-          name: 'text',
-          localized: true,
-          type: 'text',
-        },
-      ],
-      slug: globalWithDraftsSlug,
-      versions: {
-        drafts: {},
+  suite: 'localization',
+  config: {
+    admin: {
+      importMap: {
+        baseDir: path.resolve(dirname),
       },
     },
-  ],
-  localization: {
-    filterAvailableLocales: ({ locales }) => {
-      return locales.filter((locale) => locale.code !== 'xx')
-    },
-    defaultLocale,
-    fallback: true,
-    locales: [
+    collections: [
+      RichTextCollection,
+      BlocksCollection,
+      NestedArray,
+      NestedFields,
+      LocalizedDrafts,
+      LocalizedDateFields,
+      AllFieldsLocalized,
       {
-        code: 'xx',
-        label: 'FILTERED',
+        slug: 'users',
+        admin: {
+          listSearchableFields: 'name',
+        },
+        auth: true,
+        fields: [
+          {
+            name: 'name',
+            type: 'text',
+            label: { en: 'Full name' },
+          },
+          {
+            name: 'relation',
+            type: 'relationship',
+            relationTo: localizedPostsSlug,
+          },
+        ],
+        versions: false,
       },
       {
-        code: defaultLocale,
-        label: {
-          de: 'Englisch',
-          en: 'English',
-          es: 'Inglés',
+        slug: localizedPostsSlug,
+        access: openAccess,
+        admin: {
+          useAsTitle: 'title',
         },
-        rtl: false,
+        fields: [
+          {
+            name: 'title',
+            type: 'text',
+            index: true,
+            label: { en: 'Full title' },
+            localized: true,
+          },
+          {
+            name: 'description',
+            type: 'text',
+          },
+          {
+            name: 'localizedDescription',
+            type: 'text',
+            localized: true,
+          },
+          {
+            name: 'localizedCheckbox',
+            type: 'checkbox',
+            localized: true,
+          },
+          {
+            name: 'children',
+            type: 'relationship',
+            hasMany: true,
+            relationTo: localizedPostsSlug,
+          },
+          {
+            name: 'group',
+            type: 'group',
+            fields: [
+              {
+                name: 'children',
+                type: 'text',
+              },
+            ],
+          },
+          {
+            name: 'unique',
+            type: 'text',
+            localized: true,
+            unique: true,
+          },
+        ],
+        versions: false,
+      },
+      NoLocalizedFieldsCollection,
+      ArrayCollection,
+      {
+        slug: withRequiredLocalizedFields,
+        fields: [
+          {
+            name: 'title',
+            type: 'text',
+            localized: true,
+            required: true,
+          },
+          {
+            type: 'tabs',
+            tabs: [
+              {
+                fields: [
+                  {
+                    name: 'seoTitle',
+                    type: 'text',
+                    localized: true,
+                    unique: true,
+                  },
+                ],
+                label: 'SEO',
+              },
+              {
+                fields: [
+                  {
+                    name: 'nav',
+                    type: 'group',
+                    fields: [
+                      {
+                        name: 'layout',
+                        type: 'blocks',
+                        blocks: [
+                          {
+                            slug: 'text',
+                            fields: [
+                              {
+                                name: 'text',
+                                type: 'text',
+                              },
+                              {
+                                name: 'nestedArray',
+                                type: 'array',
+                                fields: [
+                                  {
+                                    name: 'text',
+                                    type: 'text',
+                                  },
+                                  {
+                                    name: 'l2',
+                                    type: 'array',
+                                    fields: [
+                                      {
+                                        name: 'l3',
+                                        type: 'array',
+                                        fields: [
+                                          {
+                                            name: 'l4',
+                                            type: 'array',
+                                            fields: [
+                                              {
+                                                name: 'superNestedText',
+                                                type: 'text',
+                                              },
+                                            ],
+                                          },
+                                        ],
+                                      },
+                                    ],
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                          {
+                            slug: 'number',
+                            fields: [
+                              {
+                                name: 'number',
+                                type: 'number',
+                              },
+                            ],
+                          },
+                        ],
+                        localized: true,
+                        required: true,
+                      },
+                    ],
+                  },
+                ],
+                label: 'Main Nav',
+              },
+              {
+                name: 'myTab',
+                fields: [
+                  {
+                    name: 'text',
+                    type: 'text',
+                  },
+                  {
+                    name: 'group',
+                    type: 'group',
+                    fields: [
+                      {
+                        name: 'nestedArray2',
+                        type: 'array',
+                        fields: [
+                          {
+                            name: 'nestedText',
+                            type: 'text',
+                          },
+                        ],
+                      },
+                      {
+                        name: 'nestedText',
+                        type: 'text',
+                      },
+                    ],
+                    localized: true,
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+        versions: false,
       },
       {
-        code: spanishLocale,
-        label: {
-          de: 'Spanisch',
-          en: 'Spanish',
-          es: 'Español',
-        },
-        rtl: false,
+        slug: withLocalizedRelSlug,
+        access: openAccess,
+        fields: [
+          // Relationship
+          {
+            name: 'localizedRelationship',
+            type: 'relationship',
+            relationTo: localizedPostsSlug,
+          },
+          // Relation hasMany
+          {
+            name: 'localizedRelationHasManyField',
+            type: 'relationship',
+            hasMany: true,
+            relationTo: localizedPostsSlug,
+          },
+          // Relation multiple relationTo
+          {
+            name: 'localizedRelationMultiRelationTo',
+            type: 'relationship',
+            relationTo: [localizedPostsSlug, cannotCreateDefaultLocale],
+          },
+          // Relation multiple relationTo hasMany
+          {
+            name: 'localizedRelationMultiRelationToHasMany',
+            type: 'relationship',
+            hasMany: true,
+            relationTo: [localizedPostsSlug, cannotCreateDefaultLocale],
+          },
+        ],
+        versions: false,
       },
       {
-        code: portugueseLocale,
-        fallbackLocale: spanishLocale,
-        label: {
-          de: 'Portugiesisch',
-          en: 'Portuguese',
-          es: 'Portugués',
-        },
+        slug: relationshipLocalizedSlug,
+        fields: [
+          {
+            name: 'relationship',
+            type: 'relationship',
+            localized: true,
+            relationTo: localizedPostsSlug,
+          },
+          {
+            name: 'relationshipHasMany',
+            type: 'relationship',
+            hasMany: true,
+            localized: true,
+            relationTo: localizedPostsSlug,
+          },
+          {
+            name: 'relationMultiRelationTo',
+            type: 'relationship',
+            localized: true,
+            relationTo: [localizedPostsSlug, cannotCreateDefaultLocale],
+          },
+          {
+            name: 'relationMultiRelationToHasMany',
+            type: 'relationship',
+            hasMany: true,
+            localized: true,
+            relationTo: [localizedPostsSlug, cannotCreateDefaultLocale],
+          },
+          {
+            name: 'arrayField',
+            type: 'array',
+            fields: [
+              {
+                name: 'nestedRelation',
+                type: 'relationship',
+                label: 'Nested Relation',
+                relationTo: localizedPostsSlug,
+              },
+            ],
+            label: 'Array Field',
+            localized: true,
+          },
+        ],
+        versions: false,
       },
       {
-        code: 'ar',
-        label: {
-          de: 'Arabisch',
-          en: 'Arabic',
-          es: 'Árabe',
+        slug: cannotCreateDefaultLocale,
+        access: {
+          ...openAccess,
+          create: ({ req }) => req.locale !== defaultLocale,
         },
-        rtl: true,
+        fields: [
+          {
+            name: 'name',
+            type: 'text',
+          },
+        ],
+        versions: false,
       },
       {
-        code: hungarianLocale,
-        label: {
-          de: 'Ungarische',
-          en: 'Hungarian',
-          es: 'Húngaro',
+        slug: localeRestrictedSlug,
+        access: {
+          ...openAccess,
+          update: ({ req }) => req.locale === spanishLocale,
         },
-        rtl: false,
+        fields: [
+          {
+            name: 'title',
+            type: 'text',
+            localized: true,
+          },
+        ],
+        versions: false,
+      },
+      NestedToArrayAndBlock,
+      Group,
+      Tab,
+      {
+        slug: localizedSortSlug,
+        access: openAccess,
+        fields: [
+          {
+            name: 'title',
+            type: 'text',
+            index: true,
+            localized: true,
+          },
+          {
+            name: 'date',
+            type: 'date',
+            localized: true,
+          },
+        ],
+        versions: false,
+      },
+      {
+        slug: blocksWithLocalizedSameName,
+        fields: [
+          {
+            name: 'blocks',
+            type: 'blocks',
+            blocks: [
+              {
+                slug: 'block_first',
+                fields: [
+                  {
+                    name: 'title',
+                    type: 'text',
+                    localized: true,
+                  },
+                ],
+              },
+              {
+                slug: 'block_second',
+                fields: [
+                  {
+                    name: 'title',
+                    type: 'text',
+                    localized: true,
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+        versions: false,
+      },
+      LocalizedWithinLocalized,
+      ArrayWithFallbackCollection,
+    ],
+    globals: [
+      {
+        slug: 'global-array',
+        fields: [
+          {
+            name: 'array',
+            type: 'array',
+            fields: [
+              {
+                name: 'text',
+                type: 'text',
+                localized: true,
+              },
+            ],
+          },
+        ],
+        versions: false,
+      },
+      {
+        slug: 'global-text',
+        fields: [
+          {
+            name: 'text',
+            type: 'text',
+            localized: true,
+          },
+        ],
+        versions: false,
+      },
+      {
+        slug: globalWithDraftsSlug,
+        fields: [
+          {
+            name: 'text',
+            type: 'text',
+            localized: true,
+          },
+        ],
+        versions: {
+          drafts: {},
+        },
       },
     ],
+    localization: {
+      defaultLocale,
+      fallback: true,
+      filterAvailableLocales: ({ locales }) => {
+        return locales.filter((locale) => locale.code !== 'xx')
+      },
+      locales: [
+        {
+          code: 'xx',
+          label: 'FILTERED',
+        },
+        {
+          code: defaultLocale,
+          label: {
+            de: 'Englisch',
+            en: 'English',
+            es: 'Inglés',
+          },
+          rtl: false,
+        },
+        {
+          code: spanishLocale,
+          label: {
+            de: 'Spanisch',
+            en: 'Spanish',
+            es: 'Español',
+          },
+          rtl: false,
+        },
+        {
+          code: portugueseLocale,
+          fallbackLocale: spanishLocale,
+          label: {
+            de: 'Portugiesisch',
+            en: 'Portuguese',
+            es: 'Portugués',
+          },
+        },
+        {
+          code: 'ar',
+          label: {
+            de: 'Arabisch',
+            en: 'Arabic',
+            es: 'Árabe',
+          },
+          rtl: true,
+        },
+        {
+          code: hungarianLocale,
+          label: {
+            de: 'Ungarische',
+            en: 'Hungarian',
+            es: 'Húngaro',
+          },
+          rtl: false,
+        },
+      ],
+    },
+    typescript: {
+      outputFile: path.resolve(dirname, 'payload-types.ts'),
+    },
   },
-  onInit: async (payload) => {
+  seed: async (payload) => {
     // On a fresh database with autoIndex enabled, the first write to a collection (or its
     // versions collection) kicks off async index builds. A subsequent seeding write can then
     // race that catalog change and fail with a transient MongoDB "catalog changes" error.
@@ -573,8 +579,8 @@ export default buildConfigWithDefaults({
     await payload.create({
       collection: localizedDateFieldsSlug,
       data: {
-        localizedDate: new Date().toISOString(),
         date: new Date().toISOString(),
+        localizedDate: new Date().toISOString(),
       },
     })
 
@@ -659,8 +665,8 @@ export default buildConfigWithDefaults({
     })
 
     await payload.update({
-      collection: relationshipLocalizedSlug,
       id: relationshipLocalized.id,
+      collection: relationshipLocalizedSlug,
       data: {
         relationMultiRelationTo: { relationTo: collection, value: localizedPost.id },
       },
@@ -668,6 +674,7 @@ export default buildConfigWithDefaults({
     })
 
     const globalArray = await payload.updateGlobal({
+      slug: 'global-array',
       data: {
         array: [
           {
@@ -678,10 +685,10 @@ export default buildConfigWithDefaults({
           },
         ],
       },
-      slug: 'global-array',
     })
 
     await payload.updateGlobal({
+      slug: 'global-array',
       data: {
         array: globalArray.array.map((row, i) => ({
           ...row,
@@ -689,10 +696,6 @@ export default buildConfigWithDefaults({
         })),
       },
       locale: 'es',
-      slug: 'global-array',
     })
-  },
-  typescript: {
-    outputFile: path.resolve(dirname, 'payload-types.ts'),
   },
 })

--- a/test/localization/int.spec.ts
+++ b/test/localization/int.spec.ts
@@ -1,11 +1,9 @@
 import type { Payload, User, Where } from 'payload'
 
-import path from 'path'
 import { createLocalReq } from 'payload'
 import { fileURLToPath } from 'url'
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { expect } from 'vitest'
 
-import type { NextRESTClient } from '../__helpers/shared/NextRESTClient.js'
 import type {
   ArrayField,
   BlocksField,
@@ -20,13 +18,14 @@ import { devUser } from '../credentials.js'
 
 // eslint-disable-next-line payload/no-relative-monorepo-imports
 import { copyDataFromLocaleHandler } from '../../packages/ui/src/utilities/copyDataFromLocale.js'
+import { test } from '../__helpers/int/vitest.js'
 import { idToString } from '../__helpers/shared/idToString.js'
-import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
 import { arrayCollectionSlug } from './collections/Array/index.js'
 import { groupSlug } from './collections/Group/index.js'
 import { nestedToArrayAndBlockCollectionSlug } from './collections/NestedToArrayAndBlock/index.js'
 import { noLocalizedFieldsCollectionSlug } from './collections/NoLocalizedFields/index.js'
 import { tabSlug } from './collections/Tab/index.js'
+import testConfig from './config.js'
 import {
   allFieldsLocalizedSlug,
   defaultLocale,
@@ -52,26 +51,13 @@ import {
 
 const collection = localizedPostsSlug
 const global = 'global-text'
-let payload: Payload
-let restClient: NextRESTClient
 
-const filename = fileURLToPath(import.meta.url)
-const dirname = path.dirname(filename)
-
-describe('Localization', () => {
-  beforeAll(async () => {
-    ;({ payload, restClient } = await initPayloadInt(dirname))
-  })
-
-  afterAll(async () => {
-    await payload.destroy()
-  })
-
-  describe('Localization with fallback true', () => {
+test.suite({ config: testConfig })('Localization', () => {
+  test.describe('Localization with fallback true', () => {
     let post1: LocalizedPost
     let postWithLocalizedData: LocalizedPost
 
-    beforeAll(async () => {
+    test.beforeEach(async ({ payload }) => {
       post1 = await payload.create({
         collection,
         data: {
@@ -112,8 +98,8 @@ describe('Localization', () => {
       })
     })
 
-    describe('Localized text', () => {
-      it('create english', async () => {
+    test.describe('Localized text', () => {
+      test('create english', async ({ payload }) => {
         const allDocs = await payload.find({
           collection,
           where: {
@@ -123,7 +109,7 @@ describe('Localization', () => {
         expect(allDocs.docs).toContainEqual(expect.objectContaining(post1))
       })
 
-      it('add spanish translation', async () => {
+      test('add spanish translation', async ({ payload }) => {
         const updated = await payload.update({
           id: post1.id,
           collection,
@@ -145,7 +131,7 @@ describe('Localization', () => {
         expect(localized.title.es).toEqual(spanishTitle)
       })
 
-      it('should fallback to english translation when empty', async () => {
+      test('should fallback to english translation when empty', async ({ payload }) => {
         await payload.update({
           id: post1.id,
           collection,
@@ -173,7 +159,7 @@ describe('Localization', () => {
         expect(localizedFallback.title.es).toEqual('')
       })
 
-      it('should show correct fallback data for arrays', async () => {
+      test('should show correct fallback data for arrays', async ({ payload }) => {
         const localizedArrayPost = await payload.create({
           collection: arrayCollectionSlug,
           data: {
@@ -203,7 +189,9 @@ describe('Localization', () => {
         expect(resultSpanishLocale.items[0].text).toEqual('localized array item')
       })
 
-      it('should fallback to spanish translation when empty and locale-specific fallback is provided', async () => {
+      test('should fallback to spanish translation when empty and locale-specific fallback is provided', async ({
+        payload,
+      }) => {
         const localizedFallback: any = await payload.findByID({
           id: postWithLocalizedData.id,
           collection,
@@ -213,7 +201,7 @@ describe('Localization', () => {
         expect(localizedFallback.title).toEqual(spanishTitle)
       })
 
-      it('should respect fallback none', async () => {
+      test('should respect fallback none', async ({ payload }) => {
         const localizedFallback: any = await payload.findByID({
           id: postWithLocalizedData.id,
           collection,
@@ -224,12 +212,12 @@ describe('Localization', () => {
         expect(localizedFallback.title).not.toBeDefined()
       })
 
-      describe('fallback locales', () => {
+      test.describe('fallback locales', () => {
         let englishData
         let spanishData
         let localizedDoc
 
-        beforeAll(async () => {
+        test.beforeEach(async ({ payload }) => {
           englishData = {
             localizedCheckbox: false,
           }
@@ -258,7 +246,9 @@ describe('Localization', () => {
           })
         })
 
-        it('should return localized fields using fallbackLocale specified in the requested locale config', async () => {
+        test('should return localized fields using fallbackLocale specified in the requested locale config', async ({
+          payload,
+        }) => {
           const portugueseDoc = await payload.findByID({
             id: localizedDoc.id,
             collection: localizedPostsSlug,
@@ -270,9 +260,9 @@ describe('Localization', () => {
         })
       })
 
-      describe('querying', () => {
+      test.describe('querying', () => {
         let localizedPost: LocalizedPost
-        beforeEach(async () => {
+        test.beforeEach(async ({ payload }) => {
           const { id } = await payload.create({
             collection,
             data: {
@@ -290,7 +280,7 @@ describe('Localization', () => {
           })
         })
 
-        it('unspecified locale returns default', async () => {
+        test('unspecified locale returns default', async ({ payload }) => {
           const localized = await payload.findByID({
             id: localizedPost.id,
             collection,
@@ -299,7 +289,7 @@ describe('Localization', () => {
           expect(localized.title).toEqual(englishTitle)
         })
 
-        it('specific locale - same as default', async () => {
+        test('specific locale - same as default', async ({ payload }) => {
           const localized = await payload.findByID({
             id: localizedPost.id,
             collection,
@@ -309,7 +299,7 @@ describe('Localization', () => {
           expect(localized.title).toEqual(englishTitle)
         })
 
-        it('specific locale - not default', async () => {
+        test('specific locale - not default', async ({ payload }) => {
           const localized = await payload.findByID({
             id: localizedPost.id,
             collection,
@@ -319,7 +309,7 @@ describe('Localization', () => {
           expect(localized.title).toEqual(spanishTitle)
         })
 
-        it('all locales', async () => {
+        test('all locales', async ({ payload }) => {
           const localized: any = await payload.findByID({
             id: localizedPost.id,
             collection,
@@ -330,7 +320,7 @@ describe('Localization', () => {
           expect(localized.title.es).toEqual(spanishTitle)
         })
 
-        it('rest all locales with all', async () => {
+        test('rest all locales with all', async ({ restClient }) => {
           const response = await restClient.GET(`/${collection}/${localizedPost.id}`, {
             query: {
               locale: 'all',
@@ -344,7 +334,7 @@ describe('Localization', () => {
           expect(localized.title.es).toEqual(spanishTitle)
         })
 
-        it('rest all locales with asterisk', async () => {
+        test('rest all locales with asterisk', async ({ restClient }) => {
           const response = await restClient.GET(`/${collection}/${localizedPost.id}`, {
             query: {
               locale: '*',
@@ -358,7 +348,7 @@ describe('Localization', () => {
           expect(localized.title.es).toEqual(spanishTitle)
         })
 
-        it('by localized field value - default locale', async () => {
+        test('by localized field value - default locale', async ({ payload }) => {
           const result = await payload.find({
             collection,
             where: {
@@ -371,7 +361,7 @@ describe('Localization', () => {
           expect(result.docs.map(({ id }) => id)).toContain(localizedPost.id)
         })
 
-        it('by localized field value - alternate locale', async () => {
+        test('by localized field value - alternate locale', async ({ payload }) => {
           const result = await payload.find({
             collection,
             locale: spanishLocale,
@@ -385,7 +375,7 @@ describe('Localization', () => {
           expect(result.docs.map(({ id }) => id)).toContain(localizedPost.id)
         })
 
-        it('by localized field value - opposite locale???', async () => {
+        test('by localized field value - opposite locale???', async ({ payload }) => {
           const result = await payload.find({
             collection,
             locale: 'all',
@@ -399,7 +389,7 @@ describe('Localization', () => {
           expect(result.docs.map(({ id }) => id)).toContain(localizedPost.id)
         })
 
-        it('by localized field value with sorting', async () => {
+        test('by localized field value with sorting', async ({ payload }) => {
           const doc_1 = await payload.create({ collection, data: { title: 'word_b' } })
           const doc_2 = await payload.create({ collection, data: { title: 'word_a' } })
           const doc_3 = await payload.create({ collection, data: { title: 'word_c' } })
@@ -423,10 +413,10 @@ describe('Localization', () => {
         })
 
         if (mongooseList.includes(process.env.PAYLOAD_DATABASE)) {
-          describe('Localized sorting', () => {
+          test.describe('Localized sorting', () => {
             let localizedAccentPostOne: LocalizedPost
             let localizedAccentPostTwo: LocalizedPost
-            beforeEach(async () => {
+            test.beforeEach(async ({ payload }) => {
               localizedAccentPostOne = await payload.create({
                 collection,
                 data: {
@@ -466,7 +456,7 @@ describe('Localization', () => {
               })
             })
 
-            it('should sort alphabetically even with accented letters', async () => {
+            test('should sort alphabetically even with accented letters', async ({ payload }) => {
               const sortByDescriptionQuery = await payload.find({
                 collection,
                 sort: 'description',
@@ -485,8 +475,8 @@ describe('Localization', () => {
       })
     })
 
-    describe('Localized date', () => {
-      it('can create a localized date', async () => {
+    test.describe('Localized date', () => {
+      test('can create a localized date', async ({ payload }) => {
         const document = await payload.create({
           collection: localizedDateFieldsSlug,
           data: {
@@ -497,7 +487,7 @@ describe('Localization', () => {
         expect(document.localizedDate).toBeTruthy()
       })
 
-      it('data is typed as string', async () => {
+      test('data is typed as string', async ({ payload }) => {
         const document = await payload.create({
           collection: localizedDateFieldsSlug,
           data: {
@@ -511,10 +501,12 @@ describe('Localization', () => {
       })
     })
 
-    describe('Localized Sort Count', () => {
+    test.describe('Localized Sort Count', () => {
       const expectedTotalDocs = 5
       const posts: LocalizedSort[] = []
-      beforeAll(async () => {
+      test.beforeEach(async ({ payload }) => {
+        posts.length = 0
+
         for (let i = 1; i <= expectedTotalDocs; i++) {
           const post = await payload.create({
             collection: localizedSortSlug,
@@ -539,7 +531,7 @@ describe('Localization', () => {
         }
       })
 
-      it('should have correct totalDocs when unsorted', async () => {
+      test('should have correct totalDocs when unsorted', async ({ payload }) => {
         const simpleQuery = await payload.find({
           collection: localizedSortSlug,
         })
@@ -553,7 +545,7 @@ describe('Localization', () => {
       })
 
       // https://github.com/payloadcms/payload/issues/4889
-      it('should have correct totalDocs when sorted by localized fields', async () => {
+      test('should have correct totalDocs when sorted by localized fields', async ({ payload }) => {
         const sortByTitleQuery = await payload.find({
           collection: localizedSortSlug,
           sort: 'title',
@@ -567,7 +559,7 @@ describe('Localization', () => {
         expect(sortByDateQuery.totalDocs).toEqual(expectedTotalDocs)
       })
 
-      it('should return correct order when sorted by localized fields', async () => {
+      test('should return correct order when sorted by localized fields', async ({ payload }) => {
         const { docs: docsAsc } = await payload.find({
           collection: localizedSortSlug,
           sort: 'title',
@@ -683,24 +675,30 @@ describe('Localization', () => {
       })
     })
 
-    describe('Localized Relationship', () => {
+    test.describe('Localized Relationship', () => {
       let localizedRelation: LocalizedPost
       let localizedRelation2: LocalizedPost
       let withRelationship: WithLocalizedRelationship
 
-      beforeAll(async () => {
-        localizedRelation = await createLocalizedPost({
-          title: {
-            [defaultLocale]: relationEnglishTitle,
-            [spanishLocale]: relationSpanishTitle,
+      test.beforeEach(async ({ payload }) => {
+        localizedRelation = await createLocalizedPost(
+          { payload },
+          {
+            title: {
+              [defaultLocale]: relationEnglishTitle,
+              [spanishLocale]: relationSpanishTitle,
+            },
           },
-        })
-        localizedRelation2 = await createLocalizedPost({
-          title: {
-            [defaultLocale]: relationEnglishTitle2,
-            [spanishLocale]: relationSpanishTitle2,
+        )
+        localizedRelation2 = await createLocalizedPost(
+          { payload },
+          {
+            title: {
+              [defaultLocale]: relationEnglishTitle2,
+              [spanishLocale]: relationSpanishTitle2,
+            },
           },
-        })
+        )
 
         withRelationship = await payload.create({
           collection: withLocalizedRelSlug,
@@ -719,8 +717,8 @@ describe('Localization', () => {
         })
       })
 
-      describe('regular relationship', () => {
-        it('can query localized relationship', async () => {
+      test.describe('regular relationship', () => {
+        test('can query localized relationship', async ({ payload }) => {
           const result = await payload.find({
             collection: withLocalizedRelSlug,
             where: {
@@ -733,7 +731,7 @@ describe('Localization', () => {
           expect(result.docs[0].id).toEqual(withRelationship.id)
         })
 
-        it('specific locale', async () => {
+        test('specific locale', async ({ payload }) => {
           const result = await payload.find({
             collection: withLocalizedRelSlug,
             locale: spanishLocale,
@@ -747,7 +745,7 @@ describe('Localization', () => {
           expect(result.docs[0].id).toEqual(withRelationship.id)
         })
 
-        it('all locales', async () => {
+        test('all locales', async ({ payload }) => {
           const result = await payload.find({
             collection: withLocalizedRelSlug,
             locale: 'all',
@@ -761,7 +759,7 @@ describe('Localization', () => {
           expect(result.docs[0].id).toEqual(withRelationship.id)
         })
 
-        it('populates relationships with all locales', async () => {
+        test('populates relationships with all locales', async ({ payload }) => {
           // the relationship fields themselves are localized on this collection
           const result: any = await payload.find({
             collection: relationshipLocalizedSlug,
@@ -777,8 +775,8 @@ describe('Localization', () => {
         })
       })
 
-      describe('relationship - hasMany', () => {
-        it('default locale', async () => {
+      test.describe('relationship - hasMany', () => {
+        test('default locale', async ({ payload }) => {
           const result = await payload.find({
             collection: withLocalizedRelSlug,
             where: {
@@ -803,7 +801,7 @@ describe('Localization', () => {
           expect(result2.docs.map(({ id }) => id)).toContain(withRelationship.id)
         })
 
-        it('specific locale', async () => {
+        test('specific locale', async ({ payload }) => {
           const result = await payload.find({
             collection: withLocalizedRelSlug,
             locale: spanishLocale,
@@ -830,7 +828,7 @@ describe('Localization', () => {
           expect(result2.docs[0].id).toEqual(withRelationship.id)
         })
 
-        it('relationship population uses locale', async () => {
+        test('relationship population uses locale', async ({ payload }) => {
           const result = await payload.findByID({
             id: withRelationship.id,
             collection: withLocalizedRelSlug,
@@ -842,7 +840,7 @@ describe('Localization', () => {
           )
         })
 
-        it('all locales', async () => {
+        test('all locales', async ({ payload }) => {
           const queryRelation = (where: Where) => {
             return payload.find({
               collection: withLocalizedRelSlug,
@@ -888,8 +886,8 @@ describe('Localization', () => {
         })
       })
 
-      describe('relationTo multi', () => {
-        it('by id', async () => {
+      test.describe('relationTo multi', () => {
+        test('by id', async ({ payload }) => {
           const result = await payload.find({
             collection: withLocalizedRelSlug,
             where: {
@@ -916,8 +914,8 @@ describe('Localization', () => {
         })
       })
 
-      describe('relationTo multi hasMany', () => {
-        it('by id', async () => {
+      test.describe('relationTo multi hasMany', () => {
+        test('by id', async ({ payload }) => {
           const result = await payload.find({
             collection: withLocalizedRelSlug,
             where: {
@@ -969,8 +967,8 @@ describe('Localization', () => {
       })
     })
 
-    describe('Localized - arrays with nested localized fields', () => {
-      it('should allow moving rows and retain existing row locale data', async () => {
+    test.describe('Localized - arrays with nested localized fields', () => {
+      test('should allow moving rows and retain existing row locale data', async ({ payload }) => {
         const globalArray: any = await payload.findGlobal({
           slug: 'global-array',
         })
@@ -990,8 +988,8 @@ describe('Localization', () => {
       })
     })
 
-    describe('Localized - required', () => {
-      it('should update without passing all required fields', async () => {
+    test.describe('Localized - required', () => {
+      test('should update without passing all required fields', async ({ payload }) => {
         const newDoc = await payload.create({
           collection: withRequiredLocalizedFields,
           data: {
@@ -1044,11 +1042,34 @@ describe('Localization', () => {
       })
     })
 
-    describe('Localized - GraphQL', () => {
+    test.describe('Localized - GraphQL', () => {
       let token
-      let client
 
-      it('should allow user to login and retrieve populated localized field', async () => {
+      test.beforeEach(async ({ restClient }) => {
+        const query = `mutation {
+          loginUser(email: "dev@payloadcms.com", password: "test") {
+            token
+            user {
+              relation {
+                title
+              }
+            }
+          }
+        }`
+
+        const { data } = await restClient
+          .GRAPHQL_POST({
+            body: JSON.stringify({ query }),
+            query: { locale: 'en' },
+          })
+          .then((res) => res.json())
+
+        token = data.loginUser.token
+      })
+
+      test('should allow user to login and retrieve populated localized field', async ({
+        restClient,
+      }) => {
         const query = `mutation {
         loginUser(email: "dev@payloadcms.com", password: "test") {
           token
@@ -1070,11 +1091,11 @@ describe('Localization', () => {
 
         expect(typeof result.token).toStrictEqual('string')
         expect(typeof result.user.relation.title).toStrictEqual('string')
-
-        token = result.token
       })
 
-      it('should allow retrieval of populated localized fields within meUser', async () => {
+      test('should allow retrieval of populated localized fields within meUser', async ({
+        restClient,
+      }) => {
         const query = `query {
         meUser {
           user {
@@ -1100,7 +1121,7 @@ describe('Localization', () => {
         expect(typeof result.user.relation.title).toStrictEqual('string')
       })
 
-      it('should create and update collections', async () => {
+      test('should create and update collections', async ({ payload, restClient }) => {
         const create = `mutation {
         createLocalizedPost(
           data: {
@@ -1159,7 +1180,7 @@ describe('Localization', () => {
         expect(result.title[spanishLocale]).toStrictEqual(spanishTitle)
       })
 
-      it('should query multiple locales', async () => {
+      test('should query multiple locales', async ({ payload, restClient }) => {
         const englishDoc = await payload.create({
           collection: localizedPostsSlug,
           data: {
@@ -1202,10 +1223,10 @@ describe('Localization', () => {
       })
     })
 
-    describe('Localized - Arrays', () => {
+    test.describe('Localized - Arrays', () => {
       let docID
 
-      beforeAll(async () => {
+      test.beforeEach(async ({ payload }) => {
         const englishDoc = await payload.create({
           collection: arrayCollectionSlug,
           data: {
@@ -1220,7 +1241,7 @@ describe('Localization', () => {
         docID = englishDoc.id
       })
 
-      it('should use default locale as fallback', async () => {
+      test('should use default locale as fallback', async ({ payload }) => {
         const spanishDoc = await payload.findByID({
           id: docID,
           collection: arrayCollectionSlug,
@@ -1230,7 +1251,7 @@ describe('Localization', () => {
         expect(spanishDoc.items[0].text).toStrictEqual(englishTitle)
       })
 
-      it('should use empty array as value', async () => {
+      test('should use empty array as value', async ({ payload }) => {
         const updatedSpanishDoc = await payload.update({
           id: docID,
           collection: arrayCollectionSlug,
@@ -1244,7 +1265,7 @@ describe('Localization', () => {
         expect(updatedSpanishDoc.items).toStrictEqual(null)
       })
 
-      it('should allow optional fallback data', async () => {
+      test('should allow optional fallback data', async ({ payload }) => {
         const englishDoc = await payload.create({
           collection: arrayCollectionSlug,
           data: {
@@ -1273,7 +1294,6 @@ describe('Localization', () => {
         })
 
         if (isMongoose(payload)) {
-          // eslint-disable-next-line vitest/no-conditional-expect
           expect(docWithoutFallback.items).toStrictEqual(null)
         } else {
           // TODO: build out compatability with SQL databases
@@ -1281,12 +1301,12 @@ describe('Localization', () => {
           // The join only has 2 states, undefined or the localized value of the requested locale.
           // If the localized value is not in the DB, there is no way to know if the value should fallback or not so we fallback if fallbackLocale is truthy.
           // In MongoDB the value can be set to null, which allows us to know that the value should fallback.
-          // eslint-disable-next-line vitest/no-conditional-expect
+
           expect(docWithoutFallback.items).toStrictEqual(englishDoc.items)
         }
       })
 
-      it('should use fallback value if setting null', async () => {
+      test('should use fallback value if setting null', async ({ payload }) => {
         await payload.update({
           id: docID,
           collection: arrayCollectionSlug,
@@ -1310,8 +1330,11 @@ describe('Localization', () => {
       })
     })
 
-    describe('Localized - Field Paths', () => {
-      it('should allow querying by non-localized field names ending in a locale', async () => {
+    test.describe('Localized - Field Paths', () => {
+      test('should allow querying by non-localized field names ending in a locale', async ({
+        payload,
+        restClient,
+      }) => {
         await payload.update({
           id: post1.id,
           collection,
@@ -1353,8 +1376,8 @@ describe('Localization', () => {
       })
     })
 
-    describe('Nested To Array And Block', () => {
-      it('should be equal to the created document', async () => {
+    test.describe('Nested To Array And Block', () => {
+      test('should be equal to the created document', async ({ payload }) => {
         const { id, blocks } = await payload.create({
           collection: nestedToArrayAndBlockCollectionSlug,
           data: {
@@ -1407,8 +1430,8 @@ describe('Localization', () => {
       })
     })
 
-    describe('Duplicate Collection', () => {
-      it('should duplicate localized document', async () => {
+    test.describe('Duplicate Collection', () => {
+      test('should duplicate localized document', async ({ payload }) => {
         const localizedPost = await payload.create({
           collection: localizedPostsSlug,
           data: {
@@ -1451,7 +1474,7 @@ describe('Localization', () => {
         expect(allLocales.localizedCheckbox.es).toBeFalsy()
       })
 
-      it('should duplicate with localized blocks', async () => {
+      test('should duplicate with localized blocks', async ({ payload }) => {
         // This test covers a few things:
         // 1. make sure we can duplicate localized blocks
         //    - in relational DBs, we need to create new block / array IDs
@@ -1619,7 +1642,9 @@ describe('Localization', () => {
         expect(allLocales.myTab.group.es.nestedArray2[1].nestedText).toStrictEqual('adios')
       })
 
-      it('should retain non-localized fields when duplicating select locales', async () => {
+      test('should retain non-localized fields when duplicating select locales', async ({
+        payload,
+      }) => {
         const post = await payload.create({
           collection,
           data: {
@@ -1655,8 +1680,8 @@ describe('Localization', () => {
       })
     })
 
-    describe('Localized group and tabs', () => {
-      it('should properly create/update/read localized group field', async () => {
+    test.describe('Localized group and tabs', () => {
+      test('should properly create/update/read localized group field', async ({ payload }) => {
         const result = await payload.create({
           collection: groupSlug,
           data: {
@@ -1695,7 +1720,9 @@ describe('Localization', () => {
         expect(docEs.groupLocalized.title).toBe('hello es')
       })
 
-      it('should properly create/update/read localized field inside of group', async () => {
+      test('should properly create/update/read localized field inside of group', async ({
+        payload,
+      }) => {
         const result = await payload.create({
           collection: groupSlug,
           locale: englishLocale,
@@ -1734,7 +1761,9 @@ describe('Localization', () => {
         expect(docEs.group.title).toBe('hello es')
       })
 
-      it('should properly create/update/read deep localized field inside of group', async () => {
+      test('should properly create/update/read deep localized field inside of group', async ({
+        payload,
+      }) => {
         const result = await payload.create({
           collection: groupSlug,
           locale: englishLocale,
@@ -1793,7 +1822,7 @@ describe('Localization', () => {
         expect(docEs.deep.blocks[0].title).toBe('hello es')
       })
 
-      it('should create/updated/read localized group with row field', async () => {
+      test('should create/updated/read localized group with row field', async ({ payload }) => {
         const doc = await payload.create({
           collection: 'groups',
           data: {
@@ -1829,7 +1858,7 @@ describe('Localization', () => {
         expect(all.groupLocalizedRow.es.text).toBe('hola world or something')
       })
 
-      it('should not crash on empty localized tab', async () => {
+      test('should not crash on empty localized tab', async ({ payload }) => {
         const result = await payload.create({
           collection: tabSlug,
           locale: englishLocale,
@@ -1841,7 +1870,9 @@ describe('Localization', () => {
         expect(result).toBeTruthy()
       })
 
-      it('should properly create/update/read array field inside localized tab field', async () => {
+      test('should properly create/update/read array field inside localized tab field', async ({
+        payload,
+      }) => {
         const result = await payload.create({
           collection: tabSlug,
           locale: englishLocale,
@@ -1881,7 +1912,7 @@ describe('Localization', () => {
         expect(docEs.tabLocalized.title).toBe('hello es')
       })
 
-      it('should properly create/update/read localized tab field', async () => {
+      test('should properly create/update/read localized tab field', async ({ payload }) => {
         const result = await payload.create({
           collection: tabSlug,
           locale: englishLocale,
@@ -1925,7 +1956,9 @@ describe('Localization', () => {
         expect(docEs.tabLocalized.array[0].title).toBe('hello es')
       })
 
-      it('should properly create/update/read localized field inside of tab', async () => {
+      test('should properly create/update/read localized field inside of tab', async ({
+        payload,
+      }) => {
         const result = await payload.create({
           collection: tabSlug,
           locale: englishLocale,
@@ -1964,7 +1997,9 @@ describe('Localization', () => {
         expect(docEs.tab.title).toBe('hello es')
       })
 
-      it('should properly create/update/read deep localized field inside of tab', async () => {
+      test('should properly create/update/read deep localized field inside of tab', async ({
+        payload,
+      }) => {
         const result = await payload.create({
           collection: tabSlug,
           locale: englishLocale,
@@ -2023,7 +2058,9 @@ describe('Localization', () => {
         expect(docEs.deep.blocks[0].title).toBe('hello es')
       })
 
-      it('should properly isolate locales for a group inside a localized tab', async () => {
+      test('should properly isolate locales for a group inside a localized tab', async ({
+        payload,
+      }) => {
         const docEs = await payload.create({
           collection: tabSlug,
           locale: spanishLocale,
@@ -2068,8 +2105,8 @@ describe('Localization', () => {
 
     // Nested localized fields do no longer have their localized property stripped in
     // this monorepo, as this is handled at runtime.
-    describe('nested localized field sanitization', () => {
-      it('ensure nested localized fields keep localized property in monorepo', () => {
+    test.describe('nested localized field sanitization', () => {
+      test('ensure nested localized fields keep localized property in monorepo', ({ payload }) => {
         const collection = payload.collections['localized-within-localized'].config
 
         expect(collection.fields[0].tabs[0].fields[0].localized).toBeDefined()
@@ -2079,9 +2116,9 @@ describe('Localization', () => {
       })
     })
 
-    describe('nested blocks', () => {
+    test.describe('nested blocks', () => {
       let id
-      it('should allow creating nested blocks per locale', async () => {
+      test('should allow creating nested blocks per locale', async ({ payload }) => {
         const doc = await payload.create({
           collection: 'blocks-fields',
           data: {
@@ -2166,8 +2203,10 @@ describe('Localization', () => {
       })
     })
 
-    describe('nested arrays', () => {
-      it('should not duplicate block rows for blocks within localized array fields', async () => {
+    test.describe('nested arrays', () => {
+      test('should not duplicate block rows for blocks within localized array fields', async ({
+        payload,
+      }) => {
         const randomDoc = (
           await payload.find({
             collection: 'localized-posts',
@@ -2288,7 +2327,7 @@ describe('Localization', () => {
         expect(enDoc2.arrayWithBlocks[0].blocksWithinArray).toEqual(blocksWithinArrayEN)
       })
 
-      it('should update localized relation within unLocalized array', async () => {
+      test('should update localized relation within unLocalized array', async ({ payload }) => {
         const randomTextDoc = (
           await payload.find({
             collection: 'localized-posts',
@@ -2348,8 +2387,8 @@ describe('Localization', () => {
       })
     })
 
-    describe('nested fields', () => {
-      it('should update localized block', async () => {
+    test.describe('nested fields', () => {
+      test('should update localized block', async ({ payload }) => {
         const doc = await payload.create({
           collection: 'blocks-fields',
           locale: 'en',
@@ -2402,7 +2441,9 @@ describe('Localization', () => {
         expect(updated.content?.[0]?.content?.[0]?.text).toBe('some-text')
       })
 
-      it('update specific locale should not erease the others in blocks and arrays', async () => {
+      test('update specific locale should not erease the others in blocks and arrays', async ({
+        payload,
+      }) => {
         const doc = await payload.create({
           collection: 'nested',
           locale: 'en',
@@ -2482,7 +2523,9 @@ describe('Localization', () => {
         })
       })
 
-      it('update specific locale should not erease the others in simple fields', async () => {
+      test('update specific locale should not erease the others in simple fields', async ({
+        payload,
+      }) => {
         const doc = await payload.create({
           collection: 'localized-posts',
           locale: 'en',
@@ -2538,7 +2581,9 @@ describe('Localization', () => {
           es: 'some-localized-description-es',
         })
       })
-      it('should allow for fields which could contain new tables within localized arrays to be stored', async () => {
+      test('should allow for fields which could contain new tables within localized arrays to be stored', async ({
+        payload,
+      }) => {
         const randomDoc = (
           await payload.find({
             collection: 'localized-posts',
@@ -2642,7 +2687,9 @@ describe('Localization', () => {
         expect(retrieved.array.es[0].text).toEqual(['hola', 'adios'])
       })
 
-      it('should allow for relationship in new tables within blocks inside of localized blocks to be stored', async () => {
+      test('should allow for relationship in new tables within blocks inside of localized blocks to be stored', async ({
+        payload,
+      }) => {
         const randomDoc = (
           await payload.find({
             collection: 'localized-posts',
@@ -2772,7 +2819,9 @@ describe('Localization', () => {
         expect(docAll.blocks.es[2].nestedBlocks[0].relation.value).toBe(randomDoc2.id)
       })
 
-      it('should allow for relationship in new tables within arrays inside of localized blocks to be stored', async () => {
+      test('should allow for relationship in new tables within arrays inside of localized blocks to be stored', async ({
+        payload,
+      }) => {
         const randomDoc = (
           await payload.find({
             collection: 'localized-posts',
@@ -2897,8 +2946,8 @@ describe('Localization', () => {
       })
     })
 
-    describe('localized with unique', () => {
-      it('localized with unique should work for each locale', async () => {
+    test.describe('localized with unique', () => {
+      test('localized with unique should work for each locale', async ({ payload }) => {
         await payload.create({
           collection: 'localized-posts',
           locale: 'ar',
@@ -2934,7 +2983,9 @@ describe('Localization', () => {
         ).rejects.toBeTruthy()
       })
 
-      it('should return correct error path without locale suffix for top-level localized unique field', async () => {
+      test('should return correct error path without locale suffix for top-level localized unique field', async ({
+        payload,
+      }) => {
         const uniqueValue = `unique-path-test-${Date.now()}`
 
         await payload.create({
@@ -2955,19 +3006,19 @@ describe('Localization', () => {
           })
           expect.unreachable('Should have thrown a ValidationError')
         } catch (error: any) {
-          // eslint-disable-next-line vitest/no-conditional-expect
           expect(error.name).toBe('ValidationError')
           const fieldError = error.data.errors[0]
 
-          // eslint-disable-next-line vitest/no-conditional-expect
           expect(fieldError.message).toContain('unique')
           // The path should be the field name without locale suffix
-          // eslint-disable-next-line vitest/no-conditional-expect
+
           expect(fieldError.path).toBe('unique')
         }
       })
 
-      it('should return correct error path without locale suffix for localized unique field inside tabs', async () => {
+      test('should return correct error path without locale suffix for localized unique field inside tabs', async ({
+        payload,
+      }) => {
         const uniqueValue = `seo-unique-test-${Date.now()}`
 
         const blockData = [{ blockType: 'text', text: 'test' }]
@@ -2998,23 +3049,21 @@ describe('Localization', () => {
           })
           expect.unreachable('Should have thrown a ValidationError')
         } catch (error: any) {
-          // eslint-disable-next-line vitest/no-conditional-expect
           expect(error.name).toBe('ValidationError')
           const fieldError = error.data.errors[0]
 
-          // eslint-disable-next-line vitest/no-conditional-expect
           expect(fieldError.message).toContain('unique')
           // The path should be the field name without locale suffix (not "seoTitle.en")
-          // eslint-disable-next-line vitest/no-conditional-expect
+
           expect(fieldError.path).toBe('seoTitle')
         }
       })
     })
 
-    describe('Copying To Locale', () => {
+    test.describe('Copying To Locale', () => {
       let user: User
 
-      beforeAll(async () => {
+      test.beforeEach(async ({ payload }) => {
         user = (
           await payload.find({
             collection: 'users',
@@ -3029,7 +3078,7 @@ describe('Localization', () => {
         user['collection'] = 'users'
       })
 
-      it('should copy to locale', async () => {
+      test('should copy to locale', async ({ payload }) => {
         const doc = await payload.create({
           collection: 'localized-posts',
           data: {
@@ -3058,7 +3107,7 @@ describe('Localization', () => {
         expect(res.localizedCheckbox).toBe(true)
       })
 
-      it('should copy block to locale', async () => {
+      test('should copy block to locale', async ({ payload }) => {
         // This was previously an e2e test but it was migrated to int
         // because at the moment only int tests run in Postgres in CI,
         // and that's where the bug occurs.
@@ -3093,7 +3142,7 @@ describe('Localization', () => {
         expect(res.content?.[0]?.content?.[0]?.text).toBe('some-text')
       })
 
-      it('should copy block inside tab to locale', async () => {
+      test('should copy block inside tab to locale', async ({ payload }) => {
         // This was previously an e2e test but it was migrated to int
         // because at the moment only int tests run in Postgres in CI,
         // and that's where the bug occurs.
@@ -3122,7 +3171,7 @@ describe('Localization', () => {
         expect(res.tabContent?.[0]?.text).toBe('some-text')
       })
 
-      it('should copy localized nested to arrays', async () => {
+      test('should copy localized nested to arrays', async ({ payload }) => {
         const doc = await payload.create({
           collection: 'nested',
           locale: 'en',
@@ -3160,7 +3209,7 @@ describe('Localization', () => {
         expect(refreshedDoc.topLevelArray).toHaveLength(1)
       })
 
-      it('should copy localized arrays', async () => {
+      test('should copy localized arrays', async ({ payload }) => {
         const doc = await payload.create({
           collection: 'nested',
           locale: 'en',
@@ -3194,7 +3243,9 @@ describe('Localization', () => {
         expect(refreshedDoc.topLevelArrayLocalized?.[0]?.text).toBe('some-text')
       })
 
-      it('should copy nested arrays through tabs within localized arrays', async () => {
+      test('should copy nested arrays through tabs within localized arrays', async ({
+        payload,
+      }) => {
         const doc = await payload.create({
           collection: arrayCollectionSlug,
           data: {
@@ -3231,7 +3282,9 @@ describe('Localization', () => {
         }
       })
 
-      it('should copy to locale without losing data when autosave and drafts are enabled', async () => {
+      test('should copy to locale without losing data when autosave and drafts are enabled', async ({
+        payload,
+      }) => {
         // The blocks-fields collection has versions.drafts.autosave: true
         // This test verifies that copyToLocale doesn't cause data loss
         // when operating on a collection with autosave enabled
@@ -3318,7 +3371,9 @@ describe('Localization', () => {
         expect(esDocAfter.content?.[0]?.text).toBe('English block text')
       })
 
-      it('should copy to locale without losing draft data when autosave is enabled', async () => {
+      test('should copy to locale without losing draft data when autosave is enabled', async ({
+        payload,
+      }) => {
         // Create a document with draft content
         const doc = await payload.create({
           collection: 'blocks-fields',
@@ -3368,7 +3423,9 @@ describe('Localization', () => {
         expect(draftAfter.content?.[0]?.text).toBe('Draft block text')
       })
 
-      it('should not overwrite published content when source has both published and draft versions', async () => {
+      test('should not overwrite published content when source has both published and draft versions', async ({
+        payload,
+      }) => {
         // Create published doc in en
         const doc = await payload.create({
           collection: 'blocks-fields',
@@ -3430,10 +3487,10 @@ describe('Localization', () => {
       })
     })
 
-    describe('Multiple fallback locales', () => {
-      describe('Local API', () => {
-        describe('Collections', () => {
-          it('should allow fallback locale to be an array', async () => {
+    test.describe('Multiple fallback locales', () => {
+      test.describe('Local API', () => {
+        test.describe('Collections', () => {
+          test('should allow fallback locale to be an array', async ({ payload }) => {
             const result = await payload.findByID({
               id: postWithLocalizedData.id,
               collection,
@@ -3445,7 +3502,9 @@ describe('Localization', () => {
             expect((result as any).title).toBe(spanishTitle)
           })
 
-          it('should pass over fallback locales until it finds one that exists', async () => {
+          test('should pass over fallback locales until it finds one that exists', async ({
+            payload,
+          }) => {
             const result = await payload.findByID({
               id: postWithLocalizedData.id,
               collection,
@@ -3457,7 +3516,7 @@ describe('Localization', () => {
             expect((result as any).title).toBe(spanishTitle)
           })
 
-          it('should return undefined if no fallback locales exist', async () => {
+          test('should return undefined if no fallback locales exist', async ({ payload }) => {
             const result = await payload.findByID({
               id: postWithLocalizedData.id,
               collection,
@@ -3470,8 +3529,8 @@ describe('Localization', () => {
           })
         })
 
-        describe('Globals', () => {
-          it('should allow fallback locale to be an array', async () => {
+        test.describe('Globals', () => {
+          test('should allow fallback locale to be an array', async ({ payload }) => {
             const result = await payload.findGlobal({
               slug: global,
               locale: portugueseLocale,
@@ -3482,7 +3541,9 @@ describe('Localization', () => {
             expect(result.text).toBe(spanishTitle)
           })
 
-          it('should pass over fallback locales until it finds one that exists', async () => {
+          test('should pass over fallback locales until it finds one that exists', async ({
+            payload,
+          }) => {
             const result = await payload.findGlobal({
               slug: global,
               locale: portugueseLocale,
@@ -3492,7 +3553,7 @@ describe('Localization', () => {
             expect(result.text).toBe(spanishTitle)
           })
 
-          it('should return undefined if no fallback locales exist', async () => {
+          test('should return undefined if no fallback locales exist', async ({ payload }) => {
             const result = await payload.findGlobal({
               slug: global,
               locale: portugueseLocale,
@@ -3505,9 +3566,9 @@ describe('Localization', () => {
         })
       })
 
-      describe('REST API', () => {
-        describe('Collections', () => {
-          it('should allow fallback locale to be an array', async () => {
+      test.describe('REST API', () => {
+        test.describe('Collections', () => {
+          test('should allow fallback locale to be an array', async ({ restClient }) => {
             const response = await restClient.GET(
               `/${collection}/${postWithLocalizedData.id}?locale=pt&fallbackLocale[]=es&fallbackLocale[]=en`,
             )
@@ -3518,7 +3579,9 @@ describe('Localization', () => {
             expect(result.title).toEqual(spanishTitle)
           })
 
-          it('should pass over fallback locales until it finds one that exists', async () => {
+          test('should pass over fallback locales until it finds one that exists', async ({
+            restClient,
+          }) => {
             const response = await restClient.GET(
               `/${collection}/${postWithLocalizedData.id}?locale=pt&fallbackLocale[]=hu&fallbackLocale[]=ar&fallbackLocale[]=es`,
             )
@@ -3529,7 +3592,7 @@ describe('Localization', () => {
             expect(result.title).toEqual(spanishTitle)
           })
 
-          it('should return undefined if no fallback locales exist', async () => {
+          test('should return undefined if no fallback locales exist', async ({ restClient }) => {
             const response = await restClient.GET(
               `/${collection}/${postWithLocalizedData.id}?locale=pt&fallbackLocale[]=hu&fallbackLocale[]=ar`,
             )
@@ -3541,8 +3604,8 @@ describe('Localization', () => {
           })
         })
 
-        describe('Globals', () => {
-          it('should allow fallback locale to be an array', async () => {
+        test.describe('Globals', () => {
+          test('should allow fallback locale to be an array', async ({ restClient }) => {
             const response = await restClient.GET(
               `/globals/${global}?locale=pt&fallbackLocale[]=es&fallbackLocale[]=en`,
             )
@@ -3552,7 +3615,9 @@ describe('Localization', () => {
             expect(result.text).toBe(spanishTitle)
           })
 
-          it('should pass over fallback locales until it finds one that exists', async () => {
+          test('should pass over fallback locales until it finds one that exists', async ({
+            restClient,
+          }) => {
             const response = await restClient.GET(
               `/globals/${global}?locale=pt&fallbackLocale[]=hu&fallbackLocale[]=ar&fallbackLocale[]=es`,
             )
@@ -3563,7 +3628,7 @@ describe('Localization', () => {
             expect(result.text).toBe(spanishTitle)
           })
 
-          it('should return undefined if no fallback locales exist', async () => {
+          test('should return undefined if no fallback locales exist', async ({ restClient }) => {
             const response = await restClient.GET(
               `/globals/${global}?locale=pt&fallbackLocale[]=hu&fallbackLocale[]=ar`,
             )
@@ -3576,9 +3641,9 @@ describe('Localization', () => {
         })
       })
 
-      describe('GraphQL', () => {
-        describe('Collections', () => {
-          it('should allow fallback locale to be an array', async () => {
+      test.describe('GraphQL', () => {
+        test.describe('Collections', () => {
+          test('should allow fallback locale to be an array', async ({ payload, restClient }) => {
             const query = `
       {
         LocalizedPost(id: ${idToString(postWithLocalizedData.id, payload)}, locale: pt) {
@@ -3598,7 +3663,10 @@ describe('Localization', () => {
             expect(data.LocalizedPost.title).toStrictEqual(spanishTitle)
           })
 
-          it('should pass over fallback locales until it finds one that exists', async () => {
+          test('should pass over fallback locales until it finds one that exists', async ({
+            payload,
+            restClient,
+          }) => {
             const query = `
       {
         LocalizedPost(id: ${idToString(postWithLocalizedData.id, payload)}, locale: pt) {
@@ -3617,7 +3685,10 @@ describe('Localization', () => {
             expect(queryResult.LocalizedPost.title).toBe(spanishTitle)
           })
 
-          it('should return null if no fallback locales exist', async () => {
+          test('should return null if no fallback locales exist', async ({
+            payload,
+            restClient,
+          }) => {
             const query = `
       {
         LocalizedPost(id: ${idToString(postWithLocalizedData.id, payload)}, locale: pt) {
@@ -3637,8 +3708,8 @@ describe('Localization', () => {
           })
         })
 
-        describe('Globals', () => {
-          it('should allow fallback locale to be an array', async () => {
+        test.describe('Globals', () => {
+          test('should allow fallback locale to be an array', async ({ restClient }) => {
             const query = `query {
               GlobalText {
                 text
@@ -3655,7 +3726,9 @@ describe('Localization', () => {
             expect(queryResult.GlobalText.text).toBe(spanishTitle)
           })
 
-          it('should pass over fallback locales until it finds one that exists', async () => {
+          test('should pass over fallback locales until it finds one that exists', async ({
+            restClient,
+          }) => {
             const query = `query {
               GlobalText {
                 text
@@ -3672,7 +3745,7 @@ describe('Localization', () => {
             expect(queryResult.GlobalText.text).toBe(spanishTitle)
           })
 
-          it('should return null if no fallback locales exist', async () => {
+          test('should return null if no fallback locales exist', async ({ restClient }) => {
             const query = `query {
               GlobalText {
                 text
@@ -3693,11 +3766,11 @@ describe('Localization', () => {
     })
   })
 
-  describe('Localization with fallback false', () => {
+  test.describe('Localization with fallback false', () => {
     let post1: LocalizedPost
     let postWithLocalizedData: LocalizedPost
 
-    beforeAll(async () => {
+    test.beforeEach(async ({ payload }) => {
       if (payload.config.localization) {
         payload.config.localization.fallback = false
       }
@@ -3726,8 +3799,8 @@ describe('Localization', () => {
       })
     })
 
-    describe('fallback locale', () => {
-      it('create english', async () => {
+    test.describe('fallback locale', () => {
+      test('create english', async ({ payload }) => {
         const allDocs = await payload.find({
           collection,
           where: {
@@ -3737,7 +3810,7 @@ describe('Localization', () => {
         expect(allDocs.docs).toContainEqual(expect.objectContaining(post1))
       })
 
-      it('add spanish translation', async () => {
+      test('add spanish translation', async ({ payload }) => {
         const updated = await payload.update({
           id: post1.id,
           collection,
@@ -3759,7 +3832,7 @@ describe('Localization', () => {
         expect(localized.title.es).toEqual(spanishTitle)
       })
 
-      it('should not fallback to english', async () => {
+      test('should not fallback to english', async ({ payload }) => {
         const retrievedDoc = await payload.findByID({
           id: post1.id,
           collection,
@@ -3769,7 +3842,7 @@ describe('Localization', () => {
         expect(retrievedDoc.title).not.toBeDefined()
       })
 
-      it('should fallback to english with explicit fallbackLocale', async () => {
+      test('should fallback to english with explicit fallbackLocale', async ({ payload }) => {
         const fallbackDoc = await payload.findByID({
           id: post1.id,
           collection,
@@ -3780,7 +3853,9 @@ describe('Localization', () => {
         expect(fallbackDoc.title).toBe(englishTitle)
       })
 
-      it('should not fallback to spanish translation and no explicit fallback is provided', async () => {
+      test('should not fallback to spanish translation and no explicit fallback is provided', async ({
+        payload,
+      }) => {
         const localizedFallback: any = await payload.findByID({
           id: postWithLocalizedData.id,
           collection,
@@ -3790,7 +3865,7 @@ describe('Localization', () => {
         expect(localizedFallback.title).not.toBeDefined()
       })
 
-      it('should respect fallback none', async () => {
+      test('should respect fallback none', async ({ payload }) => {
         const localizedFallback: any = await payload.findByID({
           id: postWithLocalizedData.id,
           collection,
@@ -3801,7 +3876,7 @@ describe('Localization', () => {
         expect(localizedFallback.title).not.toBeDefined()
       })
 
-      it('should respect fallback: false on relationship values', async () => {
+      test('should respect fallback: false on relationship values', async ({ payload }) => {
         const originalPost = await payload.create({
           collection: allFieldsLocalizedSlug,
           data: {
@@ -3839,15 +3914,15 @@ describe('Localization', () => {
       })
     })
 
-    afterAll(() => {
-      if (payload.config.localization) {
-        payload.config.localization.fallback = true
+    test.afterAll(({ payloadInstance }) => {
+      if (payloadInstance.config.localization) {
+        payloadInstance.config.localization.fallback = true
       }
     })
   })
 
-  describe('Localized data shape', () => {
-    beforeEach(async () => {
+  test.describe('Localized data shape', () => {
+    test.beforeEach(async ({ payload }) => {
       await payload.delete({
         collection: allFieldsLocalizedSlug,
         where: {
@@ -3857,7 +3932,9 @@ describe('Localization', () => {
         },
       })
     })
-    it('should only nest the top level localized field values under locale keys', async () => {
+    test('should only nest the top level localized field values under locale keys', async ({
+      payload,
+    }) => {
       const doc = await payload.create({
         collection: allFieldsLocalizedSlug,
         data: {
@@ -3956,8 +4033,10 @@ describe('Localization', () => {
     })
   })
 
-  describe('Localization like fields', () => {
-    it('should not localize fields that merely resemble localization fields', async () => {
+  test.describe('Localization like fields', () => {
+    test('should not localize fields that merely resemble localization fields', async ({
+      payload,
+    }) => {
       const doc = await payload.create({
         collection: noLocalizedFieldsCollectionSlug,
         data: {
@@ -3982,10 +4061,10 @@ describe('Localization', () => {
     })
   })
 
-  describe('localize status', () => {
-    describe('collections', () => {
-      describe('on create', () => {
-        it('should set other locales to draft upon creation', async () => {
+  test.describe('localize status', () => {
+    test.describe('collections', () => {
+      test.describe('on create', () => {
+        test('should set other locales to draft upon creation', async ({ payload }) => {
           // Only MongoDB initializes all locales to draft on create
           // SQL databases do not do this otherwise all fields get initialized to null
           if (!mongooseList.includes(process.env.PAYLOAD_DATABASE || '')) {
@@ -4010,7 +4089,7 @@ describe('Localization', () => {
           expect(esDoc._status).toContain('draft')
         })
 
-        it('should allow publishing of all locales upon creation', async () => {
+        test('should allow publishing of all locales upon creation', async ({ payload }) => {
           const doc = await payload.create({
             collection: allFieldsLocalizedSlug,
             data: {
@@ -4031,8 +4110,8 @@ describe('Localization', () => {
         })
       })
 
-      describe('querying', () => {
-        it('should return correct data based on draft arg', async () => {
+      test.describe('querying', () => {
+        test('should return correct data based on draft arg', async ({ payload }) => {
           // NOTE: passes in MongoDB, fails in PG
           // -> fails to query on version._status.[localeCode] in `replaceWithDraftIfAvailable` when locale = 'all'
 
@@ -4115,7 +4194,7 @@ describe('Localization', () => {
           expect(latestVersionDoc.text!.es).toBe('spanish draft 2')
         })
 
-        it('should allow querying metadata per locale', async () => {
+        test('should allow querying metadata per locale', async ({ payload }) => {
           const doc = await payload.create({
             collection: allFieldsLocalizedSlug,
             data: {
@@ -4202,8 +4281,8 @@ describe('Localization', () => {
         })
       })
 
-      describe('on update', () => {
-        it('should publish and unpublish single locales', async () => {
+      test.describe('on update', () => {
+        test('should publish and unpublish single locales', async ({ payload }) => {
           const doc = await payload.create({
             collection: allFieldsLocalizedSlug,
             data: {
@@ -4259,7 +4338,7 @@ describe('Localization', () => {
           expect(latestVersion.text!.en).toBe('en draft')
         })
 
-        it('should publish and unpublish all', async () => {
+        test('should publish and unpublish all', async ({ payload }) => {
           const doc = await payload.create({
             collection: allFieldsLocalizedSlug,
             data: {
@@ -4322,9 +4401,9 @@ describe('Localization', () => {
       })
     })
 
-    describe('globals', () => {
-      describe('querying', () => {
-        it('should return correct data based on draft arg', async () => {
+    test.describe('globals', () => {
+      test.describe('querying', () => {
+        test('should return correct data based on draft arg', async ({ payload }) => {
           // NOTE: passes in MongoDB, fails in PG
           // -> fails to query on version._status.[localeCode] in `replaceWithDraftIfAvailable` when locale = 'all'
 
@@ -4402,8 +4481,8 @@ describe('Localization', () => {
         })
       })
 
-      describe('on update', () => {
-        it('should publish and unpublish single locales', async () => {
+      test.describe('on update', () => {
+        test('should publish and unpublish single locales', async ({ payload }) => {
           const doc = await payload.updateGlobal({
             slug: globalWithDraftsSlug,
             data: {
@@ -4455,7 +4534,7 @@ describe('Localization', () => {
           expect(latestVersion.text!.en).toBe('en draft')
         })
 
-        it('should publish and unpublish all', async () => {
+        test('should publish and unpublish all', async ({ payload }) => {
           const doc = await payload.updateGlobal({
             slug: globalWithDraftsSlug,
             data: {
@@ -4513,10 +4592,10 @@ describe('Localization', () => {
       })
     })
 
-    describe('fallback behavior', () => {
+    test.describe('fallback behavior', () => {
       let allFieldsPostWithLocalizedData: any
 
-      beforeAll(async () => {
+      test.beforeEach(async ({ payload }) => {
         allFieldsPostWithLocalizedData = await payload.create({
           collection: allFieldsLocalizedSlug,
           data: {
@@ -4535,7 +4614,7 @@ describe('Localization', () => {
         })
       })
 
-      it('should fallback to english translation when empty', async () => {
+      test('should fallback to english translation when empty', async ({ payload }) => {
         await payload.update({
           id: allFieldsPostWithLocalizedData.id,
           collection: allFieldsLocalizedSlug,
@@ -4563,7 +4642,7 @@ describe('Localization', () => {
         expect(retrievedInSpanish.text).toEqual(englishTitle)
       })
 
-      it('should respect fallback none', async () => {
+      test('should respect fallback none', async ({ payload }) => {
         const localizedFallback: any = await payload.findByID({
           id: allFieldsPostWithLocalizedData.id,
           collection: allFieldsLocalizedSlug,
@@ -4576,8 +4655,8 @@ describe('Localization', () => {
     })
   })
 
-  describe('localized queries', () => {
-    it('should count versions with query on localized field', async () => {
+  test.describe('localized queries', () => {
+    test('should count versions with query on localized field', async ({ payload }) => {
       await payload.create({
         collection: localizedDraftsSlug,
         data: {
@@ -4597,7 +4676,9 @@ describe('Localization', () => {
       expect(result2.totalDocs).toBe(1)
     })
 
-    it('should count global versions with query on localized field respecting locale', async () => {
+    test('should count global versions with query on localized field respecting locale', async ({
+      payload,
+    }) => {
       await payload.updateGlobal({
         slug: globalWithDraftsSlug,
         data: { text: 'global count en', _status: 'published' },
@@ -4630,12 +4711,15 @@ describe('Localization', () => {
   })
 })
 
-async function createLocalizedPost(data: {
-  title: {
-    [defaultLocale]: string
-    [spanishLocale]: string
-  }
-}): Promise<LocalizedPost> {
+async function createLocalizedPost(
+  { payload }: { payload: Payload },
+  data: {
+    title: {
+      [defaultLocale]: string
+      [spanishLocale]: string
+    }
+  },
+): Promise<LocalizedPost> {
   const localizedRelation: any = await payload.create({
     collection,
     data: {

--- a/test/localization/int.spec.ts
+++ b/test/localization/int.spec.ts
@@ -25,7 +25,6 @@ import { groupSlug } from './collections/Group/index.js'
 import { nestedToArrayAndBlockCollectionSlug } from './collections/NestedToArrayAndBlock/index.js'
 import { noLocalizedFieldsCollectionSlug } from './collections/NoLocalizedFields/index.js'
 import { tabSlug } from './collections/Tab/index.js'
-import testConfig from './config.js'
 import {
   allFieldsLocalizedSlug,
   defaultLocale,
@@ -52,7 +51,7 @@ import {
 const collection = localizedPostsSlug
 const global = 'global-text'
 
-test.suite({ config: testConfig })('Localization', () => {
+test.suite({ config: './config.ts' })('Localization', () => {
   test.describe('Localization with fallback true', () => {
     let post1: LocalizedPost
     let postWithLocalizedData: LocalizedPost

--- a/test/localization/localizeStatus.config.ts
+++ b/test/localization/localizeStatus.config.ts
@@ -7,57 +7,60 @@ const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
 export default buildConfigWithDefaults({
-  collections: [
-    {
-      slug: 'users',
-      auth: true,
-      fields: [],
-      versions: false,
-    },
-    {
-      slug: 'testMigrationPosts',
-      fields: [
-        {
-          name: 'title',
-          type: 'text',
-          // NOT localized - so no locales table for versions will be created
-        },
-      ],
-      versions: {
-        drafts: true,
+  suite: 'localization-localize-status',
+  config: {
+    collections: [
+      {
+        slug: 'users',
+        auth: true,
+        fields: [],
+        versions: false,
       },
-    },
-    {
-      slug: 'testMigrationArticles',
-      fields: [
-        {
-          name: 'title',
-          type: 'text',
-          localized: true, // This WILL create a locales table
+      {
+        slug: 'testMigrationPosts',
+        fields: [
+          {
+            name: 'title',
+            type: 'text',
+            // NOT localized - so no locales table for versions will be created
+          },
+        ],
+        versions: {
+          drafts: true,
         },
-      ],
-      versions: {
-        drafts: true,
       },
-    },
-    {
-      slug: 'testNoVersions',
-      fields: [
-        {
-          name: 'title',
-          type: 'text',
-          localized: true,
+      {
+        slug: 'testMigrationArticles',
+        fields: [
+          {
+            name: 'title',
+            type: 'text',
+            localized: true, // This WILL create a locales table
+          },
+        ],
+        versions: {
+          drafts: true,
         },
-      ],
-      // Explicitly disabled — migration should skip collections without versions
-      versions: false,
+      },
+      {
+        slug: 'testNoVersions',
+        fields: [
+          {
+            name: 'title',
+            type: 'text',
+            localized: true,
+          },
+        ],
+        // Explicitly disabled — migration should skip collections without versions
+        versions: false,
+      },
+    ],
+    localization: {
+      defaultLocale: 'en',
+      locales: ['en', 'es', 'de'],
     },
-  ],
-  localization: {
-    defaultLocale: 'en',
-    locales: ['en', 'es', 'de'],
-  },
-  typescript: {
-    outputFile: path.resolve(dirname, 'localizeStatus-payload-types.ts'),
+    typescript: {
+      outputFile: path.resolve(dirname, 'localizeStatus-payload-types.ts'),
+    },
   },
 })

--- a/test/localization/localizeStatus.int.spec.ts
+++ b/test/localization/localizeStatus.int.spec.ts
@@ -11,9 +11,8 @@ import { fileURLToPath } from 'url'
 import { expect } from 'vitest'
 
 import { test } from '../__helpers/int/vitest.js'
-import testConfig from './localizeStatus.config.js'
 
-test.suite({ config: testConfig })('localizeStatus migration', () => {
+test.suite({ config: './localizeStatus.config.ts' })('localizeStatus migration', () => {
   test.beforeEach(async () => {
     if (process.env.PAYLOAD_DATABASE === 'mongodb' || !process.env.PAYLOAD_DATABASE) {
       // Wait for MongoDB to finish building indexes to avoid

--- a/test/localization/localizeStatus.int.spec.ts
+++ b/test/localization/localizeStatus.int.spec.ts
@@ -6,42 +6,29 @@ import { migratePostgresLocalizeStatus } from '@payloadcms/db-postgres/migration
 import { migrateSqliteLocalizeStatus } from '@payloadcms/db-sqlite/migration-utils'
 import { sql as drizzleSql } from 'drizzle-orm'
 import { Types } from 'mongoose'
-import path from 'path'
 import { wait } from 'payload/shared'
 import { fileURLToPath } from 'url'
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { expect } from 'vitest'
 
-import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
+import { test } from '../__helpers/int/vitest.js'
+import testConfig from './localizeStatus.config.js'
 
-const filename = fileURLToPath(import.meta.url)
-const dirname = path.dirname(filename)
-
-let payload: Payload
-
-describe('localizeStatus migration', () => {
-  beforeAll(async () => {
-    const result = await initPayloadInt(dirname, undefined, undefined, 'localizeStatus.config.ts')
-    payload = result.payload
-
+test.suite({ config: testConfig })('localizeStatus migration', () => {
+  test.beforeEach(async () => {
     if (process.env.PAYLOAD_DATABASE === 'mongodb' || !process.env.PAYLOAD_DATABASE) {
       // Wait for MongoDB to finish building indexes to avoid
       // "Unable to write to collection due to catalog changes" errors
       await wait(1000)
     }
   })
-  afterAll(async () => {
-    if (payload?.db && typeof payload.db.destroy === 'function') {
-      await payload.db.destroy()
-    }
-  })
 
-  describe.skipIf(process.env.PAYLOAD_DATABASE !== 'postgres')('PostgreSQL', () => {
+  test.options({ db: (adapter) => adapter === 'postgres' }).describe('PostgreSQL', () => {
     // Reset both test collections to their pre-migration database shape before every
     // scenario so each test is self-contained and order-independent. Real users' databases
     // will be in this pre-migration state; the runtime schema (localizeStatus auto-inferred)
     // is reverted here via raw SQL. Each scenario's migration mutates the schema, so this
     // must run before every test rather than once.
-    beforeEach(async () => {
+    test.beforeEach(async ({ payload }) => {
       const db = payload.db
 
       // testMigrationPosts: title is NOT localized, so versions have no locales table.
@@ -83,8 +70,8 @@ describe('localizeStatus migration', () => {
       await db.drizzle.execute(sql`DELETE FROM test_migration_articles`)
     })
 
-    describe('Scenario 1: Creating new locales table', () => {
-      it('should migrate non-localized _status to localized', async () => {
+    test.describe('Scenario 1: Creating new locales table', () => {
+      test('should migrate non-localized _status to localized', async ({ payload }) => {
         const db = payload.db
 
         // At this point, Payload has created:
@@ -178,8 +165,8 @@ describe('localizeStatus migration', () => {
       })
     })
 
-    describe('Scenario 2: Adding to existing locales table', () => {
-      it('should add _status column to existing locales table', async () => {
+    test.describe('Scenario 2: Adding to existing locales table', () => {
+      test('should add _status column to existing locales table', async ({ payload }) => {
         const db = payload.db
 
         // Schema is in pre-migration state (set up in the beforeEach hook):
@@ -283,8 +270,8 @@ describe('localizeStatus migration', () => {
       })
     })
 
-    describe('Scenario 3: Demonstrate version history migration', () => {
-      it('should show how version rows are transformed', async () => {
+    test.describe('Scenario 3: Demonstrate version history migration', () => {
+      test('should show how version rows are transformed', async ({ payload }) => {
         const db = payload.db
 
         // Create a complex version history
@@ -378,8 +365,8 @@ describe('localizeStatus migration', () => {
       })
     })
 
-    describe('Scenario 4: Test publishedLocale handling', () => {
-      it('should handle publishedLocale correctly', async () => {
+    test.describe('Scenario 4: Test publishedLocale handling', () => {
+      test('should handle publishedLocale correctly', async ({ payload }) => {
         const db = payload.db
 
         // Use testMigrationArticles which has localized fields and thus an existing locales table
@@ -543,8 +530,10 @@ describe('localizeStatus migration', () => {
       })
     })
 
-    describe('Scenario 5: Skip collections without versions', () => {
-      it('should skip migration for collections without versions enabled', async () => {
+    test.describe('Scenario 5: Skip collections without versions', () => {
+      test('should skip migration for collections without versions enabled', async ({
+        payload,
+      }) => {
         // Create a document in the collection without versions
         const doc = await payload.create({
           collection: 'testNoVersions',
@@ -577,11 +566,15 @@ describe('localizeStatus migration', () => {
     })
   })
 
-  describe.skipIf(process.env.PAYLOAD_DATABASE !== 'sqlite')('SQLite', () => {
+  test.options({ db: (adapter) => adapter === 'sqlite' }).describe('SQLite', () => {
     // Mirror the PostgreSQL suite: revert the runtime (post-migration) schema back to its
     // pre-migration shape before every scenario so each test is self-contained. SQLite has no
     // `ADD COLUMN IF NOT EXISTS` / `DROP COLUMN IF EXISTS`, so we guard with pragma_table_info.
-    const columnExists = async (tableName: string, columnName: string): Promise<boolean> => {
+    const columnExists = async (
+      { payload }: { payload: Payload },
+      tableName: string,
+      columnName: string,
+    ): Promise<boolean> => {
       const rows = (await payload.db.drizzle.all(
         drizzleSql.raw(
           `SELECT COUNT(*) as count FROM pragma_table_info('${tableName}') WHERE name = '${columnName}'`,
@@ -591,19 +584,24 @@ describe('localizeStatus migration', () => {
     }
 
     const addColumnIfMissing = async (
+      { payload }: { payload: Payload },
       tableName: string,
       columnName: string,
       definition: string,
     ): Promise<void> => {
-      if (!(await columnExists(tableName, columnName))) {
+      if (!(await columnExists({ payload }, tableName, columnName))) {
         await payload.db.drizzle.run(
           drizzleSql.raw(`ALTER TABLE "${tableName}" ADD COLUMN ${definition}`),
         )
       }
     }
 
-    const dropColumnIfExists = async (tableName: string, columnName: string): Promise<void> => {
-      if (await columnExists(tableName, columnName)) {
+    const dropColumnIfExists = async (
+      { payload }: { payload: Payload },
+      tableName: string,
+      columnName: string,
+    ): Promise<void> => {
+      if (await columnExists({ payload }, tableName, columnName)) {
         // SQLite refuses to drop a column referenced by an index, so drop those indexes first.
         const indexes = (await payload.db.drizzle.all(
           drizzleSql.raw(
@@ -623,39 +621,61 @@ describe('localizeStatus migration', () => {
       }
     }
 
-    beforeEach(async () => {
+    test.beforeEach(async ({ payload }) => {
       const drizzle = payload.db.drizzle
 
       // testMigrationPosts: title is NOT localized, so versions have no locales table pre-migration.
       await drizzle.run(drizzleSql.raw(`DROP TABLE IF EXISTS _test_migration_posts_v_locales`))
       await addColumnIfMissing(
+        { payload },
         '_test_migration_posts_v',
         'version__status',
         `version__status TEXT DEFAULT 'draft'`,
       )
-      await addColumnIfMissing('_test_migration_posts_v', 'snapshot', `snapshot INTEGER`)
-      await addColumnIfMissing('test_migration_posts', '_status', `_status TEXT DEFAULT 'draft'`)
+      await addColumnIfMissing(
+        { payload },
+        '_test_migration_posts_v',
+        'snapshot',
+        `snapshot INTEGER`,
+      )
+      await addColumnIfMissing(
+        { payload },
+        'test_migration_posts',
+        '_status',
+        `_status TEXT DEFAULT 'draft'`,
+      )
       await drizzle.run(drizzleSql.raw(`DELETE FROM _test_migration_posts_v`))
       await drizzle.run(drizzleSql.raw(`DELETE FROM test_migration_posts`))
 
       // testMigrationArticles: title IS localized, so locales tables exist.
       await addColumnIfMissing(
+        { payload },
         '_test_migration_articles_v',
         'version__status',
         `version__status TEXT DEFAULT 'draft'`,
       )
-      await addColumnIfMissing('_test_migration_articles_v', 'snapshot', `snapshot INTEGER`)
-      await dropColumnIfExists('_test_migration_articles_v_locales', 'version__status')
-      await addColumnIfMissing('test_migration_articles', '_status', `_status TEXT DEFAULT 'draft'`)
-      await dropColumnIfExists('test_migration_articles_locales', '_status')
+      await addColumnIfMissing(
+        { payload },
+        '_test_migration_articles_v',
+        'snapshot',
+        `snapshot INTEGER`,
+      )
+      await dropColumnIfExists({ payload }, '_test_migration_articles_v_locales', 'version__status')
+      await addColumnIfMissing(
+        { payload },
+        'test_migration_articles',
+        '_status',
+        `_status TEXT DEFAULT 'draft'`,
+      )
+      await dropColumnIfExists({ payload }, 'test_migration_articles_locales', '_status')
       await drizzle.run(drizzleSql.raw(`DELETE FROM _test_migration_articles_v_locales`))
       await drizzle.run(drizzleSql.raw(`DELETE FROM _test_migration_articles_v`))
       await drizzle.run(drizzleSql.raw(`DELETE FROM test_migration_articles_locales`))
       await drizzle.run(drizzleSql.raw(`DELETE FROM test_migration_articles`))
     })
 
-    describe('Scenario 1: Creating new locales table', () => {
-      it('should migrate non-localized _status to localized', async () => {
+    test.describe('Scenario 1: Creating new locales table', () => {
+      test('should migrate non-localized _status to localized', async ({ payload }) => {
         const drizzle = payload.db.drizzle
 
         const post1 = await payload.create({
@@ -683,8 +703,10 @@ describe('localizeStatus migration', () => {
           payload,
         })
 
-        expect(await tableExists('_test_migration_posts_v_locales')).toBe(true)
-        expect(await columnExists('_test_migration_posts_v', 'version__status')).toBe(false)
+        expect(await tableExists({ payload }, '_test_migration_posts_v_locales')).toBe(true)
+        expect(await columnExists({ payload }, '_test_migration_posts_v', 'version__status')).toBe(
+          false,
+        )
 
         const localesData = (await drizzle.all(
           drizzleSql.raw(
@@ -709,8 +731,8 @@ describe('localizeStatus migration', () => {
       })
     })
 
-    describe('Scenario 2: Adding to existing locales table', () => {
-      it('should add version__status column to existing locales table', async () => {
+    test.describe('Scenario 2: Adding to existing locales table', () => {
+      test('should add version__status column to existing locales table', async ({ payload }) => {
         const drizzle = payload.db.drizzle
 
         const articleResult = (await drizzle.all(
@@ -762,9 +784,9 @@ describe('localizeStatus migration', () => {
           payload,
         })
 
-        expect(await columnExists('_test_migration_articles_v_locales', 'version__status')).toBe(
-          true,
-        )
+        expect(
+          await columnExists({ payload }, '_test_migration_articles_v_locales', 'version__status'),
+        ).toBe(true)
 
         const localesData = (await drizzle.all(
           drizzleSql.raw(
@@ -779,8 +801,8 @@ describe('localizeStatus migration', () => {
       })
     })
 
-    describe('Scenario 3: Test publishedLocale handling', () => {
-      it('should handle publishedLocale correctly', async () => {
+    test.describe('Scenario 3: Test publishedLocale handling', () => {
+      test('should handle publishedLocale correctly', async ({ payload }) => {
         const drizzle = payload.db.drizzle
 
         await drizzle.run(drizzleSql.raw(`DELETE FROM _test_migration_articles_v`))
@@ -869,8 +891,10 @@ describe('localizeStatus migration', () => {
       })
     })
 
-    describe('Scenario 4: Skip collections without versions', () => {
-      it('should skip migration for collections without versions enabled', async () => {
+    test.describe('Scenario 4: Skip collections without versions', () => {
+      test('should skip migration for collections without versions enabled', async ({
+        payload,
+      }) => {
         const doc = await payload.create({
           collection: 'testNoVersions',
           data: { title: 'Test document' },
@@ -886,11 +910,14 @@ describe('localizeStatus migration', () => {
           }),
         ).resolves.not.toThrow()
 
-        expect(await tableExists('_test_no_versions_v')).toBe(false)
+        expect(await tableExists({ payload }, '_test_no_versions_v')).toBe(false)
       })
     })
 
-    async function tableExists(tableName: string): Promise<boolean> {
+    async function tableExists(
+      { payload }: { payload: Payload },
+      tableName: string,
+    ): Promise<boolean> {
       const rows = (await payload.db.drizzle.all(
         drizzleSql.raw(
           `SELECT COUNT(*) as count FROM sqlite_master WHERE type='table' AND name='${tableName}'`,
@@ -900,13 +927,13 @@ describe('localizeStatus migration', () => {
     }
   })
 
-  describe.skipIf(process.env.PAYLOAD_DATABASE !== 'mongodb')('MongoDB', () => {
+  test.options({ db: (adapter) => adapter === 'mongodb' }).describe('MongoDB', () => {
     // Force collection and index creation to finish before the timed writes below.
     // With autoIndex enabled on a fresh database, the first write to a versions
     // collection kicks off async index builds; a subsequent write can then race
     // with that catalog change and fail with a transient "catalog changes" error.
     // Model.init() resolves once autoCreate and autoIndex have completed.
-    beforeAll(async () => {
+    test.beforeEach(async ({ payload }) => {
       const db = payload.db as any
       const slugs = ['testMigrationPosts', 'testMigrationArticles']
 
@@ -916,8 +943,10 @@ describe('localizeStatus migration', () => {
       }
     })
 
-    describe('MongoDB version status migration', () => {
-      it('should migrate version._status from string to per-locale object', async () => {
+    test.describe('MongoDB version status migration', () => {
+      test('should migrate version._status from string to per-locale object', async ({
+        payload,
+      }) => {
         // Step 1: Create a post with a version
         const post = await payload.create({
           collection: 'testMigrationPosts',
@@ -971,7 +1000,7 @@ describe('localizeStatus migration', () => {
         expect(migratedVersion.version._status.de).toBe('published')
       })
 
-      it('should handle publishedLocale when migrating', async () => {
+      test('should handle publishedLocale when migrating', async ({ payload }) => {
         // This test simulates OLD data that was created before localizeStatus existed.
         // Old data has _status as a string and publishedLocale to indicate which locale was published.
         // We insert raw version documents to replicate what old Payload code would have written.

--- a/test/localization/testMigration.ts
+++ b/test/localization/testMigration.ts
@@ -14,13 +14,11 @@ import { localizeStatus } from '@payloadcms/db-mongodb/migration-utils'
 import { sql } from '@payloadcms/db-postgres'
 import { migratePostgresLocalizeStatus } from '@payloadcms/db-postgres/migration-utils'
 import { Types } from 'mongoose'
-import path from 'path'
-import { fileURLToPath } from 'url'
+import { getPayload } from 'payload'
 
-import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
-
-const filename = fileURLToPath(import.meta.url)
-const dirname = path.dirname(filename)
+import { resetAndSeed } from '../__helpers/shared/clearAndSeed/resetAndSeed.js'
+import { getTestDataConfig } from '../__helpers/shared/clearAndSeed/testDataConfig.js'
+import testConfig from './localizeStatus.config.js'
 
 async function main() {
   console.log('🚀 Starting localizeStatus migration test...\n')
@@ -29,12 +27,15 @@ async function main() {
   console.log(`Database: ${dbType}\n`)
 
   // Initialize Payload
-  const { payload } = await initPayloadInt(
-    dirname,
-    undefined,
-    undefined,
-    'localizeStatus.config.ts',
-  )
+  const config = await testConfig
+  const payload = await getPayload({ config, cron: true })
+  const testDataConfig = getTestDataConfig(config)
+
+  if (!testDataConfig) {
+    throw new Error('Test suite metadata was not registered by buildConfigWithDefaults.')
+  }
+
+  await resetAndSeed({ payload, ...testDataConfig })
 
   console.log('✅ Payload initialized\n')
 
@@ -140,7 +141,7 @@ async function main() {
   console.log()
 
   // Cleanup
-  await payload.db.destroy()
+  await payload.destroy()
   console.log('✨ Test completed successfully!')
 }
 

--- a/test/queues/cli.int.spec.ts
+++ b/test/queues/cli.int.spec.ts
@@ -3,10 +3,9 @@ import { wait } from 'payload/shared'
 import { expect } from 'vitest'
 
 import { test } from '../__helpers/int/vitest.js'
-import testConfig from './config.js'
 import { waitUntilAutorunIsDone } from './utilities.js'
 
-test.suite({ config: testConfig, cron: false })('Queues - CLI', () => {
+test.suite({ config: './config.ts', cron: false })('Queues - CLI', () => {
   test('ensure consecutive getPayload call with cron: true will autorun jobs', async ({
     config,
     payload,

--- a/test/queues/cli.int.spec.ts
+++ b/test/queues/cli.int.spec.ts
@@ -1,18 +1,16 @@
 import { _internal_jobSystemGlobals, _internal_resetJobSystemGlobals, getPayload } from 'payload'
 import { wait } from 'payload/shared'
-import { describe, expect } from 'vitest'
+import { expect } from 'vitest'
 
 import { test } from '../__helpers/int/vitest.js'
+import testConfig from './config.js'
 import { waitUntilAutorunIsDone } from './utilities.js'
 
-describe('Queues - CLI', () => {
+test.suite({ config: testConfig, cron: false })('Queues - CLI', () => {
   test('ensure consecutive getPayload call with cron: true will autorun jobs', async ({
     config,
+    payload,
   }) => {
-    const payload = await getPayload({
-      config,
-    })
-
     await payload.jobs.queue({
       workflow: 'inlineTaskTest',
       queue: 'autorunSecond',
@@ -51,9 +49,11 @@ describe('Queues - CLI', () => {
     // Wait 3 seconds to ensure all currently-running crons are done. If we shut down the db while a function is running, it can cause issues
     // Cron function runs may persist after a test has finished
     await wait(3000)
-    // Now we can destroy the payload instance
-    await _payload2.destroy()
-    await payload.destroy()
+    // getPayload may return the fixture-owned instance for the same config. Leave that instance
+    // connected for the fixture's next per-test reset; the file-scoped fixture destroys it later.
+    if (_payload2 !== payload) {
+      await _payload2.destroy()
+    }
     _internal_resetJobSystemGlobals()
 
     if (previousDropDatabase === undefined) {

--- a/test/queues/config.crashWorker.ts
+++ b/test/queues/config.crashWorker.ts
@@ -1,7 +1,7 @@
 import { sqliteAdapter } from '@payloadcms/db-sqlite'
 
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
-import { getConfig } from './getConfig.js'
+import { getConfig, seed } from './getConfig.js'
 
 const idType =
   process.env.PAYLOAD_DATABASE === 'sqlite-uuid'
@@ -11,12 +11,16 @@ const idType =
       : undefined
 
 export default buildConfigWithDefaults({
-  ...getConfig(),
-  db: sqliteAdapter({
-    client: {
-      url: process.env.SQLITE_URL || process.env.DATABASE_URL || 'file:./payload.db',
-    },
-    ...(idType ? { idType } : { autoIncrement: true }),
-    push: false,
-  }),
+  suite: 'queues-crash-worker',
+  config: {
+    ...getConfig(),
+    db: sqliteAdapter({
+      client: {
+        url: process.env.SQLITE_URL || process.env.DATABASE_URL || 'file:./payload.db',
+      },
+      ...(idType ? { idType } : { autoIncrement: true }),
+      push: false,
+    }),
+  },
+  seed,
 })

--- a/test/queues/config.postgreslogs.ts
+++ b/test/queues/config.postgreslogs.ts
@@ -1,7 +1,7 @@
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
 /* eslint-disable no-restricted-exports */
 import { defaultPostgresUrl } from '../dbAdapters.js'
-import { getConfig } from './getConfig.js'
+import { getConfig, seed } from './getConfig.js'
 
 const config = getConfig()
 
@@ -15,6 +15,10 @@ export const databaseAdapter = postgresAdapter({
 })
 
 export default buildConfigWithDefaults({
-  ...config,
-  db: databaseAdapter,
+  suite: 'queues-postgreslogs',
+  config: {
+    ...config,
+    db: databaseAdapter,
+  },
+  seed,
 })

--- a/test/queues/config.schedules-autocron.ts
+++ b/test/queues/config.schedules-autocron.ts
@@ -1,22 +1,26 @@
 /* eslint-disable no-restricted-exports */
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
-import { getConfig } from './getConfig.js'
+import { getConfig, seed } from './getConfig.js'
 import { EverySecondMax2Task } from './tasks/EverySecondMax2Task.js'
 import { EverySecondTask } from './tasks/EverySecondTask.js'
 
 const config = getConfig()
 
 export default buildConfigWithDefaults({
-  ...config,
-  jobs: {
-    ...config.jobs,
-    tasks: [...(config?.jobs?.tasks || []), EverySecondTask, EverySecondMax2Task],
-    autoRun: [
-      {
-        // @ts-expect-error not undefined
-        ...config.jobs.autoRun[0],
-        disableScheduling: false,
-      },
-    ],
+  suite: 'queues-schedules-autocron',
+  config: {
+    ...config,
+    jobs: {
+      ...config.jobs,
+      tasks: [...(config?.jobs?.tasks || []), EverySecondTask, EverySecondMax2Task],
+      autoRun: [
+        {
+          // @ts-expect-error not undefined
+          ...config.jobs.autoRun[0],
+          disableScheduling: false,
+        },
+      ],
+    },
   },
+  seed,
 })

--- a/test/queues/config.schedules.ts
+++ b/test/queues/config.schedules.ts
@@ -1,22 +1,26 @@
 /* eslint-disable no-restricted-exports */
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
-import { getConfig } from './getConfig.js'
+import { getConfig, seed } from './getConfig.js'
 import { EverySecondMax2Task } from './tasks/EverySecondMax2Task.js'
 import { EverySecondTask } from './tasks/EverySecondTask.js'
 
 const config = getConfig()
 
 export default buildConfigWithDefaults({
-  ...config,
-  jobs: {
-    ...config.jobs,
-    tasks: [...(config?.jobs?.tasks || []), EverySecondTask, EverySecondMax2Task],
-    autoRun: [
-      {
-        // @ts-expect-error not undefined
-        ...config.jobs.autoRun[0],
-        disableScheduling: true,
-      },
-    ],
+  suite: 'queues-schedules',
+  config: {
+    ...config,
+    jobs: {
+      ...config.jobs,
+      tasks: [...(config?.jobs?.tasks || []), EverySecondTask, EverySecondMax2Task],
+      autoRun: [
+        {
+          // @ts-expect-error not undefined
+          ...config.jobs.autoRun[0],
+          disableScheduling: true,
+        },
+      ],
+    },
   },
+  seed,
 })

--- a/test/queues/config.ts
+++ b/test/queues/config.ts
@@ -1,4 +1,4 @@
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
-import { getConfig } from './getConfig.js'
+import { getConfig, seed } from './getConfig.js'
 
-export default buildConfigWithDefaults(getConfig())
+export default buildConfigWithDefaults({ suite: 'queues', config: getConfig(), seed })

--- a/test/queues/getConfig.ts
+++ b/test/queues/getConfig.ts
@@ -48,25 +48,21 @@ const dirname = path.dirname(fileURLToPath(import.meta.url))
 
 // Needs to be a function to prevent object reference issues due to duplicative configs
 export const getConfig: () => Partial<Config> = () => ({
+  admin: {
+    autoLogin: {
+      email: devUser.email,
+      password: devUser.password,
+      prefillOnly: true,
+    },
+    importMap: {
+      baseDir: path.resolve(dirname),
+    },
+  },
   collections: [
     {
       slug: 'posts',
       admin: {
         useAsTitle: 'title',
-      },
-      hooks: {
-        afterChange: [
-          async ({ req, doc, context }) => {
-            await req.payload.jobs.queue({
-              workflow: context.useJSONWorkflow ? 'updatePostJSONWorkflow' : 'updatePost',
-              input: {
-                post: doc.id,
-                message: 'hello',
-              },
-              req,
-            })
-          },
-        ],
       },
       fields: [
         {
@@ -87,6 +83,20 @@ export const getConfig: () => Partial<Config> = () => ({
           type: 'text',
         },
       ],
+      hooks: {
+        afterChange: [
+          async ({ context, doc, req }) => {
+            await req.payload.jobs.queue({
+              input: {
+                message: 'hello',
+                post: doc.id,
+              },
+              req,
+              workflow: context.useJSONWorkflow ? 'updatePostJSONWorkflow' : 'updatePost',
+            })
+          },
+        ],
+      },
       versions: false,
     },
     {
@@ -104,16 +114,7 @@ export const getConfig: () => Partial<Config> = () => ({
       versions: false,
     },
   ],
-  admin: {
-    importMap: {
-      baseDir: path.resolve(dirname),
-    },
-    autoLogin: {
-      prefillOnly: true,
-      email: devUser.email,
-      password: devUser.password,
-    },
-  },
+  editor: lexicalEditor(),
   jobs: {
     autoRun: [
       {
@@ -125,7 +126,6 @@ export const getConfig: () => Partial<Config> = () => ({
       },
       // add as many cron jobs as you want
     ],
-    shouldAutoRun: () => true,
     jobsCollectionOverrides: ({ defaultJobsCollection }) => {
       return {
         ...defaultJobsCollection,
@@ -140,6 +140,7 @@ export const getConfig: () => Partial<Config> = () => ({
         lifo: '-createdAt',
       },
     },
+    shouldAutoRun: () => true,
     tasks: [
       UpdatePostTask,
       UpdatePostStep2Task,
@@ -182,13 +183,9 @@ export const getConfig: () => Partial<Config> = () => ({
       throwsInHandlerRetries1Workflow,
     ],
   },
-  editor: lexicalEditor(),
-  onInit: async (payload) => {
-    if (process.env.SEED_IN_CONFIG_ONINIT !== 'false') {
-      await seed(payload)
-    }
-  },
   typescript: {
     outputFile: path.resolve(dirname, 'payload-types.ts'),
   },
 })
+
+export { seed }

--- a/test/queues/int.spec.ts
+++ b/test/queues/int.spec.ts
@@ -15,7 +15,6 @@ import { expect } from 'vitest'
 
 import { test } from '../__helpers/int/vitest.js'
 import { devUser } from '../credentials.js'
-import testConfig from './config.js'
 import { waitUntilAutorunIsDone } from './utilities.js'
 
 const { email, password } = devUser
@@ -25,7 +24,7 @@ const dirname = path.dirname(filename)
 _internal_jobSystemGlobals.shouldAutoRun = false
 _internal_jobSystemGlobals.shouldAutoSchedule = false
 
-test.suite({ config: testConfig })('Queues - Payload', () => {
+test.suite({ config: './config.ts' })('Queues - Payload', () => {
   let processingLeaseDefaults: {
     duration: number
     safetyBuffer: number

--- a/test/queues/int.spec.ts
+++ b/test/queues/int.spec.ts
@@ -11,58 +11,49 @@ import {
 } from 'payload'
 import { wait } from 'payload/shared'
 import { fileURLToPath } from 'url'
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
-
-import type { NextRESTClient } from '../__helpers/shared/NextRESTClient.js'
+import { expect } from 'vitest'
 
 import { test } from '../__helpers/int/vitest.js'
-import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
 import { devUser } from '../credentials.js'
-import { clearAndSeedEverything } from './seed.js'
+import testConfig from './config.js'
 import { waitUntilAutorunIsDone } from './utilities.js'
 
 const { email, password } = devUser
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
-describe('Queues - Payload', () => {
-  let payload: Payload
+_internal_jobSystemGlobals.shouldAutoRun = false
+_internal_jobSystemGlobals.shouldAutoSchedule = false
+
+test.suite({ config: testConfig })('Queues - Payload', () => {
   let processingLeaseDefaults: {
     duration: number
     safetyBuffer: number
   }
-  let restClient: NextRESTClient
   let token: string
   let user: User
 
-  beforeAll(async () => {
-    process.env.SEED_IN_CONFIG_ONINIT = 'false' // Makes it so the payload config onInit seed is not run. Otherwise, the seed would be run unnecessarily twice for the initial test run - once for beforeEach and once for onInit
-    ;({ payload, restClient } = await initPayloadInt(dirname))
+  test.beforeEach(async ({ payload }) => {
     processingLeaseDefaults = { ...payload.config.jobs.processingLease }
   })
 
-  afterAll(async () => {
+  test.afterAll(async () => {
     // Ensure no new crons are scheduled
     _internal_jobSystemGlobals.shouldAutoRun = false
     _internal_jobSystemGlobals.shouldAutoSchedule = false
     // Wait 3 seconds to ensure all currently-running crons are done. If we shut down the db while a function is running, it can cause issues
     // Cron function runs may persist after a test has finished
     await wait(3000)
-    // Now we can destroy the payload instance
-    await payload.destroy()
     _internal_resetJobSystemGlobals()
   })
 
-  afterEach(() => {
-    _internal_resetJobSystemGlobals()
+  test.afterEach(({ payload }) => {
+    _internal_jobSystemGlobals.shouldAutoRun = false
+    _internal_jobSystemGlobals.shouldAutoSchedule = false
     Object.assign(payload.config.jobs.processingLease, processingLeaseDefaults)
   })
 
-  beforeEach(async () => {
-    // Set autorun to false during seed process to ensure no crons are scheduled, which may affect the tests
-    _internal_jobSystemGlobals.shouldAutoRun = false
-    _internal_jobSystemGlobals.shouldAutoSchedule = false
-    await clearAndSeedEverything(payload)
+  test.beforeEach(async ({ payload, restClient }) => {
     const data = await restClient
       .POST('/users/login', {
         body: JSON.stringify({
@@ -81,8 +72,8 @@ describe('Queues - Payload', () => {
     _internal_jobSystemGlobals.shouldAutoSchedule = true
   })
 
-  describe('default config', () => {
-    it('should always add the jobs stats global and job metadata field', () => {
+  test.describe('default config', () => {
+    test('should always add the jobs stats global and job metadata field', ({ payload }) => {
       const jobsCollection = payload.config.collections.find(({ slug }) => slug === 'payload-jobs')
       const jobsStatsGlobal = payload.config.globals.find(
         ({ slug }) => slug === 'payload-jobs-stats',
@@ -96,8 +87,8 @@ describe('Queues - Payload', () => {
     })
   })
 
-  describe('access control', () => {
-    it('should deny raw job creation when access control is enabled', async () => {
+  test.describe('access control', () => {
+    test('should deny raw job creation when access control is enabled', async ({ payload }) => {
       const req = await createLocalReq({ user }, payload)
 
       await expect(
@@ -115,7 +106,7 @@ describe('Queues - Payload', () => {
       ).rejects.toThrow()
     })
 
-    it('should deny raw job reads when access control is enabled', async () => {
+    test('should deny raw job reads when access control is enabled', async ({ payload }) => {
       const req = await createLocalReq({ user }, payload)
       const job = await payload.jobs.queue({
         task: 'CreateSimple',
@@ -134,7 +125,7 @@ describe('Queues - Payload', () => {
       ).rejects.toThrow()
     })
 
-    it('should deny raw job updates when access control is enabled', async () => {
+    test('should deny raw job updates when access control is enabled', async ({ payload }) => {
       const req = await createLocalReq({ user }, payload)
       const job = await payload.jobs.queue({
         task: 'CreateSimple',
@@ -165,7 +156,7 @@ describe('Queues - Payload', () => {
       expect(unchangedJob.input).toEqual({ message: 'protected job' })
     })
 
-    it('should deny raw job deletion when access control is enabled', async () => {
+    test('should deny raw job deletion when access control is enabled', async ({ payload }) => {
       const req = await createLocalReq({ user }, payload)
       const job = await payload.jobs.queue({
         task: 'CreateSimple',
@@ -191,7 +182,7 @@ describe('Queues - Payload', () => {
       expect(unchangedJob.id).toBe(job.id)
     })
 
-    it('will run access control on jobs runner run endpoint', async () => {
+    test('will run access control on jobs runner run endpoint', async ({ restClient }) => {
       const response = await restClient.GET('/payload-jobs/run?silent=true', {
         headers: {
           // Authorization: `JWT ${token}`,
@@ -199,7 +190,7 @@ describe('Queues - Payload', () => {
       }) // Needs to be a rest call to test auth
       expect(response.status).toBe(401)
     })
-    it('will return 200 from jobs runner', async () => {
+    test('will return 200 from jobs runner', async ({ restClient }) => {
       const response = await restClient.GET('/payload-jobs/run?silent=true', {
         headers: {
           Authorization: `JWT ${token}`,
@@ -209,7 +200,9 @@ describe('Queues - Payload', () => {
       expect(response.status).toBe(200)
     })
 
-    it('will fail access control on local api .queue when passing overrideAccess: false', async () => {
+    test('will fail access control on local api .queue when passing overrideAccess: false', async ({
+      payload,
+    }) => {
       await expect(
         payload.jobs.queue({
           task: 'CreateSimple',
@@ -221,7 +214,9 @@ describe('Queues - Payload', () => {
       ).rejects.toThrow(Forbidden)
     })
 
-    it('will pass access control on local api .queue when passing overrideAccess: false', async () => {
+    test('will pass access control on local api .queue when passing overrideAccess: false', async ({
+      payload,
+    }) => {
       const req = await createLocalReq({ user }, payload)
       const result = await payload.jobs.queue({
         task: 'CreateSimple',
@@ -236,7 +231,9 @@ describe('Queues - Payload', () => {
       expect(result.input.message).toBe('from single task')
     })
 
-    it('will fail access control on local api .run when passing overrideAccess: false', async () => {
+    test('will fail access control on local api .run when passing overrideAccess: false', async ({
+      payload,
+    }) => {
       await expect(
         payload.jobs.run({
           overrideAccess: false,
@@ -244,7 +241,9 @@ describe('Queues - Payload', () => {
       ).rejects.toThrow(Forbidden)
     })
 
-    it('will pass access control on local api .run when passing overrideAccess: false', async () => {
+    test('will pass access control on local api .run when passing overrideAccess: false', async ({
+      payload,
+    }) => {
       const req = await createLocalReq({ user }, payload)
       const result = await payload.jobs.run({
         overrideAccess: false,
@@ -254,7 +253,9 @@ describe('Queues - Payload', () => {
       expect(result).toBeDefined()
     })
 
-    it('will fail access control on local api .runByID when passing overrideAccess: false', async () => {
+    test('will fail access control on local api .runByID when passing overrideAccess: false', async ({
+      payload,
+    }) => {
       await expect(
         payload.jobs.runByID({
           id: '1',
@@ -263,7 +264,9 @@ describe('Queues - Payload', () => {
       ).rejects.toThrow(Forbidden)
     })
 
-    it('will pass access control on local api .runByID when passing overrideAccess: false', async () => {
+    test('will pass access control on local api .runByID when passing overrideAccess: false', async ({
+      payload,
+    }) => {
       const req = await createLocalReq({ user }, payload)
 
       // Queue a job first so we have a valid ID
@@ -284,7 +287,9 @@ describe('Queues - Payload', () => {
       expect(result).toBeDefined()
     })
 
-    it('will fail access control on local api .cancel when passing overrideAccess: false', async () => {
+    test('will fail access control on local api .cancel when passing overrideAccess: false', async ({
+      payload,
+    }) => {
       payload.config.jobs.deleteJobOnComplete = false
 
       // Queue a job without running it
@@ -317,7 +322,9 @@ describe('Queues - Payload', () => {
       expect(jobAfterCancel.error?.cancelled).toBeUndefined()
     })
 
-    it('will pass access control on local api .cancel when passing overrideAccess: false', async () => {
+    test('will pass access control on local api .cancel when passing overrideAccess: false', async ({
+      payload,
+    }) => {
       payload.config.jobs.deleteJobOnComplete = false
 
       const req = await createLocalReq({ user }, payload)
@@ -351,7 +358,9 @@ describe('Queues - Payload', () => {
       expect(jobAfterCancel.error?.cancelled).toBe(true)
     })
 
-    it('will fail access control on local api .cancelByID when passing overrideAccess: false', async () => {
+    test('will fail access control on local api .cancelByID when passing overrideAccess: false', async ({
+      payload,
+    }) => {
       payload.config.jobs.deleteJobOnComplete = false
 
       // Queue a job without running it
@@ -380,7 +389,9 @@ describe('Queues - Payload', () => {
       expect(jobAfterCancel.error?.cancelled).toBeUndefined()
     })
 
-    it('will pass access control on local api .cancelByID when passing overrideAccess: false', async () => {
+    test('will pass access control on local api .cancelByID when passing overrideAccess: false', async ({
+      payload,
+    }) => {
       payload.config.jobs.deleteJobOnComplete = false
 
       const req = await createLocalReq({ user }, payload)
@@ -415,7 +426,7 @@ describe('Queues - Payload', () => {
   // postgres:
   // QueryError: The following path cannot be queried: document.relationTo
   // This test is to ensure that the bug is fixed
-  it('can create and update new jobs', async () => {
+  test('can create and update new jobs', async ({ payload }) => {
     const job = await payload.create({
       collection: 'payload-jobs',
       data: {
@@ -440,7 +451,7 @@ describe('Queues - Payload', () => {
     expect(updatedJob.input.message).toBe('2')
   })
 
-  it('can create new jobs', async () => {
+  test('can create new jobs', async ({ payload }) => {
     const newPost = await payload.create({
       collection: 'posts',
       data: {
@@ -467,7 +478,7 @@ describe('Queues - Payload', () => {
     expect(postAfterJobs.jobStep2Ran).toBe('hellohellohellohello')
   })
 
-  it('can create new JSON-workflow jobs', async () => {
+  test('can create new JSON-workflow jobs', async ({ payload }) => {
     const newPost = await payload.create({
       collection: 'posts',
       data: {
@@ -497,7 +508,7 @@ describe('Queues - Payload', () => {
     expect(postAfterJobs.jobStep2Ran).toBe('hellohellohellohello')
   })
 
-  it('ensure job retrying works', async () => {
+  test('ensure job retrying works', async ({ payload }) => {
     payload.config.jobs.deleteJobOnComplete = false
     const job = await payload.jobs.queue({
       workflow: 'retriesTest',
@@ -533,7 +544,7 @@ describe('Queues - Payload', () => {
     expect(jobAfterRun.input.amountRetried).toBe(3)
   })
 
-  it('ensure workflow-level retries are respected', async () => {
+  test('ensure workflow-level retries are respected', async ({ payload }) => {
     payload.config.jobs.deleteJobOnComplete = false
     const job = await payload.jobs.queue({
       workflow: 'retriesWorkflowLevelTest',
@@ -568,7 +579,7 @@ describe('Queues - Payload', () => {
     expect(jobAfterRun.input.amountRetried).toBe(2)
   })
 
-  it('ensure workflows dont limit retries if no retries property is set', async () => {
+  test('ensure workflows dont limit retries if no retries property is set', async ({ payload }) => {
     payload.config.jobs.deleteJobOnComplete = false
     const job = await payload.jobs.queue({
       workflow: 'workflowNoRetriesSet',
@@ -603,7 +614,9 @@ describe('Queues - Payload', () => {
     expect(jobAfterRun.input.amountRetried).toBe(3)
   })
 
-  it('ensure workflows dont retry if retries set to 0, even if individual tasks have retries > 0 set', async () => {
+  test('ensure workflows dont retry if retries set to 0, even if individual tasks have retries > 0 set', async ({
+    payload,
+  }) => {
     payload.config.jobs.deleteJobOnComplete = false
     const job = await payload.jobs.queue({
       workflow: 'workflowRetries0',
@@ -638,7 +651,9 @@ describe('Queues - Payload', () => {
     expect(jobAfterRun.input.amountRetried).toBe(0)
   })
 
-  it('ensure workflows dont retry if neither workflows nor tasks have retries set', async () => {
+  test('ensure workflows dont retry if neither workflows nor tasks have retries set', async ({
+    payload,
+  }) => {
     payload.config.jobs.deleteJobOnComplete = false
     const job = await payload.jobs.queue({
       workflow: 'workflowAndTasksRetriesUndefined',
@@ -673,7 +688,9 @@ describe('Queues - Payload', () => {
     expect(jobAfterRun.input.amountRetried).toBe(0)
   })
 
-  it('ensure workflows retry if workflows have retries set and tasks do not have retries set, due to tasks inheriting workflow retries', async () => {
+  test('ensure workflows retry if workflows have retries set and tasks do not have retries set, due to tasks inheriting workflow retries', async ({
+    payload,
+  }) => {
     payload.config.jobs.deleteJobOnComplete = false
     const job = await payload.jobs.queue({
       workflow: 'workflowRetries2TasksRetriesUndefined',
@@ -708,7 +725,9 @@ describe('Queues - Payload', () => {
     expect(jobAfterRun.input.amountRetried).toBe(2)
   })
 
-  it('ensure workflows do not retry if workflows have retries set and tasks have retries set to 0', async () => {
+  test('ensure workflows do not retry if workflows have retries set and tasks have retries set to 0', async ({
+    payload,
+  }) => {
     payload.config.jobs.deleteJobOnComplete = false
     const job = await payload.jobs.queue({
       workflow: 'workflowRetries2TasksRetries0',
@@ -744,7 +763,7 @@ describe('Queues - Payload', () => {
   })
 
   // Task rollbacks are not supported in the current version of Payload. This test will be re-enabled when task rollbacks are supported once we figure out the transaction issues
-  it.skip('ensure failed tasks are rolled back via transactions', async () => {
+  test.skip('ensure failed tasks are rolled back via transactions', async ({ payload }) => {
     const job = await payload.jobs.queue({
       workflow: 'retriesRollbackTest',
       input: {
@@ -778,7 +797,7 @@ describe('Queues - Payload', () => {
     expect(jobAfterRun.input.amountRetried).toBe(4)
   })
 
-  it('ensure backoff strategy of task is respected', async () => {
+  test('ensure backoff strategy of task is respected', async ({ payload }) => {
     payload.config.jobs.deleteJobOnComplete = false
     const job = await payload.jobs.queue({
       workflow: 'retriesBackoffTest',
@@ -864,7 +883,9 @@ describe('Queues - Payload', () => {
     expect(durations[3]).toBeGreaterThan(2400)
   })
 
-  it('should run a job only once when multiple workers poll the same queue', async () => {
+  test('should run a job only once when multiple workers poll the same queue', async ({
+    payload,
+  }) => {
     _internal_jobSystemGlobals.shouldAutoRun = false
     payload.config.jobs.deleteJobOnComplete = false
 
@@ -902,7 +923,9 @@ describe('Queues - Payload', () => {
     expect(workersThatRanTheJob).toHaveLength(1)
   })
 
-  it('should run a job only once when multiple workers run the same job by ID', async () => {
+  test('should run a job only once when multiple workers run the same job by ID', async ({
+    payload,
+  }) => {
     _internal_jobSystemGlobals.shouldAutoRun = false
     payload.config.jobs.deleteJobOnComplete = false
 
@@ -938,7 +961,7 @@ describe('Queues - Payload', () => {
     expect(workersThatRanTheJob).toHaveLength(1)
   })
 
-  it('ensure jobs run in FIFO order by default', async () => {
+  test('ensure jobs run in FIFO order by default', async ({ payload }) => {
     await payload.jobs.queue({
       workflow: 'inlineTaskTestDelayed',
       input: {
@@ -971,7 +994,7 @@ describe('Queues - Payload', () => {
     expect(allSimples.docs?.[1]?.title).toBe('task 2')
   })
 
-  it('ensure jobs can run LIFO if processingOrder is passed', async () => {
+  test('ensure jobs can run LIFO if processingOrder is passed', async ({ payload }) => {
     await payload.jobs.queue({
       workflow: 'inlineTaskTestDelayed',
       input: {
@@ -1005,7 +1028,9 @@ describe('Queues - Payload', () => {
     expect(allSimples.docs?.[1]?.title).toBe('task 1')
   })
 
-  it('ensure job config processingOrder using queues object is respected', async () => {
+  test('ensure job config processingOrder using queues object is respected', async ({
+    payload,
+  }) => {
     await payload.jobs.queue({
       workflow: 'inlineTaskTestDelayed',
       queue: 'lifo',
@@ -1041,7 +1066,7 @@ describe('Queues - Payload', () => {
     expect(allSimples.docs?.[1]?.title).toBe('task 1')
   })
 
-  it('can create new inline jobs', async () => {
+  test('can create new inline jobs', async ({ payload }) => {
     await payload.jobs.queue({
       workflow: 'inlineTaskTest',
       input: {
@@ -1060,7 +1085,7 @@ describe('Queues - Payload', () => {
     expect(allSimples.docs[0]?.title).toBe('hello!')
   })
 
-  it('should respect deleteJobOnComplete true default configuration', async () => {
+  test('should respect deleteJobOnComplete true default configuration', async ({ payload }) => {
     const { id } = await payload.jobs.queue({
       workflow: 'inlineTaskTest',
       input: {
@@ -1077,7 +1102,7 @@ describe('Queues - Payload', () => {
     expect(after).toBeNull()
   })
 
-  it('should not delete failed jobs if deleteJobOnComplete is true', async () => {
+  test('should not delete failed jobs if deleteJobOnComplete is true', async ({ payload }) => {
     const { id } = await payload.jobs.queue({
       workflow: 'failsImmediately',
       input: {},
@@ -1094,7 +1119,7 @@ describe('Queues - Payload', () => {
     expect(after?.processingToken).toBeFalsy()
   })
 
-  it('should respect deleteJobOnComplete false configuration', async () => {
+  test('should respect deleteJobOnComplete false configuration', async ({ payload }) => {
     payload.config.jobs.deleteJobOnComplete = false
     const { id } = await payload.jobs.queue({
       workflow: 'inlineTaskTest',
@@ -1114,7 +1139,7 @@ describe('Queues - Payload', () => {
     expect(after?.processingToken).toBeFalsy()
   })
 
-  it('can queue single tasks', async () => {
+  test('can queue single tasks', async ({ payload }) => {
     await payload.jobs.queue({
       task: 'CreateSimple',
       input: {
@@ -1133,18 +1158,20 @@ describe('Queues - Payload', () => {
     expect(allSimples.docs[0]?.title).toBe('from single task')
   })
 
-  describe('when a queued task slug is no longer registered in config', () => {
-    let originalTasks: typeof payload.config.jobs.tasks
+  test.describe('when a queued task slug is no longer registered in config', () => {
+    let originalTasks: Payload['config']['jobs']['tasks']
 
-    beforeEach(() => {
+    test.beforeEach(({ payload }) => {
       originalTasks = payload.config.jobs.tasks
     })
 
-    afterEach(() => {
+    test.afterEach(({ payload }) => {
       payload.config.jobs.tasks = originalTasks
     })
 
-    it('should permanently fail the job after one attempt instead of retrying forever', async () => {
+    test('should permanently fail the job after one attempt instead of retrying forever', async ({
+      payload,
+    }) => {
       payload.config.jobs.deleteJobOnComplete = false
 
       const job = await payload.jobs.queue({
@@ -1169,7 +1196,9 @@ describe('Queues - Payload', () => {
       expect(jobAfterRun.totalTried).toBe(1)
     })
 
-    it('should permanently fail when a workflow handler calls a task that has been removed', async () => {
+    test('should permanently fail when a workflow handler calls a task that has been removed', async ({
+      payload,
+    }) => {
       payload.config.jobs.deleteJobOnComplete = false
 
       const job = await payload.jobs.queue({
@@ -1194,7 +1223,9 @@ describe('Queues - Payload', () => {
     })
   })
 
-  it('should not retry a workflow with no retries configured when its handler throws', async () => {
+  test('should not retry a workflow with no retries configured when its handler throws', async ({
+    payload,
+  }) => {
     payload.config.jobs.deleteJobOnComplete = false
 
     const job = await payload.jobs.queue({
@@ -1214,7 +1245,9 @@ describe('Queues - Payload', () => {
     expect(jobAfterRun.totalTried).toBe(1)
   })
 
-  it('should retry a workflow with retries=1 exactly once when its handler throws', async () => {
+  test('should retry a workflow with retries=1 exactly once when its handler throws', async ({
+    payload,
+  }) => {
     payload.config.jobs.deleteJobOnComplete = false
 
     const job = await payload.jobs.queue({
@@ -1242,11 +1275,11 @@ describe('Queues - Payload', () => {
     expect(jobAfterRun.processingUntil).toBeFalsy()
   })
 
-  describe('worker recovery', () => {
+  test.describe('worker recovery', () => {
     // The child process can share the file-backed SQLite test database.
     test.options({ db: (type) => type.startsWith('sqlite') })(
       'should recover a job after its worker process is killed',
-      async () => {
+      async ({ payload }) => {
         _internal_jobSystemGlobals.shouldAutoRun = false
         payload.config.jobs.deleteJobOnComplete = false
 
@@ -1274,7 +1307,6 @@ describe('Queues - Payload', () => {
               CRASH_WORKER_LEASE_DURATION: '1000',
               CRASH_WORKER_LEASE_SAFETY_BUFFER: '100',
               PAYLOAD_DROP_DATABASE: 'false',
-              SEED_IN_CONFIG_ONINIT: 'false',
             },
             stdio: ['ignore', 'ignore', 'pipe'],
           },
@@ -1358,7 +1390,9 @@ describe('Queues - Payload', () => {
       },
     )
 
-    it('should let only one replacement worker recover a job after its original worker stops responding', async () => {
+    test('should let only one replacement worker recover a job after its original worker stops responding', async ({
+      payload,
+    }) => {
       _internal_jobSystemGlobals.shouldAutoRun = false
       payload.config.jobs.deleteJobOnComplete = false
       // Short lease (shorter than 500ms task delay in longRunning workflow) to simulate lease expiry
@@ -1424,7 +1458,9 @@ describe('Queues - Payload', () => {
       expect(completedJob.totalTried).toBe(1)
     })
 
-    it('should not let another worker pick up a healthy long-running job', async () => {
+    test('should not let another worker pick up a healthy long-running job', async ({
+      payload,
+    }) => {
       _internal_jobSystemGlobals.shouldAutoRun = false
       expect(payload.config.jobs.processingLease.duration).toBe(20 * 60 * 1000)
       expect(payload.config.jobs.processingLease.safetyBuffer).toBe(30_000)
@@ -1472,7 +1508,7 @@ describe('Queues - Payload', () => {
       expect(completedJob.totalTried).toBe(1)
     })
 
-    it('should recover an interrupted job without consuming a retry', async () => {
+    test('should recover an interrupted job without consuming a retry', async ({ payload }) => {
       _internal_jobSystemGlobals.shouldAutoRun = false
       payload.config.jobs.deleteJobOnComplete = false
       payload.config.jobs.processingLease.duration = 300
@@ -1506,7 +1542,9 @@ describe('Queues - Payload', () => {
       expect(completedJob.totalTried).toBe(1)
     })
 
-    it('should ignore task results from a timed-out worker after another worker recovers the job', async () => {
+    test('should ignore task results from a timed-out worker after another worker recovers the job', async ({
+      payload,
+    }) => {
       _internal_jobSystemGlobals.shouldAutoRun = false
       payload.config.jobs.deleteJobOnComplete = false
       payload.config.jobs.processingLease.duration = 300
@@ -1555,7 +1593,10 @@ describe('Queues - Payload', () => {
     })
   })
 
-  it('can queue and run via the endpoint single tasks without workflows', async () => {
+  test('can queue and run via the endpoint single tasks without workflows', async ({
+    payload,
+    restClient,
+  }) => {
     const workflowsRef = payload.config.jobs.workflows
     delete payload.config.jobs.workflows
     await payload.jobs.queue({
@@ -1582,7 +1623,7 @@ describe('Queues - Payload', () => {
   })
 
   // Task rollbacks are not supported in the current version of Payload. This test will be re-enabled when task rollbacks are supported once we figure out the transaction issues
-  it.skip('transaction test against payload-jobs collection', async () => {
+  test.skip('transaction test against payload-jobs collection', async ({ payload }) => {
     // This kinds of emulates what happens when multiple jobs are queued and then run in parallel.
     const runWorkflowFN = async (i: number) => {
       const { id } = await payload.create({
@@ -1692,7 +1733,7 @@ describe('Queues - Payload', () => {
     expect(allSimples.totalDocs).toBe(30)
   })
 
-  it('can queue single tasks 8 times', async () => {
+  test('can queue single tasks 8 times', async ({ payload }) => {
     for (let i = 0; i < 8; i++) {
       await payload.jobs.queue({
         task: 'CreateSimple',
@@ -1714,7 +1755,7 @@ describe('Queues - Payload', () => {
     expect(allSimples.docs[7]?.title).toBe('from single task')
   })
 
-  it('can queue single tasks hundreds of times', async () => {
+  test('can queue single tasks hundreds of times', async ({ payload }) => {
     const numberOfTasks = 150
     // TODO: Ramp up the limit from 150 to 500 or 1000, to test reliability of the database
     payload.config.jobs.deleteJobOnComplete = false
@@ -1747,7 +1788,7 @@ describe('Queues - Payload', () => {
     expect(allSimples.docs[numberOfTasks - 1]?.title).toBe('from single task')
   })
 
-  it('ensure default jobs run limit of 10 works', async () => {
+  test('ensure default jobs run limit of 10 works', async ({ payload }) => {
     for (let i = 0; i < 65; i++) {
       await payload.jobs.queue({
         task: 'CreateSimple',
@@ -1769,7 +1810,7 @@ describe('Queues - Payload', () => {
     expect(allSimples.docs[9]?.title).toBe('from single task')
   })
 
-  it('ensure jobs run limit can be customized', async () => {
+  test('ensure jobs run limit can be customized', async ({ payload }) => {
     for (let i = 0; i < 110; i++) {
       await payload.jobs.queue({
         task: 'CreateSimple',
@@ -1795,7 +1836,7 @@ describe('Queues - Payload', () => {
     expect(allSimples.docs[41]?.title).toBe('from single task')
   })
 
-  it('can queue different kinds of single tasks multiple times', async () => {
+  test('can queue different kinds of single tasks multiple times', async ({ payload }) => {
     for (let i = 0; i < 3; i++) {
       await payload.jobs.queue({
         task: 'CreateSimpleWithDuplicateMessage',
@@ -1841,7 +1882,7 @@ describe('Queues - Payload', () => {
     expect(amountOfCreateSimpleWithDuplicateMessage).toBe(6)
   })
 
-  it('can queue external tasks', async () => {
+  test('can queue external tasks', async ({ payload }) => {
     await payload.jobs.queue({
       task: 'ExternalTask',
       input: {
@@ -1860,7 +1901,7 @@ describe('Queues - Payload', () => {
     expect(allSimples.docs[0]?.title).toBe('external')
   })
 
-  it('can queue external workflow that is running external task', async () => {
+  test('can queue external workflow that is running external task', async ({ payload }) => {
     await payload.jobs.queue({
       workflow: 'externalWorkflow',
       input: {
@@ -1879,7 +1920,7 @@ describe('Queues - Payload', () => {
     expect(allSimples.docs[0]?.title).toBe('externalWorkflow')
   })
 
-  it('ensure payload.jobs.runByID works and only runs the specified job', async () => {
+  test('ensure payload.jobs.runByID works and only runs the specified job', async ({ payload }) => {
     payload.config.jobs.deleteJobOnComplete = false
 
     let lastJobID: null | number | string = null
@@ -1923,7 +1964,9 @@ describe('Queues - Payload', () => {
     expect(allCompletedJobs.docs[0]?.id).toBe(lastJobID)
   })
 
-  it('ensure where query for id in payload.jobs.run works and only runs the specified job', async () => {
+  test('ensure where query for id in payload.jobs.run works and only runs the specified job', async ({
+    payload,
+  }) => {
     payload.config.jobs.deleteJobOnComplete = false
 
     let lastJobID: null | number | string = null
@@ -1971,7 +2014,9 @@ describe('Queues - Payload', () => {
     expect(allCompletedJobs.docs[0]?.id).toBe(lastJobID)
   })
 
-  it('ensure where query for input data in payload.jobs.run works and only runs the specified job', async () => {
+  test('ensure where query for input data in payload.jobs.run works and only runs the specified job', async ({
+    payload,
+  }) => {
     payload.config.jobs.deleteJobOnComplete = false
 
     for (let i = 0; i < 3; i++) {
@@ -2014,7 +2059,7 @@ describe('Queues - Payload', () => {
     expect((allCompletedJobs.docs[0]?.input as any).message).toBe('from single task 2')
   })
 
-  it('can run sub-tasks', async () => {
+  test('can run sub-tasks', async ({ payload }) => {
     payload.config.jobs.deleteJobOnComplete = false
     const job = await payload.jobs.queue({
       workflow: 'subTask',
@@ -2054,7 +2099,7 @@ describe('Queues - Payload', () => {
     expect(jobAfterRun?.log?.[2]?.taskID).toBe('create two docs')
   })
 
-  it('ensure successful sub-tasks are not retried', async () => {
+  test('ensure successful sub-tasks are not retried', async ({ payload }) => {
     payload.config.jobs.deleteJobOnComplete = false
 
     const job = await payload.jobs.queue({
@@ -2093,7 +2138,7 @@ describe('Queues - Payload', () => {
     expect(jobAfterRun.input.amountTask1Retried).toBe(0)
   })
 
-  it('ensure jobs can be cancelled using payload.jobs.cancelByID', async () => {
+  test('ensure jobs can be cancelled using payload.jobs.cancelByID', async ({ payload }) => {
     payload.config.jobs.deleteJobOnComplete = false
 
     const job = await payload.jobs.queue({
@@ -2142,7 +2187,7 @@ describe('Queues - Payload', () => {
     expect(runResponse.jobStatus).toBeUndefined()
   })
 
-  it('ensure jobs can be cancelled using payload.jobs.cancel', async () => {
+  test('ensure jobs can be cancelled using payload.jobs.cancel', async ({ payload }) => {
     payload.config.jobs.deleteJobOnComplete = false
 
     const job = await payload.jobs.queue({
@@ -2181,7 +2226,9 @@ describe('Queues - Payload', () => {
     expect(jobAfterRun.processingUntil).toBeFalsy()
   })
 
-  it('ensure jobs can cancel themselves by throwing a JobCancelledError in workflow handler', async () => {
+  test('ensure jobs can cancel themselves by throwing a JobCancelledError in workflow handler', async ({
+    payload,
+  }) => {
     payload.config.jobs.deleteJobOnComplete = false
 
     /**
@@ -2278,7 +2325,9 @@ describe('Queues - Payload', () => {
     }
   })
 
-  it('ensure jobs can cancel themselves by throwing a JobCancelledError in task handler', async () => {
+  test('ensure jobs can cancel themselves by throwing a JobCancelledError in task handler', async ({
+    payload,
+  }) => {
     payload.config.jobs.deleteJobOnComplete = false
 
     /**
@@ -2377,7 +2426,7 @@ describe('Queues - Payload', () => {
     }
   })
 
-  it('can tasks throw error', async () => {
+  test('can tasks throw error', async ({ payload }) => {
     payload.config.jobs.deleteJobOnComplete = false
 
     const job = await payload.jobs.queue({
@@ -2398,7 +2447,7 @@ describe('Queues - Payload', () => {
     expect(jobAfterRun?.log?.[0]?.state).toBe('failed')
   })
 
-  it('can reliably run workflows with parallel tasks', async () => {
+  test('can reliably run workflows with parallel tasks', async ({ payload }) => {
     if (process.env.PAYLOAD_DATABASE === 'supabase') {
       // TODO: This test is flaky on supabase in CI, so we skip it for now
       return
@@ -2442,7 +2491,9 @@ describe('Queues - Payload', () => {
     }
   })
 
-  it('can reliably run workflows with parallel tasks that complete immediately', async () => {
+  test('can reliably run workflows with parallel tasks that complete immediately', async ({
+    payload,
+  }) => {
     const amount = 20
     payload.config.jobs.deleteJobOnComplete = false
 
@@ -2466,7 +2517,7 @@ describe('Queues - Payload', () => {
     expect(jobAfterRun.log?.length).toBe(amount)
   })
 
-  it('can create and autorun jobs', async () => {
+  test('can create and autorun jobs', async ({ payload }) => {
     await payload.jobs.queue({
       workflow: 'inlineTaskTest',
       queue: 'autorunSecond',
@@ -2489,8 +2540,10 @@ describe('Queues - Payload', () => {
     expect(allSimples?.docs?.[0]?.title).toBe('hello!')
   })
 
-  describe('concurrency controls', () => {
-    it('should store concurrencyKey when queuing jobs with concurrency config', async () => {
+  test.describe('concurrency controls', () => {
+    test('should store concurrencyKey when queuing jobs with concurrency config', async ({
+      payload,
+    }) => {
       payload.config.jobs.deleteJobOnComplete = false
 
       const job = await payload.jobs.queue({
@@ -2503,7 +2556,9 @@ describe('Queues - Payload', () => {
       expect(job.concurrencyKey).toBe('exclusive:resource-1')
     })
 
-    it('should not store concurrencyKey for workflows without concurrency config', async () => {
+    test('should not store concurrencyKey for workflows without concurrency config', async ({
+      payload,
+    }) => {
       payload.config.jobs.deleteJobOnComplete = false
 
       const job = await payload.jobs.queue({
@@ -2516,7 +2571,7 @@ describe('Queues - Payload', () => {
       expect(job.concurrencyKey).toBeFalsy()
     })
 
-    it('should run jobs with different concurrencyKeys in parallel', async () => {
+    test('should run jobs with different concurrencyKeys in parallel', async ({ payload }) => {
       payload.config.jobs.deleteJobOnComplete = false
 
       // Queue two jobs with different resourceIds (different concurrency keys)
@@ -2553,7 +2608,9 @@ describe('Queues - Payload', () => {
       expect(job2After.completedAt).toBeDefined()
     })
 
-    it('should run jobs with same concurrencyKey exclusively (one at a time)', async () => {
+    test('should run jobs with same concurrencyKey exclusively (one at a time)', async ({
+      payload,
+    }) => {
       payload.config.jobs.deleteJobOnComplete = false
 
       // Queue two jobs with the SAME resourceId (same concurrency key)
@@ -2607,7 +2664,7 @@ describe('Queues - Payload', () => {
       expect(job2Final.completedAt).toBeDefined()
     })
 
-    it('should verify exclusive concurrency prevents race conditions', async () => {
+    test('should verify exclusive concurrency prevents race conditions', async ({ payload }) => {
       payload.config.jobs.deleteJobOnComplete = false
 
       // Queue 3 jobs with the same concurrency key
@@ -2673,7 +2730,9 @@ describe('Queues - Payload', () => {
       expect(completedCount3).toBe(3)
     })
 
-    it('should allow parallel execution for jobs without concurrency config', async () => {
+    test('should allow parallel execution for jobs without concurrency config', async ({
+      payload,
+    }) => {
       payload.config.jobs.deleteJobOnComplete = false
 
       // Queue two jobs with the same resourceId but NO concurrency config
@@ -2714,7 +2773,9 @@ describe('Queues - Payload', () => {
       expect(job2After.completedAt).toBeDefined()
     })
 
-    it('should handle mixed scenario: concurrent and non-concurrent jobs together', async () => {
+    test('should handle mixed scenario: concurrent and non-concurrent jobs together', async ({
+      payload,
+    }) => {
       payload.config.jobs.deleteJobOnComplete = false
 
       // Queue jobs: 2 with same concurrency key, 1 with different key, 1 without concurrency
@@ -2767,7 +2828,7 @@ describe('Queues - Payload', () => {
       expect(concurrentJob2After.completedAt).toBeDefined()
     })
 
-    it('should preserve FIFO order for jobs with same concurrencyKey', async () => {
+    test('should preserve FIFO order for jobs with same concurrencyKey', async ({ payload }) => {
       payload.config.jobs.deleteJobOnComplete = false
 
       // Queue 3 jobs with same key in specific order
@@ -2828,7 +2889,9 @@ describe('Queues - Payload', () => {
       expect(results[2].completedAt).toBeDefined() // C completed
     })
 
-    it('should preserve LIFO order when processingOrder is set to -createdAt', async () => {
+    test('should preserve LIFO order when processingOrder is set to -createdAt', async ({
+      payload,
+    }) => {
       payload.config.jobs.deleteJobOnComplete = false
 
       // Queue 3 jobs with same key in specific order
@@ -2892,7 +2955,9 @@ describe('Queues - Payload', () => {
       expect(results[2].completedAt).toBeDefined() // C completed
     })
 
-    it('should block new pending jobs when a job with same key is already running', async () => {
+    test('should block new pending jobs when a job with same key is already running', async ({
+      payload,
+    }) => {
       payload.config.jobs.deleteJobOnComplete = false
 
       // Queue and start running a long job
@@ -2939,7 +3004,9 @@ describe('Queues - Payload', () => {
       expect(pendingJobFinal.completedAt).toBeDefined()
     })
 
-    it('should pass queue name to concurrency key function for queue-specific concurrency', async () => {
+    test('should pass queue name to concurrency key function for queue-specific concurrency', async ({
+      payload,
+    }) => {
       payload.config.jobs.deleteJobOnComplete = false
 
       // Queue jobs to different queues with same resource ID
@@ -2976,8 +3043,8 @@ describe('Queues - Payload', () => {
       expect(results[1].completedAt).toBeDefined()
     })
 
-    describe('supersedes', () => {
-      it('should delete older pending jobs when supersedes is enabled', async () => {
+    test.describe('supersedes', () => {
+      test('should delete older pending jobs when supersedes is enabled', async ({ payload }) => {
         payload.config.jobs.deleteJobOnComplete = false
 
         // Queue 3 jobs with same key - newer ones should supersede older pending ones
@@ -3024,7 +3091,7 @@ describe('Queues - Payload', () => {
         expect(jobCAfter.concurrencyKey).toBe('supersedes:supersedes-test')
       })
 
-      it('should not delete running jobs when supersedes is enabled', async () => {
+      test('should not delete running jobs when supersedes is enabled', async ({ payload }) => {
         payload.config.jobs.deleteJobOnComplete = false
 
         // Queue and start running a job
@@ -3078,7 +3145,7 @@ describe('Queues - Payload', () => {
         expect(finalResults[1].completedAt).toBeDefined()
       })
 
-      it('should handle supersedes with multiple sequential queues', async () => {
+      test('should handle supersedes with multiple sequential queues', async ({ payload }) => {
         payload.config.jobs.deleteJobOnComplete = false
 
         // Queue jobs sequentially - each new job should delete previous pending ones
@@ -3142,7 +3209,9 @@ describe('Queues - Payload', () => {
         expect(finalJob.completedAt).toBeDefined()
       })
 
-      it('should supersede middle job when one is running and another queued', async () => {
+      test('should supersede middle job when one is running and another queued', async ({
+        payload,
+      }) => {
         payload.config.jobs.deleteJobOnComplete = false
 
         // Queue and start running first job
@@ -3223,8 +3292,8 @@ describe('Queues - Payload', () => {
     })
   })
 
-  describe('cron recovery', () => {
-    it('should recover cron after a transient DB error in jobs.run', async () => {
+  test.describe('cron recovery', () => {
+    test('should recover cron after a transient DB error in jobs.run', async ({ payload }) => {
       // --- Step 1: Verify cron works normally ---
 
       _internal_jobSystemGlobals.shouldAutoRun = false

--- a/test/queues/postgres-logs.int.spec.ts
+++ b/test/queues/postgres-logs.int.spec.ts
@@ -1,59 +1,33 @@
-import type { Payload } from 'payload'
+import { expect, vitest } from 'vitest'
 
-import assert from 'assert'
-import path from 'path'
-import { fileURLToPath } from 'url'
-import { afterAll, beforeAll, describe, expect, it, vitest } from 'vitest'
-
-import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
+import { test } from '../__helpers/int/vitest.js'
+import testConfig from './config.postgreslogs.js'
 import { withoutAutoRun } from './utilities.js'
 
-const filename = fileURLToPath(import.meta.url)
-const dirname = path.dirname(filename)
+test.suite({ config: testConfig, cron: false, db: (adapter) => adapter.startsWith('postgres') })(
+  'queues - postgres logs',
+  () => {
+    test('ensure running jobs uses minimal db calls', async ({ payload }) => {
+      await withoutAutoRun(async () => {
+        await payload.jobs.queue({
+          task: 'DoNothingTask',
+          input: {
+            message: 'test',
+          },
+        })
 
-const describePostgres = process.env.PAYLOAD_DATABASE?.startsWith('postgres')
-  ? describe
-  : describe.skip
+        // Count every console log (= db call)
+        const consoleCount = vitest.spyOn(console, 'log').mockImplementation(() => {})
 
-let payload: Payload
+        const res = await payload.jobs.run({})
 
-describePostgres('queues - postgres logs', () => {
-  beforeAll(async () => {
-    const initialized = await initPayloadInt(
-      dirname,
-      undefined,
-      undefined,
-      'config.postgreslogs.ts',
-    )
-    assert(initialized.payload)
-    assert(initialized.restClient)
-    ;({ payload } = initialized)
-  })
-
-  afterAll(async () => {
-    await payload?.destroy()
-  })
-
-  it('ensure running jobs uses minimal db calls', async () => {
-    await withoutAutoRun(async () => {
-      await payload.jobs.queue({
-        task: 'DoNothingTask',
-        input: {
-          message: 'test',
-        },
+        expect(res).toEqual({
+          jobStatus: { '1': { status: 'success' } },
+          remainingJobsFromQueried: 0,
+        })
+        expect(consoleCount).toHaveBeenCalledTimes(16)
+        consoleCount.mockRestore()
       })
-
-      // Count every console log (= db call)
-      const consoleCount = vitest.spyOn(console, 'log').mockImplementation(() => {})
-
-      const res = await payload.jobs.run({})
-
-      expect(res).toEqual({
-        jobStatus: { '1': { status: 'success' } },
-        remainingJobsFromQueried: 0,
-      })
-      expect(consoleCount).toHaveBeenCalledTimes(16)
-      consoleCount.mockRestore()
     })
-  })
-})
+  },
+)

--- a/test/queues/postgres-logs.int.spec.ts
+++ b/test/queues/postgres-logs.int.spec.ts
@@ -1,33 +1,33 @@
 import { expect, vitest } from 'vitest'
 
 import { test } from '../__helpers/int/vitest.js'
-import testConfig from './config.postgreslogs.js'
 import { withoutAutoRun } from './utilities.js'
 
-test.suite({ config: testConfig, cron: false, db: (adapter) => adapter.startsWith('postgres') })(
-  'queues - postgres logs',
-  () => {
-    test('ensure running jobs uses minimal db calls', async ({ payload }) => {
-      await withoutAutoRun(async () => {
-        await payload.jobs.queue({
-          task: 'DoNothingTask',
-          input: {
-            message: 'test',
-          },
-        })
-
-        // Count every console log (= db call)
-        const consoleCount = vitest.spyOn(console, 'log').mockImplementation(() => {})
-
-        const res = await payload.jobs.run({})
-
-        expect(res).toEqual({
-          jobStatus: { '1': { status: 'success' } },
-          remainingJobsFromQueried: 0,
-        })
-        expect(consoleCount).toHaveBeenCalledTimes(16)
-        consoleCount.mockRestore()
+test.suite({
+  config: './config.postgreslogs.ts',
+  cron: false,
+  db: (adapter) => adapter.startsWith('postgres'),
+})('queues - postgres logs', () => {
+  test('ensure running jobs uses minimal db calls', async ({ payload }) => {
+    await withoutAutoRun(async () => {
+      await payload.jobs.queue({
+        task: 'DoNothingTask',
+        input: {
+          message: 'test',
+        },
       })
+
+      // Count every console log (= db call)
+      const consoleCount = vitest.spyOn(console, 'log').mockImplementation(() => {})
+
+      const res = await payload.jobs.run({})
+
+      expect(res).toEqual({
+        jobStatus: { '1': { status: 'success' } },
+        remainingJobsFromQueried: 0,
+      })
+      expect(consoleCount).toHaveBeenCalledTimes(16)
+      consoleCount.mockRestore()
     })
-  },
-)
+  })
+})

--- a/test/queues/schedules-autocron.int.spec.ts
+++ b/test/queues/schedules-autocron.int.spec.ts
@@ -1,106 +1,89 @@
-import path from 'path'
-import { _internal_jobSystemGlobals, _internal_resetJobSystemGlobals, type Payload } from 'payload'
+import { _internal_jobSystemGlobals, _internal_resetJobSystemGlobals } from 'payload'
 import { wait } from 'payload/shared'
 import { fileURLToPath } from 'url'
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { expect } from 'vitest'
 
-import type { NextRESTClient } from '../__helpers/shared/NextRESTClient.js'
-
+import { test } from '../__helpers/int/vitest.js'
 import { devUser } from '../credentials.js'
-import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
-import { clearAndSeedEverything } from './seed.js'
+import testConfig from './config.schedules-autocron.js'
 
-let payload: Payload
-let restClient: NextRESTClient
 let token: string
 
 const { email, password } = devUser
-const filename = fileURLToPath(import.meta.url)
-const dirname = path.dirname(filename)
 
-describe('Queues - scheduling, with automatic scheduling handling', () => {
-  beforeAll(async () => {
-    process.env.SEED_IN_CONFIG_ONINIT = 'false' // Makes it so the payload config onInit seed is not run. Otherwise, the seed would be run unnecessarily twice for the initial test run - once for beforeEach and once for onInit
-    ;({ payload, restClient } = await initPayloadInt(
-      dirname,
-      undefined,
-      undefined,
-      'config.schedules-autocron.ts',
-    ))
-  })
+_internal_jobSystemGlobals.shouldAutoRun = false
+_internal_jobSystemGlobals.shouldAutoSchedule = false
 
-  afterAll(async () => {
-    // Ensure no new crons are scheduled
-    _internal_jobSystemGlobals.shouldAutoRun = false
-    _internal_jobSystemGlobals.shouldAutoSchedule = false
-    // Wait 3 seconds to ensure all currently-running crons are done. If we shut down the db while a function is running, it can cause issues
-    // Cron function runs may persist after a test has finished
-    await wait(3000)
-    // Now we can destroy the payload instance
-    await payload.destroy()
-    _internal_resetJobSystemGlobals()
-  })
-
-  afterEach(() => {
-    _internal_resetJobSystemGlobals()
-  })
-
-  beforeEach(async () => {
-    // Set autorun to false during seed process to ensure no crons are scheduled, which may affect the tests
-    _internal_jobSystemGlobals.shouldAutoRun = false
-    _internal_jobSystemGlobals.shouldAutoSchedule = false
-
-    await clearAndSeedEverything(payload)
-    const data = await restClient
-      .POST('/users/login', {
-        body: JSON.stringify({
-          email,
-          password,
-        }),
-      })
-      .then((res) => res.json())
-
-    if (data.token) {
-      token = data.token
-    }
-    payload.config.jobs.deleteJobOnComplete = true
-    _internal_jobSystemGlobals.shouldAutoRun = true
-    _internal_jobSystemGlobals.shouldAutoSchedule = true
-  })
-
-  it('can auto-schedule through automatic crons and autorun jobs', async () => {
-    // Do not call payload.jobs.run() or payload.jobs.handleSchedules() - payload should automatically schedule crons for auto-scheduling
-
-    // Autorun and Autoschedule runs every second - so should have autorun at least twice after 3.5 seconds. Case with the lowest amount of jobs completed,
-    // if autoschedule runs after the first autorun:
-    // Second 1: Autorun runs => no jobs
-    // Second 1: Autoschedule runs => scheduels 1 job
-    // Second 2: Autorun runs => runs 1 job => 1
-    // Second 2: Autoschedule runs => schedules 1 job
-    // Second 3: Autorun runs => runs 1 job => 2
-    // Second 3: Autoschedule runs => schedules 1 job
-    // Status after 3.5 seconds: 2 jobs running, 1 job scheduled
-
-    // Best case - most amounts of jobs completed:
-    // Second 1: Autoschedule runs => schedules 1 job
-    // Second 1: Autorun runs => runs 1 job => 1
-    // Second 2: Autoschedule runs => schedules 1 job
-    // Second 2: Autorun runs => runs 1 job => 2
-    // Second 3: Autoschedule runs => schedules 1 job
-    // Second 3: Autorun runs => runs 1 job => 3
-    // Status after 3.5 seconds: 3 jobs running, no jobs scheduled
-    const minJobsCompleted = 2
-    const maxJobsCompleted = 3
-
-    await new Promise((resolve) => setTimeout(resolve, 3500)) // 3 seconds + 0.5 seconds to ensure the last job has been completed
-
-    const allSimples = await payload.find({
-      collection: 'simple',
-      limit: 100,
+test.suite({ config: testConfig })(
+  'Queues - scheduling, with automatic scheduling handling',
+  () => {
+    test.afterAll(async () => {
+      // Ensure no new crons are scheduled
+      _internal_jobSystemGlobals.shouldAutoRun = false
+      _internal_jobSystemGlobals.shouldAutoSchedule = false
+      // Wait 3 seconds to ensure all currently-running crons are done. If we shut down the db while a function is running, it can cause issues
+      // Cron function runs may persist after a test has finished
+      await wait(3000)
+      _internal_resetJobSystemGlobals()
     })
 
-    expect(allSimples.totalDocs).toBeGreaterThanOrEqual(minJobsCompleted)
-    expect(allSimples.totalDocs).toBeLessThanOrEqual(maxJobsCompleted)
-    expect(allSimples?.docs?.[0]?.title).toBe('This task runs every second')
-  })
-})
+    test.afterEach(() => {
+      _internal_jobSystemGlobals.shouldAutoRun = false
+      _internal_jobSystemGlobals.shouldAutoSchedule = false
+    })
+
+    test.beforeEach(async ({ payload, restClient }) => {
+      const data = await restClient
+        .POST('/users/login', {
+          body: JSON.stringify({
+            email,
+            password,
+          }),
+        })
+        .then((res) => res.json())
+
+      if (data.token) {
+        token = data.token
+      }
+      payload.config.jobs.deleteJobOnComplete = true
+      _internal_jobSystemGlobals.shouldAutoRun = true
+      _internal_jobSystemGlobals.shouldAutoSchedule = true
+    })
+
+    test('can auto-schedule through automatic crons and autorun jobs', async ({ payload }) => {
+      // Do not call payload.jobs.run() or payload.jobs.handleSchedules() - payload should automatically schedule crons for auto-scheduling
+
+      // Autorun and Autoschedule runs every second - so should have autorun at least twice after 3.5 seconds. Case with the lowest amount of jobs completed,
+      // if autoschedule runs after the first autorun:
+      // Second 1: Autorun runs => no jobs
+      // Second 1: Autoschedule runs => scheduels 1 job
+      // Second 2: Autorun runs => runs 1 job => 1
+      // Second 2: Autoschedule runs => schedules 1 job
+      // Second 3: Autorun runs => runs 1 job => 2
+      // Second 3: Autoschedule runs => schedules 1 job
+      // Status after 3.5 seconds: 2 jobs running, 1 job scheduled
+
+      // Best case - most amounts of jobs completed:
+      // Second 1: Autoschedule runs => schedules 1 job
+      // Second 1: Autorun runs => runs 1 job => 1
+      // Second 2: Autoschedule runs => schedules 1 job
+      // Second 2: Autorun runs => runs 1 job => 2
+      // Second 3: Autoschedule runs => schedules 1 job
+      // Second 3: Autorun runs => runs 1 job => 3
+      // Status after 3.5 seconds: 3 jobs running, no jobs scheduled
+      const minJobsCompleted = 2
+      const maxJobsCompleted = 3
+
+      await new Promise((resolve) => setTimeout(resolve, 3500)) // 3 seconds + 0.5 seconds to ensure the last job has been completed
+
+      const allSimples = await payload.find({
+        collection: 'simple',
+        limit: 100,
+      })
+
+      expect(allSimples.totalDocs).toBeGreaterThanOrEqual(minJobsCompleted)
+      expect(allSimples.totalDocs).toBeLessThanOrEqual(maxJobsCompleted)
+      expect(allSimples?.docs?.[0]?.title).toBe('This task runs every second')
+    })
+  },
+)

--- a/test/queues/schedules-autocron.int.spec.ts
+++ b/test/queues/schedules-autocron.int.spec.ts
@@ -5,7 +5,6 @@ import { expect } from 'vitest'
 
 import { test } from '../__helpers/int/vitest.js'
 import { devUser } from '../credentials.js'
-import testConfig from './config.schedules-autocron.js'
 
 let token: string
 
@@ -14,7 +13,7 @@ const { email, password } = devUser
 _internal_jobSystemGlobals.shouldAutoRun = false
 _internal_jobSystemGlobals.shouldAutoSchedule = false
 
-test.suite({ config: testConfig })(
+test.suite({ config: './config.schedules-autocron.ts' })(
   'Queues - scheduling, with automatic scheduling handling',
   () => {
     test.afterAll(async () => {

--- a/test/queues/schedules.int.spec.ts
+++ b/test/queues/schedules.int.spec.ts
@@ -1,383 +1,390 @@
-import path from 'path'
-import { describe, beforeAll, afterAll, afterEach, beforeEach, it, expect } from 'vitest'
-import { _internal_jobSystemGlobals, _internal_resetJobSystemGlobals, type Payload } from 'payload'
+import { _internal_jobSystemGlobals, _internal_resetJobSystemGlobals } from 'payload'
 import { wait } from 'payload/shared'
 import { fileURLToPath } from 'url'
+import { expect } from 'vitest'
 
-import type { NextRESTClient } from '../__helpers/shared/NextRESTClient.js'
-
+import { test } from '../__helpers/int/vitest.js'
 import { devUser } from '../credentials.js'
-import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
-import { clearAndSeedEverything } from './seed.js'
+import testConfig from './config.schedules.js'
 import { timeFreeze, timeTravel, waitUntilAutorunIsDone, withoutAutoRun } from './utilities.js'
 
-let payload: Payload
-let restClient: NextRESTClient
 let token: string
 
 const { email, password } = devUser
-const filename = fileURLToPath(import.meta.url)
-const dirname = path.dirname(filename)
 
-describe('Queues - scheduling, without automatic scheduling handling', () => {
-  beforeAll(async () => {
-    process.env.SEED_IN_CONFIG_ONINIT = 'false' // Makes it so the payload config onInit seed is not run. Otherwise, the seed would be run unnecessarily twice for the initial test run - once for beforeEach and once for onInit
-    ;({ payload, restClient } = await initPayloadInt(
-      dirname,
-      undefined,
-      undefined,
-      'config.schedules.ts',
-    ))
-  })
+_internal_jobSystemGlobals.shouldAutoRun = false
+_internal_jobSystemGlobals.shouldAutoSchedule = false
 
-  afterAll(async () => {
-    // Ensure no new crons are scheduled
-    _internal_jobSystemGlobals.shouldAutoRun = false
-    _internal_jobSystemGlobals.shouldAutoSchedule = false
-    // Wait 3 seconds to ensure all currently-running crons are done. If we shut down the db while a function is running, it can cause issues
-    // Cron function runs may persist after a test has finished
-    await wait(3000)
-    // Now we can destroy the payload instance
-    await payload.destroy()
-    _internal_resetJobSystemGlobals()
-  })
-
-  afterEach(() => {
-    _internal_resetJobSystemGlobals()
-  })
-
-  beforeEach(async () => {
-    // Set autorun to false during seed process to ensure no crons are scheduled, which may affect the tests
-    _internal_jobSystemGlobals.shouldAutoRun = false
-    _internal_jobSystemGlobals.shouldAutoSchedule = false
-    await clearAndSeedEverything(payload)
-    const data = await restClient
-      .POST('/users/login', {
-        body: JSON.stringify({
-          email,
-          password,
-        }),
-      })
-      .then((res) => res.json())
-
-    if (data.token) {
-      token = data.token
-    }
-    payload.config.jobs.deleteJobOnComplete = true
-    _internal_jobSystemGlobals.shouldAutoRun = true
-    _internal_jobSystemGlobals.shouldAutoSchedule = true
-  })
-
-  it('can auto-schedule through local API and autorun jobs', async () => {
-    // Do not call payload.jobs.queue() - the `EverySecond` task should be scheduled here
-    await payload.jobs.handleSchedules({ queue: 'autorunSecond' })
-
-    // Do not call payload.jobs.run{silent: true})
-
-    await waitUntilAutorunIsDone({
-      payload,
-      queue: 'autorunSecond',
-      onlyScheduled: true,
+test.suite({ config: testConfig })(
+  'Queues - scheduling, without automatic scheduling handling',
+  () => {
+    test.afterAll(async () => {
+      // Ensure no new crons are scheduled
+      _internal_jobSystemGlobals.shouldAutoRun = false
+      _internal_jobSystemGlobals.shouldAutoSchedule = false
+      // Wait 3 seconds to ensure all currently-running crons are done. If we shut down the db while a function is running, it can cause issues
+      // Cron function runs may persist after a test has finished
+      await wait(3000)
+      _internal_resetJobSystemGlobals()
     })
 
-    const allSimples = await payload.find({
-      collection: 'simple',
-      limit: 100,
+    test.afterEach(() => {
+      _internal_jobSystemGlobals.shouldAutoRun = false
+      _internal_jobSystemGlobals.shouldAutoSchedule = false
     })
 
-    expect(allSimples.totalDocs).toBe(1)
-    expect(allSimples?.docs?.[0]?.title).toBe('This task runs every second')
-  })
-
-  it('can auto-schedule through local API and autorun jobs when passing allQueues', async () => {
-    // Do not call payload.jobs.queue() - the `EverySecond` task should be scheduled here
-    await payload.jobs.handleSchedules({ queue: 'autorunSecond', allQueues: true })
-
-    // Do not call payload.jobs.run{silent: true})
-
-    await waitUntilAutorunIsDone({
-      payload,
-      queue: 'autorunSecond',
-      onlyScheduled: true,
-    })
-
-    const allSimples = await payload.find({
-      collection: 'simple',
-      limit: 100,
-    })
-
-    expect(allSimples.totalDocs).toBe(1)
-    expect(allSimples?.docs?.[0]?.title).toBe('This task runs every second')
-  })
-
-  it('should not auto-schedule through local API and autorun jobs when not passing queue and schedule is not set on the default queue', async () => {
-    // Do not call payload.jobs.queue() - the `EverySecond` task should be scheduled here
-    await payload.jobs.handleSchedules()
-
-    // Do not call payload.jobs.run{silent: true})
-
-    await waitUntilAutorunIsDone({
-      payload,
-      queue: 'autorunSecond',
-      onlyScheduled: true,
-    })
-
-    const allSimples = await payload.find({
-      collection: 'simple',
-      limit: 100,
-    })
-
-    expect(allSimples.totalDocs).toBe(0)
-  })
-
-  it('can auto-schedule through handleSchedules REST API and autorun jobs', async () => {
-    // Do not call payload.jobs.queue() - the `EverySecond` task should be scheduled here
-    await restClient.GET('/payload-jobs/handle-schedules?queue=autorunSecond', {
-      headers: {
-        Authorization: `JWT ${token}`,
-      },
-    })
-
-    // Do not call payload.jobs.run({silent: true})
-
-    await waitUntilAutorunIsDone({
-      payload,
-      queue: 'autorunSecond',
-      onlyScheduled: true,
-    })
-
-    const allSimples = await payload.find({
-      collection: 'simple',
-      limit: 100,
-    })
-
-    expect(allSimples.totalDocs).toBe(1)
-    expect(allSimples?.docs?.[0]?.title).toBe('This task runs every second')
-  })
-
-  it('can auto-schedule through run REST API and autorun jobs', async () => {
-    // Do not call payload.jobs.queue() - the `EverySecond` task should be scheduled here
-    await restClient.GET('/payload-jobs/run?silent=true&allQueues=true', {
-      headers: {
-        Authorization: `JWT ${token}`,
-      },
-    })
-
-    await waitUntilAutorunIsDone({
-      payload,
-      queue: 'autorunSecond',
-      onlyScheduled: true,
-    })
-
-    const allSimples = await payload.find({
-      collection: 'simple',
-      limit: 100,
-    })
-
-    expect(allSimples.totalDocs).toBe(1)
-    expect(allSimples?.docs?.[0]?.title).toBe('This task runs every second')
-  })
-
-  it('do not auto-schedule through run REST API when passing disableScheduling=true', async () => {
-    // Do not call payload.jobs.queue() - the `EverySecond` task should be scheduled here
-    await restClient.GET('/payload-jobs/run?silent=true&disableScheduling=true', {
-      headers: {
-        Authorization: `JWT ${token}`,
-      },
-    })
-
-    await waitUntilAutorunIsDone({
-      payload,
-      queue: 'autorunSecond',
-      onlyScheduled: true,
-    })
-
-    const allSimples = await payload.find({
-      collection: 'simple',
-      limit: 100,
-    })
-
-    expect(allSimples.totalDocs).toBe(0)
-  })
-
-  it('ensure scheduler does not schedule more jobs than needed if executed sequentially', async () => {
-    await withoutAutoRun(async () => {
-      for (let i = 0; i < 3; i++) {
-        await payload.jobs.handleSchedules({ allQueues: true })
-      }
-    })
-
-    await waitUntilAutorunIsDone({
-      payload,
-      queue: 'autorunSecond',
-      onlyScheduled: true,
-    })
-
-    const allSimples = await payload.find({
-      collection: 'simple',
-      limit: 100,
-    })
-
-    expect(allSimples.totalDocs).toBe(1)
-    expect(allSimples?.docs?.[0]?.title).toBe('This task runs every second')
-  })
-
-  it('ensure scheduler max-one-job condition, by default, ignores jobs not scheduled by scheduler', async () => {
-    await withoutAutoRun(async () => {
-      for (let i = 0; i < 2; i++) {
-        await payload.jobs.queue({
-          task: 'EverySecond',
-          queue: 'autorunSecond',
-          input: {
-            message: 'This task runs every second',
-          },
+    test.beforeEach(async ({ payload, restClient }) => {
+      const data = await restClient
+        .POST('/users/login', {
+          body: JSON.stringify({
+            email,
+            password,
+          }),
         })
+        .then((res) => res.json())
+
+      if (data.token) {
+        token = data.token
       }
-      for (let i = 0; i < 3; i++) {
-        await payload.jobs.handleSchedules({ allQueues: true })
-      }
+      payload.config.jobs.deleteJobOnComplete = true
+      _internal_jobSystemGlobals.shouldAutoRun = true
+      _internal_jobSystemGlobals.shouldAutoSchedule = true
     })
 
-    await waitUntilAutorunIsDone({
-      payload,
-      queue: 'autorunSecond',
-      onlyScheduled: true,
-    })
+    test('can auto-schedule through local API and autorun jobs', async ({ payload }) => {
+      // Do not call payload.jobs.queue() - the `EverySecond` task should be scheduled here
+      await payload.jobs.handleSchedules({ queue: 'autorunSecond' })
 
-    const allSimples = await payload.find({
-      collection: 'simple',
-      limit: 100,
-    })
-
-    expect(allSimples.totalDocs).toBe(3)
-    expect(allSimples?.docs?.[0]?.title).toBe('This task runs every second')
-  })
-
-  it('ensure scheduler max-one-job condition, respects jobs not scheduled by scheduler due to task setting onlyScheduled: false', async () => {
-    timeFreeze()
-    await withoutAutoRun(async () => {
-      for (let i = 0; i < 2; i++) {
-        await payload.jobs.queue({
-          task: 'EverySecondMax2',
-          input: {
-            message: 'This task runs every second - max 2 per second',
-          },
-        })
-      }
-      for (let i = 0; i < 3; i++) {
-        await payload.jobs.handleSchedules({ queue: 'default' })
-      }
-    })
-
-    timeTravel(20) // Advance time to satisfy the waitUntil of newly scheduled jobs
-
-    await payload.jobs.run({
-      limit: 100,
-      silent: true,
-    })
-
-    const allSimples = await payload.find({
-      collection: 'simple',
-      limit: 100,
-    })
-
-    expect(allSimples.totalDocs).toBe(2) // Would be 4 by default, if only scheduled jobs were respected in handleSchedules condition
-    expect(allSimples?.docs?.[0]?.title).toBe('This task runs every second - max 2 per second')
-  })
-
-  it('ensure scheduler does not schedule more jobs than needed if executed sequentially - max. 2 jobs configured', async () => {
-    timeFreeze()
-    for (let i = 0; i < 3; i++) {
-      await payload.jobs.handleSchedules({ queue: 'default' })
-    }
-
-    // Advance time to satisfy the waitUntil of newly scheduled jobs
-    timeTravel(20)
-
-    // default queue is not scheduled to autorun
-    await payload.jobs.run({
-      silent: true,
-    })
-
-    const allSimples = await payload.find({
-      collection: 'simple',
-      limit: 100,
-    })
-
-    expect(allSimples.totalDocs).toBe(2)
-    expect(allSimples?.docs?.[0]?.title).toBe('This task runs every second - max 2 per second')
-  })
-
-  it('ensure job is scheduled every second', async () => {
-    timeFreeze()
-    for (let i = 0; i < 3; i++) {
-      await withoutAutoRun(async () => {
-        // Call it twice to test that it only schedules one
-        await payload.jobs.handleSchedules({ allQueues: true })
-        await payload.jobs.handleSchedules({ allQueues: true })
-      })
-      // Advance time to satisfy the waitUntil of newly scheduled jobs
-      timeTravel(20)
+      // Do not call payload.jobs.run{silent: true})
 
       await waitUntilAutorunIsDone({
         payload,
         queue: 'autorunSecond',
         onlyScheduled: true,
       })
-    }
 
-    const allSimples = await payload.find({
-      collection: 'simple',
-      limit: 100,
+      const allSimples = await payload.find({
+        collection: 'simple',
+        limit: 100,
+      })
+
+      expect(allSimples.totalDocs).toBe(1)
+      expect(allSimples?.docs?.[0]?.title).toBe('This task runs every second')
     })
 
-    expect(allSimples.totalDocs).toBe(3)
-    expect(allSimples?.docs?.[0]?.title).toBe('This task runs every second')
-  })
+    test('can auto-schedule through local API and autorun jobs when passing allQueues', async ({
+      payload,
+    }) => {
+      // Do not call payload.jobs.queue() - the `EverySecond` task should be scheduled here
+      await payload.jobs.handleSchedules({ queue: 'autorunSecond', allQueues: true })
 
-  it('ensure job is scheduled every second - max. 2 jobs configured', async () => {
-    timeFreeze()
+      // Do not call payload.jobs.run{silent: true})
 
-    for (let i = 0; i < 3; i++) {
-      await withoutAutoRun(async () => {
-        // Call it 3x to test that it only schedules two
-        await payload.jobs.handleSchedules({ queue: 'default' })
-        await payload.jobs.handleSchedules({ queue: 'default' })
-        await payload.jobs.handleSchedules({ queue: 'default' })
+      await waitUntilAutorunIsDone({
+        payload,
+        queue: 'autorunSecond',
+        onlyScheduled: true,
       })
+
+      const allSimples = await payload.find({
+        collection: 'simple',
+        limit: 100,
+      })
+
+      expect(allSimples.totalDocs).toBe(1)
+      expect(allSimples?.docs?.[0]?.title).toBe('This task runs every second')
+    })
+
+    test('should not auto-schedule through local API and autorun jobs when not passing queue and schedule is not set on the default queue', async ({
+      payload,
+    }) => {
+      // Do not call payload.jobs.queue() - the `EverySecond` task should be scheduled here
+      await payload.jobs.handleSchedules()
+
+      // Do not call payload.jobs.run{silent: true})
+
+      await waitUntilAutorunIsDone({
+        payload,
+        queue: 'autorunSecond',
+        onlyScheduled: true,
+      })
+
+      const allSimples = await payload.find({
+        collection: 'simple',
+        limit: 100,
+      })
+
+      expect(allSimples.totalDocs).toBe(0)
+    })
+
+    test('can auto-schedule through handleSchedules REST API and autorun jobs', async ({
+      payload,
+      restClient,
+    }) => {
+      // Do not call payload.jobs.queue() - the `EverySecond` task should be scheduled here
+      await restClient.GET('/payload-jobs/handle-schedules?queue=autorunSecond', {
+        headers: {
+          Authorization: `JWT ${token}`,
+        },
+      })
+
+      // Do not call payload.jobs.run({silent: true})
+
+      await waitUntilAutorunIsDone({
+        payload,
+        queue: 'autorunSecond',
+        onlyScheduled: true,
+      })
+
+      const allSimples = await payload.find({
+        collection: 'simple',
+        limit: 100,
+      })
+
+      expect(allSimples.totalDocs).toBe(1)
+      expect(allSimples?.docs?.[0]?.title).toBe('This task runs every second')
+    })
+
+    test('can auto-schedule through run REST API and autorun jobs', async ({
+      payload,
+      restClient,
+    }) => {
+      // Do not call payload.jobs.queue() - the `EverySecond` task should be scheduled here
+      await restClient.GET('/payload-jobs/run?silent=true&allQueues=true', {
+        headers: {
+          Authorization: `JWT ${token}`,
+        },
+      })
+
+      await waitUntilAutorunIsDone({
+        payload,
+        queue: 'autorunSecond',
+        onlyScheduled: true,
+      })
+
+      const allSimples = await payload.find({
+        collection: 'simple',
+        limit: 100,
+      })
+
+      expect(allSimples.totalDocs).toBe(1)
+      expect(allSimples?.docs?.[0]?.title).toBe('This task runs every second')
+    })
+
+    test('do not auto-schedule through run REST API when passing disableScheduling=true', async ({
+      payload,
+      restClient,
+    }) => {
+      // Do not call payload.jobs.queue() - the `EverySecond` task should be scheduled here
+      await restClient.GET('/payload-jobs/run?silent=true&disableScheduling=true', {
+        headers: {
+          Authorization: `JWT ${token}`,
+        },
+      })
+
+      await waitUntilAutorunIsDone({
+        payload,
+        queue: 'autorunSecond',
+        onlyScheduled: true,
+      })
+
+      const allSimples = await payload.find({
+        collection: 'simple',
+        limit: 100,
+      })
+
+      expect(allSimples.totalDocs).toBe(0)
+    })
+
+    test('ensure scheduler does not schedule more jobs than needed if executed sequentially', async ({
+      payload,
+    }) => {
+      await withoutAutoRun(async () => {
+        for (let i = 0; i < 3; i++) {
+          await payload.jobs.handleSchedules({ allQueues: true })
+        }
+      })
+
+      await waitUntilAutorunIsDone({
+        payload,
+        queue: 'autorunSecond',
+        onlyScheduled: true,
+      })
+
+      const allSimples = await payload.find({
+        collection: 'simple',
+        limit: 100,
+      })
+
+      expect(allSimples.totalDocs).toBe(1)
+      expect(allSimples?.docs?.[0]?.title).toBe('This task runs every second')
+    })
+
+    test('ensure scheduler max-one-job condition, by default, ignores jobs not scheduled by scheduler', async ({
+      payload,
+    }) => {
+      await withoutAutoRun(async () => {
+        for (let i = 0; i < 2; i++) {
+          await payload.jobs.queue({
+            task: 'EverySecond',
+            queue: 'autorunSecond',
+            input: {
+              message: 'This task runs every second',
+            },
+          })
+        }
+        for (let i = 0; i < 3; i++) {
+          await payload.jobs.handleSchedules({ allQueues: true })
+        }
+      })
+
+      await waitUntilAutorunIsDone({
+        payload,
+        queue: 'autorunSecond',
+        onlyScheduled: true,
+      })
+
+      const allSimples = await payload.find({
+        collection: 'simple',
+        limit: 100,
+      })
+
+      expect(allSimples.totalDocs).toBe(3)
+      expect(allSimples?.docs?.[0]?.title).toBe('This task runs every second')
+    })
+
+    test('ensure scheduler max-one-job condition, respects jobs not scheduled by scheduler due to task setting onlyScheduled: false', async ({
+      payload,
+    }) => {
+      timeFreeze()
+      await withoutAutoRun(async () => {
+        for (let i = 0; i < 2; i++) {
+          await payload.jobs.queue({
+            task: 'EverySecondMax2',
+            input: {
+              message: 'This task runs every second - max 2 per second',
+            },
+          })
+        }
+        for (let i = 0; i < 3; i++) {
+          await payload.jobs.handleSchedules({ queue: 'default' })
+        }
+      })
+
+      timeTravel(20) // Advance time to satisfy the waitUntil of newly scheduled jobs
+
+      await payload.jobs.run({
+        limit: 100,
+        silent: true,
+      })
+
+      const allSimples = await payload.find({
+        collection: 'simple',
+        limit: 100,
+      })
+
+      expect(allSimples.totalDocs).toBe(2) // Would be 4 by default, if only scheduled jobs were respected in handleSchedules condition
+      expect(allSimples?.docs?.[0]?.title).toBe('This task runs every second - max 2 per second')
+    })
+
+    test('ensure scheduler does not schedule more jobs than needed if executed sequentially - max. 2 jobs configured', async ({
+      payload,
+    }) => {
+      timeFreeze()
+      for (let i = 0; i < 3; i++) {
+        await payload.jobs.handleSchedules({ queue: 'default' })
+      }
 
       // Advance time to satisfy the waitUntil of newly scheduled jobs
       timeTravel(20)
 
-      // default queue is not scheduled to autorun => run manually
+      // default queue is not scheduled to autorun
       await payload.jobs.run({
         silent: true,
       })
-    }
 
-    const allSimples = await payload.find({
-      collection: 'simple',
-      limit: 100,
-      where: {
-        title: {
-          equals: 'This task runs every second - max 2 per second',
+      const allSimples = await payload.find({
+        collection: 'simple',
+        limit: 100,
+      })
+
+      expect(allSimples.totalDocs).toBe(2)
+      expect(allSimples?.docs?.[0]?.title).toBe('This task runs every second - max 2 per second')
+    })
+
+    test('ensure job is scheduled every second', async ({ payload }) => {
+      timeFreeze()
+      for (let i = 0; i < 3; i++) {
+        await withoutAutoRun(async () => {
+          // Call it twice to test that it only schedules one
+          await payload.jobs.handleSchedules({ allQueues: true })
+          await payload.jobs.handleSchedules({ allQueues: true })
+        })
+        // Advance time to satisfy the waitUntil of newly scheduled jobs
+        timeTravel(20)
+
+        await waitUntilAutorunIsDone({
+          payload,
+          queue: 'autorunSecond',
+          onlyScheduled: true,
+        })
+      }
+
+      const allSimples = await payload.find({
+        collection: 'simple',
+        limit: 100,
+      })
+
+      expect(allSimples.totalDocs).toBe(3)
+      expect(allSimples?.docs?.[0]?.title).toBe('This task runs every second')
+    })
+
+    test('ensure job is scheduled every second - max. 2 jobs configured', async ({ payload }) => {
+      timeFreeze()
+
+      for (let i = 0; i < 3; i++) {
+        await withoutAutoRun(async () => {
+          // Call it 3x to test that it only schedules two
+          await payload.jobs.handleSchedules({ queue: 'default' })
+          await payload.jobs.handleSchedules({ queue: 'default' })
+          await payload.jobs.handleSchedules({ queue: 'default' })
+        })
+
+        // Advance time to satisfy the waitUntil of newly scheduled jobs
+        timeTravel(20)
+
+        // default queue is not scheduled to autorun => run manually
+        await payload.jobs.run({
+          silent: true,
+        })
+      }
+
+      const allSimples = await payload.find({
+        collection: 'simple',
+        limit: 100,
+        where: {
+          title: {
+            equals: 'This task runs every second - max 2 per second',
+          },
         },
-      },
+      })
+
+      expect(allSimples.totalDocs).toBe(6)
+      expect(allSimples?.docs?.[0]?.title).toBe('This task runs every second - max 2 per second')
     })
 
-    expect(allSimples.totalDocs).toBe(6)
-    expect(allSimples?.docs?.[0]?.title).toBe('This task runs every second - max 2 per second')
-  })
+    test('should not auto-schedule through automatic crons if scheduler set to manual', async ({
+      payload,
+    }) => {
+      // Autorun runs every second - so should definitely be done if we wait 2 seconds
+      await new Promise((resolve) => setTimeout(resolve, 2000)) // Should not flake, as we are expecting nothing to happen
 
-  it('should not auto-schedule through automatic crons if scheduler set to manual', async () => {
-    // Autorun runs every second - so should definitely be done if we wait 2 seconds
-    await new Promise((resolve) => setTimeout(resolve, 2000)) // Should not flake, as we are expecting nothing to happen
+      const allSimples = await payload.find({
+        collection: 'simple',
+        limit: 100,
+      })
 
-    const allSimples = await payload.find({
-      collection: 'simple',
-      limit: 100,
+      expect(allSimples.totalDocs).toBe(0)
     })
-
-    expect(allSimples.totalDocs).toBe(0)
-  })
-})
+  },
+)

--- a/test/queues/schedules.int.spec.ts
+++ b/test/queues/schedules.int.spec.ts
@@ -5,7 +5,6 @@ import { expect } from 'vitest'
 
 import { test } from '../__helpers/int/vitest.js'
 import { devUser } from '../credentials.js'
-import testConfig from './config.schedules.js'
 import { timeFreeze, timeTravel, waitUntilAutorunIsDone, withoutAutoRun } from './utilities.js'
 
 let token: string
@@ -15,7 +14,7 @@ const { email, password } = devUser
 _internal_jobSystemGlobals.shouldAutoRun = false
 _internal_jobSystemGlobals.shouldAutoSchedule = false
 
-test.suite({ config: testConfig })(
+test.suite({ config: './config.schedules.ts' })(
   'Queues - scheduling, without automatic scheduling handling',
   () => {
     test.afterAll(async () => {

--- a/test/storage-azure/client-uploads/config.ts
+++ b/test/storage-azure/client-uploads/config.ts
@@ -24,20 +24,48 @@ dotenv.config({
 })
 
 export default buildConfigWithDefaults({
-  admin: {
-    importMap: {
-      baseDir: path.resolve(dirname, '..'),
+  suite: 'storage-azure-client-uploads',
+  config: {
+    admin: {
+      importMap: {
+        baseDir: path.resolve(dirname, '..'),
+      },
+    },
+    collections: [
+      Media,
+      MediaWithPrefix,
+      MediaWithDocPrefix,
+      MediaHeaderOnly,
+      MediaHeaderOnlyWithSizes,
+      Users,
+    ],
+    storage: [
+      azureStorage({
+        allowContainerCreate: process.env.AZURE_STORAGE_ALLOW_CONTAINER_CREATE === 'true',
+        baseURL: process.env.AZURE_STORAGE_ACCOUNT_BASEURL!,
+        clientUploads: true,
+        collections: {
+          [mediaHeaderOnlySlug]: true,
+          [mediaHeaderOnlyWithSizesSlug]: true,
+          [mediaSlug]: true,
+          // Configure a collection-level prefix on this slug to test that
+          // a custom `prefix.defaultValue` does override the static prefix
+          [mediaWithDocPrefixSlug]: {
+            prefix: 'docprefix-collection',
+          },
+          [mediaWithPrefixSlug]: {
+            prefix,
+          },
+        },
+        connectionString: process.env.AZURE_STORAGE_CONNECTION_STRING!,
+        containerName: process.env.AZURE_STORAGE_CONTAINER_NAME!,
+      }),
+    ],
+    typescript: {
+      outputFile: path.resolve(dirname, 'payload-types.ts'),
     },
   },
-  collections: [
-    Media,
-    MediaWithPrefix,
-    MediaWithDocPrefix,
-    MediaHeaderOnly,
-    MediaHeaderOnlyWithSizes,
-    Users,
-  ],
-  onInit: async (payload) => {
+  seed: async (payload) => {
     await payload.create({
       collection: 'users',
       data: {
@@ -45,30 +73,5 @@ export default buildConfigWithDefaults({
         password: devUser.password,
       },
     })
-  },
-  storage: [
-    azureStorage({
-      collections: {
-        [mediaHeaderOnlySlug]: true,
-        [mediaHeaderOnlyWithSizesSlug]: true,
-        [mediaSlug]: true,
-        // Configure a collection-level prefix on this slug to test that
-        // a custom `prefix.defaultValue` does override the static prefix
-        [mediaWithDocPrefixSlug]: {
-          prefix: 'docprefix-collection',
-        },
-        [mediaWithPrefixSlug]: {
-          prefix,
-        },
-      },
-      allowContainerCreate: process.env.AZURE_STORAGE_ALLOW_CONTAINER_CREATE === 'true',
-      baseURL: process.env.AZURE_STORAGE_ACCOUNT_BASEURL!,
-      clientUploads: true,
-      connectionString: process.env.AZURE_STORAGE_CONNECTION_STRING!,
-      containerName: process.env.AZURE_STORAGE_CONTAINER_NAME!,
-    }),
-  ],
-  typescript: {
-    outputFile: path.resolve(dirname, 'payload-types.ts'),
   },
 })

--- a/test/storage-azure/client-uploads/int.spec.ts
+++ b/test/storage-azure/client-uploads/int.spec.ts
@@ -1,16 +1,16 @@
 import type { ContainerClient } from '@azure/storage-blob'
-import type { Payload, UploadInstructions } from 'payload'
+import type { UploadInstructions } from 'payload'
 
 import { BlobServiceClient, BlockBlobClient } from '@azure/storage-blob'
 import { readFileSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
 import path from 'path'
 import { fileURLToPath } from 'url'
-import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+import { expect, vi } from 'vitest'
 
 import type { NextRESTClient } from '../../__helpers/shared/NextRESTClient.js'
 
-import { initPayloadInt } from '../../__helpers/shared/initPayloadInt.js'
+import { test } from '../../__helpers/int/vitest.js'
 import { mediaSlug } from '../shared.js'
 import { mediaHeaderOnlySlug } from './collections/MediaHeaderOnly.js'
 import { mediaHeaderOnlyWithSizesSlug } from './collections/MediaHeaderOnlyWithSizes.js'
@@ -18,13 +18,10 @@ import { mediaWithDocPrefixSlug } from './collections/MediaWithDocPrefix.js'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
-
-let payload: Payload
-let restClient: NextRESTClient
 let containerClient: ContainerClient
 let TEST_CONTAINER: string
 
-describe('@payloadcms/storage-azure clientUploads', () => {
+test.suite({ config: './config.ts' })('@payloadcms/storage-azure clientUploads', () => {
   const clearContainer = async () => {
     for await (const blob of containerClient.listBlobsFlat()) {
       await containerClient.deleteBlob(blob.name)
@@ -42,11 +39,13 @@ describe('@payloadcms/storage-azure clientUploads', () => {
     file,
     filename,
     mimeType,
+    restClient,
   }: {
     collectionSlug: string
     file: Buffer
     filename: string
     mimeType: string
+    restClient: NextRESTClient
   }) => {
     const instructions = (await restClient
       .POST('/upload-instructions', {
@@ -74,9 +73,7 @@ describe('@payloadcms/storage-azure clientUploads', () => {
     return form
   }
 
-  beforeAll(async () => {
-    ;({ payload, restClient } = await initPayloadInt(dirname))
-
+  test.beforeEach(async () => {
     TEST_CONTAINER = process.env.AZURE_STORAGE_CONTAINER_NAME!
     containerClient = BlobServiceClient.fromConnectionString(
       process.env.AZURE_STORAGE_CONNECTION_STRING!,
@@ -85,11 +82,7 @@ describe('@payloadcms/storage-azure clientUploads', () => {
     await clearContainer()
   }, 90000)
 
-  afterAll(async () => {
-    await payload.destroy()
-  })
-
-  afterEach(async () => {
+  test.afterEach(async () => {
     await clearContainer()
   })
 
@@ -98,7 +91,10 @@ describe('@payloadcms/storage-azure clientUploads', () => {
    * endpoint should sanitize the filename (e.g. `duplicate-target-1.png`) so the
    * browser SDK upload lands on a fresh blob instead of overwriting the existing one.
    */
-  it('sanitizes the filename when a duplicate already exists', async () => {
+  test('sanitizes the filename when a duplicate already exists', async ({
+    payload,
+    restClient,
+  }) => {
     const dupFilename = 'duplicate-target.png'
     const fileBuffer = await readFile(`${dirname}/../../uploads/image.png`)
 
@@ -147,7 +143,7 @@ describe('@payloadcms/storage-azure clientUploads', () => {
     await payload.delete({ id: seedDoc.id, collection: mediaSlug })
   })
 
-  it('preserves a user-defined prefix.defaultValue across the plugin', async () => {
+  test('preserves a user-defined prefix.defaultValue across the plugin', async ({ payload }) => {
     const upload = await payload.create({
       collection: mediaWithDocPrefixSlug,
       data: {},
@@ -175,17 +171,19 @@ describe('@payloadcms/storage-azure clientUploads', () => {
    * depends on the uploaded MIME type as well as collection configuration, so `audio/mpeg`
    * selects `'none'` while `image/jpeg` selects `'header'`.
    */
-  describe('header-only and no-content requirements (real Azure handler)', () => {
+  test.describe('header-only and no-content requirements (real Azure handler)', () => {
     const createdIds: (number | string)[] = []
 
-    afterEach(async () => {
+    test.afterEach(async ({ payload }) => {
       for (const id of createdIds) {
         await payload.delete({ id, collection: mediaHeaderOnlySlug })
       }
       createdIds.length = 0
     })
 
-    it('does not read a client-uploaded non-image when metadata is sufficient', async () => {
+    test('does not read a client-uploaded non-image when metadata is sufficient', async ({
+      restClient,
+    }) => {
       const file = readFileSync(path.resolve(dirname, '../../uploads/audio.mp3'))
       expect(file.length).toBe(23_334)
 
@@ -194,6 +192,7 @@ describe('@payloadcms/storage-azure clientUploads', () => {
         file,
         filename: 'no-content-tripwire.mp3',
         mimeType: 'audio/mpeg',
+        restClient,
       })
 
       const getPropertiesSpy = vi.spyOn(BlockBlobClient.prototype, 'getProperties')
@@ -216,7 +215,9 @@ describe('@payloadcms/storage-azure clientUploads', () => {
       }
     })
 
-    it('creates a document from a client-uploaded image via the real Azure handler', async () => {
+    test('creates a document from a client-uploaded image via the real Azure handler', async ({
+      restClient,
+    }) => {
       const file = readFileSync(path.resolve(dirname, '../../uploads/2mb.jpg'))
       expect(file.length).toBe(2_215_474)
 
@@ -225,6 +226,7 @@ describe('@payloadcms/storage-azure clientUploads', () => {
         file,
         filename: 'header-only-tripwire.jpg',
         mimeType: 'image/jpeg',
+        restClient,
       })
 
       const getPropertiesSpy = vi.spyOn(BlockBlobClient.prototype, 'getProperties')
@@ -262,17 +264,19 @@ describe('@payloadcms/storage-azure clientUploads', () => {
    * requirement anyway - handing `createImageSizes` a truncated buffer and crashing instead of
    * fetching the full file through the real Azure handler.
    */
-  describe('imageSizes with a large upload (real Azure handler)', () => {
+  test.describe('imageSizes with a large upload (real Azure handler)', () => {
     const createdIds: (number | string)[] = []
 
-    afterEach(async () => {
+    test.afterEach(async ({ payload }) => {
       for (const id of createdIds) {
         await payload.delete({ id, collection: mediaHeaderOnlyWithSizesSlug })
       }
       createdIds.length = 0
     })
 
-    it('creates a document and generates image sizes from a large client-uploaded image via the real Azure handler', async () => {
+    test('creates a document and generates image sizes from a large client-uploaded image via the real Azure handler', async ({
+      restClient,
+    }) => {
       const file = readFileSync(path.resolve(dirname, '../../uploads/2mb.jpg'))
       expect(file.length).toBe(2_215_474)
 
@@ -281,6 +285,7 @@ describe('@payloadcms/storage-azure clientUploads', () => {
         file,
         filename: 'large-with-sizes.jpg',
         mimeType: 'image/jpeg',
+        restClient,
       })
 
       const downloadSpy = vi.spyOn(BlockBlobClient.prototype, 'download')

--- a/test/storage-azure/config.ts
+++ b/test/storage-azure/config.ts
@@ -21,13 +21,35 @@ dotenv.config({
 })
 
 export default buildConfigWithDefaults({
-  admin: {
-    importMap: {
-      baseDir: path.resolve(dirname),
+  suite: 'storage-azure',
+  config: {
+    admin: {
+      importMap: {
+        baseDir: path.resolve(dirname),
+      },
     },
+    collections: [Media, MediaWithPrefix, Users],
+    storage: [
+      azureStorage({
+        allowContainerCreate: process.env.AZURE_STORAGE_ALLOW_CONTAINER_CREATE === 'true',
+        baseURL: process.env.AZURE_STORAGE_ACCOUNT_BASEURL!,
+        clientUploads: true,
+        collections: {
+          [mediaSlug]: true,
+          [mediaWithPrefixSlug]: {
+            prefix,
+          },
+        },
+        connectionString: process.env.AZURE_STORAGE_CONNECTION_STRING!,
+        containerName: process.env.AZURE_STORAGE_CONTAINER_NAME!,
+      }),
+    ],
+    typescript: {
+      outputFile: path.resolve(dirname, 'payload-types.ts'),
+    },
+    upload: uploadOptions,
   },
-  collections: [Media, MediaWithPrefix, Users],
-  onInit: async (payload) => {
+  seed: async (payload) => {
     await payload.create({
       collection: 'users',
       data: {
@@ -35,24 +57,5 @@ export default buildConfigWithDefaults({
         password: devUser.password,
       },
     })
-  },
-  storage: [
-    azureStorage({
-      collections: {
-        [mediaSlug]: true,
-        [mediaWithPrefixSlug]: {
-          prefix,
-        },
-      },
-      allowContainerCreate: process.env.AZURE_STORAGE_ALLOW_CONTAINER_CREATE === 'true',
-      baseURL: process.env.AZURE_STORAGE_ACCOUNT_BASEURL!,
-      clientUploads: true,
-      connectionString: process.env.AZURE_STORAGE_CONNECTION_STRING!,
-      containerName: process.env.AZURE_STORAGE_CONTAINER_NAME!,
-    }),
-  ],
-  upload: uploadOptions,
-  typescript: {
-    outputFile: path.resolve(dirname, 'payload-types.ts'),
   },
 })

--- a/test/storage-azure/int.spec.ts
+++ b/test/storage-azure/int.spec.ts
@@ -8,13 +8,12 @@ import { fileURLToPath } from 'url'
 import { expect } from 'vitest'
 
 import { test } from '../__helpers/int/vitest.js'
-import testConfig from './config.js'
 import { mediaSlug, mediaWithPrefixSlug, prefix } from './shared.js'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
-test.suite({ config: testConfig })('@payloadcms/storage-azure', () => {
+test.suite({ config: './config.ts' })('@payloadcms/storage-azure', () => {
   let TEST_CONTAINER: string
   let client: ContainerClient
 

--- a/test/storage-azure/int.spec.ts
+++ b/test/storage-azure/int.spec.ts
@@ -5,20 +5,16 @@ import { BlobServiceClient } from '@azure/storage-blob'
 import { readFile } from 'node:fs/promises'
 import path from 'path'
 import { fileURLToPath } from 'url'
-import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { expect } from 'vitest'
 
-import type { NextRESTClient } from '../__helpers/shared/NextRESTClient.js'
-
-import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
+import { test } from '../__helpers/int/vitest.js'
+import testConfig from './config.js'
 import { mediaSlug, mediaWithPrefixSlug, prefix } from './shared.js'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
-let restClient: NextRESTClient
-let payload: Payload
-
-describe('@payloadcms/storage-azure', () => {
+test.suite({ config: testConfig })('@payloadcms/storage-azure', () => {
   let TEST_CONTAINER: string
   let client: ContainerClient
 
@@ -28,8 +24,7 @@ describe('@payloadcms/storage-azure', () => {
     }
   }
 
-  beforeAll(async () => {
-    ;({ payload, restClient } = await initPayloadInt(dirname))
+  test.beforeEach(async () => {
     TEST_CONTAINER = process.env.AZURE_STORAGE_CONTAINER_NAME!
 
     const blobServiceClient = BlobServiceClient.fromConnectionString(
@@ -41,15 +36,11 @@ describe('@payloadcms/storage-azure', () => {
     await clearContainer()
   }, 90000)
 
-  afterAll(async () => {
-    await payload.destroy()
-  })
-
-  afterEach(async () => {
+  test.afterEach(async () => {
     await clearContainer()
   })
 
-  it('preserves mime type when uploaded via rest endpoint', async () => {
+  test('preserves mime type when uploaded via rest endpoint', async ({ restClient }) => {
     const fileBuffer = await readFile(`${dirname}/../uploads/image.png`)
 
     const data = new FormData()
@@ -63,7 +54,7 @@ describe('@payloadcms/storage-azure', () => {
     expect(response.headers.get('content-type')).toEqual('image/png')
   })
 
-  it('can upload', async () => {
+  test('can upload', async ({ payload }) => {
     const upload = await payload.create({
       collection: mediaSlug,
       data: {},
@@ -71,11 +62,11 @@ describe('@payloadcms/storage-azure', () => {
     })
 
     expect(upload.id).toBeTruthy()
-    await verifyUploads({ collectionSlug: mediaSlug, uploadId: upload.id })
+    await verifyUploads({ payload }, { collectionSlug: mediaSlug, uploadId: upload.id })
     expect(upload.url).toEqual(`/api/${mediaSlug}/file/${String(upload.filename)}`)
   })
 
-  it('can upload with prefix', async () => {
+  test('can upload with prefix', async ({ payload }) => {
     const upload = await payload.create({
       collection: mediaWithPrefixSlug,
       data: {},
@@ -83,30 +74,36 @@ describe('@payloadcms/storage-azure', () => {
     })
 
     expect(upload.id).toBeTruthy()
-    await verifyUploads({
-      collectionSlug: mediaWithPrefixSlug,
-      uploadId: upload.id,
-      prefix,
-    })
+    await verifyUploads(
+      { payload },
+      {
+        collectionSlug: mediaWithPrefixSlug,
+        uploadId: upload.id,
+        prefix,
+      },
+    )
     expect(upload.url).toEqual(
       `/api/${mediaWithPrefixSlug}/file/${String(upload.filename)}?prefix=${prefix}`,
     )
   })
 
-  it('returns 404 for non-existing file', async () => {
+  test('returns 404 for non-existing file', async ({ restClient }) => {
     const response = await restClient.GET(`/${mediaSlug}/file/nonexistent.png`)
     expect(response.status).toBe(404)
   })
 
-  async function verifyUploads({
-    collectionSlug,
-    uploadId,
-    prefix = '',
-  }: {
-    collectionSlug: CollectionSlug
-    prefix?: string
-    uploadId: number | string
-  }) {
+  async function verifyUploads(
+    { payload }: { payload: Payload },
+    {
+      collectionSlug,
+      uploadId,
+      prefix = '',
+    }: {
+      collectionSlug: CollectionSlug
+      prefix?: string
+      uploadId: number | string
+    },
+  ) {
     const uploadData = (await payload.findByID({
       collection: collectionSlug,
       id: uploadId,

--- a/test/storage-azure/streamingUploads.config.ts
+++ b/test/storage-azure/streamingUploads.config.ts
@@ -20,13 +20,36 @@ dotenv.config({
 })
 
 export default buildConfigWithDefaults({
-  admin: {
-    importMap: {
-      baseDir: path.resolve(dirname),
+  suite: 'storage-azure-streaming-uploads',
+  config: {
+    admin: {
+      importMap: {
+        baseDir: path.resolve(dirname),
+      },
+    },
+    collections: [Media, MediaWithPrefix, Users],
+    storage: [
+      azureStorage({
+        allowContainerCreate: process.env.AZURE_STORAGE_ALLOW_CONTAINER_CREATE === 'true',
+        baseURL: process.env.AZURE_STORAGE_ACCOUNT_BASEURL,
+        collections: {
+          [mediaSlug]: true,
+          [mediaWithPrefixSlug]: {
+            prefix,
+          },
+        },
+        connectionString: process.env.AZURE_STORAGE_CONNECTION_STRING,
+        containerName: process.env.AZURE_STORAGE_CONTAINER_NAME,
+      }),
+    ],
+    typescript: {
+      outputFile: path.resolve(dirname, 'payload-types.ts'),
+    },
+    upload: {
+      useTempFiles: true,
     },
   },
-  collections: [Media, MediaWithPrefix, Users],
-  onInit: async (payload) => {
+  seed: async (payload) => {
     await payload.create({
       collection: 'users',
       data: {
@@ -34,25 +57,5 @@ export default buildConfigWithDefaults({
         password: devUser.password,
       },
     })
-  },
-  storage: [
-    azureStorage({
-      collections: {
-        [mediaSlug]: true,
-        [mediaWithPrefixSlug]: {
-          prefix,
-        },
-      },
-      allowContainerCreate: process.env.AZURE_STORAGE_ALLOW_CONTAINER_CREATE === 'true',
-      baseURL: process.env.AZURE_STORAGE_ACCOUNT_BASEURL,
-      connectionString: process.env.AZURE_STORAGE_CONNECTION_STRING,
-      containerName: process.env.AZURE_STORAGE_CONTAINER_NAME,
-    }),
-  ],
-  upload: {
-    useTempFiles: true,
-  },
-  typescript: {
-    outputFile: path.resolve(dirname, 'payload-types.ts'),
   },
 })

--- a/test/storage-azure/streamingUploads.int.spec.ts
+++ b/test/storage-azure/streamingUploads.int.spec.ts
@@ -5,30 +5,20 @@ import { BlobServiceClient } from '@azure/storage-blob'
 import { readFile } from 'node:fs/promises'
 import path from 'path'
 import { fileURLToPath } from 'url'
-import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { expect } from 'vitest'
 
-import type { NextRESTClient } from '../__helpers/shared/NextRESTClient.js'
-
-import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
+import { test } from '../__helpers/int/vitest.js'
+import testConfig from './config.js'
 import { mediaSlug, mediaWithPrefixSlug, prefix } from './shared.js'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
-let restClient: NextRESTClient
-let payload: Payload
-
-describe('@payloadcms/storage-azure streamingUploads', () => {
+test.suite({ config: testConfig })('@payloadcms/storage-azure streamingUploads', () => {
   let TEST_CONTAINER: string
   let client: ContainerClient
 
-  beforeAll(async () => {
-    ;({ payload, restClient } = await initPayloadInt(
-      dirname,
-      undefined,
-      undefined,
-      path.resolve(dirname, 'streamingUploads.config.ts'),
-    ))
+  test.beforeEach(async () => {
     TEST_CONTAINER = process.env.AZURE_STORAGE_CONTAINER_NAME!
 
     const blobServiceClient = BlobServiceClient.fromConnectionString(
@@ -40,15 +30,11 @@ describe('@payloadcms/storage-azure streamingUploads', () => {
     await clearContainer()
   }, 90000)
 
-  afterAll(async () => {
-    await payload.destroy()
-  })
-
-  afterEach(async () => {
+  test.afterEach(async () => {
     await clearContainer()
   })
 
-  it('preserves mime type when uploaded via rest endpoint', async () => {
+  test('preserves mime type when uploaded via rest endpoint', async ({ restClient }) => {
     const fileBuffer = await readFile(path.resolve(dirname, '../uploads/image.png'))
 
     const data = new FormData()
@@ -62,7 +48,7 @@ describe('@payloadcms/storage-azure streamingUploads', () => {
     expect(response.headers.get('content-type')).toEqual('image/png')
   })
 
-  it('can upload', async () => {
+  test('can upload', async ({ payload }) => {
     const upload = await payload.create({
       collection: mediaSlug,
       data: {},
@@ -70,11 +56,11 @@ describe('@payloadcms/storage-azure streamingUploads', () => {
     })
 
     expect(upload.id).toBeTruthy()
-    await verifyUploads({ collectionSlug: mediaSlug, uploadId: upload.id })
+    await verifyUploads({ payload }, { collectionSlug: mediaSlug, uploadId: upload.id })
     expect(upload.url).toEqual(`/api/${mediaSlug}/file/${String(upload.filename)}`)
   })
 
-  it('can upload with prefix', async () => {
+  test('can upload with prefix', async ({ payload }) => {
     const upload = await payload.create({
       collection: mediaWithPrefixSlug,
       data: {},
@@ -82,17 +68,20 @@ describe('@payloadcms/storage-azure streamingUploads', () => {
     })
 
     expect(upload.id).toBeTruthy()
-    await verifyUploads({
-      collectionSlug: mediaWithPrefixSlug,
-      uploadId: upload.id,
-      prefix,
-    })
+    await verifyUploads(
+      { payload },
+      {
+        collectionSlug: mediaWithPrefixSlug,
+        uploadId: upload.id,
+        prefix,
+      },
+    )
     expect(upload.url).toEqual(
       `/api/${mediaWithPrefixSlug}/file/${String(upload.filename)}?prefix=${encodeURIComponent(prefix)}`,
     )
   })
 
-  it('returns 404 for non-existing file', async () => {
+  test('returns 404 for non-existing file', async ({ restClient }) => {
     const response = await restClient.GET(`/${mediaSlug}/file/nonexistent.png`)
     expect(response.status).toBe(404)
   })
@@ -103,15 +92,18 @@ describe('@payloadcms/storage-azure streamingUploads', () => {
     }
   }
 
-  async function verifyUploads({
-    collectionSlug,
-    uploadId,
-    prefix = '',
-  }: {
-    collectionSlug: CollectionSlug
-    prefix?: string
-    uploadId: number | string
-  }) {
+  async function verifyUploads(
+    { payload }: { payload: Payload },
+    {
+      collectionSlug,
+      uploadId,
+      prefix = '',
+    }: {
+      collectionSlug: CollectionSlug
+      prefix?: string
+      uploadId: number | string
+    },
+  ) {
     const uploadData = (await payload.findByID({
       collection: collectionSlug,
       id: uploadId,

--- a/test/storage-azure/streamingUploads.int.spec.ts
+++ b/test/storage-azure/streamingUploads.int.spec.ts
@@ -8,13 +8,12 @@ import { fileURLToPath } from 'url'
 import { expect } from 'vitest'
 
 import { test } from '../__helpers/int/vitest.js'
-import testConfig from './config.js'
 import { mediaSlug, mediaWithPrefixSlug, prefix } from './shared.js'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
-test.suite({ config: testConfig })('@payloadcms/storage-azure streamingUploads', () => {
+test.suite({ config: './config.ts' })('@payloadcms/storage-azure streamingUploads', () => {
   let TEST_CONTAINER: string
   let client: ContainerClient
 

--- a/test/storage-gcs/config.ts
+++ b/test/storage-gcs/config.ts
@@ -20,13 +20,35 @@ dotenv.config({
 })
 
 export default buildConfigWithDefaults({
-  admin: {
-    importMap: {
-      baseDir: path.resolve(dirname),
+  suite: 'storage-gcs',
+  config: {
+    admin: {
+      importMap: {
+        baseDir: path.resolve(dirname),
+      },
     },
+    collections: [Media, MediaWithPrefix, Users],
+    storage: [
+      gcsStorage({
+        bucket: process.env.GCS_BUCKET,
+        collections: {
+          [mediaSlug]: true,
+          [mediaWithPrefixSlug]: {
+            prefix,
+          },
+        },
+        options: {
+          apiEndpoint: process.env.GCS_ENDPOINT,
+          projectId: process.env.GCS_PROJECT_ID,
+        },
+      }),
+    ],
+    typescript: {
+      outputFile: path.resolve(dirname, 'payload-types.ts'),
+    },
+    upload: uploadOptions,
   },
-  collections: [Media, MediaWithPrefix, Users],
-  onInit: async (payload) => {
+  seed: async (payload) => {
     await payload.create({
       collection: 'users',
       data: {
@@ -34,24 +56,5 @@ export default buildConfigWithDefaults({
         password: devUser.password,
       },
     })
-  },
-  storage: [
-    gcsStorage({
-      collections: {
-        [mediaSlug]: true,
-        [mediaWithPrefixSlug]: {
-          prefix,
-        },
-      },
-      bucket: process.env.GCS_BUCKET,
-      options: {
-        apiEndpoint: process.env.GCS_ENDPOINT,
-        projectId: process.env.GCS_PROJECT_ID,
-      },
-    }),
-  ],
-  upload: uploadOptions,
-  typescript: {
-    outputFile: path.resolve(dirname, 'payload-types.ts'),
   },
 })

--- a/test/storage-r2/config.ts
+++ b/test/storage-r2/config.ts
@@ -30,13 +30,37 @@ const cloudflare =
     : await getCloudflareContext({ async: true })
 
 export default buildConfigWithDefaults({
-  admin: {
-    importMap: {
-      baseDir: path.resolve(dirname),
+  suite: 'storage-r2',
+  config: {
+    admin: {
+      importMap: {
+        baseDir: path.resolve(dirname),
+      },
+    },
+    collections: [Media, MediaWithPrefix, MediaClient, Users],
+    storage: [
+      r2Storage({
+        bucket: cloudflare.env.R2,
+        collections: {
+          'media-with-prefix': {
+            prefix: 'test-prefix',
+          },
+          [mediaSlug]: true,
+        },
+      }),
+      r2Storage({
+        bucket: cloudflare.env.R2,
+        clientUploads: true,
+        collections: {
+          'media-client': true,
+        },
+      }),
+    ],
+    typescript: {
+      outputFile: path.resolve(dirname, 'payload-types.ts'),
     },
   },
-  collections: [Media, MediaWithPrefix, MediaClient, Users],
-  onInit: async (payload) => {
+  seed: async (payload) => {
     await payload.create({
       collection: 'users',
       data: {
@@ -45,27 +69,6 @@ export default buildConfigWithDefaults({
       },
     })
   },
-  storage: [
-    r2Storage({
-      bucket: cloudflare.env.R2,
-      collections: {
-        [mediaSlug]: true,
-        'media-with-prefix': {
-          prefix: 'test-prefix',
-        },
-      },
-    }),
-    r2Storage({
-      bucket: cloudflare.env.R2,
-      collections: {
-        'media-client': true,
-      },
-      clientUploads: true,
-    }),
-  ],
-  typescript: {
-    outputFile: path.resolve(dirname, 'payload-types.ts'),
-  },
 })
 
 // Adapted from https://github.com/opennextjs/opennextjs-cloudflare/blob/d00b3a13e42e65aad76fba41774815726422cc39/packages/cloudflare/src/api/cloudflare-context.ts#L328C36-L328C46
@@ -73,9 +76,9 @@ function getCloudflareContextFromWrangler(): Promise<CloudflareContext> {
   return import(/* webpackIgnore: true */ `${'__wrangler'.replaceAll('_', '')}`).then(
     ({ getPlatformProxy }) =>
       getPlatformProxy({
+        configPath: path.resolve(dirname, 'wrangler.jsonc'),
         environment: process.env.CLOUDFLARE_ENV,
         experimental: { remoteBindings: cloudflareRemoteBindings },
-        configPath: path.resolve(dirname, 'wrangler.jsonc'),
       } satisfies GetPlatformProxyOptions),
   )
 }

--- a/test/storage-s3/client-uploads/config.ts
+++ b/test/storage-s3/client-uploads/config.ts
@@ -26,20 +26,56 @@ dotenv.config({
 })
 
 export default buildConfigWithDefaults({
-  admin: {
-    importMap: {
-      baseDir: path.resolve(dirname, '..'),
+  suite: 'storage-s3-client-uploads',
+  config: {
+    admin: {
+      importMap: {
+        baseDir: path.resolve(dirname, '..'),
+      },
+    },
+    collections: [
+      Media,
+      MediaWithPrefix,
+      MediaContainer,
+      MediaHeaderOnly,
+      MediaHeaderOnlyWithSizes,
+      Users,
+    ],
+    storage: [
+      s3Storage({
+        bucket: process.env.S3_BUCKET!,
+        clientUploads: {
+          access: ({ req }) => (req.headers.get('x-disallow-access') ? false : true),
+        },
+        collections: {
+          [mediaHeaderOnlySlug]: true,
+          [mediaHeaderOnlyWithSizesSlug]: true,
+          [mediaSlug]: true,
+          [mediaWithPrefixSlug]: {
+            prefix: 'test-prefix',
+          },
+        },
+        config: {
+          credentials: {
+            accessKeyId: process.env.S3_ACCESS_KEY_ID!,
+            secretAccessKey: process.env.S3_SECRET_ACCESS_KEY!,
+          },
+          endpoint: process.env.S3_ENDPOINT,
+          forcePathStyle: process.env.S3_FORCE_PATH_STYLE === 'true',
+          region: process.env.S3_REGION,
+        },
+      }),
+    ],
+    typescript: {
+      outputFile: path.resolve(dirname, 'payload-types.ts'),
+    },
+    upload: {
+      limits: {
+        fileSize: 10 * 1024 * 1024, // 10 MB
+      },
     },
   },
-  collections: [
-    Media,
-    MediaWithPrefix,
-    MediaContainer,
-    MediaHeaderOnly,
-    MediaHeaderOnlyWithSizes,
-    Users,
-  ],
-  onInit: async (payload) => {
+  seed: async (payload) => {
     await payload.create({
       collection: 'users',
       data: {
@@ -47,38 +83,5 @@ export default buildConfigWithDefaults({
         password: devUser.password,
       },
     })
-  },
-  storage: [
-    s3Storage({
-      collections: {
-        [mediaHeaderOnlySlug]: true,
-        [mediaHeaderOnlyWithSizesSlug]: true,
-        [mediaSlug]: true,
-        [mediaWithPrefixSlug]: {
-          prefix: 'test-prefix',
-        },
-      },
-      bucket: process.env.S3_BUCKET!,
-      clientUploads: {
-        access: ({ req }) => (req.headers.get('x-disallow-access') ? false : true),
-      },
-      config: {
-        credentials: {
-          accessKeyId: process.env.S3_ACCESS_KEY_ID!,
-          secretAccessKey: process.env.S3_SECRET_ACCESS_KEY!,
-        },
-        endpoint: process.env.S3_ENDPOINT,
-        forcePathStyle: process.env.S3_FORCE_PATH_STYLE === 'true',
-        region: process.env.S3_REGION,
-      },
-    }),
-  ],
-  upload: {
-    limits: {
-      fileSize: 10 * 1024 * 1024, // 10 MB
-    },
-  },
-  typescript: {
-    outputFile: path.resolve(dirname, 'payload-types.ts'),
   },
 })

--- a/test/storage-s3/client-uploads/int.spec.ts
+++ b/test/storage-s3/client-uploads/int.spec.ts
@@ -1,14 +1,12 @@
-import type { Payload, UploadInstructions } from 'payload'
+import type { UploadInstructions } from 'payload'
 
 import { readFileSync } from 'fs'
 import path from 'path'
 import { assert } from 'ts-essentials'
 import { fileURLToPath } from 'url'
-import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { expect } from 'vitest'
 
-import type { NextRESTClient } from '../../__helpers/shared/NextRESTClient.js'
-
-import { initPayloadInt } from '../../__helpers/shared/initPayloadInt.js'
+import { test } from '../../__helpers/int/vitest.js'
 import { mediaHeaderOnlySlug, mediaHeaderOnlyWithSizesSlug } from '../shared.js'
 import {
   clearTestBucket,
@@ -17,12 +15,10 @@ import {
   getTestBucketName,
   MB,
 } from '../test-utils.js'
+import testConfig from './config.js'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
-
-let restClient: NextRESTClient
-let payload: Payload
 
 const signedURLEndpoint = '/upload-instructions'
 
@@ -39,15 +35,13 @@ const signedURLBody = (
     mimeType,
   })
 
-describe('@payloadcms/storage-s3 clientUploads', () => {
-  beforeAll(async () => {
-    ;({ payload, restClient } = await initPayloadInt(dirname))
-
+test.suite({ config: testConfig })('@payloadcms/storage-s3 clientUploads', () => {
+  test.beforeEach(async () => {
     await createTestBucket()
     await clearTestBucket()
   })
 
-  it('should generate a signed upload URL', async () => {
+  test('should generate a signed upload URL', async ({ restClient }) => {
     const file = readFileSync(path.resolve(dirname, '../../uploads/image.png'))
 
     const instructions = await restClient
@@ -103,7 +97,9 @@ describe('@payloadcms/storage-s3 clientUploads', () => {
     expect(res.ContentType).toBe('image/png')
   })
 
-  it("should reject signed URL generation by access control when 'x-disallow-access' header is set", async () => {
+  test("should reject signed URL generation by access control when 'x-disallow-access' header is set", async ({
+    restClient,
+  }) => {
     const response = await restClient.POST(signedURLEndpoint, {
       body: signedURLBody('media', 'image.png', MB(1), 'image/png'),
       headers: {
@@ -114,7 +110,7 @@ describe('@payloadcms/storage-s3 clientUploads', () => {
     expect(response.status).toBe(403)
   })
 
-  it('should generate signed URL for file within size limit', async () => {
+  test('should generate signed URL for file within size limit', async ({ restClient }) => {
     const response = await restClient.POST(signedURLEndpoint, {
       body: signedURLBody('media', 'small-file.png', 500_000, 'image/png'),
     })
@@ -128,7 +124,7 @@ describe('@payloadcms/storage-s3 clientUploads', () => {
     expect(url).toContain('small-file.png')
   })
 
-  it('should reject file exceeding size limit', async () => {
+  test('should reject file exceeding size limit', async ({ restClient }) => {
     const response = await restClient.POST(signedURLEndpoint, {
       body: signedURLBody('media', 'large-file.png', MB(11), 'image/png'),
     })
@@ -141,7 +137,7 @@ describe('@payloadcms/storage-s3 clientUploads', () => {
     expect(errors[0].message).toMatch(/got: 11\.0\dMB/)
   })
 
-  it('should reject file exactly at limit boundary', async () => {
+  test('should reject file exactly at limit boundary', async ({ restClient }) => {
     const response = await restClient.POST(signedURLEndpoint, {
       body: signedURLBody('media', 'boundary-file.png', MB(10.1), 'image/png'),
     })
@@ -152,7 +148,7 @@ describe('@payloadcms/storage-s3 clientUploads', () => {
     expect(errors[0].message).toContain('Exceeded file size limit')
   })
 
-  it('should accept file exactly at limit', async () => {
+  test('should accept file exactly at limit', async ({ restClient }) => {
     const response = await restClient.POST(signedURLEndpoint, {
       body: signedURLBody('media', 'exact-limit.png', MB(10), 'image/png'),
     })
@@ -164,7 +160,9 @@ describe('@payloadcms/storage-s3 clientUploads', () => {
     expect(url).toBeDefined()
   })
 
-  it('should not allow bypassing with passing a smaller file size but uploading a larger file', async () => {
+  test('should not allow bypassing with passing a smaller file size but uploading a larger file', async ({
+    restClient,
+  }) => {
     const declaredFilesize = MB(5)
     const actualFilesize = MB(15)
     const mimeType = 'text/plain'
@@ -201,8 +199,8 @@ describe('@payloadcms/storage-s3 clientUploads', () => {
     expect(uploadResponse.status).toBe(403)
   })
 
-  describe('filename handling', () => {
-    it('should sanitize special characters in filename', async () => {
+  test.describe('filename handling', () => {
+    test('should sanitize special characters in filename', async ({ restClient }) => {
       const file = readFileSync(path.resolve(dirname, '../../uploads/image.png'))
 
       const {
@@ -219,7 +217,7 @@ describe('@payloadcms/storage-s3 clientUploads', () => {
       expect(url).not.toContain('..')
     })
 
-    it('should sanitize deeply nested special characters in filename', async () => {
+    test('should sanitize deeply nested special characters in filename', async ({ restClient }) => {
       const file = readFileSync(path.resolve(dirname, '../../uploads/image.png'))
 
       const {
@@ -242,7 +240,7 @@ describe('@payloadcms/storage-s3 clientUploads', () => {
       expect(url).not.toContain('other-prefix')
     })
 
-    it('should sanitize backslash characters in filename', async () => {
+    test('should sanitize backslash characters in filename', async ({ restClient }) => {
       const file = readFileSync(path.resolve(dirname, '../../uploads/image.png'))
 
       const {
@@ -259,7 +257,7 @@ describe('@payloadcms/storage-s3 clientUploads', () => {
       expect(url).not.toContain('..')
     })
 
-    it('should allow normal filenames with prefix', async () => {
+    test('should allow normal filenames with prefix', async ({ restClient }) => {
       const file = readFileSync(path.resolve(dirname, '../../uploads/image.png'))
 
       const {
@@ -285,17 +283,19 @@ describe('@payloadcms/storage-s3 clientUploads', () => {
    * full round trip end to end is the only way to exercise the real handler for this path, since
    * unit tests mock the handler and never see that crash.
    */
-  describe('header-only content requirement (real S3 handler)', () => {
+  test.describe('header-only content requirement (real S3 handler)', () => {
     const createdIds: (number | string)[] = []
 
-    afterEach(async () => {
+    test.afterEach(async ({ payload }) => {
       for (const id of createdIds) {
         await payload.delete({ id, collection: mediaHeaderOnlySlug })
       }
       createdIds.length = 0
     })
 
-    it('creates a document from a client-uploaded image via the real S3 handler', async () => {
+    test('creates a document from a client-uploaded image via the real S3 handler', async ({
+      restClient,
+    }) => {
       const file = readFileSync(path.resolve(dirname, '../../uploads/image.png'))
 
       const instructions = await restClient
@@ -340,17 +340,19 @@ describe('@payloadcms/storage-s3 clientUploads', () => {
    * requirement anyway - handing `createImageSizes` a truncated buffer and crashing instead of
    * fetching the full file through the real S3 handler.
    */
-  describe('imageSizes with a large upload (real S3 handler)', () => {
+  test.describe('imageSizes with a large upload (real S3 handler)', () => {
     const createdIds: (number | string)[] = []
 
-    afterEach(async () => {
+    test.afterEach(async ({ payload }) => {
       for (const id of createdIds) {
         await payload.delete({ id, collection: mediaHeaderOnlyWithSizesSlug })
       }
       createdIds.length = 0
     })
 
-    it('creates a document and generates image sizes from a large client-uploaded image via the real S3 handler', async () => {
+    test('creates a document and generates image sizes from a large client-uploaded image via the real S3 handler', async ({
+      restClient,
+    }) => {
       const file = readFileSync(path.resolve(dirname, '../../uploads/2mb.jpg'))
       expect(file.length).toBeGreaterThan(1024 * 1024)
 
@@ -395,11 +397,7 @@ describe('@payloadcms/storage-s3 clientUploads', () => {
     }, 60000)
   })
 
-  afterAll(async () => {
-    await payload.destroy()
-  })
-
-  afterEach(async () => {
+  test.afterEach(async () => {
     await clearTestBucket()
   })
 })

--- a/test/storage-s3/client-uploads/int.spec.ts
+++ b/test/storage-s3/client-uploads/int.spec.ts
@@ -15,7 +15,6 @@ import {
   getTestBucketName,
   MB,
 } from '../test-utils.js'
-import testConfig from './config.js'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
@@ -35,7 +34,7 @@ const signedURLBody = (
     mimeType,
   })
 
-test.suite({ config: testConfig })('@payloadcms/storage-s3 clientUploads', () => {
+test.suite({ config: './config.ts' })('@payloadcms/storage-s3 clientUploads', () => {
   test.beforeEach(async () => {
     await createTestBucket()
     await clearTestBucket()

--- a/test/storage-s3/config.ts
+++ b/test/storage-s3/config.ts
@@ -30,21 +30,83 @@ dotenv.config({
 })
 
 export default buildConfigWithDefaults({
-  admin: {
-    importMap: {
-      baseDir: path.resolve(dirname),
+  suite: 'storage-s3',
+  config: {
+    admin: {
+      importMap: {
+        baseDir: path.resolve(dirname),
+      },
+    },
+    collections: [
+      Media,
+      MediaWithAlwaysInsertFields,
+      MediaWithDirectAccess,
+      MediaWithDynamicPrefix,
+      MediaWithPrefix,
+      MediaWithSignedDownloads,
+      Users,
+    ],
+    storage: [
+      s3Storage({
+        bucket: process.env.S3_BUCKET!,
+        collections: {
+          [mediaSlug]: true,
+          [mediaWithDirectAccessSlug]: {
+            disablePayloadAccessControl: true,
+          },
+          [mediaWithDynamicPrefixSlug]: true,
+          [mediaWithPrefixSlug]: {
+            prefix,
+          },
+          [mediaWithSignedDownloadsSlug]: {
+            signedDownloads: {
+              shouldUseSignedURL: (args) => {
+                return args.req.headers.get('X-Disable-Signed-URL') !== 'true'
+              },
+            },
+          },
+        },
+        config: {
+          credentials: {
+            accessKeyId: process.env.S3_ACCESS_KEY_ID!,
+            secretAccessKey: process.env.S3_SECRET_ACCESS_KEY!,
+          },
+          endpoint: process.env.S3_ENDPOINT,
+          forcePathStyle: process.env.S3_FORCE_PATH_STYLE === 'true',
+          region: process.env.S3_REGION,
+        },
+      }),
+      // Test alwaysInsertFields with enabled: false
+      s3Storage({
+        alwaysInsertFields: true,
+        bucket: process.env.S3_BUCKET!,
+        collections: {
+          [mediaWithAlwaysInsertFieldsSlug]: {
+            prefix: '',
+          },
+        },
+        config: {
+          credentials: {
+            accessKeyId: process.env.S3_ACCESS_KEY_ID!,
+            secretAccessKey: process.env.S3_SECRET_ACCESS_KEY!,
+          },
+          endpoint: process.env.S3_ENDPOINT,
+          forcePathStyle: process.env.S3_FORCE_PATH_STYLE === 'true',
+          region: process.env.S3_REGION,
+        },
+        enabled: false,
+      }),
+    ],
+    typescript: {
+      outputFile: path.resolve(dirname, 'payload-types.ts'),
+    },
+    upload: {
+      limits: {
+        fileSize: 1_000_000, // 1MB
+      },
     },
   },
-  collections: [
-    Media,
-    MediaWithAlwaysInsertFields,
-    MediaWithDirectAccess,
-    MediaWithDynamicPrefix,
-    MediaWithPrefix,
-    MediaWithSignedDownloads,
-    Users,
-  ],
-  onInit: async (payload) => {
+  seed: async (payload) => {
     await payload.create({
       collection: 'users',
       data: {
@@ -52,64 +114,5 @@ export default buildConfigWithDefaults({
         password: devUser.password,
       },
     })
-  },
-  storage: [
-    s3Storage({
-      collections: {
-        [mediaSlug]: true,
-        [mediaWithDirectAccessSlug]: {
-          disablePayloadAccessControl: true,
-        },
-        [mediaWithDynamicPrefixSlug]: true,
-        [mediaWithPrefixSlug]: {
-          prefix,
-        },
-        [mediaWithSignedDownloadsSlug]: {
-          signedDownloads: {
-            shouldUseSignedURL: (args) => {
-              return args.req.headers.get('X-Disable-Signed-URL') !== 'true'
-            },
-          },
-        },
-      },
-      bucket: process.env.S3_BUCKET!,
-      config: {
-        credentials: {
-          accessKeyId: process.env.S3_ACCESS_KEY_ID!,
-          secretAccessKey: process.env.S3_SECRET_ACCESS_KEY!,
-        },
-        endpoint: process.env.S3_ENDPOINT,
-        forcePathStyle: process.env.S3_FORCE_PATH_STYLE === 'true',
-        region: process.env.S3_REGION,
-      },
-    }),
-    // Test alwaysInsertFields with enabled: false
-    s3Storage({
-      alwaysInsertFields: true,
-      collections: {
-        [mediaWithAlwaysInsertFieldsSlug]: {
-          prefix: '',
-        },
-      },
-      bucket: process.env.S3_BUCKET!,
-      config: {
-        credentials: {
-          accessKeyId: process.env.S3_ACCESS_KEY_ID!,
-          secretAccessKey: process.env.S3_SECRET_ACCESS_KEY!,
-        },
-        endpoint: process.env.S3_ENDPOINT,
-        forcePathStyle: process.env.S3_FORCE_PATH_STYLE === 'true',
-        region: process.env.S3_REGION,
-      },
-      enabled: false,
-    }),
-  ],
-  upload: {
-    limits: {
-      fileSize: 1_000_000, // 1MB
-    },
-  },
-  typescript: {
-    outputFile: path.resolve(dirname, 'payload-types.ts'),
   },
 })

--- a/test/storage-s3/int.spec.ts
+++ b/test/storage-s3/int.spec.ts
@@ -3,7 +3,6 @@ import { fileURLToPath } from 'url'
 import { expect } from 'vitest'
 
 import { test } from '../__helpers/int/vitest.js'
-import testConfig from './config.js'
 import {
   mediaSlug,
   mediaWithAlwaysInsertFieldsSlug,
@@ -23,7 +22,7 @@ import {
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
-test.suite({ config: testConfig })('@payloadcms/storage-s3', () => {
+test.suite({ config: './config.ts' })('@payloadcms/storage-s3', () => {
   test.beforeEach(async () => {
     await createTestBucket()
     await clearTestBucket()

--- a/test/storage-s3/int.spec.ts
+++ b/test/storage-s3/int.spec.ts
@@ -1,12 +1,9 @@
-import type { Payload } from 'payload'
-
 import path from 'path'
 import { fileURLToPath } from 'url'
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { expect } from 'vitest'
 
-import type { NextRESTClient } from '../__helpers/shared/NextRESTClient.js'
-
-import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
+import { test } from '../__helpers/int/vitest.js'
+import testConfig from './config.js'
 import {
   mediaSlug,
   mediaWithAlwaysInsertFieldsSlug,
@@ -26,26 +23,16 @@ import {
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
-let restClient: NextRESTClient
-
-let payload: Payload
-
-describe('@payloadcms/storage-s3', () => {
-  beforeAll(async () => {
-    ;({ payload, restClient } = await initPayloadInt(dirname))
-
+test.suite({ config: testConfig })('@payloadcms/storage-s3', () => {
+  test.beforeEach(async () => {
     await createTestBucket()
     await clearTestBucket()
   })
-
-  afterAll(async () => {
-    await payload.destroy()
-  })
-  afterEach(async () => {
+  test.afterEach(async () => {
     await clearTestBucket()
   })
 
-  it('can upload', async () => {
+  test('can upload', async ({ payload }) => {
     const upload = await payload.create({
       collection: mediaSlug,
       data: {},
@@ -63,7 +50,7 @@ describe('@payloadcms/storage-s3', () => {
     expect(upload.url).toEqual(`/api/${mediaSlug}/file/${String(upload.filename)}`)
   })
 
-  it('can upload with prefix', async () => {
+  test('can upload with prefix', async ({ payload }) => {
     const upload = await payload.create({
       collection: mediaWithPrefixSlug,
       data: {},
@@ -83,7 +70,9 @@ describe('@payloadcms/storage-s3', () => {
     )
   })
 
-  it('has prefix field with alwaysInsertFields even when plugin is disabled', async () => {
+  test('has prefix field with alwaysInsertFields even when plugin is disabled', async ({
+    payload,
+  }) => {
     // This collection uses a s3Storage plugin with enabled: false but alwaysInsertFields: true
     // The upload will use local storage, but the prefix field should still exist
     const upload = await payload.create({
@@ -99,7 +88,7 @@ describe('@payloadcms/storage-s3', () => {
     expect(upload.prefix).toBe('test')
   })
 
-  it('can download with signed downloads', async () => {
+  test('can download with signed downloads', async ({ payload, restClient }) => {
     await payload.create({
       collection: mediaWithSignedDownloadsSlug,
       data: {},
@@ -110,13 +99,13 @@ describe('@payloadcms/storage-s3', () => {
     expect(response.status).toBe(302)
     const url = response.headers.get('Location')
     expect(url).toBeDefined()
-    expect(url!).toContain(`/${getTestBucketName()}/image.png`)
-    expect(new URLSearchParams(url!).get('x-id')).toBe('GetObject')
-    const file = await fetch(url!)
+    expect(url).toContain(`/${getTestBucketName()}/image.png`)
+    expect(new URLSearchParams(url).get('x-id')).toBe('GetObject')
+    const file = await fetch(url)
     expect(file.headers.get('Content-Type')).toBe('image/png')
   })
 
-  it('should skip signed download', async () => {
+  test('should skip signed download', async ({ payload, restClient }) => {
     await payload.create({
       collection: mediaWithSignedDownloadsSlug,
       data: {},
@@ -130,12 +119,15 @@ describe('@payloadcms/storage-s3', () => {
     expect(response.headers.get('Content-Type')).toBe('image/png')
   })
 
-  it('should return 404 when the file is not found', async () => {
+  test('should return 404 when the file is not found', async ({ restClient }) => {
     const response = await restClient.GET(`/${mediaSlug}/file/missing.png`)
     expect(response.status).toBe(404)
   })
 
-  it('should return 304 with empty body when the ETag matches', async () => {
+  test('should return 304 with empty body when the ETag matches', async ({
+    payload,
+    restClient,
+  }) => {
     await payload.create({
       collection: mediaWithSignedDownloadsSlug,
       data: {},
@@ -165,8 +157,10 @@ describe('@payloadcms/storage-s3', () => {
     expect(body).toBe('')
   })
 
-  describe('disablePayloadAccessControl', () => {
-    it('should return direct S3 URL with encoded filename when uploading file with spaces', async () => {
+  test.describe('disablePayloadAccessControl', () => {
+    test('should return direct S3 URL with encoded filename when uploading file with spaces', async ({
+      payload,
+    }) => {
       const upload = await payload.create({
         collection: mediaWithDirectAccessSlug,
         data: {},
@@ -206,7 +200,9 @@ describe('@payloadcms/storage-s3', () => {
       expect(dbDoc.url).not.toMatch(/^\/api\//)
     })
 
-    it('should store full S3 URLs in database for image sizes when disablePayloadAccessControl is true', async () => {
+    test('should store full S3 URLs in database for image sizes when disablePayloadAccessControl is true', async ({
+      payload,
+    }) => {
       const upload = await payload.create({
         collection: mediaWithDirectAccessSlug,
         data: {},
@@ -237,7 +233,9 @@ describe('@payloadcms/storage-s3', () => {
       await payload.delete({ collection: mediaWithDirectAccessSlug, id: upload.id })
     })
 
-    it('should return direct S3 URL without encoding issues for normal filenames', async () => {
+    test('should return direct S3 URL without encoding issues for normal filenames', async ({
+      payload,
+    }) => {
       const upload = await payload.create({
         collection: mediaWithDirectAccessSlug,
         data: {},
@@ -257,8 +255,8 @@ describe('@payloadcms/storage-s3', () => {
     })
   })
 
-  describe('storage config', () => {
-    it('should default storage to an empty array when the key is omitted', () => {
+  test.describe('storage config', () => {
+    test('should default storage to an empty array when the key is omitted', ({ payload }) => {
       // sanitize.ts sets storage = [] when the key is absent from the raw config
       // (packages/payload/src/config/sanitize.ts). Verified here because the sanitized
       // config must always expose a defined array regardless of what the user configured.
@@ -266,7 +264,7 @@ describe('@payloadcms/storage-s3', () => {
       expect(Array.isArray(payload.config.storage)).toBe(true)
     })
 
-    it('should expose adapter name and collections on each storage adapter', () => {
+    test('should expose adapter name and collections on each storage adapter', ({ payload }) => {
       const s3Adapter = payload.config.storage.find((a) => a.name === 's3')
 
       expect(s3Adapter).toBeDefined()
@@ -276,12 +274,12 @@ describe('@payloadcms/storage-s3', () => {
     })
   })
 
-  describe('R2', () => {
-    it.todo('can upload')
+  test.describe('R2', () => {
+    test.todo('can upload')
   })
 
-  describe('prefix collision detection', () => {
-    beforeEach(async () => {
+  test.describe('prefix collision detection', () => {
+    test.beforeEach(async ({ payload }) => {
       // Clear S3 bucket before each test
       await clearTestBucket()
       // Clear database records before each test
@@ -299,7 +297,7 @@ describe('@payloadcms/storage-s3', () => {
       })
     })
 
-    it('detects collision within same prefix', async () => {
+    test('detects collision within same prefix', async ({ payload }) => {
       const imageFile = path.resolve(dirname, '../uploads/image.png')
 
       // Upload twice with same prefix
@@ -321,7 +319,7 @@ describe('@payloadcms/storage-s3', () => {
       expect(upload2.prefix).toBe(prefix)
     })
 
-    it('works normally for collections without prefix', async () => {
+    test('works normally for collections without prefix', async ({ payload }) => {
       const imageFile = path.resolve(dirname, '../uploads/image.png')
 
       // Upload twice to collection without prefix
@@ -345,7 +343,7 @@ describe('@payloadcms/storage-s3', () => {
       expect(upload2.prefix).toBeUndefined()
     })
 
-    it('allows same filename under different prefixes', async () => {
+    test('allows same filename under different prefixes', async ({ payload }) => {
       const imageFile = path.resolve(dirname, '../uploads/image.png')
 
       // Upload with default prefix from config ('test-prefix')
@@ -370,7 +368,7 @@ describe('@payloadcms/storage-s3', () => {
       expect(upload2.prefix).toBe('different-prefix')
     })
 
-    it('supports multi-tenant scenario with dynamic prefix from hook', async () => {
+    test('supports multi-tenant scenario with dynamic prefix from hook', async ({ payload }) => {
       const imageFile = path.resolve(dirname, '../uploads/image.png')
 
       // Tenant A uploads logo.png

--- a/test/storage-s3/searchBeforeS3.config.ts
+++ b/test/storage-s3/searchBeforeS3.config.ts
@@ -18,13 +18,47 @@ dotenv.config({
 })
 
 export default buildConfigWithDefaults({
-  admin: {
-    importMap: {
-      baseDir: path.resolve(dirname),
+  suite: 'storage-s3-search-before-s3',
+  config: {
+    admin: {
+      importMap: {
+        baseDir: path.resolve(dirname),
+      },
+    },
+    collections: [Media, Users],
+    plugins: [
+      searchPlugin({
+        beforeSync: ({ originalDoc, searchDoc }) => {
+          return {
+            ...searchDoc,
+            title: originalDoc?.filename || 'Untitled',
+          }
+        },
+        collections: [mediaSlug],
+      }),
+    ],
+    storage: [
+      s3Storage({
+        bucket: process.env.S3_BUCKET!,
+        collections: {
+          [mediaSlug]: true,
+        },
+        config: {
+          credentials: {
+            accessKeyId: process.env.S3_ACCESS_KEY_ID!,
+            secretAccessKey: process.env.S3_SECRET_ACCESS_KEY!,
+          },
+          endpoint: process.env.S3_ENDPOINT,
+          forcePathStyle: process.env.S3_FORCE_PATH_STYLE === 'true',
+          region: process.env.S3_REGION,
+        },
+      }),
+    ],
+    typescript: {
+      outputFile: path.resolve(dirname, 'payload-types.ts'),
     },
   },
-  collections: [Media, Users],
-  onInit: async (payload) => {
+  seed: async (payload) => {
     await payload.create({
       collection: 'users',
       data: {
@@ -32,36 +66,5 @@ export default buildConfigWithDefaults({
         password: devUser.password,
       },
     })
-  },
-  plugins: [
-    searchPlugin({
-      collections: [mediaSlug],
-      beforeSync: ({ originalDoc, searchDoc }) => {
-        return {
-          ...searchDoc,
-          title: originalDoc?.filename || 'Untitled',
-        }
-      },
-    }),
-  ],
-  storage: [
-    s3Storage({
-      collections: {
-        [mediaSlug]: true,
-      },
-      bucket: process.env.S3_BUCKET!,
-      config: {
-        credentials: {
-          accessKeyId: process.env.S3_ACCESS_KEY_ID!,
-          secretAccessKey: process.env.S3_SECRET_ACCESS_KEY!,
-        },
-        endpoint: process.env.S3_ENDPOINT,
-        forcePathStyle: process.env.S3_FORCE_PATH_STYLE === 'true',
-        region: process.env.S3_REGION,
-      },
-    }),
-  ],
-  typescript: {
-    outputFile: path.resolve(dirname, 'payload-types.ts'),
   },
 })

--- a/test/storage-s3/searchBeforeS3.int.spec.ts
+++ b/test/storage-s3/searchBeforeS3.int.spec.ts
@@ -3,7 +3,6 @@ import { fileURLToPath } from 'url'
 import { expect } from 'vitest'
 
 import { test } from '../__helpers/int/vitest.js'
-import testConfig from './searchBeforeS3.config.js'
 import { mediaSlug } from './shared.js'
 import { clearTestBucket, createTestBucket, verifyUploads } from './test-utils.js'
 
@@ -17,71 +16,74 @@ const dirname = path.dirname(filename)
  * searchPlugin processes the collection config — fixing the silent upload failure
  * that occurred when s3Storage appeared after searchPlugin in the old `plugins` array.
  */
-test.suite({ config: testConfig })('Search plugin before S3 - Issue #15431', () => {
-  test.beforeEach(async () => {
-    await createTestBucket()
-    await clearTestBucket()
-  })
-
-  test.afterEach(async ({ payload }) => {
-    await payload.delete({
-      collection: mediaSlug,
-      where: { id: { exists: true } },
+test.suite({ config: './searchBeforeS3.config.ts' })(
+  'Search plugin before S3 - Issue #15431',
+  () => {
+    test.beforeEach(async () => {
+      await createTestBucket()
+      await clearTestBucket()
     })
-    // Only delete from search if the collection exists
-    if (payload.collections['search']) {
+
+    test.afterEach(async ({ payload }) => {
       await payload.delete({
-        collection: 'search',
+        collection: mediaSlug,
         where: { id: { exists: true } },
       })
-    }
-    await clearTestBucket()
-  })
-
-  test('should initialise the S3 adapter before the search plugin', ({ payload }) => {
-    // The S3 adapter must have run its init before searchPlugin consumed the collection
-    // config. If it didn't, upload hooks would be absent and the next test's S3 writes
-    // would silently fail. Verify the adapter is wired up on the sanitized config.
-    const s3Adapter = payload.config.storage.find((a) => a.name === 's3')
-
-    expect(s3Adapter).toBeDefined()
-    expect(s3Adapter!.collections).toContain(mediaSlug)
-  })
-
-  test('should upload all image sizes to S3 when search plugin is listed before S3 plugin', async ({
-    payload,
-  }) => {
-    const upload = await payload.create({
-      collection: mediaSlug,
-      data: {},
-      filePath: path.resolve(dirname, '../uploads/image.png'),
+      // Only delete from search if the collection exists
+      if (payload.collections['search']) {
+        await payload.delete({
+          collection: 'search',
+          where: { id: { exists: true } },
+        })
+      }
+      await clearTestBucket()
     })
 
-    expect(upload.id).toBeTruthy()
-    expect(upload.filename).toBeTruthy()
+    test('should initialise the S3 adapter before the search plugin', ({ payload }) => {
+      // The S3 adapter must have run its init before searchPlugin consumed the collection
+      // config. If it didn't, upload hooks would be absent and the next test's S3 writes
+      // would silently fail. Verify the adapter is wired up on the sanitized config.
+      const s3Adapter = payload.config.storage.find((a) => a.name === 's3')
 
-    await verifyUploads({
-      collectionSlug: mediaSlug,
-      uploadId: upload.id,
+      expect(s3Adapter).toBeDefined()
+      expect(s3Adapter!.collections).toContain(mediaSlug)
+    })
+
+    test('should upload all image sizes to S3 when search plugin is listed before S3 plugin', async ({
       payload,
-    })
-  })
+    }) => {
+      const upload = await payload.create({
+        collection: mediaSlug,
+        data: {},
+        filePath: path.resolve(dirname, '../uploads/image.png'),
+      })
 
-  test('should create search document when uploading media', async ({ payload }) => {
-    const upload = await payload.create({
-      collection: mediaSlug,
-      data: {},
-      filePath: path.resolve(dirname, '../uploads/image.png'),
+      expect(upload.id).toBeTruthy()
+      expect(upload.filename).toBeTruthy()
+
+      await verifyUploads({
+        collectionSlug: mediaSlug,
+        uploadId: upload.id,
+        payload,
+      })
     })
 
-    const { docs: searchDocs } = await payload.find({
-      collection: 'search',
-      where: {
-        'doc.value': { equals: upload.id },
-        'doc.relationTo': { equals: mediaSlug },
-      },
-    })
+    test('should create search document when uploading media', async ({ payload }) => {
+      const upload = await payload.create({
+        collection: mediaSlug,
+        data: {},
+        filePath: path.resolve(dirname, '../uploads/image.png'),
+      })
 
-    expect(searchDocs.length).toBe(1)
-  })
-})
+      const { docs: searchDocs } = await payload.find({
+        collection: 'search',
+        where: {
+          'doc.value': { equals: upload.id },
+          'doc.relationTo': { equals: mediaSlug },
+        },
+      })
+
+      expect(searchDocs.length).toBe(1)
+    })
+  },
+)

--- a/test/storage-s3/searchBeforeS3.int.spec.ts
+++ b/test/storage-s3/searchBeforeS3.int.spec.ts
@@ -1,17 +1,14 @@
-import type { Payload } from 'payload'
-
 import path from 'path'
 import { fileURLToPath } from 'url'
-import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { expect } from 'vitest'
 
-import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
+import { test } from '../__helpers/int/vitest.js'
+import testConfig from './searchBeforeS3.config.js'
 import { mediaSlug } from './shared.js'
 import { clearTestBucket, createTestBucket, verifyUploads } from './test-utils.js'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
-
-let payload: Payload
 
 /**
  * Verifies that storage adapters initialise before plugins.
@@ -20,23 +17,13 @@ let payload: Payload
  * searchPlugin processes the collection config — fixing the silent upload failure
  * that occurred when s3Storage appeared after searchPlugin in the old `plugins` array.
  */
-describe('Search plugin before S3 - Issue #15431', () => {
-  beforeAll(async () => {
-    ;({ payload } = await initPayloadInt(
-      dirname,
-      'storage-s3-search-before',
-      true,
-      'searchBeforeS3.config.ts',
-    ))
+test.suite({ config: testConfig })('Search plugin before S3 - Issue #15431', () => {
+  test.beforeEach(async () => {
     await createTestBucket()
     await clearTestBucket()
   })
 
-  afterAll(async () => {
-    await payload.destroy()
-  })
-
-  afterEach(async () => {
+  test.afterEach(async ({ payload }) => {
     await payload.delete({
       collection: mediaSlug,
       where: { id: { exists: true } },
@@ -51,7 +38,7 @@ describe('Search plugin before S3 - Issue #15431', () => {
     await clearTestBucket()
   })
 
-  it('should initialise the S3 adapter before the search plugin', () => {
+  test('should initialise the S3 adapter before the search plugin', ({ payload }) => {
     // The S3 adapter must have run its init before searchPlugin consumed the collection
     // config. If it didn't, upload hooks would be absent and the next test's S3 writes
     // would silently fail. Verify the adapter is wired up on the sanitized config.
@@ -61,7 +48,9 @@ describe('Search plugin before S3 - Issue #15431', () => {
     expect(s3Adapter!.collections).toContain(mediaSlug)
   })
 
-  it('should upload all image sizes to S3 when search plugin is listed before S3 plugin', async () => {
+  test('should upload all image sizes to S3 when search plugin is listed before S3 plugin', async ({
+    payload,
+  }) => {
     const upload = await payload.create({
       collection: mediaSlug,
       data: {},
@@ -78,7 +67,7 @@ describe('Search plugin before S3 - Issue #15431', () => {
     })
   })
 
-  it('should create search document when uploading media', async () => {
+  test('should create search document when uploading media', async ({ payload }) => {
     const upload = await payload.create({
       collection: mediaSlug,
       data: {},

--- a/test/storage-vercel-blob/client-uploads/compositePrefixes.int.spec.ts
+++ b/test/storage-vercel-blob/client-uploads/compositePrefixes.int.spec.ts
@@ -1,118 +1,104 @@
-import type { Payload } from 'payload'
-
 import { del, list } from '@vercel/blob'
 import { put } from '@vercel/blob/client'
 import dotenv from 'dotenv'
 import { readFileSync } from 'fs'
 import path from 'path'
 import { fileURLToPath } from 'url'
-import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { expect } from 'vitest'
 
-import type { NextRESTClient } from '../../__helpers/shared/NextRESTClient.js'
-
-import { initPayloadInt } from '../../__helpers/shared/initPayloadInt.js'
+import { test } from '../../__helpers/int/vitest.js'
 import { collectionPrefix, mediaWithCompositePrefixesSlug } from '../shared.js'
+import testConfig from './config.compositePrefixes.js'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
 dotenv.config({ path: path.resolve(dirname, '../../plugin-cloud-storage/.env.emulated') })
 
-let payload: Payload
-let restClient: NextRESTClient
-
 const createdDocIDs: Array<number | string> = []
 
-describe('@payloadcms/storage-vercel-blob clientUploads (composite prefixes)', () => {
-  beforeAll(async () => {
-    ;({ payload, restClient } = await initPayloadInt(
-      dirname,
-      undefined,
-      true,
-      'config.compositePrefixes.ts',
-    ))
-  })
-
-  afterAll(async () => {
-    await payload.destroy()
-  })
-
-  afterEach(async () => {
-    for (const id of createdDocIDs) {
-      await payload.delete({
-        id,
-        collection: mediaWithCompositePrefixesSlug,
-      })
-    }
-
-    createdDocIDs.length = 0
-
-    const { blobs } = await list()
-    if (blobs.length > 0) {
-      await del(blobs.map((b) => b.url))
-    }
-  })
-
-  it('should fetch a client-uploaded file using collection and document prefixes', async () => {
-    const docPrefix = 'document-prefix'
-    const uploadedFilename = 'client-composite-image.png'
-    const pathname = `${collectionPrefix}/${docPrefix}/${uploadedFilename}`
-    const file = readFileSync(path.resolve(dirname, '../../uploads/image.png'))
-
-    const instructionsResponse = await restClient.POST('/upload-instructions', {
-      body: JSON.stringify({
-        collectionSlug: mediaWithCompositePrefixesSlug,
-        docPrefix,
-        filename: uploadedFilename,
-        filesize: file.length,
-        mimeType: 'image/png',
-      }),
-    })
-    const instructions = (await instructionsResponse.json()) as {
-      data: { pathname: string; token: string }
-      file: {
-        uploadReference: { prefix: string }
-        filename: string
-        mimeType: string
-        size: number
+test.suite({ config: testConfig })(
+  '@payloadcms/storage-vercel-blob clientUploads (composite prefixes)',
+  () => {
+    test.afterEach(async ({ payload }) => {
+      for (const id of createdDocIDs) {
+        await payload.delete({
+          id,
+          collection: mediaWithCompositePrefixesSlug,
+        })
       }
-    }
 
-    expect(instructions.data.pathname).toBe(pathname)
+      createdDocIDs.length = 0
 
-    await put(instructions.data.pathname, new Blob([file], { type: 'image/png' }), {
-      access: 'public',
-      contentType: 'image/png',
-      token: instructions.data.token,
+      const { blobs } = await list()
+      if (blobs.length > 0) {
+        await del(blobs.map((b) => b.url))
+      }
     })
 
-    const formData = new FormData()
+    test('should fetch a client-uploaded file using collection and document prefixes', async ({
+      restClient,
+    }) => {
+      const docPrefix = 'document-prefix'
+      const uploadedFilename = 'client-composite-image.png'
+      const pathname = `${collectionPrefix}/${docPrefix}/${uploadedFilename}`
+      const file = readFileSync(path.resolve(dirname, '../../uploads/image.png'))
 
-    // build formData like the admin panel does
-    formData.append(
-      '_payload',
-      JSON.stringify({
-        prefix: docPrefix,
-      }),
-    )
-    formData.append('file', JSON.stringify(instructions.file))
+      const instructionsResponse = await restClient.POST('/upload-instructions', {
+        body: JSON.stringify({
+          collectionSlug: mediaWithCompositePrefixesSlug,
+          docPrefix,
+          filename: uploadedFilename,
+          filesize: file.length,
+          mimeType: 'image/png',
+        }),
+      })
+      const instructions = (await instructionsResponse.json()) as {
+        data: { pathname: string; token: string }
+        file: {
+          filename: string
+          mimeType: string
+          size: number
+          uploadReference: { prefix: string }
+        }
+      }
 
-    const createResponse = await restClient.POST(`/${mediaWithCompositePrefixesSlug}`, {
-      body: formData,
+      expect(instructions.data.pathname).toBe(pathname)
+
+      await put(instructions.data.pathname, new Blob([file], { type: 'image/png' }), {
+        access: 'public',
+        contentType: 'image/png',
+        token: instructions.data.token,
+      })
+
+      const formData = new FormData()
+
+      // build formData like the admin panel does
+      formData.append(
+        '_payload',
+        JSON.stringify({
+          prefix: docPrefix,
+        }),
+      )
+      formData.append('file', JSON.stringify(instructions.file))
+
+      const createResponse = await restClient.POST(`/${mediaWithCompositePrefixesSlug}`, {
+        body: formData,
+      })
+
+      expect(createResponse.status).toBe(201)
+
+      const createdDoc = await createResponse.json()
+
+      expect(createdDoc?.doc.prefix).toBe(docPrefix)
+
+      const fileResponse = await restClient.GET(
+        `/${mediaWithCompositePrefixesSlug}/file/${uploadedFilename}?prefix=${encodeURIComponent(docPrefix)}`,
+      )
+
+      expect(fileResponse.status).toBe(200)
+      const fileBuffer = await fileResponse.arrayBuffer()
+      expect(fileBuffer.byteLength).toBeGreaterThan(0)
     })
-
-    expect(createResponse.status).toBe(201)
-
-    const createdDoc = await createResponse.json()
-
-    expect(createdDoc?.doc.prefix).toBe(docPrefix)
-
-    const fileResponse = await restClient.GET(
-      `/${mediaWithCompositePrefixesSlug}/file/${uploadedFilename}?prefix=${encodeURIComponent(docPrefix)}`,
-    )
-
-    expect(fileResponse.status).toBe(200)
-    const fileBuffer = await fileResponse.arrayBuffer()
-    expect(fileBuffer.byteLength).toBeGreaterThan(0)
-  })
-})
+  },
+)

--- a/test/storage-vercel-blob/client-uploads/compositePrefixes.int.spec.ts
+++ b/test/storage-vercel-blob/client-uploads/compositePrefixes.int.spec.ts
@@ -8,7 +8,6 @@ import { expect } from 'vitest'
 
 import { test } from '../../__helpers/int/vitest.js'
 import { collectionPrefix, mediaWithCompositePrefixesSlug } from '../shared.js'
-import testConfig from './config.compositePrefixes.js'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
@@ -17,7 +16,7 @@ dotenv.config({ path: path.resolve(dirname, '../../plugin-cloud-storage/.env.emu
 
 const createdDocIDs: Array<number | string> = []
 
-test.suite({ config: testConfig })(
+test.suite({ config: './config.compositePrefixes.ts' })(
   '@payloadcms/storage-vercel-blob clientUploads (composite prefixes)',
   () => {
     test.afterEach(async ({ payload }) => {

--- a/test/storage-vercel-blob/client-uploads/config.compositePrefixes.ts
+++ b/test/storage-vercel-blob/client-uploads/config.compositePrefixes.ts
@@ -19,13 +19,34 @@ dotenv.config({
 })
 
 export default buildConfigWithDefaults({
-  admin: {
-    importMap: {
-      baseDir: path.resolve(dirname, '..'),
+  suite: 'storage-vercel-blob-client-uploads-compositePrefixes',
+  config: {
+    admin: {
+      importMap: {
+        baseDir: path.resolve(dirname, '..'),
+      },
+    },
+    collections: [Media, MediaContainer, MediaWithCompositePrefixes, Users],
+    storage: [
+      vercelBlobStorage({
+        clientUploads: {
+          access: ({ req }) => (req.headers.get('x-disallow-access') ? false : true),
+        },
+        collections: {
+          [mediaSlug]: true,
+          [mediaWithCompositePrefixesSlug]: {
+            prefix: collectionPrefix,
+          },
+        },
+        token: process.env.BLOB_READ_WRITE_TOKEN,
+        useCompositePrefixes: true,
+      }),
+    ],
+    typescript: {
+      outputFile: path.resolve(dirname, 'payload-types.ts'),
     },
   },
-  collections: [Media, MediaContainer, MediaWithCompositePrefixes, Users],
-  onInit: async (payload) => {
+  seed: async (payload) => {
     await payload.create({
       collection: 'users',
       data: {
@@ -33,23 +54,5 @@ export default buildConfigWithDefaults({
         password: devUser.password,
       },
     })
-  },
-  storage: [
-    vercelBlobStorage({
-      clientUploads: {
-        access: ({ req }) => (req.headers.get('x-disallow-access') ? false : true),
-      },
-      collections: {
-        [mediaSlug]: true,
-        [mediaWithCompositePrefixesSlug]: {
-          prefix: collectionPrefix,
-        },
-      },
-      token: process.env.BLOB_READ_WRITE_TOKEN,
-      useCompositePrefixes: true,
-    }),
-  ],
-  typescript: {
-    outputFile: path.resolve(dirname, 'payload-types.ts'),
   },
 })

--- a/test/storage-vercel-blob/client-uploads/config.ts
+++ b/test/storage-vercel-blob/client-uploads/config.ts
@@ -19,13 +19,33 @@ dotenv.config({
 })
 
 export default buildConfigWithDefaults({
-  admin: {
-    importMap: {
-      baseDir: path.resolve(dirname, '..'),
+  suite: 'storage-vercel-blob-client-uploads',
+  config: {
+    admin: {
+      importMap: {
+        baseDir: path.resolve(dirname, '..'),
+      },
+    },
+    collections: [Media, MediaWithPrefix, MediaContainer, Users],
+    storage: [
+      vercelBlobStorage({
+        clientUploads: {
+          access: ({ req }) => (req.headers.get('x-disallow-access') ? false : true),
+        },
+        collections: {
+          [mediaSlug]: true,
+          [mediaWithPrefixSlug]: {
+            prefix,
+          },
+        },
+        token: process.env.BLOB_READ_WRITE_TOKEN,
+      }),
+    ],
+    typescript: {
+      outputFile: path.resolve(dirname, 'payload-types.ts'),
     },
   },
-  collections: [Media, MediaWithPrefix, MediaContainer, Users],
-  onInit: async (payload) => {
+  seed: async (payload) => {
     await payload.create({
       collection: 'users',
       data: {
@@ -33,22 +53,5 @@ export default buildConfigWithDefaults({
         password: devUser.password,
       },
     })
-  },
-  storage: [
-    vercelBlobStorage({
-      clientUploads: {
-        access: ({ req }) => (req.headers.get('x-disallow-access') ? false : true),
-      },
-      collections: {
-        [mediaSlug]: true,
-        [mediaWithPrefixSlug]: {
-          prefix,
-        },
-      },
-      token: process.env.BLOB_READ_WRITE_TOKEN,
-    }),
-  ],
-  typescript: {
-    outputFile: path.resolve(dirname, 'payload-types.ts'),
   },
 })

--- a/test/storage-vercel-blob/client-uploads/int.spec.ts
+++ b/test/storage-vercel-blob/client-uploads/int.spec.ts
@@ -1,4 +1,4 @@
-import type { Payload, UploadInstructions } from 'payload'
+import type { UploadInstructions } from 'payload'
 
 import { del, list } from '@vercel/blob'
 import { put } from '@vercel/blob/client'
@@ -6,20 +6,16 @@ import dotenv from 'dotenv'
 import { readFileSync } from 'fs'
 import path from 'path'
 import { fileURLToPath } from 'url'
-import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { expect } from 'vitest'
 
-import type { NextRESTClient } from '../../__helpers/shared/NextRESTClient.js'
-
-import { initPayloadInt } from '../../__helpers/shared/initPayloadInt.js'
+import { test } from '../../__helpers/int/vitest.js'
 import { prefix } from '../shared.js'
+import testConfig from './config.js'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
 dotenv.config({ path: path.resolve(dirname, '../../plugin-cloud-storage/.env.emulated') })
-
-let payload: Payload
-let restClient: NextRESTClient
 
 const uploadInstructionsPath = '/upload-instructions'
 
@@ -40,23 +36,15 @@ const uploadMetadata = (collectionSlug?: string, filesize = 1) => ({
   mimeType: 'image/png',
 })
 
-describe('@payloadcms/storage-vercel-blob clientUploads', () => {
-  beforeAll(async () => {
-    ;({ payload, restClient } = await initPayloadInt(dirname))
-  })
-
-  afterAll(async () => {
-    await payload.destroy()
-  })
-
-  afterEach(async () => {
+test.suite({ config: testConfig })('@payloadcms/storage-vercel-blob clientUploads', () => {
+  test.afterEach(async () => {
     const { blobs } = await list()
     if (blobs.length > 0) {
       await del(blobs.map((b) => b.url))
     }
   })
 
-  it('should upload a file via client upload flow', async () => {
+  test('should upload a file via client upload flow', async ({ restClient }) => {
     const file = readFileSync(path.resolve(dirname, '../../uploads/image.png'))
     const instructionsResponse = await restClient.POST(uploadInstructionsPath, {
       body: JSON.stringify(uploadMetadata('media', file.length)),
@@ -88,7 +76,7 @@ describe('@payloadcms/storage-vercel-blob clientUploads', () => {
     expect(uploaded).toBeDefined()
   })
 
-  it("should reject upload when 'x-disallow-access' header is set", async () => {
+  test("should reject upload when 'x-disallow-access' header is set", async ({ restClient }) => {
     const file = readFileSync(path.resolve(dirname, '../../uploads/image.png'))
 
     const response = await restClient.POST(uploadInstructionsPath, {
@@ -99,7 +87,7 @@ describe('@payloadcms/storage-vercel-blob clientUploads', () => {
     expect(response.status).toBe(403)
   })
 
-  it('should reject invalid upload metadata', async () => {
+  test('should reject invalid upload metadata', async ({ restClient }) => {
     for (const body of [
       uploadMetadata(),
       uploadMetadata('constructor'),
@@ -113,7 +101,7 @@ describe('@payloadcms/storage-vercel-blob clientUploads', () => {
     }
   })
 
-  it('should upload a file with prefix via client upload flow', async () => {
+  test('should upload a file with prefix via client upload flow', async ({ restClient }) => {
     const file = readFileSync(path.resolve(dirname, '../../uploads/image.png'))
     const instructionsResponse = await restClient.POST(uploadInstructionsPath, {
       body: JSON.stringify(uploadMetadata('media-with-prefix', file.length)),

--- a/test/storage-vercel-blob/client-uploads/int.spec.ts
+++ b/test/storage-vercel-blob/client-uploads/int.spec.ts
@@ -10,7 +10,6 @@ import { expect } from 'vitest'
 
 import { test } from '../../__helpers/int/vitest.js'
 import { prefix } from '../shared.js'
-import testConfig from './config.js'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
@@ -36,7 +35,7 @@ const uploadMetadata = (collectionSlug?: string, filesize = 1) => ({
   mimeType: 'image/png',
 })
 
-test.suite({ config: testConfig })('@payloadcms/storage-vercel-blob clientUploads', () => {
+test.suite({ config: './config.ts' })('@payloadcms/storage-vercel-blob clientUploads', () => {
   test.afterEach(async () => {
     const { blobs } = await list()
     if (blobs.length > 0) {

--- a/test/storage-vercel-blob/config.ts
+++ b/test/storage-vercel-blob/config.ts
@@ -33,20 +33,52 @@ dotenv.config({
 })
 
 export default buildConfigWithDefaults({
-  admin: {
-    importMap: {
-      baseDir: path.resolve(dirname),
+  suite: 'storage-vercel-blob',
+  config: {
+    admin: {
+      importMap: {
+        baseDir: path.resolve(dirname),
+      },
+    },
+    collections: [
+      Media,
+      MediaWithAlwaysInsertFields,
+      MediaWithDirectAccess,
+      MediaWithDynamicPrefix,
+      MediaWithPrefix,
+      Users,
+    ],
+    storage: [
+      vercelBlobStorage({
+        collections: {
+          [mediaSlug]: true,
+          [mediaWithDirectAccessSlug]: {
+            disablePayloadAccessControl: true,
+          },
+          [mediaWithDynamicPrefixSlug]: true,
+          [mediaWithPrefixSlug]: {
+            prefix,
+          },
+        },
+        token: process.env.BLOB_READ_WRITE_TOKEN,
+      }),
+      // Test alwaysInsertFields with enabled: false
+      vercelBlobStorage({
+        alwaysInsertFields: true,
+        collections: {
+          [mediaWithAlwaysInsertFieldsSlug]: {
+            prefix: '',
+          },
+        },
+        enabled: false,
+        token: process.env.BLOB_READ_WRITE_TOKEN,
+      }),
+    ],
+    typescript: {
+      outputFile: path.resolve(dirname, 'payload-types.ts'),
     },
   },
-  collections: [
-    Media,
-    MediaWithAlwaysInsertFields,
-    MediaWithDirectAccess,
-    MediaWithDynamicPrefix,
-    MediaWithPrefix,
-    Users,
-  ],
-  onInit: async (payload) => {
+  seed: async (payload) => {
     await payload.create({
       collection: 'users',
       data: {
@@ -54,34 +86,5 @@ export default buildConfigWithDefaults({
         password: devUser.password,
       },
     })
-  },
-  storage: [
-    vercelBlobStorage({
-      collections: {
-        [mediaSlug]: true,
-        [mediaWithDirectAccessSlug]: {
-          disablePayloadAccessControl: true,
-        },
-        [mediaWithDynamicPrefixSlug]: true,
-        [mediaWithPrefixSlug]: {
-          prefix,
-        },
-      },
-      token: process.env.BLOB_READ_WRITE_TOKEN,
-    }),
-    // Test alwaysInsertFields with enabled: false
-    vercelBlobStorage({
-      alwaysInsertFields: true,
-      collections: {
-        [mediaWithAlwaysInsertFieldsSlug]: {
-          prefix: '',
-        },
-      },
-      enabled: false,
-      token: process.env.BLOB_READ_WRITE_TOKEN,
-    }),
-  ],
-  typescript: {
-    outputFile: path.resolve(dirname, 'payload-types.ts'),
   },
 })

--- a/test/storage-vercel-blob/int.spec.ts
+++ b/test/storage-vercel-blob/int.spec.ts
@@ -4,7 +4,6 @@ import { fileURLToPath } from 'url'
 import { expect } from 'vitest'
 
 import { test } from '../__helpers/int/vitest.js'
-import testConfig from './config.js'
 import {
   mediaSlug,
   mediaWithAlwaysInsertFieldsSlug,
@@ -20,7 +19,7 @@ const dirname = path.dirname(filename)
 
 dotenv.config({ path: path.resolve(dirname, '../plugin-cloud-storage/.env.emulated') })
 
-test.suite({ config: testConfig })('@payloadcms/storage-vercel-blob', () => {
+test.suite({ config: './config.ts' })('@payloadcms/storage-vercel-blob', () => {
   test.beforeEach(async () => {
     await clearTestBlobs()
   })

--- a/test/storage-vercel-blob/int.spec.ts
+++ b/test/storage-vercel-blob/int.spec.ts
@@ -1,13 +1,10 @@
-import type { Payload } from 'payload'
-
 import dotenv from 'dotenv'
 import path from 'path'
 import { fileURLToPath } from 'url'
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { expect } from 'vitest'
 
-import type { NextRESTClient } from '../__helpers/shared/NextRESTClient.js'
-
-import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
+import { test } from '../__helpers/int/vitest.js'
+import testConfig from './config.js'
 import {
   mediaSlug,
   mediaWithAlwaysInsertFieldsSlug,
@@ -23,21 +20,12 @@ const dirname = path.dirname(filename)
 
 dotenv.config({ path: path.resolve(dirname, '../plugin-cloud-storage/.env.emulated') })
 
-let payload: Payload
-let restClient: NextRESTClient
-
-describe('@payloadcms/storage-vercel-blob', () => {
-  beforeAll(async () => {
-    ;({ payload, restClient } = await initPayloadInt(dirname))
-
+test.suite({ config: testConfig })('@payloadcms/storage-vercel-blob', () => {
+  test.beforeEach(async () => {
     await clearTestBlobs()
   })
 
-  afterAll(async () => {
-    await payload.destroy()
-  })
-
-  afterEach(async () => {
+  test.afterEach(async ({ payload }) => {
     await clearTestBlobs()
     await Promise.all([
       payload.delete({ collection: mediaSlug, where: {} }),
@@ -48,7 +36,7 @@ describe('@payloadcms/storage-vercel-blob', () => {
     ])
   })
 
-  it('can upload', async () => {
+  test('can upload', async ({ payload }) => {
     const upload = await payload.create({
       collection: mediaSlug,
       data: {},
@@ -66,7 +54,7 @@ describe('@payloadcms/storage-vercel-blob', () => {
     expect(upload.url).toEqual(`/api/${mediaSlug}/file/${String(upload.filename)}`)
   })
 
-  it('can upload with prefix', async () => {
+  test('can upload with prefix', async ({ payload }) => {
     const upload = await payload.create({
       collection: mediaWithPrefixSlug,
       data: {},
@@ -87,7 +75,9 @@ describe('@payloadcms/storage-vercel-blob', () => {
     )
   })
 
-  it('has prefix field with alwaysInsertFields even when plugin is disabled', async () => {
+  test('has prefix field with alwaysInsertFields even when plugin is disabled', async ({
+    payload,
+  }) => {
     const upload = await payload.create({
       collection: mediaWithAlwaysInsertFieldsSlug,
       data: {
@@ -100,12 +90,15 @@ describe('@payloadcms/storage-vercel-blob', () => {
     expect(upload.prefix).toBe('test')
   })
 
-  it('should return 404 when the file is not found', async () => {
+  test('should return 404 when the file is not found', async ({ restClient }) => {
     const response = await restClient.GET(`/${mediaSlug}/file/missing.png`)
     expect(response.status).toBe(404)
   })
 
-  it('should serve file through static handler with correct headers', async () => {
+  test('should serve file through static handler with correct headers', async ({
+    payload,
+    restClient,
+  }) => {
     await payload.create({
       collection: mediaSlug,
       data: {},
@@ -120,7 +113,7 @@ describe('@payloadcms/storage-vercel-blob', () => {
     expect(response.headers.get('X-Universal-Truth')).toBe('Set')
   })
 
-  it('should return 304 when ETag matches', async () => {
+  test('should return 304 when ETag matches', async ({ payload, restClient }) => {
     await payload.create({
       collection: mediaSlug,
       data: {},
@@ -139,8 +132,8 @@ describe('@payloadcms/storage-vercel-blob', () => {
     expect(second.status).toBe(304)
   })
 
-  describe('disablePayloadAccessControl', () => {
-    it('should return direct blob URL when uploading', async () => {
+  test.describe('disablePayloadAccessControl', () => {
+    test('should return direct blob URL when uploading', async ({ payload }) => {
       const upload = await payload.create({
         collection: mediaWithDirectAccessSlug,
         data: {},
@@ -157,7 +150,7 @@ describe('@payloadcms/storage-vercel-blob', () => {
       expect(response.headers.get('Content-Type')).toBe('image/png')
     })
 
-    it('should store full blob URLs for image sizes in database', async () => {
+    test('should store full blob URLs for image sizes in database', async ({ payload }) => {
       const upload = await payload.create({
         collection: mediaWithDirectAccessSlug,
         data: {},
@@ -176,7 +169,9 @@ describe('@payloadcms/storage-vercel-blob', () => {
       expect(dbDoc?.sizes?.thumbnail?.url).not.toMatch(/^\/api\//)
     })
 
-    it('should return direct blob URL with encoded filename for file with spaces', async () => {
+    test('should return direct blob URL with encoded filename for file with spaces', async ({
+      payload,
+    }) => {
       const upload = await payload.create({
         collection: mediaWithDirectAccessSlug,
         data: {},
@@ -193,15 +188,15 @@ describe('@payloadcms/storage-vercel-blob', () => {
     })
   })
 
-  describe('prefix collision detection', () => {
-    beforeEach(async () => {
+  test.describe('prefix collision detection', () => {
+    test.beforeEach(async ({ payload }) => {
       await clearTestBlobs()
       await payload.delete({ collection: mediaWithPrefixSlug, where: {} })
       await payload.delete({ collection: mediaSlug, where: {} })
       await payload.delete({ collection: mediaWithAlwaysInsertFieldsSlug, where: {} })
     })
 
-    it('detects collision within same prefix', async () => {
+    test('detects collision within same prefix', async ({ payload }) => {
       const imageFile = path.resolve(dirname, '../uploads/image.png')
 
       const upload1 = await payload.create({
@@ -222,7 +217,7 @@ describe('@payloadcms/storage-vercel-blob', () => {
       expect(upload2.prefix).toBe(prefix)
     })
 
-    it('works normally for collections without prefix', async () => {
+    test('works normally for collections without prefix', async ({ payload }) => {
       const imageFile = path.resolve(dirname, '../uploads/image.png')
 
       const upload1 = await payload.create({
@@ -245,7 +240,7 @@ describe('@payloadcms/storage-vercel-blob', () => {
       expect(upload2.prefix).toBeUndefined()
     })
 
-    it('allows same filename under different prefixes', async () => {
+    test('allows same filename under different prefixes', async ({ payload }) => {
       const imageFile = path.resolve(dirname, '../uploads/image.png')
 
       const upload1 = await payload.create({
@@ -266,7 +261,7 @@ describe('@payloadcms/storage-vercel-blob', () => {
       expect(upload2.prefix).toBe('different-prefix')
     })
 
-    it('supports multi-tenant scenario with dynamic prefix from hook', async () => {
+    test('supports multi-tenant scenario with dynamic prefix from hook', async ({ payload }) => {
       const imageFile = path.resolve(dirname, '../uploads/image.png')
 
       const tenantAUpload = await payload.create({


### PR DESCRIPTION
## What?

Migrates 19 integration suites from a mix of module-scoped `initPayloadInt`, config `onInit` seeding, and manual lifecycle hooks to explicit Vitest fixtures:

- configs move test seeding out of `onInit` and register `{ suite, config, seed }` with `buildConfigWithDefaults`
- root `describe` blocks become `test.suite({ config })`
- lifecycle-only `beforeAll`, `beforeEach`, and `afterAll` hooks are removed where the fixture now owns initialization, reset/seed, and teardown

For these suites, Payload is created once per file, reset and optionally seeded once before each test that requests `payload`, `restClient`, or `sdk`, and destroyed after the file.

## Why?

This makes test isolation consistent and removes reliance on config `onInit` hooks for seeding.

Migration batch 2/5 in stack #17993. Depends on #17988.
