### PR TITLE
test: migrate integration suites (3/5)

### DIFF
--- a/test/bulk-edit/config.ts
+++ b/test/bulk-edit/config.ts
@@ -11,19 +11,17 @@ const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
 export default buildConfigWithDefaults({
-  collections: [PostsCollection, TabsCollection, RestrictedTabsCollection],
-  admin: {
-    importMap: {
-      baseDir: path.resolve(dirname),
+  suite: 'bulk-edit',
+  config: {
+    admin: {
+      importMap: {
+        baseDir: path.resolve(dirname),
+      },
+    },
+    collections: [PostsCollection, TabsCollection, RestrictedTabsCollection],
+    typescript: {
+      outputFile: path.resolve(dirname, 'payload-types.ts'),
     },
   },
-  onInit: async (payload) => {
-    // IMPORTANT: This should only seed, not clear the database.
-    if (process.env.SEED_IN_CONFIG_ONINIT !== 'false') {
-      await seed(payload)
-    }
-  },
-  typescript: {
-    outputFile: path.resolve(dirname, 'payload-types.ts'),
-  },
+  seed,
 })

--- a/test/bulk-edit/e2e.spec.ts
+++ b/test/bulk-edit/e2e.spec.ts
@@ -54,7 +54,6 @@ test.describe('Bulk Edit', () => {
     // await throttleTest({ page, context, delay: 'Fast 3G' })
     await reInitializeDB({
       serverURL,
-      snapshotKey: 'bulkEdit',
     })
     await page.goto(postsUrl.admin)
   })

--- a/test/collections-graphql/config.ts
+++ b/test/collections-graphql/config.ts
@@ -39,405 +39,404 @@ const collectionWithName = (
 }
 
 export default buildConfigWithDefaults({
-  admin: {
-    importMap: {
-      baseDir: path.resolve(dirname),
-    },
-  },
-  collections: [
-    {
-      slug: 'users',
-      access: openAccess,
-      auth: true,
-      fields: [],
-      versions: false,
-    },
-    {
-      slug: pointSlug,
-      access: openAccess,
-      fields: [
-        {
-          name: 'point',
-          type: 'point',
-        },
-      ],
-      versions: false,
-    },
-    {
-      slug,
-      access: openAccess,
-      fields: [
-        {
-          name: 'title',
-          type: 'text',
-        },
-        {
-          name: 'description',
-          type: 'text',
-        },
-        {
-          name: 'number',
-          type: 'number',
-        },
-        {
-          name: 'min',
-          type: 'number',
-          min: 10,
-        },
-        // Relationship
-        {
-          name: 'relationField',
-          type: 'relationship',
-          relationTo: relationSlug,
-        },
-        {
-          name: 'relationToCustomID',
-          type: 'relationship',
-          relationTo: 'custom-ids',
-        },
-        // Relation hasMany
-        {
-          name: 'relationHasManyField',
-          type: 'relationship',
-          hasMany: true,
-          relationTo: relationSlug,
-        },
-        // Relation multiple relationTo
-        {
-          name: 'relationMultiRelationTo',
-          type: 'relationship',
-          relationTo: [relationSlug, 'dummy'],
-        },
-        // Relation multiple relationTo hasMany
-        {
-          name: 'relationMultiRelationToHasMany',
-          type: 'relationship',
-          hasMany: true,
-          relationTo: [relationSlug, 'dummy'],
-        },
-        {
-          name: 'A1',
-          type: 'group',
-          fields: [
-            {
-              name: 'A2',
-              type: 'text',
-              defaultValue: 'textInRowInGroup',
-            },
-          ],
-        },
-        {
-          name: 'B1',
-          type: 'group',
-          fields: [
-            {
-              type: 'collapsible',
-              fields: [
-                {
-                  name: 'B2',
-                  type: 'text',
-                  defaultValue: 'textInRowInGroup',
-                },
-              ],
-              label: 'Collapsible',
-            },
-          ],
-        },
-        {
-          name: 'C1',
-          type: 'group',
-          fields: [
-            {
-              name: 'C2Text',
-              type: 'text',
-            },
-            {
-              type: 'row',
-              fields: [
-                {
-                  type: 'collapsible',
-                  fields: [
-                    {
-                      name: 'C2',
-                      type: 'group',
-                      fields: [
-                        {
-                          type: 'row',
-                          fields: [
-                            {
-                              type: 'collapsible',
-                              fields: [
-                                {
-                                  name: 'C3',
-                                  type: 'text',
-                                },
-                              ],
-                              label: 'Collapsible2',
-                            },
-                          ],
-                        },
-                      ],
-                    },
-                  ],
-                  label: 'Collapsible2',
-                },
-              ],
-            },
-          ],
-        },
-        {
-          type: 'tabs',
-          tabs: [
-            {
-              name: 'D1',
-              fields: [
-                {
-                  name: 'D2',
-                  type: 'group',
-                  fields: [
-                    {
-                      type: 'row',
-                      fields: [
-                        {
-                          type: 'collapsible',
-                          fields: [
-                            {
-                              type: 'tabs',
-                              tabs: [
-                                {
-                                  fields: [
-                                    {
-                                      name: 'D3',
-                                      type: 'group',
-                                      fields: [
-                                        {
-                                          type: 'row',
-                                          fields: [
-                                            {
-                                              type: 'collapsible',
-                                              fields: [
-                                                {
-                                                  name: 'D4',
-                                                  type: 'text',
-                                                },
-                                              ],
-                                              label: 'Collapsible2',
-                                            },
-                                          ],
-                                        },
-                                      ],
-                                    },
-                                  ],
-                                  label: 'Tab1',
-                                },
-                              ],
-                            },
-                          ],
-                          label: 'Collapsible2',
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
-              label: 'Tab1',
-            },
-          ],
-        },
-      ],
-      versions: { drafts: true },
-    },
-    {
-      slug: 'custom-ids',
-      access: {
-        read: () => true,
+  suite: 'collections-graphql',
+  config: {
+    admin: {
+      importMap: {
+        baseDir: path.resolve(dirname),
       },
-      fields: [
-        {
-          name: 'id',
-          type: 'number',
-        },
-        {
-          name: 'title',
-          type: 'text',
-        },
-      ],
-      versions: false,
     },
-    collectionWithName(relationSlug, {
-      access: {
-        ...openAccess,
-        read: () => {
-          return { name: { not_equals: 'restricted' } }
-        },
+    collections: [
+      {
+        slug: 'users',
+        access: openAccess,
+        auth: true,
+        fields: [],
+        versions: false,
       },
-      versions: { drafts: true },
-    }),
-    collectionWithName('dummy'),
-    {
-      ...collectionWithName(errorOnHookSlug),
-      fields: [
-        {
-          name: 'title',
-          type: 'text',
-        },
-        {
-          name: 'errorBeforeChange',
-          type: 'checkbox',
-        },
-      ],
-      hooks: {
-        afterDelete: [
-          ({ doc }) => {
-            if (doc?.errorAfterDelete) {
-              throw new Error('Error After Delete Thrown')
-            }
+      {
+        slug: pointSlug,
+        access: openAccess,
+        fields: [
+          {
+            name: 'point',
+            type: 'point',
           },
         ],
-        beforeChange: [
-          ({ originalDoc }) => {
-            if (originalDoc?.errorBeforeChange) {
-              throw new Error('Error Before Change Thrown')
-            }
+        versions: false,
+      },
+      {
+        slug,
+        access: openAccess,
+        fields: [
+          {
+            name: 'title',
+            type: 'text',
           },
-        ],
-      },
-      versions: false,
-    },
-    {
-      slug: 'payload-api-test-ones',
-      access: {
-        read: () => true,
-      },
-      fields: [
-        {
-          name: 'payloadAPI',
-          type: 'text',
-          hooks: {
-            afterRead: [({ req }) => req.payloadAPI],
+          {
+            name: 'description',
+            type: 'text',
           },
-        },
-      ],
-      versions: false,
-    },
-    {
-      slug: 'payload-api-test-twos',
-      access: {
-        read: () => true,
-      },
-      fields: [
-        {
-          name: 'payloadAPI',
-          type: 'text',
-          hooks: {
-            afterRead: [({ req }) => req.payloadAPI],
+          {
+            name: 'number',
+            type: 'number',
           },
-        },
-        {
-          name: 'relation',
-          type: 'relationship',
-          relationTo: 'payload-api-test-ones',
-        },
-      ],
-      versions: false,
-    },
-    {
-      slug: 'content-type',
-      access: {
-        read: () => true,
-      },
-      fields: [
-        {
-          name: 'contentType',
-          type: 'text',
-          hooks: {
-            afterRead: [({ req }) => req.headers?.get('content-type')],
+          {
+            name: 'min',
+            type: 'number',
+            min: 10,
           },
-        },
-      ],
-      versions: false,
-    },
-    {
-      slug: 'cyclical-relationship',
-      access: openAccess,
-      fields: [
-        {
-          name: 'title',
-          type: 'text',
-          localized: true,
-        },
-        {
-          name: 'relationToSelf',
-          type: 'relationship',
-          relationTo: 'cyclical-relationship',
-        },
-        {
-          name: 'media',
-          type: 'upload',
-          relationTo: 'media',
-        },
-      ],
-      versions: {
-        drafts: true,
-      },
-    },
-    {
-      slug: 'media',
-      access: openAccess,
-      fields: [
-        {
-          name: 'title',
-          type: 'text',
-        },
-      ],
-      upload: true,
-      versions: false,
-    },
-    {
-      slug: 'sort',
-      fields: [
-        {
-          name: 'title',
-          type: 'text',
-        },
-        {
-          name: 'number',
-          type: 'number',
-        },
-      ],
-      versions: false,
-    },
-  ],
-  graphQL: {
-    queries: (GraphQL) => {
-      return {
-        QueryWithInternalError: {
-          type: new GraphQL.GraphQLObjectType({
-            name: 'QueryWithInternalError',
-            fields: {
-              text: {
-                type: GraphQL.GraphQLString,
+          // Relationship
+          {
+            name: 'relationField',
+            type: 'relationship',
+            relationTo: relationSlug,
+          },
+          {
+            name: 'relationToCustomID',
+            type: 'relationship',
+            relationTo: 'custom-ids',
+          },
+          // Relation hasMany
+          {
+            name: 'relationHasManyField',
+            type: 'relationship',
+            hasMany: true,
+            relationTo: relationSlug,
+          },
+          // Relation multiple relationTo
+          {
+            name: 'relationMultiRelationTo',
+            type: 'relationship',
+            relationTo: [relationSlug, 'dummy'],
+          },
+          // Relation multiple relationTo hasMany
+          {
+            name: 'relationMultiRelationToHasMany',
+            type: 'relationship',
+            hasMany: true,
+            relationTo: [relationSlug, 'dummy'],
+          },
+          {
+            name: 'A1',
+            type: 'group',
+            fields: [
+              {
+                name: 'A2',
+                type: 'text',
+                defaultValue: 'textInRowInGroup',
               },
-            },
-          }),
-          resolve: () => {
-            // Throwing an internal error with potentially sensitive data
-            throw new Error('Lost connection to the Pentagon. Secret data: ******')
+            ],
+          },
+          {
+            name: 'B1',
+            type: 'group',
+            fields: [
+              {
+                type: 'collapsible',
+                fields: [
+                  {
+                    name: 'B2',
+                    type: 'text',
+                    defaultValue: 'textInRowInGroup',
+                  },
+                ],
+                label: 'Collapsible',
+              },
+            ],
+          },
+          {
+            name: 'C1',
+            type: 'group',
+            fields: [
+              {
+                name: 'C2Text',
+                type: 'text',
+              },
+              {
+                type: 'row',
+                fields: [
+                  {
+                    type: 'collapsible',
+                    fields: [
+                      {
+                        name: 'C2',
+                        type: 'group',
+                        fields: [
+                          {
+                            type: 'row',
+                            fields: [
+                              {
+                                type: 'collapsible',
+                                fields: [
+                                  {
+                                    name: 'C3',
+                                    type: 'text',
+                                  },
+                                ],
+                                label: 'Collapsible2',
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                    label: 'Collapsible2',
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            type: 'tabs',
+            tabs: [
+              {
+                name: 'D1',
+                fields: [
+                  {
+                    name: 'D2',
+                    type: 'group',
+                    fields: [
+                      {
+                        type: 'row',
+                        fields: [
+                          {
+                            type: 'collapsible',
+                            fields: [
+                              {
+                                type: 'tabs',
+                                tabs: [
+                                  {
+                                    fields: [
+                                      {
+                                        name: 'D3',
+                                        type: 'group',
+                                        fields: [
+                                          {
+                                            type: 'row',
+                                            fields: [
+                                              {
+                                                type: 'collapsible',
+                                                fields: [
+                                                  {
+                                                    name: 'D4',
+                                                    type: 'text',
+                                                  },
+                                                ],
+                                                label: 'Collapsible2',
+                                              },
+                                            ],
+                                          },
+                                        ],
+                                      },
+                                    ],
+                                    label: 'Tab1',
+                                  },
+                                ],
+                              },
+                            ],
+                            label: 'Collapsible2',
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+                label: 'Tab1',
+              },
+            ],
+          },
+        ],
+        versions: { drafts: true },
+      },
+      {
+        slug: 'custom-ids',
+        access: {
+          read: () => true,
+        },
+        fields: [
+          {
+            name: 'id',
+            type: 'number',
+          },
+          {
+            name: 'title',
+            type: 'text',
+          },
+        ],
+        versions: false,
+      },
+      collectionWithName(relationSlug, {
+        access: {
+          ...openAccess,
+          read: () => {
+            return { name: { not_equals: 'restricted' } }
           },
         },
-      }
+        versions: { drafts: true },
+      }),
+      collectionWithName('dummy'),
+      {
+        ...collectionWithName(errorOnHookSlug),
+        fields: [
+          {
+            name: 'title',
+            type: 'text',
+          },
+          {
+            name: 'errorBeforeChange',
+            type: 'checkbox',
+          },
+        ],
+        hooks: {
+          afterDelete: [
+            ({ doc }) => {
+              if (doc?.errorAfterDelete) {
+                throw new Error('Error After Delete Thrown')
+              }
+            },
+          ],
+          beforeChange: [
+            ({ originalDoc }) => {
+              if (originalDoc?.errorBeforeChange) {
+                throw new Error('Error Before Change Thrown')
+              }
+            },
+          ],
+        },
+        versions: false,
+      },
+      {
+        slug: 'payload-api-test-ones',
+        access: {
+          read: () => true,
+        },
+        fields: [
+          {
+            name: 'payloadAPI',
+            type: 'text',
+            hooks: {
+              afterRead: [({ req }) => req.payloadAPI],
+            },
+          },
+        ],
+        versions: false,
+      },
+      {
+        slug: 'payload-api-test-twos',
+        access: {
+          read: () => true,
+        },
+        fields: [
+          {
+            name: 'payloadAPI',
+            type: 'text',
+            hooks: {
+              afterRead: [({ req }) => req.payloadAPI],
+            },
+          },
+          {
+            name: 'relation',
+            type: 'relationship',
+            relationTo: 'payload-api-test-ones',
+          },
+        ],
+        versions: false,
+      },
+      {
+        slug: 'content-type',
+        access: {
+          read: () => true,
+        },
+        fields: [
+          {
+            name: 'contentType',
+            type: 'text',
+            hooks: {
+              afterRead: [({ req }) => req.headers?.get('content-type')],
+            },
+          },
+        ],
+        versions: false,
+      },
+      {
+        slug: 'cyclical-relationship',
+        access: openAccess,
+        fields: [
+          {
+            name: 'title',
+            type: 'text',
+            localized: true,
+          },
+          {
+            name: 'relationToSelf',
+            type: 'relationship',
+            relationTo: 'cyclical-relationship',
+          },
+          {
+            name: 'media',
+            type: 'upload',
+            relationTo: 'media',
+          },
+        ],
+        versions: {
+          drafts: true,
+        },
+      },
+      {
+        slug: 'media',
+        access: openAccess,
+        fields: [
+          {
+            name: 'title',
+            type: 'text',
+          },
+        ],
+        upload: true,
+        versions: false,
+      },
+      {
+        slug: 'sort',
+        fields: [
+          {
+            name: 'title',
+            type: 'text',
+          },
+          {
+            name: 'number',
+            type: 'number',
+          },
+        ],
+        versions: false,
+      },
+    ],
+    graphQL: {
+      queries: (GraphQL) => {
+        return {
+          QueryWithInternalError: {
+            type: new GraphQL.GraphQLObjectType({
+              name: 'QueryWithInternalError',
+              fields: {
+                text: {
+                  type: GraphQL.GraphQLString,
+                },
+              },
+            }),
+            resolve: () => {
+              // Throwing an internal error with potentially sensitive data
+              throw new Error('Lost connection to the Pentagon. Secret data: ******')
+            },
+          },
+        }
+      },
+    },
+    localization: {
+      defaultLocale: 'en',
+      locales: ['en', 'es'],
+    },
+    typescript: {
+      outputFile: path.resolve(dirname, 'payload-types.ts'),
     },
   },
-  localization: {
-    defaultLocale: 'en',
-    locales: ['en', 'es'],
-  },
-  onInit: async (payload) => {
-    if (process.env.SEED_IN_CONFIG_ONINIT !== 'false') {
-      await seed(payload)
-    }
-  },
-  typescript: {
-    outputFile: path.resolve(dirname, 'payload-types.ts'),
-  },
+  seed,
 })

--- a/test/collections-graphql/int.spec.ts
+++ b/test/collections-graphql/int.spec.ts
@@ -4,50 +4,33 @@ import { fileURLToPath } from 'node:url'
 import path from 'path'
 import { getFileByPath, mapAsync } from 'payload'
 import { wait } from 'payload/shared'
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { expect } from 'vitest'
 
-import type { NextRESTClient } from '../__helpers/shared/NextRESTClient.js'
 import type { Post } from './payload-types.js'
 
+import { test } from '../__helpers/int/vitest.js'
 import { idToString } from '../__helpers/shared/idToString.js'
-import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
-import { clearAndSeedEverything } from './seed.js'
+import testConfig from './config.js'
 import { errorOnHookSlug, pointSlug, relationSlug, slug } from './shared.js'
 
 const formatID = (id: number | string) => (typeof id === 'number' ? id : `"${id}"`)
 
 const title = 'title'
 
-let restClient: NextRESTClient
-let payload: Payload
-
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
-describe('collections-graphql', () => {
-  beforeAll(async () => {
-    process.env.SEED_IN_CONFIG_ONINIT = 'false'
-    ;({ payload, restClient } = await initPayloadInt(dirname))
-  })
-
-  afterAll(async () => {
-    await payload.destroy()
-  })
-
-  beforeEach(async () => {
-    await clearAndSeedEverything(payload)
-  })
-
-  describe('CRUD', () => {
+test.suite({ config: testConfig })('collections-graphql', () => {
+  test.describe('CRUD', () => {
     let existingDoc: Post
     let existingDocGraphQLID
 
-    beforeEach(async () => {
-      existingDoc = await createPost()
+    test.beforeEach(async ({ payload }) => {
+      existingDoc = await createPost({ payload })
       existingDocGraphQLID = idToString(existingDoc.id, payload)
     })
 
-    it('should create', async () => {
+    test('should create', async ({ restClient }) => {
       const query = `mutation {
           createPost(data: {title: "${title}"}) {
           id
@@ -64,7 +47,7 @@ describe('collections-graphql', () => {
       expect(doc.id).toBeDefined()
     })
 
-    it('should create using graphql variables', async () => {
+    test('should create using graphql variables', async ({ restClient }) => {
       const query = `mutation Create($title: String!) {
           createPost(data: {title: $title}) {
           id
@@ -86,7 +69,7 @@ describe('collections-graphql', () => {
       expect(doc.id).toBeDefined()
     })
 
-    it('should read', async () => {
+    test('should read', async ({ restClient }) => {
       const query = `query {
         Post(id: ${existingDocGraphQLID}) {
           id
@@ -101,7 +84,7 @@ describe('collections-graphql', () => {
       expect(doc).toMatchObject({ id: existingDoc.id, title })
     })
 
-    it('should find', async () => {
+    test('should find', async ({ restClient }) => {
       const query = `query {
         Posts {
           docs {
@@ -118,7 +101,7 @@ describe('collections-graphql', () => {
       expect(docs).toContainEqual(expect.objectContaining({ id: existingDoc.id }))
     })
 
-    it('should sort by multiple fields', async () => {
+    test('should sort by multiple fields', async ({ payload, restClient }) => {
       const doc1 = await payload.create({ collection: 'sort', data: { title: 'a', number: 1 } })
       const doc2 = await payload.create({ collection: 'sort', data: { title: 'b', number: 1 } })
       const doc3 = await payload.create({ collection: 'sort', data: { title: 'a', number: 2 } })
@@ -142,7 +125,7 @@ describe('collections-graphql', () => {
       expect(docs.map((doc) => doc.id)).toEqual([doc3.id, doc1.id, doc4.id, doc2.id])
     })
 
-    it('should not fail with sort as empty string', async () => {
+    test('should not fail with sort as empty string', async ({ restClient }) => {
       const query = `query {
         Sorts(sort: "") {
           docs {
@@ -161,7 +144,7 @@ describe('collections-graphql', () => {
       expect(docs).toBeTruthy()
     })
 
-    it('should count', async () => {
+    test('should count', async ({ restClient }) => {
       const query = `query {
         countPosts {
           totalDocs
@@ -175,7 +158,7 @@ describe('collections-graphql', () => {
       expect(typeof totalDocs).toBe('number')
     })
 
-    it('should read using multiple queries', async () => {
+    test('should read using multiple queries', async ({ restClient }) => {
       const query = `query {
           postIDs: Posts {
             docs {
@@ -202,7 +185,10 @@ describe('collections-graphql', () => {
       expect(singlePost.id).toBeDefined()
     })
 
-    it('should commit or rollback multiple mutations independently', async () => {
+    test('should commit or rollback multiple mutations independently', async ({
+      payload,
+      restClient,
+    }) => {
       const firstTitle = 'first title'
       const secondTitle = 'second title'
       const first = await payload.create({
@@ -268,7 +254,7 @@ describe('collections-graphql', () => {
       expect(updateSecondResult).toStrictEqual(second)
     })
 
-    it('should retain payload api', async () => {
+    test('should retain payload api', async ({ restClient }) => {
       const query = `
         query {
           PayloadApiTestTwos {
@@ -290,7 +276,7 @@ describe('collections-graphql', () => {
       expect(res.docs[0].relation.payloadAPI).toStrictEqual('GraphQL')
     })
 
-    it('should have access to headers in resolver', async () => {
+    test('should have access to headers in resolver', async ({ restClient }) => {
       const query = `query {
         ContentTypes {
           docs {
@@ -304,7 +290,7 @@ describe('collections-graphql', () => {
       expect(data.ContentTypes?.docs[0]?.contentType).toEqual('application/json')
     })
 
-    it('should update existing', async () => {
+    test('should update existing', async ({ restClient }) => {
       const updatedTitle = 'updated title'
 
       const query = `mutation {
@@ -321,7 +307,7 @@ describe('collections-graphql', () => {
       expect(doc).toMatchObject({ id: existingDoc.id, title: updatedTitle })
     })
 
-    it('should delete', async () => {
+    test('should delete', async ({ restClient }) => {
       const query = `mutation {
         deletePost(id: ${existingDocGraphQLID}) {
           id
@@ -341,9 +327,12 @@ describe('collections-graphql', () => {
     })
   })
 
-  describe('Querying', () => {
-    describe('nested has-many relationship queries', () => {
-      it('should query a nested has-many relationship through GraphQL', async () => {
+  test.describe('Querying', () => {
+    test.describe('nested has-many relationship queries', () => {
+      test('should query a nested has-many relationship through GraphQL', async ({
+        payload,
+        restClient,
+      }) => {
         const recalls = await payload.create({
           collection: relationSlug,
           data: { name: 'recalls' },
@@ -354,17 +343,26 @@ describe('collections-graphql', () => {
           data: { name: 'electric-cars' },
         })
 
-        const mixedPost = await createPost({
-          relationHasManyField: [recalls.id, electricCars.id],
-        })
+        const mixedPost = await createPost(
+          { payload },
+          {
+            relationHasManyField: [recalls.id, electricCars.id],
+          },
+        )
 
-        const electricCarsPost = await createPost({
-          relationHasManyField: [electricCars.id],
-        })
+        const electricCarsPost = await createPost(
+          { payload },
+          {
+            relationHasManyField: [electricCars.id],
+          },
+        )
 
-        const postWithoutRelations = await createPost({
-          relationHasManyField: [],
-        })
+        const postWithoutRelations = await createPost(
+          { payload },
+          {
+            relationHasManyField: [],
+          },
+        )
 
         const fixtureIDFilters = [mixedPost.id, electricCarsPost.id, postWithoutRelations.id]
           .map((id) => `{ id: { equals: ${formatID(id)} } }`)
@@ -391,16 +389,16 @@ describe('collections-graphql', () => {
       })
     })
 
-    describe('Operators', () => {
+    test.describe('Operators', () => {
       let post1: Post
       let post2: Post
 
-      beforeEach(async () => {
-        post1 = await createPost({ title: 'post1' })
-        post2 = await createPost({ title: 'post2' })
+      test.beforeEach(async ({ payload }) => {
+        post1 = await createPost({ payload }, { title: 'post1' })
+        post2 = await createPost({ payload }, { title: 'post2' })
       })
 
-      it('equals', async () => {
+      test('equals', async ({ restClient }) => {
         const query = `query {
           Posts(where:{title: {equals:"${post1.title}"}}) {
             docs {
@@ -417,7 +415,7 @@ describe('collections-graphql', () => {
         expect(docs).toContainEqual(expect.objectContaining({ id: post1.id, title: post1.title }))
       })
 
-      it('not_equals', async () => {
+      test('not_equals', async ({ restClient }) => {
         const query = `query {
           Posts(where:{title: {not_equals:"${post1.title}"}}) {
             docs {
@@ -438,8 +436,8 @@ describe('collections-graphql', () => {
         expect(docsWithWhereTitleNotEqualPostTitle).toHaveLength(0)
       })
 
-      it('like', async () => {
-        const postWithWords = await createPost({ title: 'the quick brown fox' })
+      test('like', async ({ payload, restClient }) => {
+        const postWithWords = await createPost({ payload }, { title: 'the quick brown fox' })
         const query = `query {
           Posts(where:{title: {like:"${postWithWords.title?.split(' ')[1]}"}}) {
             docs {
@@ -457,7 +455,7 @@ describe('collections-graphql', () => {
         expect(docs[0]).toMatchObject({ id: postWithWords.id, title: postWithWords.title })
       })
 
-      it('contains', async () => {
+      test('contains', async ({ restClient }) => {
         const query = `query {
           Posts(where:{title: {contains:"${post1.title?.slice(0, 4)}"}}) {
             docs {
@@ -476,8 +474,8 @@ describe('collections-graphql', () => {
         expect(docs).toContainEqual(expect.objectContaining({ id: post2.id, title: post2.title }))
       })
 
-      it('exists - true', async () => {
-        const withDescription = await createPost({ description: 'description' })
+      test('exists - true', async ({ payload, restClient }) => {
+        const withDescription = await createPost({ payload }, { description: 'description' })
         const query = `query {
           Posts(where:{description: {exists:true}}) {
             docs {
@@ -497,8 +495,8 @@ describe('collections-graphql', () => {
         )
       })
 
-      it('exists - false', async () => {
-        const withDescription = await createPost({ description: 'description' })
+      test('exists - false', async ({ payload, restClient }) => {
+        const withDescription = await createPost({ payload }, { description: 'description' })
         const query = `query {
           Posts(where:{description: {exists:false}}) {
             docs {
@@ -516,16 +514,16 @@ describe('collections-graphql', () => {
         expect(docs).toContainEqual(expect.objectContaining({ id: post1.id }))
       })
 
-      describe('numbers', () => {
+      test.describe('numbers', () => {
         let numPost1: Post
         let numPost2: Post
 
-        beforeEach(async () => {
-          numPost1 = await createPost({ number: 1 })
-          numPost2 = await createPost({ number: 2 })
+        test.beforeEach(async ({ payload }) => {
+          numPost1 = await createPost({ payload }, { number: 1 })
+          numPost2 = await createPost({ payload }, { number: 2 })
         })
 
-        it('greater_than', async () => {
+        test('greater_than', async ({ restClient }) => {
           const query = `query {
             Posts(where:{number: {greater_than:1}}) {
               docs {
@@ -542,7 +540,7 @@ describe('collections-graphql', () => {
           expect(docs.map(({ id }) => id)).toContain(numPost2.id)
         })
 
-        it('greater_than_equal', async () => {
+        test('greater_than_equal', async ({ restClient }) => {
           const query = `query {
             Posts(where:{number: {greater_than_equal:1}}) {
               docs {
@@ -560,7 +558,7 @@ describe('collections-graphql', () => {
           expect(docs).toContainEqual(expect.objectContaining({ id: numPost2.id }))
         })
 
-        it('less_than', async () => {
+        test('less_than', async ({ restClient }) => {
           const query = `query {
             Posts(where:{number: {less_than:2}}) {
               docs {
@@ -578,7 +576,7 @@ describe('collections-graphql', () => {
           expect(docs).toContainEqual(expect.objectContaining({ id: numPost1.id }))
         })
 
-        it('less_than_equal', async () => {
+        test('less_than_equal', async ({ restClient }) => {
           const query = `query {
             Posts(where:{number: {less_than_equal:2}}) {
               docs {
@@ -598,7 +596,7 @@ describe('collections-graphql', () => {
         })
       })
 
-      it('or', async () => {
+      test('or', async ({ restClient }) => {
         const query = `query {
           Posts(
             where: {OR: [{ title: { equals: "${post1.title}" } }, { title: { equals: "${post2.title}" } }]
@@ -619,7 +617,7 @@ describe('collections-graphql', () => {
         expect(docs).toContainEqual(expect.objectContaining({ id: post2.id }))
       })
 
-      it('or - 1 result', async () => {
+      test('or - 1 result', async ({ restClient }) => {
         const query = `query {
           Posts(
             where: {OR: [{ title: { equals: "${post1.title}" } }, { title: { equals: "nope" } }]
@@ -640,8 +638,8 @@ describe('collections-graphql', () => {
         expect(docs).not.toContainEqual(expect.objectContaining({ id: post2.id }))
       })
 
-      it('and', async () => {
-        const specialPost = await createPost({ description: 'special-123123' })
+      test('and', async ({ payload, restClient }) => {
+        const specialPost = await createPost({ payload }, { description: 'special-123123' })
 
         const query = `query {
           Posts(
@@ -666,11 +664,11 @@ describe('collections-graphql', () => {
         expect(docs).toContainEqual(expect.objectContaining({ id: specialPost.id }))
       })
 
-      describe('near', () => {
+      test.describe('near', () => {
         const point = [10, 20]
         const [lat, lng] = point
 
-        it('should return a document near a point', async () => {
+        test('should return a document near a point', async ({ payload, restClient }) => {
           if (payload.db.name === 'sqlite') {
             return
           }
@@ -698,7 +696,7 @@ describe('collections-graphql', () => {
           expect(docs).toHaveLength(1)
         })
 
-        it('should not return a point far away', async () => {
+        test('should not return a point far away', async ({ payload, restClient }) => {
           if (payload.db.name === 'sqlite') {
             return
           }
@@ -726,7 +724,7 @@ describe('collections-graphql', () => {
           expect(docs).toHaveLength(0)
         })
 
-        it('should sort find results by nearest distance', async () => {
+        test('should sort find results by nearest distance', async ({ payload, restClient }) => {
           if (payload.db.name === 'sqlite') {
             return
           }
@@ -775,7 +773,7 @@ describe('collections-graphql', () => {
         })
       })
 
-      describe('within', () => {
+      test.describe('within', () => {
         type Point = [number, number]
         const polygon: Point[] = [
           [9.0, 19.0], // bottom-left
@@ -785,7 +783,10 @@ describe('collections-graphql', () => {
           [9.0, 19.0], // back to starting point to close the polygon
         ]
 
-        it('should return a document with the point inside the polygon', async () => {
+        test('should return a document with the point inside the polygon', async ({
+          payload,
+          restClient,
+        }) => {
           if (payload.db.name === 'sqlite') {
             return
           }
@@ -816,7 +817,10 @@ describe('collections-graphql', () => {
           expect(docs[0].point).toEqual([10, 20])
         })
 
-        it('should not return a document with the point outside the polygon', async () => {
+        test('should not return a document with the point outside the polygon', async ({
+          payload,
+          restClient,
+        }) => {
           if (payload.db.name === 'sqlite') {
             return
           }
@@ -848,7 +852,7 @@ describe('collections-graphql', () => {
         })
       })
 
-      describe('intersects', () => {
+      test.describe('intersects', () => {
         type Point = [number, number]
         const polygon: Point[] = [
           [9.0, 19.0], // bottom-left
@@ -858,7 +862,10 @@ describe('collections-graphql', () => {
           [9.0, 19.0], // back to starting point to close the polygon
         ]
 
-        it('should return a document with the point intersecting the polygon', async () => {
+        test('should return a document with the point intersecting the polygon', async ({
+          payload,
+          restClient,
+        }) => {
           if (payload.db.name === 'sqlite') {
             return
           }
@@ -889,7 +896,10 @@ describe('collections-graphql', () => {
           expect(docs[0].point).toEqual([10, 20])
         })
 
-        it('should not return a document with the point not intersecting a smaller polygon', async () => {
+        test('should not return a document with the point not intersecting a smaller polygon', async ({
+          payload,
+          restClient,
+        }) => {
           if (payload.db.name === 'sqlite') {
             return
           }
@@ -921,8 +931,14 @@ describe('collections-graphql', () => {
         })
       })
 
-      it('can query deeply nested fields within rows, tabs, collapsibles', async () => {
-        const withNestedField = await createPost({ D1: { D2: { D3: { D4: 'nested message' } } } })
+      test('can query deeply nested fields within rows, tabs, collapsibles', async ({
+        payload,
+        restClient,
+      }) => {
+        const withNestedField = await createPost(
+          { payload },
+          { D1: { D2: { D3: { D4: 'nested message' } } } },
+        )
         const query = `{
           Posts(where: { D1__D2__D3__D4: { equals: "nested message" } }) {
             docs {
@@ -951,8 +967,8 @@ describe('collections-graphql', () => {
       })
     })
 
-    describe('relationships', () => {
-      it('should query on relationships with custom IDs', async () => {
+    test.describe('relationships', () => {
+      test('should query on relationships with custom IDs', async ({ restClient }) => {
         const query = `query {
           Posts(where: { title: { equals: "has custom ID relation" }}) {
             docs {
@@ -975,7 +991,7 @@ describe('collections-graphql', () => {
         expect(docs[0].relationToCustomID.id).toStrictEqual(1)
       })
 
-      it('should query on relationships with custom IDs - count', async () => {
+      test('should query on relationships with custom IDs - count', async ({ restClient }) => {
         const query = `query {
           countPosts(where: { title: { equals: "has custom ID relation" }}) {
             totalDocs
@@ -990,7 +1006,10 @@ describe('collections-graphql', () => {
         expect(totalDocs).toStrictEqual(1)
       })
 
-      it('should query a document with a deleted relationship', async () => {
+      test('should query a document with a deleted relationship', async ({
+        payload,
+        restClient,
+      }) => {
         const relation = await payload.create({
           collection: relationSlug,
           data: {
@@ -1032,7 +1051,10 @@ describe('collections-graphql', () => {
         expect(docs[0].relationField).toBeFalsy()
       })
 
-      it('should query a document with a deleted relationship hasMany', async () => {
+      test('should query a document with a deleted relationship hasMany', async ({
+        payload,
+        restClient,
+      }) => {
         const relation = await payload.create({
           collection: relationSlug,
           data: {
@@ -1074,7 +1096,7 @@ describe('collections-graphql', () => {
         expect(docs[0].relationHasManyField).toHaveLength(0)
       })
 
-      it('should query relationships with locale', async () => {
+      test('should query relationships with locale', async ({ payload, restClient }) => {
         const newDoc = await payload.create({
           collection: 'cyclical-relationship',
           data: {
@@ -1112,7 +1134,10 @@ describe('collections-graphql', () => {
         expect(queriedDoc.title).toEqual(queriedDoc.relationToSelf.title)
       })
 
-      it('should still query hasMany relationships when some document was deleted', async () => {
+      test('should still query hasMany relationships when some document was deleted', async ({
+        payload,
+        restClient,
+      }) => {
         const relation_1_draft = await payload.create({
           collection: 'relation',
           data: { _status: 'draft', name: 'relation_1_draft' },
@@ -1160,7 +1185,10 @@ describe('collections-graphql', () => {
         expect(queriedDoc.relationHasManyField[0].id).toBe(relation_2.id)
       })
 
-      it('should still query hasMany relationships when user doesnt have access to some document', async () => {
+      test('should still query hasMany relationships when user doesnt have access to some document', async ({
+        payload,
+        restClient,
+      }) => {
         const relation_1_draft = await payload.create({
           collection: 'relation',
           data: { name: 'restricted' },
@@ -1207,7 +1235,7 @@ describe('collections-graphql', () => {
     })
   })
 
-  it('should query correctly with draft argument', async () => {
+  test('should query correctly with draft argument', async ({ payload, restClient }) => {
     const publishValue = '1'
     const draftValue = '2'
 
@@ -1280,7 +1308,7 @@ describe('collections-graphql', () => {
     expect(queriedDoc2.relationToSelf.title).toEqual(draftValue)
   })
 
-  it('should query upload enabled docs', async () => {
+  test('should query upload enabled docs', async ({ payload, restClient }) => {
     const file = await getFileByPath(path.resolve(dirname, '../uploads/test-image.jpg'))
 
     const mediaDoc = await payload.create({
@@ -1317,8 +1345,10 @@ describe('collections-graphql', () => {
     expect(queriedDoc.media.title).toEqual('example')
   })
 
-  describe('Error Handler', () => {
-    it('should return have an array of errors when making a bad request', async () => {
+  test.describe('Error Handler', () => {
+    test('should return have an array of errors when making a bad request', async ({
+      restClient,
+    }) => {
       const query = `query {
           Posts(where: { title: { exists: true }}) {
               docs {
@@ -1335,7 +1365,9 @@ describe('collections-graphql', () => {
       expect(typeof errors[0].message).toBe('string')
     })
 
-    it('should return have an array of errors when failing to pass validation', async () => {
+    test('should return have an array of errors when failing to pass validation', async ({
+      restClient,
+    }) => {
       const query = `mutation {
           createPost(data: {min: 1}) {
               id
@@ -1355,7 +1387,9 @@ describe('collections-graphql', () => {
       expect(typeof errors[0].locations).toBeDefined()
     })
 
-    it('should return have an array of errors when failing multiple mutations', async () => {
+    test('should return have an array of errors when failing multiple mutations', async ({
+      restClient,
+    }) => {
       const query = `mutation createTest {
           test1:createUser(data: { email: "test@test.com", password: "test" }) {
               email
@@ -1408,7 +1442,9 @@ describe('collections-graphql', () => {
       expect(errors[2].extensions.data.errors[0].path).toEqual('email')
     })
 
-    it('should return the minimum allowed information about internal errors', async () => {
+    test('should return the minimum allowed information about internal errors', async ({
+      restClient,
+    }) => {
       let error
       // language=graphQL
       const query = `query {
@@ -1433,7 +1469,7 @@ describe('collections-graphql', () => {
   })
 })
 
-async function createPost(overrides?: Partial<Post>) {
+async function createPost({ payload }: { payload: Payload }, overrides?: Partial<Post>) {
   const doc = await payload.create({
     collection: slug,
     data: { title: 'title', ...overrides },

--- a/test/collections-graphql/int.spec.ts
+++ b/test/collections-graphql/int.spec.ts
@@ -10,7 +10,6 @@ import type { Post } from './payload-types.js'
 
 import { test } from '../__helpers/int/vitest.js'
 import { idToString } from '../__helpers/shared/idToString.js'
-import testConfig from './config.js'
 import { errorOnHookSlug, pointSlug, relationSlug, slug } from './shared.js'
 
 const formatID = (id: number | string) => (typeof id === 'number' ? id : `"${id}"`)
@@ -20,7 +19,7 @@ const title = 'title'
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
-test.suite({ config: testConfig })('collections-graphql', () => {
+test.suite({ config: './config.ts' })('collections-graphql', () => {
   test.describe('CRUD', () => {
     let existingDoc: Post
     let existingDocGraphQLID

--- a/test/collections-rest/config.ts
+++ b/test/collections-rest/config.ts
@@ -46,313 +46,319 @@ export const errorOnHookSlug = 'error-on-hooks'
 export const endpointsSlug = 'endpoints'
 
 export default buildConfigWithDefaults({
-  admin: {
-    importMap: {
-      baseDir: path.resolve(dirname),
-    },
-  },
-  collections: [
-    {
-      slug: postsSlug,
-      access: openAccess,
-      fields: [
-        {
-          name: 'title',
-          type: 'text',
-        },
-        {
-          name: 'description',
-          type: 'text',
-        },
-        {
-          name: 'number',
-          type: 'number',
-        },
-        {
-          name: 'fakeLocalization',
-          type: 'text',
-          // field is localized even though the config localization is not on
-          localized: true,
-        },
-        // Relationship
-        {
-          name: 'relationField',
-          type: 'relationship',
-          relationTo: relationSlug,
-        },
-        // Relation hasMany
-        {
-          name: 'relationHasManyField',
-          type: 'relationship',
-          hasMany: true,
-          relationTo: relationSlug,
-        },
-        // Relation multiple relationTo
-        {
-          name: 'relationMultiRelationTo',
-          type: 'relationship',
-          relationTo: [relationSlug, 'dummy'],
-        },
-        // Relation multiple relationTo hasMany
-        {
-          name: 'relationMultiRelationToHasMany',
-          type: 'relationship',
-          hasMany: true,
-          relationTo: [relationSlug, 'dummy'],
-        },
-        {
-          name: 'restrictedField',
-          type: 'text',
-          access: {
-            read: () => false,
-          },
-        },
-        {
-          type: 'tabs',
-          tabs: [
-            {
-              name: 'D1',
-              fields: [
-                {
-                  name: 'D2',
-                  type: 'group',
-                  fields: [
-                    {
-                      type: 'row',
-                      fields: [
-                        {
-                          type: 'collapsible',
-                          fields: [
-                            {
-                              type: 'tabs',
-                              tabs: [
-                                {
-                                  fields: [
-                                    {
-                                      name: 'D3',
-                                      type: 'group',
-                                      fields: [
-                                        {
-                                          type: 'row',
-                                          fields: [
-                                            {
-                                              type: 'collapsible',
-                                              fields: [
-                                                {
-                                                  name: 'D4',
-                                                  type: 'text',
-                                                },
-                                              ],
-                                              label: 'Collapsible2',
-                                            },
-                                          ],
-                                        },
-                                      ],
-                                    },
-                                  ],
-                                  label: 'Tab1',
-                                },
-                              ],
-                            },
-                          ],
-                          label: 'Collapsible2',
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
-              label: 'Tab1',
-            },
-          ],
-        },
-      ],
-      versions: false,
-    },
-    {
-      slug: pointSlug,
-      access: openAccess,
-      fields: [
-        {
-          name: 'point',
-          type: 'point',
-        },
-      ],
-      versions: false,
-    },
-    collectionWithName(relationSlug),
-    {
-      slug: 'dummy',
-      access: openAccess,
-      fields: [
-        {
-          name: 'title',
-          type: 'text',
-        },
-        {
-          name: 'name',
-          type: 'text',
-          access: {
-            read: () => false,
-          },
-        },
-      ],
-      versions: false,
-    },
-    {
-      slug: customIdSlug,
-      access: openAccess,
-      fields: [
-        {
-          name: 'id',
-          type: 'text',
-        },
-        {
-          type: 'row',
-          fields: [
-            {
-              name: 'name',
-              type: 'text',
-            },
-          ],
-        },
-      ],
-      versions: false,
-    },
-    {
-      slug: customIdNumberSlug,
-      access: openAccess,
-      fields: [
-        {
-          name: 'id',
-          type: 'number',
-        },
-        {
-          name: 'name',
-          type: 'text',
-        },
-      ],
-      versions: false,
-    },
-    {
-      slug: errorOnHookSlug,
-      access: openAccess,
-      fields: [
-        {
-          name: 'text',
-          type: 'text',
-        },
-        {
-          name: 'errorBeforeChange',
-          type: 'checkbox',
-        },
-        {
-          name: 'errorAfterDelete',
-          type: 'checkbox',
-        },
-      ],
-      hooks: {
-        afterDelete: [
-          ({ doc }) => {
-            if (doc?.errorAfterDelete) {
-              throw new Error('Error After Delete Thrown')
-            }
-          },
-        ],
-        beforeChange: [
-          ({ originalDoc }) => {
-            if (originalDoc?.errorBeforeChange) {
-              throw new Error('Error Before Change Thrown')
-            }
-          },
-        ],
+  suite: 'collections-rest',
+  config: {
+    admin: {
+      importMap: {
+        baseDir: path.resolve(dirname),
       },
-      versions: false,
     },
-    {
-      slug: endpointsSlug,
-      fields: [],
-      endpoints: methods.map((method) => ({
-        method,
+    bodyParser: {
+      limits: {
+        fieldSize: 2 * 1024 * 1024, // 2MB
+      },
+    },
+    collections: [
+      {
+        slug: postsSlug,
+        access: openAccess,
+        fields: [
+          {
+            name: 'title',
+            type: 'text',
+          },
+          {
+            name: 'description',
+            type: 'text',
+          },
+          {
+            name: 'number',
+            type: 'number',
+          },
+          {
+            name: 'fakeLocalization',
+            type: 'text',
+            // field is localized even though the config localization is not on
+            localized: true,
+          },
+          // Relationship
+          {
+            name: 'relationField',
+            type: 'relationship',
+            relationTo: relationSlug,
+          },
+          // Relation hasMany
+          {
+            name: 'relationHasManyField',
+            type: 'relationship',
+            hasMany: true,
+            relationTo: relationSlug,
+          },
+          // Relation multiple relationTo
+          {
+            name: 'relationMultiRelationTo',
+            type: 'relationship',
+            relationTo: [relationSlug, 'dummy'],
+          },
+          // Relation multiple relationTo hasMany
+          {
+            name: 'relationMultiRelationToHasMany',
+            type: 'relationship',
+            hasMany: true,
+            relationTo: [relationSlug, 'dummy'],
+          },
+          {
+            name: 'restrictedField',
+            type: 'text',
+            access: {
+              read: () => false,
+            },
+          },
+          {
+            type: 'tabs',
+            tabs: [
+              {
+                name: 'D1',
+                fields: [
+                  {
+                    name: 'D2',
+                    type: 'group',
+                    fields: [
+                      {
+                        type: 'row',
+                        fields: [
+                          {
+                            type: 'collapsible',
+                            fields: [
+                              {
+                                type: 'tabs',
+                                tabs: [
+                                  {
+                                    fields: [
+                                      {
+                                        name: 'D3',
+                                        type: 'group',
+                                        fields: [
+                                          {
+                                            type: 'row',
+                                            fields: [
+                                              {
+                                                type: 'collapsible',
+                                                fields: [
+                                                  {
+                                                    name: 'D4',
+                                                    type: 'text',
+                                                  },
+                                                ],
+                                                label: 'Collapsible2',
+                                              },
+                                            ],
+                                          },
+                                        ],
+                                      },
+                                    ],
+                                    label: 'Tab1',
+                                  },
+                                ],
+                              },
+                            ],
+                            label: 'Collapsible2',
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+                label: 'Tab1',
+              },
+            ],
+          },
+        ],
+        versions: false,
+      },
+      {
+        slug: pointSlug,
+        access: openAccess,
+        fields: [
+          {
+            name: 'point',
+            type: 'point',
+          },
+        ],
+        versions: false,
+      },
+      collectionWithName(relationSlug),
+      {
+        slug: 'dummy',
+        access: openAccess,
+        fields: [
+          {
+            name: 'title',
+            type: 'text',
+          },
+          {
+            name: 'name',
+            type: 'text',
+            access: {
+              read: () => false,
+            },
+          },
+        ],
+        versions: false,
+      },
+      {
+        slug: customIdSlug,
+        access: openAccess,
+        fields: [
+          {
+            name: 'id',
+            type: 'text',
+          },
+          {
+            type: 'row',
+            fields: [
+              {
+                name: 'name',
+                type: 'text',
+              },
+            ],
+          },
+        ],
+        versions: false,
+      },
+      {
+        slug: customIdNumberSlug,
+        access: openAccess,
+        fields: [
+          {
+            name: 'id',
+            type: 'number',
+          },
+          {
+            name: 'name',
+            type: 'text',
+          },
+        ],
+        versions: false,
+      },
+      {
+        slug: errorOnHookSlug,
+        access: openAccess,
+        fields: [
+          {
+            name: 'text',
+            type: 'text',
+          },
+          {
+            name: 'errorBeforeChange',
+            type: 'checkbox',
+          },
+          {
+            name: 'errorAfterDelete',
+            type: 'checkbox',
+          },
+        ],
+        hooks: {
+          afterDelete: [
+            ({ doc }) => {
+              if (doc?.errorAfterDelete) {
+                throw new Error('Error After Delete Thrown')
+              }
+            },
+          ],
+          beforeChange: [
+            ({ originalDoc }) => {
+              if (originalDoc?.errorBeforeChange) {
+                throw new Error('Error Before Change Thrown')
+              }
+            },
+          ],
+        },
+        versions: false,
+      },
+      {
+        slug: endpointsSlug,
+        endpoints: methods.map((method) => ({
+          handler: () => new Response(`${method} response`),
+          method,
+          path: `/${method}-test`,
+        })),
+        fields: [],
+        versions: false,
+      },
+      {
+        slug: 'disabled-bulk-edit-docs',
+        disableBulkEdit: true,
+        fields: [
+          {
+            name: 'text',
+            type: 'text',
+          },
+        ],
+        versions: false,
+      },
+      {
+        slug: 'disabled-bulk-delete-docs',
+        disableBulkDelete: true,
+        fields: [
+          {
+            name: 'text',
+            type: 'text',
+          },
+        ],
+        versions: false,
+      },
+      LargeDocuments,
+    ],
+    endpoints: [
+      {
+        handler: async ({ payload }) => {
+          await payload.sendEmail({
+            from: 'dev@payloadcms.com',
+            html: 'This is a test email.',
+            subject: 'Test Email',
+            to: devUser.email,
+            // to recreate a failing email transport, add the following credentials
+            // to the `email` property of `payload.init()` in `../dev.ts`
+            // the app should fail to send the email, but the error should be handled without crashing the app
+            // transportOptions: {
+            //   host: 'smtp.ethereal.email',
+            //   port: 587,
+            // },
+          })
+
+          return Response.json({ message: 'Email sent' })
+        },
+        method: 'get',
+        path: '/send-test-email',
+      },
+      {
+        handler: () => {
+          // Throwing an internal error with potentially sensitive data
+          throw new Error('Lost connection to the Pentagon. Secret data: ******')
+        },
+        method: 'get',
+        path: '/internal-error-here',
+      },
+      {
+        handler: () => {
+          // Throwing an internal error with potentially sensitive data
+          throw new APIError('Connected to the Pentagon. Secret data: ******')
+        },
+        method: 'get',
+        path: '/api-error-here',
+      },
+      ...methods.map((method) => ({
         handler: () => new Response(`${method} response`),
+        method,
         path: `/${method}-test`,
       })),
-      versions: false,
-    },
-    {
-      slug: 'disabled-bulk-edit-docs',
-      fields: [
-        {
-          name: 'text',
-          type: 'text',
-        },
-      ],
-      disableBulkEdit: true,
-      versions: false,
-    },
-    {
-      slug: 'disabled-bulk-delete-docs',
-      fields: [
-        {
-          name: 'text',
-          type: 'text',
-        },
-      ],
-      disableBulkDelete: true,
-      versions: false,
-    },
-    LargeDocuments,
-  ],
-  bodyParser: {
-    limits: {
-      fieldSize: 2 * 1024 * 1024, // 2MB
+    ],
+    typescript: {
+      outputFile: path.resolve(dirname, 'payload-types.ts'),
     },
   },
-  endpoints: [
-    {
-      handler: async ({ payload }) => {
-        await payload.sendEmail({
-          from: 'dev@payloadcms.com',
-          html: 'This is a test email.',
-          subject: 'Test Email',
-          to: devUser.email,
-          // to recreate a failing email transport, add the following credentials
-          // to the `email` property of `payload.init()` in `../dev.ts`
-          // the app should fail to send the email, but the error should be handled without crashing the app
-          // transportOptions: {
-          //   host: 'smtp.ethereal.email',
-          //   port: 587,
-          // },
-        })
-
-        return Response.json({ message: 'Email sent' })
-      },
-      method: 'get',
-      path: '/send-test-email',
-    },
-    {
-      handler: () => {
-        // Throwing an internal error with potentially sensitive data
-        throw new Error('Lost connection to the Pentagon. Secret data: ******')
-      },
-      method: 'get',
-      path: '/internal-error-here',
-    },
-    {
-      handler: () => {
-        // Throwing an internal error with potentially sensitive data
-        throw new APIError('Connected to the Pentagon. Secret data: ******')
-      },
-      method: 'get',
-      path: '/api-error-here',
-    },
-    ...methods.map((method) => ({
-      method,
-      handler: () => new Response(`${method} response`),
-      path: `/${method}-test`,
-    })),
-  ],
-  onInit: async (payload) => {
+  seed: async (payload) => {
     await payload.create({
       collection: 'users',
       data: {
@@ -442,8 +448,5 @@ export default buildConfigWithDefaults({
         name: 'name',
       },
     })
-  },
-  typescript: {
-    outputFile: path.resolve(dirname, 'payload-types.ts'),
   },
 })

--- a/test/collections-rest/int.spec.ts
+++ b/test/collections-rest/int.spec.ts
@@ -2,19 +2,18 @@ import type { Payload, SanitizedCollectionConfig } from 'payload'
 
 import { randomBytes, randomUUID } from 'crypto'
 import { serialize } from 'object-to-formdata'
-import path from 'path'
 import { APIError, NotFound } from 'payload'
 import { fileURLToPath } from 'url'
-import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { expect, vi } from 'vitest'
 
 import type { NextRESTClient } from '../__helpers/shared/NextRESTClient.js'
 import type { Relation } from './config.js'
 import type { Post } from './payload-types.js'
 
+import { test } from '../__helpers/int/vitest.js'
 import { getFormDataSize } from '../__helpers/shared/getFormDataSize.js'
-import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
 import { largeDocumentsCollectionSlug } from './collections/LargeDocuments.js'
-import {
+import testConfig, {
   customIdNumberSlug,
   customIdSlug,
   endpointsSlug,
@@ -25,36 +24,22 @@ import {
   relationSlug,
 } from './config.js'
 
-const filename = fileURLToPath(import.meta.url)
-const dirname = path.dirname(filename)
-
-let restClient: NextRESTClient
-let payload: Payload
-
-describe('collections-rest', () => {
-  beforeAll(async () => {
-    ;({ payload, restClient } = await initPayloadInt(dirname))
+test.suite({ config: testConfig })('collections-rest', () => {
+  test.beforeEach(async ({ payload }) => {
+    await clearDocs({ payload })
   })
 
-  afterAll(async () => {
-    await payload.destroy()
-  })
-
-  beforeEach(async () => {
-    await clearDocs()
-  })
-
-  describe('CRUD', () => {
-    it('should create', async () => {
+  test.describe('CRUD', () => {
+    test('should create', async ({ restClient }) => {
       const data = {
         title: 'title',
       }
-      const doc = await createPost(data)
+      const doc = await createPost({ restClient }, data)
 
       expect(doc).toMatchObject(data)
     })
 
-    it('should return 400 when request body contains malformed JSON', async () => {
+    test('should return 400 when request body contains malformed JSON', async ({ restClient }) => {
       const response = await restClient.POST(`/${postsSlug}`, {
         body: '{ invalid json',
       })
@@ -66,9 +51,9 @@ describe('collections-rest', () => {
       expect(result.errors[0].message).toEqual('Invalid JSON')
     })
 
-    it('should find', async () => {
-      const post1 = await createPost()
-      const post2 = await createPost()
+    test('should find', async ({ restClient }) => {
+      const post1 = await createPost({ restClient })
+      const post2 = await createPost({ restClient })
       const response = await restClient.GET(`/${postsSlug}`)
       const result = await response.json()
 
@@ -79,9 +64,9 @@ describe('collections-rest', () => {
       expect(result.docs).toEqual(expect.arrayContaining(expectedDocs))
     })
 
-    it('should count', async () => {
-      await createPost()
-      await createPost()
+    test('should count', async ({ restClient }) => {
+      await createPost({ restClient })
+      await createPost({ restClient })
       const response = await restClient.GET(`/${postsSlug}/count`)
       const result = await response.json()
 
@@ -89,9 +74,9 @@ describe('collections-rest', () => {
       expect(result).toEqual({ totalDocs: 2 })
     })
 
-    it('should find where id', async () => {
-      const post1 = await createPost()
-      await createPost()
+    test('should find where id', async ({ restClient }) => {
+      const post1 = await createPost({ restClient })
+      await createPost({ restClient })
       const response = await restClient.GET(`/${postsSlug}`, {
         query: {
           where: { id: { equals: post1.id } },
@@ -104,9 +89,9 @@ describe('collections-rest', () => {
       expect(result.docs[0].id).toEqual(post1.id)
     })
 
-    it('should find with pagination false', async () => {
-      const post1 = await createPost()
-      const post2 = await createPost()
+    test('should find with pagination false', async ({ payload, restClient }) => {
+      const post1 = await createPost({ restClient })
+      const post2 = await createPost({ restClient })
 
       const { docs, totalDocs } = await payload.find({
         collection: postsSlug,
@@ -121,8 +106,8 @@ describe('collections-rest', () => {
       expect(totalDocs).toEqual(2)
     })
 
-    it('should update existing', async () => {
-      const { id, description } = await createPost({ description: 'desc' })
+    test('should update existing', async ({ restClient }) => {
+      const { id, description } = await createPost({ restClient }, { description: 'desc' })
       const updatedTitle = 'updated-title'
 
       const response = await restClient.PATCH(`/${postsSlug}/${id}`, {
@@ -135,7 +120,10 @@ describe('collections-rest', () => {
       expect(doc.description).toEqual(description) // Check was not modified
     })
 
-    it('can handle REST API requests with over 1mb of multipart/form-data', async () => {
+    test('can handle REST API requests with over 1mb of multipart/form-data', async ({
+      payload,
+      restClient,
+    }) => {
       const doc = await payload.create({
         collection: largeDocumentsCollectionSlug,
         data: {},
@@ -176,10 +164,10 @@ describe('collections-rest', () => {
       expect(res.doc.array[0].text).toEqual(arrayData[0].text)
     })
 
-    describe('Bulk operations', () => {
-      it('should bulk update', async () => {
+    test.describe('Bulk operations', () => {
+      test('should bulk update', async ({ restClient }) => {
         for (let i = 0; i < 11; i++) {
-          await createPost({ description: `desc ${i}` })
+          await createPost({ restClient }, { description: `desc ${i}` })
         }
 
         const description = 'updated'
@@ -198,10 +186,10 @@ describe('collections-rest', () => {
         expect(docs.pop().description).toEqual(description)
       })
 
-      it('should bulk update with limit', async () => {
+      test('should bulk update with limit', async ({ payload, restClient }) => {
         const ids = []
         for (let i = 0; i < 3; i++) {
-          const post = await createPost({ description: `to-update` })
+          const post = await createPost({ restClient }, { description: `to-update` })
           ids.push(post.id)
         }
 
@@ -228,9 +216,9 @@ describe('collections-rest', () => {
         expect(resDocs.at(-1).description).toEqual('to-update')
       })
 
-      it('should not bulk update with a bad query', async () => {
+      test('should not bulk update with a bad query', async ({ payload, restClient }) => {
         for (let i = 0; i < 2; i++) {
-          await createPost({ description: `desc ${i}` })
+          await createPost({ restClient }, { description: `desc ${i}` })
         }
 
         const description = 'updated'
@@ -255,9 +243,12 @@ describe('collections-rest', () => {
         expect(docs.pop().description).not.toEqual(description)
       })
 
-      it('should not bulk update with a bad relationship query', async () => {
+      test('should not bulk update with a bad relationship query', async ({
+        payload,
+        restClient,
+      }) => {
         for (let i = 0; i < 2; i++) {
-          await createPost({ description: `desc ${i}` })
+          await createPost({ restClient }, { description: `desc ${i}` })
         }
 
         const description = 'updated'
@@ -285,7 +276,10 @@ describe('collections-rest', () => {
         expect(docs.pop().description).not.toEqual(description)
       })
 
-      it('should not bulk update with a read restricted field query', async () => {
+      test('should not bulk update with a read restricted field query', async ({
+        payload,
+        restClient,
+      }) => {
         const { id } = await payload.create({
           collection: postsSlug,
           data: {
@@ -315,7 +309,7 @@ describe('collections-rest', () => {
         expect(doc.description).toBeFalsy()
       })
 
-      it('should return formatted errors for bulk updates', async () => {
+      test('should return formatted errors for bulk updates', async ({ payload, restClient }) => {
         const text = 'bulk-update-test-errors'
         const errorDoc = await payload.create({
           collection: errorOnHookSlug,
@@ -350,10 +344,10 @@ describe('collections-rest', () => {
         expect(result.docs[0].text).toEqual(update)
       })
 
-      it('should bulk delete', async () => {
+      test('should bulk delete', async ({ restClient }) => {
         const count = 11
         for (let i = 0; i < count; i++) {
-          await createPost({ description: `desc ${i}` })
+          await createPost({ restClient }, { description: `desc ${i}` })
         }
 
         const response = await restClient.DELETE(`/${postsSlug}`, {
@@ -366,12 +360,12 @@ describe('collections-rest', () => {
         expect(docs).toHaveLength(count)
       })
 
-      it('should use the configured bulk delete strategy', async () => {
+      test('should use the configured bulk delete strategy', async ({ payload, restClient }) => {
         const deleteOneSpy = vi.spyOn(payload.db, 'deleteOne')
         const deleteManySpy = vi.spyOn(payload.db, 'deleteMany')
 
         const countDeleteCalls = async (count: number) => {
-          await createPosts(count)
+          await createPosts({ restClient }, count)
 
           deleteOneSpy.mockClear()
           deleteManySpy.mockClear()
@@ -405,7 +399,7 @@ describe('collections-rest', () => {
         expect(isPerDocument || many.deleteMany === few.deleteMany).toBe(true)
       })
 
-      it('should return formatted errors for bulk deletes', async () => {
+      test('should return formatted errors for bulk deletes', async ({ payload, restClient }) => {
         await payload.create({
           collection: errorOnHookSlug,
           data: {
@@ -434,9 +428,9 @@ describe('collections-rest', () => {
       })
     })
 
-    describe('Custom ID', () => {
-      describe('string', () => {
-        it('should create', async () => {
+    test.describe('Custom ID', () => {
+      test.describe('string', () => {
+        test('should create', async ({ restClient }) => {
           const customId = `custom-${randomBytes(32).toString('hex').slice(0, 12)}`
           const customIdName = 'custom-id-name'
           const { doc } = await restClient
@@ -448,7 +442,7 @@ describe('collections-rest', () => {
           expect(doc.name).toEqual(customIdName)
         })
 
-        it('should find', async () => {
+        test('should find', async ({ restClient }) => {
           const customId = `custom-${randomBytes(32).toString('hex').slice(0, 12)}`
           const { doc } = await restClient
             .POST(`/${customIdSlug}`, {
@@ -462,7 +456,7 @@ describe('collections-rest', () => {
           expect(id).toEqual(doc.id)
         })
 
-        it('should query - equals', async () => {
+        test('should query - equals', async ({ restClient }) => {
           const customId = `custom-${randomBytes(32).toString('hex').slice(0, 12)}`
           const { doc } = await restClient
             .POST(`/${customIdSlug}`, {
@@ -480,7 +474,7 @@ describe('collections-rest', () => {
           expect(docs.map(({ id }) => id)).toContain(doc.id)
         })
 
-        it('should query - like', async () => {
+        test('should query - like', async ({ restClient }) => {
           const customId = `custom-${randomBytes(32).toString('hex').slice(0, 12)}`
           const { doc } = await restClient
             .POST(`/${customIdSlug}`, {
@@ -498,7 +492,7 @@ describe('collections-rest', () => {
           expect(docs.map(({ id }) => id)).toContain(doc.id)
         })
 
-        it('should update', async () => {
+        test('should update', async ({ restClient }) => {
           const customId = `custom-${randomBytes(32).toString('hex').slice(0, 12)}`
           const { doc } = await restClient
             .POST(`/${customIdSlug}`, {
@@ -515,8 +509,8 @@ describe('collections-rest', () => {
         })
       })
 
-      describe('number', () => {
-        it('should create', async () => {
+      test.describe('number', () => {
+        test('should create', async ({ restClient }) => {
           const customId = Math.floor(Math.random() * 1_000_000) + 1
           const { doc } = await restClient
             .POST(`/${customIdNumberSlug}`, {
@@ -526,7 +520,7 @@ describe('collections-rest', () => {
           expect(doc.id).toEqual(customId)
         })
 
-        it('should find', async () => {
+        test('should find', async ({ restClient }) => {
           const customId = Math.floor(Math.random() * 1_000_000) + 1
           const { doc } = await restClient
             .POST(`/${customIdNumberSlug}`, {
@@ -539,7 +533,7 @@ describe('collections-rest', () => {
           expect(id).toEqual(doc.id)
         })
 
-        it('should update', async () => {
+        test('should update', async ({ restClient }) => {
           const customId = Math.floor(Math.random() * 1_000_000) + 1
           const { doc } = await restClient
             .POST(`/${customIdNumberSlug}`, {
@@ -554,7 +548,7 @@ describe('collections-rest', () => {
           expect(updatedDoc.name).toEqual('updated')
         })
 
-        it('should allow querying by in', async () => {
+        test('should allow querying by in', async ({ restClient }) => {
           const id = 98234698237
           await restClient.POST(`/${customIdNumberSlug}`, {
             body: JSON.stringify({ id, name: 'query using in operator' }),
@@ -572,8 +566,8 @@ describe('collections-rest', () => {
       })
     })
 
-    it('should delete', async () => {
-      const { id } = await createPost()
+    test('should delete', async ({ restClient }) => {
+      const { id } = await createPost({ restClient })
 
       const response = await restClient.DELETE(`/${postsSlug}/${id}`)
       const { doc } = await response.json()
@@ -582,8 +576,8 @@ describe('collections-rest', () => {
       expect(doc.id).toEqual(id)
     })
 
-    it('should include metadata', async () => {
-      await createPosts(11)
+    test('should include metadata', async ({ restClient }) => {
+      await createPosts({ restClient }, 11)
 
       const result = await restClient.GET(`/${postsSlug}`).then((res) => res.json())
 
@@ -598,16 +592,16 @@ describe('collections-rest', () => {
     })
   })
 
-  describe('Querying', () => {
-    it.todo('should allow querying by a field within a group')
-    describe('Relationships', () => {
+  test.describe('Querying', () => {
+    test.todo('should allow querying by a field within a group')
+    test.describe('Relationships', () => {
       let post: Post
       let relation: Relation
       let relation2: Relation
       const nameToQuery = 'name'
       const nameToQuery2 = 'name2'
 
-      beforeEach(async () => {
+      test.beforeEach(async ({ restClient }) => {
         ;({ doc: relation } = await restClient
           .POST(`/${relationSlug}`, {
             body: JSON.stringify({ name: nameToQuery }),
@@ -619,15 +613,18 @@ describe('collections-rest', () => {
           })
           .then((res) => res.json()))
 
-        post = await createPost({
-          relationField: relation.id,
-        })
+        post = await createPost(
+          { restClient },
+          {
+            relationField: relation.id,
+          },
+        )
 
-        await createPost() // Extra post to allow asserting totalDoc count
+        await createPost({ restClient }) // Extra post to allow asserting totalDoc count
       })
 
-      describe('regular relationship', () => {
-        it('query by property value', async () => {
+      test.describe('regular relationship', () => {
+        test('query by property value', async ({ restClient }) => {
           const response = await restClient.GET(`/${postsSlug}`, {
             query: {
               where: { relationField: { equals: relation.id } },
@@ -640,7 +637,7 @@ describe('collections-rest', () => {
           expect(result.totalDocs).toEqual(1)
         })
 
-        it('should count query by property value', async () => {
+        test('should count query by property value', async ({ restClient }) => {
           const response = await restClient.GET(`/${postsSlug}/count`, {
             query: {
               where: { relationField: { equals: relation.id } },
@@ -652,7 +649,7 @@ describe('collections-rest', () => {
           expect(result).toEqual({ totalDocs: 1 })
         })
 
-        it('query by id', async () => {
+        test('query by id', async ({ restClient }) => {
           const response = await restClient.GET(`/${postsSlug}`, {
             query: {
               where: { relationField: { equals: relation.id } },
@@ -665,7 +662,7 @@ describe('collections-rest', () => {
           expect(result.totalDocs).toEqual(1)
         })
 
-        it('should query LIKE by ID', async () => {
+        test('should query LIKE by ID', async ({ payload, restClient }) => {
           const post = await payload.create({
             collection: postsSlug,
             data: {
@@ -689,10 +686,13 @@ describe('collections-rest', () => {
         })
       })
 
-      it('should query nested relationship - hasMany', async () => {
-        const post1 = await createPost({
-          relationHasManyField: [relation.id, relation2.id],
-        })
+      test('should query nested relationship - hasMany', async ({ restClient }) => {
+        const post1 = await createPost(
+          { restClient },
+          {
+            relationHasManyField: [relation.id, relation2.id],
+          },
+        )
 
         const response = await restClient.GET(`/${postsSlug}`, {
           query: {
@@ -718,12 +718,15 @@ describe('collections-rest', () => {
         expect(result2.totalDocs).toEqual(1)
       })
 
-      describe('relationTo multi', () => {
-        it('nested by id', async () => {
-          const post1 = await createPost({
-            relationMultiRelationTo: { relationTo: relationSlug, value: relation.id },
-          })
-          await createPost()
+      test.describe('relationTo multi', () => {
+        test('nested by id', async ({ restClient }) => {
+          const post1 = await createPost(
+            { restClient },
+            {
+              relationMultiRelationTo: { relationTo: relationSlug, value: relation.id },
+            },
+          )
+          await createPost({ restClient })
 
           const response = await restClient.GET(`/${postsSlug}`, {
             query: {
@@ -738,11 +741,14 @@ describe('collections-rest', () => {
         })
       })
 
-      it('should query relationships by not_equals', async () => {
-        const ogPost = await createPost({
-          relationMultiRelationTo: { relationTo: relationSlug, value: relation.id },
-        })
-        await createPost()
+      test('should query relationships by not_equals', async ({ restClient }) => {
+        const ogPost = await createPost(
+          { restClient },
+          {
+            relationMultiRelationTo: { relationTo: relationSlug, value: relation.id },
+          },
+        )
+        await createPost({ restClient })
 
         const response = await restClient.GET(`/${postsSlug}`, {
           query: {
@@ -762,15 +768,18 @@ describe('collections-rest', () => {
         expect(foundExcludedDoc).toBe(false)
       })
 
-      describe('relationTo multi hasMany', () => {
-        it('nested by id', async () => {
-          const post1 = await createPost({
-            relationMultiRelationToHasMany: [
-              { relationTo: relationSlug, value: relation.id },
-              { relationTo: relationSlug, value: relation2.id },
-            ],
-          })
-          await createPost()
+      test.describe('relationTo multi hasMany', () => {
+        test('nested by id', async ({ restClient }) => {
+          const post1 = await createPost(
+            { restClient },
+            {
+              relationMultiRelationToHasMany: [
+                { relationTo: relationSlug, value: relation.id },
+                { relationTo: relationSlug, value: relation2.id },
+              ],
+            },
+          )
+          await createPost({ restClient })
 
           const response = await restClient.GET(`/${postsSlug}`, {
             query: {
@@ -796,14 +805,16 @@ describe('collections-rest', () => {
           expect(result2.totalDocs).toEqual(1)
         })
 
-        it.todo('nested by property value')
+        test.todo('nested by property value')
       })
     })
 
-    describe('Edge cases', () => {
-      it('should query a localized field without localization configured', async () => {
+    test.describe('Edge cases', () => {
+      test('should query a localized field without localization configured', async ({
+        restClient,
+      }) => {
         const test = 'test'
-        await createPost({ fakeLocalization: test })
+        await createPost({ restClient }, { fakeLocalization: test })
 
         const response = await restClient.GET(`/${postsSlug}`, {
           query: {
@@ -816,7 +827,9 @@ describe('collections-rest', () => {
         expect(result.docs).toHaveLength(1)
       })
 
-      it('should not error when attempting to sort on a field that does not exist', async () => {
+      test('should not error when attempting to sort on a field that does not exist', async ({
+        restClient,
+      }) => {
         const response = await restClient.GET(`/${postsSlug}`, {
           query: {
             sort: 'fake',
@@ -827,11 +840,11 @@ describe('collections-rest', () => {
       })
     })
 
-    describe('Operators', () => {
-      it('equals', async () => {
+    test.describe('Operators', () => {
+      test('equals', async ({ restClient }) => {
         const valueToQuery = 'valueToQuery'
-        const post1 = await createPost({ title: valueToQuery })
-        await createPost()
+        const post1 = await createPost({ restClient }, { title: valueToQuery })
+        await createPost({ restClient })
         const response = await restClient.GET(`/${postsSlug}`, {
           query: {
             where: { title: { equals: valueToQuery } },
@@ -844,10 +857,10 @@ describe('collections-rest', () => {
         expect(result.docs).toEqual([post1])
       })
 
-      it('not_equals', async () => {
-        const post1 = await createPost({ title: 'not-equals' })
-        const post2 = await createPost()
-        const post3 = await createPost({ title: undefined })
+      test('not_equals', async ({ restClient }) => {
+        const post1 = await createPost({ restClient }, { title: 'not-equals' })
+        const post2 = await createPost({ restClient })
+        const post3 = await createPost({ restClient }, { title: undefined })
         const response = await restClient.GET(`/${postsSlug}`, {
           query: {
             where: { title: { not_equals: post1.title } },
@@ -860,9 +873,9 @@ describe('collections-rest', () => {
         expect(result.docs).toEqual([post3, post2])
       })
 
-      it('in', async () => {
-        const post1 = await createPost({ title: 'my-title' })
-        await createPost()
+      test('in', async ({ restClient }) => {
+        const post1 = await createPost({ restClient }, { title: 'my-title' })
+        await createPost({ restClient })
         const response = await restClient.GET(`/${postsSlug}`, {
           query: {
             where: { title: { in: [post1.title] } },
@@ -875,9 +888,9 @@ describe('collections-rest', () => {
         expect(result.totalDocs).toEqual(1)
       })
 
-      it('not_in', async () => {
-        const post1 = await createPost({ title: 'not-me' })
-        const post2 = await createPost()
+      test('not_in', async ({ restClient }) => {
+        const post1 = await createPost({ restClient }, { title: 'not-me' })
+        const post2 = await createPost({ restClient })
         const response = await restClient.GET(`/${postsSlug}`, {
           query: {
             where: { title: { not_in: [post1.title] } },
@@ -890,15 +903,15 @@ describe('collections-rest', () => {
         expect(result.totalDocs).toEqual(1)
       })
 
-      it('not_in (relationships)', async () => {
+      test('not_in (relationships)', async ({ payload, restClient }) => {
         const relationship = await payload.create({
           collection: relationSlug,
           data: {},
         })
 
-        await createPost({ relationField: relationship.id, title: 'not-me' })
+        await createPost({ restClient }, { relationField: relationship.id, title: 'not-me' })
         // await createPost({ relationMultiRelationTo: relationship.id, title: 'not-me' })
-        const post2 = await createPost({ title: 'me' })
+        const post2 = await createPost({ restClient }, { title: 'me' })
         const response = await restClient.GET(`/${postsSlug}`, {
           query: {
             where: { relationField: { not_in: [relationship.id] } },
@@ -920,15 +933,18 @@ describe('collections-rest', () => {
         expect(emptyNotInResponse.status).toEqual(200)
       })
 
-      it('in (relationships)', async () => {
+      test('in (relationships)', async ({ payload, restClient }) => {
         const relationship = await payload.create({
           collection: relationSlug,
           data: {},
         })
 
-        const post1 = await createPost({ relationField: relationship.id, title: 'me' })
+        const post1 = await createPost(
+          { restClient },
+          { relationField: relationship.id, title: 'me' },
+        )
         // await createPost({ relationMultiRelationTo: relationship.id, title: 'not-me' })
-        await createPost({ title: 'not-me' })
+        await createPost({ restClient }, { title: 'not-me' })
         const response = await restClient.GET(`/${postsSlug}`, {
           query: {
             where: { relationField: { in: [relationship.id] } },
@@ -950,8 +966,8 @@ describe('collections-rest', () => {
         expect(emptyNotInResponse.status).toEqual(200)
       })
 
-      it('like', async () => {
-        const post1 = await createPost({ title: 'prefix-value' })
+      test('like', async ({ restClient }) => {
+        const post1 = await createPost({ restClient }, { title: 'prefix-value' })
 
         const response = await restClient.GET(`/${postsSlug}`, {
           query: {
@@ -965,15 +981,18 @@ describe('collections-rest', () => {
         expect(result.totalDocs).toEqual(1)
       })
 
-      describe('like - special characters', () => {
+      test.describe('like - special characters', () => {
         const specialCharacters = '~!@#$%^&*()_+-+[]{}|;:"<>,.?/})'
 
-        it.each(specialCharacters.split(''))(
+        test.for(specialCharacters.split(''))(
           'like - special characters - %s',
-          async (character) => {
-            const post1 = await createPost({
-              title: specialCharacters,
-            })
+          async (character, { restClient }) => {
+            const post1 = await createPost(
+              { restClient },
+              {
+                title: specialCharacters,
+              },
+            )
 
             const response = await restClient.GET(`/${postsSlug}`, {
               query: {
@@ -993,8 +1012,8 @@ describe('collections-rest', () => {
         )
       })
 
-      it('like - cyrillic characters', async () => {
-        const post1 = await createPost({ title: 'Тест' })
+      test('like - cyrillic characters', async ({ restClient }) => {
+        const post1 = await createPost({ restClient }, { title: 'Тест' })
 
         const response = await restClient.GET(`/${postsSlug}`, {
           query: {
@@ -1012,8 +1031,11 @@ describe('collections-rest', () => {
         expect(result.totalDocs).toEqual(1)
       })
 
-      it('like - cyrillic characters in multiple words', async () => {
-        const post1 = await createPost({ title: 'привет, это тест полезной нагрузки' })
+      test('like - cyrillic characters in multiple words', async ({ restClient }) => {
+        const post1 = await createPost(
+          { restClient },
+          { title: 'привет, это тест полезной нагрузки' },
+        )
 
         const response = await restClient.GET(`/${postsSlug}`, {
           query: {
@@ -1031,8 +1053,11 @@ describe('collections-rest', () => {
         expect(result.totalDocs).toEqual(1)
       })
 
-      it('like - partial word match', async () => {
-        const post = await createPost({ title: 'separate words should partially match' })
+      test('like - partial word match', async ({ restClient }) => {
+        const post = await createPost(
+          { restClient },
+          { title: 'separate words should partially match' },
+        )
         const response = await restClient.GET(`/${postsSlug}`, {
           query: {
             where: {
@@ -1049,8 +1074,8 @@ describe('collections-rest', () => {
         expect(result.totalDocs).toEqual(1)
       })
 
-      it('like - id should not crash', async () => {
-        const post = await createPost({ title: 'post' })
+      test('like - id should not crash', async ({ restClient }) => {
+        const post = await createPost({ restClient }, { title: 'post' })
 
         const response = await restClient.GET(`/${postsSlug}`, {
           query: {
@@ -1065,9 +1090,9 @@ describe('collections-rest', () => {
         expect(response.status).toEqual(200)
       })
 
-      it('exists - true', async () => {
-        const postWithDesc = await createPost({ description: 'exists' })
-        await createPost({ description: undefined })
+      test('exists - true', async ({ restClient }) => {
+        const postWithDesc = await createPost({ restClient }, { description: 'exists' })
+        await createPost({ restClient }, { description: undefined })
         const response = await restClient.GET(`/${postsSlug}`, {
           query: {
             where: {
@@ -1084,9 +1109,9 @@ describe('collections-rest', () => {
         expect(result.docs).toEqual([postWithDesc])
       })
 
-      it('exists - false', async () => {
-        const postWithoutDesc = await createPost({ description: undefined })
-        await createPost({ description: 'exists' })
+      test('exists - false', async ({ restClient }) => {
+        const postWithoutDesc = await createPost({ restClient }, { description: undefined })
+        await createPost({ restClient }, { description: 'exists' })
         const response = await restClient.GET(`/${postsSlug}`, {
           query: {
             where: {
@@ -1103,15 +1128,15 @@ describe('collections-rest', () => {
         expect(result.docs).toEqual([postWithoutDesc])
       })
 
-      describe('numbers', () => {
+      test.describe('numbers', () => {
         let post1: Post
         let post2: Post
-        beforeEach(async () => {
-          post1 = await createPost({ number: 1 })
-          post2 = await createPost({ number: 2 })
+        test.beforeEach(async ({ restClient }) => {
+          post1 = await createPost({ restClient }, { number: 1 })
+          post2 = await createPost({ restClient }, { number: 2 })
         })
 
-        it('greater_than', async () => {
+        test('greater_than', async ({ restClient }) => {
           const response = await restClient.GET(`/${postsSlug}`, {
             query: {
               where: {
@@ -1128,7 +1153,7 @@ describe('collections-rest', () => {
           expect(result.docs).toEqual([post2])
         })
 
-        it('greater_than_equal', async () => {
+        test('greater_than_equal', async ({ restClient }) => {
           const response = await restClient.GET(`/${postsSlug}`, {
             query: {
               where: {
@@ -1147,7 +1172,7 @@ describe('collections-rest', () => {
           expect(result.docs).toEqual(expect.arrayContaining(expectedDocs))
         })
 
-        it('less_than', async () => {
+        test('less_than', async ({ restClient }) => {
           const response = await restClient.GET(`/${postsSlug}`, {
             query: {
               where: {
@@ -1164,7 +1189,7 @@ describe('collections-rest', () => {
           expect(result.docs).toEqual([post1])
         })
 
-        it('less_than_equal', async () => {
+        test('less_than_equal', async ({ restClient }) => {
           const response = await restClient.GET(`/${postsSlug}`, {
             query: {
               where: {
@@ -1184,10 +1209,10 @@ describe('collections-rest', () => {
         })
       })
 
-      describe('near', () => {
+      test.describe('near', () => {
         const point = [10, 20]
         const [lat, lng] = point
-        it('should return a document near a point', async () => {
+        test('should return a document near a point', async ({ payload, restClient }) => {
           if (payload.db.name === 'sqlite') {
             return
           }
@@ -1222,7 +1247,10 @@ describe('collections-rest', () => {
           expect(resultCount.totalDocs).toBe(1)
         })
 
-        it('should omit maxDistance and return a document from minDistance', async () => {
+        test('should omit maxDistance and return a document from minDistance', async ({
+          payload,
+          restClient,
+        }) => {
           if (payload.db.name === 'sqlite') {
             return
           }
@@ -1243,7 +1271,10 @@ describe('collections-rest', () => {
           expect(result.docs).toHaveLength(1)
         })
 
-        it('should omit maxDistance and not return a document because exceeds minDistance', async () => {
+        test('should omit maxDistance and not return a document because exceeds minDistance', async ({
+          payload,
+          restClient,
+        }) => {
           if (payload.db.name === 'sqlite') {
             return
           }
@@ -1265,7 +1296,10 @@ describe('collections-rest', () => {
         })
 
         // https://github.com/payloadcms/payload/issues/14471 - ensure geospatial queries use true geodetic meters, not the distorted meters of EPSG:3857
-        it('should use true geodetic meters at high latitudes', async () => {
+        test('should use true geodetic meters at high latitudes', async ({
+          payload,
+          restClient,
+        }) => {
           if (payload.db.name === 'sqlite') {
             return
           }
@@ -1307,7 +1341,7 @@ describe('collections-rest', () => {
           }
         })
 
-        it('should not return a point far away', async () => {
+        test('should not return a point far away', async ({ payload, restClient }) => {
           if (payload.db.name === 'sqlite') {
             return
           }
@@ -1328,7 +1362,7 @@ describe('collections-rest', () => {
           expect(result.docs).toHaveLength(0)
         })
 
-        it('should sort find results by nearest distance', async () => {
+        test('should sort find results by nearest distance', async ({ payload, restClient }) => {
           if (payload.db.name === 'sqlite') {
             return
           }
@@ -1374,7 +1408,7 @@ describe('collections-rest', () => {
         })
       })
 
-      describe('within', () => {
+      test.describe('within', () => {
         type Point = [number, number]
         const polygon: Point[] = [
           [9.0, 19.0], // bottom-left
@@ -1383,7 +1417,10 @@ describe('collections-rest', () => {
           [11.0, 19.0], // bottom-right
           [9.0, 19.0], // back to starting point to close the polygon
         ]
-        it('should return a document with the point inside the polygon', async () => {
+        test('should return a document with the point inside the polygon', async ({
+          payload,
+          restClient,
+        }) => {
           if (payload.db.name === 'sqlite') {
             return
           }
@@ -1406,7 +1443,10 @@ describe('collections-rest', () => {
           expect(result.docs).toHaveLength(1)
         })
 
-        it('should not return a document with the point outside a smaller polygon', async () => {
+        test('should not return a document with the point outside a smaller polygon', async ({
+          payload,
+          restClient,
+        }) => {
           if (payload.db.name === 'sqlite') {
             return
           }
@@ -1429,7 +1469,7 @@ describe('collections-rest', () => {
         })
       })
 
-      describe('intersects', () => {
+      test.describe('intersects', () => {
         type Point = [number, number]
         const polygon: Point[] = [
           [9.0, 19.0], // bottom-left
@@ -1439,7 +1479,10 @@ describe('collections-rest', () => {
           [9.0, 19.0], // back to starting point to close the polygon
         ]
 
-        it('should return a document with the point intersecting the polygon', async () => {
+        test('should return a document with the point intersecting the polygon', async ({
+          payload,
+          restClient,
+        }) => {
           if (payload.db.name === 'sqlite') {
             return
           }
@@ -1462,7 +1505,10 @@ describe('collections-rest', () => {
           expect(result.docs).toHaveLength(1)
         })
 
-        it('should not return a document with the point not intersecting a smaller polygon', async () => {
+        test('should not return a document with the point not intersecting a smaller polygon', async ({
+          payload,
+          restClient,
+        }) => {
           if (payload.db.name === 'sqlite') {
             return
           }
@@ -1485,10 +1531,10 @@ describe('collections-rest', () => {
         })
       })
 
-      it('or', async () => {
-        const post1 = await createPost({ title: 'post1' })
-        const post2 = await createPost({ title: 'post2' })
-        await createPost()
+      test('or', async ({ restClient }) => {
+        const post1 = await createPost({ restClient }, { title: 'post1' })
+        const post2 = await createPost({ restClient }, { title: 'post2' })
+        await createPost({ restClient })
 
         const response = await restClient.GET(`/${postsSlug}`, {
           query: {
@@ -1516,9 +1562,9 @@ describe('collections-rest', () => {
         expect(result.docs).toEqual(expect.arrayContaining(expectedDocs))
       })
 
-      it('or - 1 result', async () => {
-        const post1 = await createPost({ title: 'post1' })
-        await createPost()
+      test('or - 1 result', async ({ restClient }) => {
+        const post1 = await createPost({ restClient }, { title: 'post1' })
+        await createPost({ restClient })
 
         const response = await restClient.GET(`/${postsSlug}`, {
           query: {
@@ -1546,11 +1592,11 @@ describe('collections-rest', () => {
         expect(result.docs).toEqual(expect.arrayContaining(expectedDocs))
       })
 
-      it('and', async () => {
+      test('and', async ({ restClient }) => {
         const description = 'description'
-        const post1 = await createPost({ description, title: 'post1' })
-        await createPost({ description, title: 'post2' }) // Diff title, same desc
-        await createPost()
+        const post1 = await createPost({ restClient }, { description, title: 'post1' })
+        await createPost({ restClient }, { description, title: 'post2' }) // Diff title, same desc
+        await createPost({ restClient })
 
         const response = await restClient.GET(`/${postsSlug}`, {
           query: {
@@ -1577,10 +1623,10 @@ describe('collections-rest', () => {
         expect(result.docs).toEqual([post1])
       })
 
-      describe('pagination', () => {
+      test.describe('pagination', () => {
         let relatedDoc
 
-        beforeEach(async () => {
+        test.beforeEach(async ({ payload, restClient }) => {
           relatedDoc = await payload.create({
             collection: relationSlug,
             data: {
@@ -1588,15 +1634,18 @@ describe('collections-rest', () => {
             },
           })
           for (let i = 0; i < 10; i++) {
-            await createPost({
-              number: i,
-              relationField: relatedDoc.id,
-              title: 'paginate-test',
-            })
+            await createPost(
+              { restClient },
+              {
+                number: i,
+                relationField: relatedDoc.id,
+                title: 'paginate-test',
+              },
+            )
           }
         })
 
-        it('should paginate with where query', async () => {
+        test('should paginate with where query', async ({ restClient }) => {
           const query = {
             limit: 4,
             where: {
@@ -1645,7 +1694,7 @@ describe('collections-rest', () => {
           expect(page3.totalPages).toStrictEqual(3)
         })
 
-        it('should paginate with where query on relationships', async () => {
+        test('should paginate with where query on relationships', async ({ restClient }) => {
           const query = {
             limit: 4,
             where: {
@@ -1694,14 +1743,14 @@ describe('collections-rest', () => {
           expect(page3.totalPages).toStrictEqual(3)
         })
 
-        describe('limit', () => {
-          beforeEach(async () => {
+        test.describe('limit', () => {
+          test.beforeEach(async ({ restClient }) => {
             for (let i = 0; i < 50; i++) {
-              await createPost({ number: i, title: 'limit-test' })
+              await createPost({ restClient }, { number: i, title: 'limit-test' })
             }
           })
 
-          it('should query a limited set of docs', async () => {
+          test('should query a limited set of docs', async ({ restClient }) => {
             const response = await restClient.GET(`/${postsSlug}`, {
               query: {
                 limit: 15,
@@ -1718,7 +1767,7 @@ describe('collections-rest', () => {
             expect(result.docs).toHaveLength(15)
           })
 
-          it('should query all docs when limit=0', async () => {
+          test('should query all docs when limit=0', async ({ restClient }) => {
             const response = await restClient.GET(`/${postsSlug}`, {
               query: {
                 limit: 0,
@@ -1738,10 +1787,15 @@ describe('collections-rest', () => {
         })
       })
 
-      it('can query deeply nested fields within rows, tabs, collapsibles', async () => {
-        const withDeeplyNestedField = await createPost({
-          D1: { D2: { D3: { D4: 'nested message' } } },
-        })
+      test('can query deeply nested fields within rows, tabs, collapsibles', async ({
+        restClient,
+      }) => {
+        const withDeeplyNestedField = await createPost(
+          { restClient },
+          {
+            D1: { D2: { D3: { D4: 'nested message' } } },
+          },
+        )
 
         const result = await restClient
           .GET(`/${postsSlug}`, {
@@ -1761,8 +1815,10 @@ describe('collections-rest', () => {
     })
   })
 
-  describe('Error Handler', () => {
-    it('should return the minimum allowed information about internal errors', async () => {
+  test.describe('Error Handler', () => {
+    test('should return the minimum allowed information about internal errors', async ({
+      restClient,
+    }) => {
       const response = await restClient.GET('/internal-error-here')
       const result = await response.json()
       expect(response.status).toBe(500)
@@ -1770,7 +1826,10 @@ describe('collections-rest', () => {
       expect(result.errors[0].message).toStrictEqual('Something went wrong.')
     })
 
-    it('should execute afterError hook on root level and modify result/status', async () => {
+    test('should execute afterError hook on root level and modify result/status', async ({
+      payload,
+      restClient,
+    }) => {
       let err: unknown
       let errResult: any
 
@@ -1801,7 +1860,10 @@ describe('collections-rest', () => {
       payload.config.hooks.afterError = []
     })
 
-    it('should execute afterError hook on collection level and modify result', async () => {
+    test('should execute afterError hook on collection level and modify result', async ({
+      payload,
+      restClient,
+    }) => {
       let err: unknown
       let errResult: any
       let collection: SanitizedCollectionConfig
@@ -1816,7 +1878,7 @@ describe('collections-rest', () => {
         },
       ]
 
-      const post = await createPost({})
+      const post = await createPost({ restClient }, {})
 
       const response = await restClient.GET(
         `/${postsSlug}/${typeof post.id === 'number' ? 1000 : randomUUID()}`,
@@ -1840,9 +1902,12 @@ describe('collections-rest', () => {
     })
   })
 
-  describe('Local', () => {
-    it('findByID should throw NotFound if the doc was not found, if disableErrors: true then return null', async () => {
-      const post = await createPost()
+  test.describe('Local', () => {
+    test('findByID should throw NotFound if the doc was not found, if disableErrors: true then return null', async ({
+      payload,
+      restClient,
+    }) => {
+      const post = await createPost({ restClient })
       const id = typeof post.id === 'string' ? randomUUID() : 999
       await expect(payload.findByID({ collection: 'posts', id })).rejects.toBeInstanceOf(NotFound)
       await expect(
@@ -1851,15 +1916,15 @@ describe('collections-rest', () => {
     })
   })
 
-  describe('Custom endpoints', () => {
-    it('should execute custom root endpoints', async () => {
+  test.describe('Custom endpoints', () => {
+    test('should execute custom root endpoints', async ({ restClient }) => {
       for (const method of methods) {
         const response = await restClient[method.toUpperCase()](`/${method}-test`, {})
         await expect(response.text()).resolves.toBe(`${method} response`)
       }
     })
 
-    it('should execute custom collection endpoints', async () => {
+    test('should execute custom collection endpoints', async ({ restClient }) => {
       for (const method of methods) {
         const response = await restClient[method.toUpperCase()](
           `/${endpointsSlug}/${method}-test`,
@@ -1870,7 +1935,7 @@ describe('collections-rest', () => {
     })
   })
 
-  it('should not mount auth endpoints for collection without auth', async () => {
+  test('should not mount auth endpoints for collection without auth', async ({ restClient }) => {
     const authEndpoints = [
       {
         method: 'post',
@@ -1914,7 +1979,7 @@ describe('collections-rest', () => {
     }
   })
 
-  it('should not mount upload endpoints for collection without auth', async () => {
+  test('should not mount upload endpoints for collection without auth', async ({ restClient }) => {
     const uploadEndpoints = [
       {
         method: 'get',
@@ -1937,7 +2002,10 @@ describe('collections-rest', () => {
     }
   })
 
-  it('should disable bulk edit for the collection with disableBulkEdit: true', async () => {
+  test('should disable bulk edit for the collection with disableBulkEdit: true', async ({
+    payload,
+    restClient,
+  }) => {
     const res = await restClient.PATCH('/disabled-bulk-edit-docs?where[id][equals]=0', {})
     expect(res.status).toBe(403)
 
@@ -1959,7 +2027,10 @@ describe('collections-rest', () => {
     ).resolves.toBeTruthy()
   })
 
-  it('should disable bulk delete for the collection with disableBulkDelete: true', async () => {
+  test('should disable bulk delete for the collection with disableBulkDelete: true', async ({
+    payload,
+    restClient,
+  }) => {
     const res = await restClient.DELETE('/disabled-bulk-delete-docs?where[id][equals]=0')
     expect(res.status).toBe(403)
 
@@ -1992,7 +2063,10 @@ describe('collections-rest', () => {
   })
 })
 
-async function createPost(overrides?: Partial<Post>) {
+async function createPost(
+  { restClient }: { restClient: NextRESTClient },
+  overrides?: Partial<Post>,
+) {
   const { doc } = await restClient
     .POST(`/${postsSlug}`, {
       body: JSON.stringify({ title: 'title', ...overrides }),
@@ -2001,13 +2075,13 @@ async function createPost(overrides?: Partial<Post>) {
   return doc
 }
 
-async function createPosts(count: number) {
+async function createPosts({ restClient }: { restClient: NextRESTClient }, count: number) {
   for (let i = 0; i < count; i++) {
-    await createPost()
+    await createPost({ restClient })
   }
 }
 
-async function clearDocs(): Promise<void> {
+async function clearDocs({ payload }: { payload: Payload }): Promise<void> {
   await payload.delete({
     collection: postsSlug,
     where: { id: { exists: true } },

--- a/test/collections-rest/int.spec.ts
+++ b/test/collections-rest/int.spec.ts
@@ -13,7 +13,7 @@ import type { Post } from './payload-types.js'
 import { test } from '../__helpers/int/vitest.js'
 import { getFormDataSize } from '../__helpers/shared/getFormDataSize.js'
 import { largeDocumentsCollectionSlug } from './collections/LargeDocuments.js'
-import testConfig, {
+import {
   customIdNumberSlug,
   customIdSlug,
   endpointsSlug,
@@ -24,7 +24,7 @@ import testConfig, {
   relationSlug,
 } from './config.js'
 
-test.suite({ config: testConfig })('collections-rest', () => {
+test.suite({ config: './config.ts' })('collections-rest', () => {
   test.beforeEach(async ({ payload }) => {
     await clearDocs({ payload })
   })

--- a/test/config/config.ts
+++ b/test/config/config.ts
@@ -6,118 +6,128 @@ import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
 import { devUser } from '../credentials.js'
 
 export default buildConfigWithDefaults({
-  admin: {
-    importMap: {
-      baseDir: path.resolve(dirname),
+  suite: 'config',
+  config: {
+    admin: {
+      importMap: {
+        baseDir: path.resolve(dirname),
+      },
     },
-  },
-  cli: {
-    commands: {
-      'start-server': './customScript.ts',
+    cli: {
+      commands: {
+        'start-server': './customScript.ts',
+      },
     },
-  },
-  collections: [
-    {
-      slug: 'pages',
-      labels: {
-        // Purposefully exclude `singular` to test default inheritance
-        plural: 'Pages',
-      },
-      access: {
-        create: () => true,
-        delete: () => true,
-        read: () => true,
-        update: () => true,
-      },
-      custom: {
-        externalLink: 'https://foo.bar',
-      },
-      endpoints: [
-        {
-          custom: { examples: [{ type: 'response', value: { message: 'hi' } }] },
-          handler: () => {
-            return Response.json({ message: 'hi' })
-          },
-          method: 'get',
-          path: '/hello',
+    collections: [
+      {
+        slug: 'pages',
+        access: {
+          create: () => true,
+          delete: () => true,
+          read: () => true,
+          update: () => true,
         },
-      ],
-      fields: [
-        {
-          name: 'title',
-          type: 'text',
-          custom: {
-            description: 'The title of this page',
-          },
+        custom: {
+          externalLink: 'https://foo.bar',
         },
-        {
-          name: 'myBlocks',
-          type: 'blocks',
-          blocks: [
-            {
-              slug: 'blockOne',
-              custom: {
-                description: 'The blockOne of this page',
-              },
-              fields: [
-                {
-                  name: 'blockOneField',
-                  type: 'text',
-                },
-                {
-                  name: 'blockTwoField',
-                  type: 'text',
-                },
-              ],
+        endpoints: [
+          {
+            custom: { examples: [{ type: 'response', value: { message: 'hi' } }] },
+            handler: () => {
+              return Response.json({ message: 'hi' })
             },
-          ],
-          custom: {
-            description: 'The blocks of this page',
+            method: 'get',
+            path: '/hello',
           },
+        ],
+        fields: [
+          {
+            name: 'title',
+            type: 'text',
+            custom: {
+              description: 'The title of this page',
+            },
+          },
+          {
+            name: 'myBlocks',
+            type: 'blocks',
+            blocks: [
+              {
+                slug: 'blockOne',
+                custom: {
+                  description: 'The blockOne of this page',
+                },
+                fields: [
+                  {
+                    name: 'blockOneField',
+                    type: 'text',
+                  },
+                  {
+                    name: 'blockTwoField',
+                    type: 'text',
+                  },
+                ],
+              },
+            ],
+            custom: {
+              description: 'The blocks of this page',
+            },
+          },
+        ],
+        labels: {
+          // Purposefully exclude `singular` to test default inheritance
+          plural: 'Pages',
         },
-      ],
-      versions: false,
-    },
-  ],
-  custom: { name: 'Customer portal' },
-  endpoints: [
-    {
-      custom: { description: 'Get the sanitized payload config' },
-      handler: (req) => {
-        return Response.json(req.payload.config)
+        versions: false,
       },
-      method: 'get',
-      path: '/config',
+    ],
+    cors: {
+      headers: ['x-custom-header'],
+      origins: '*',
     },
-  ],
-  globals: [
-    {
-      slug: 'my-global',
-      custom: { foo: 'bar' },
-      endpoints: [
-        {
-          custom: { params: [{ name: 'name', type: 'string', in: 'query' }] },
-          handler: (req) => {
-            const sp = new URL(req.url).searchParams
-            return Response.json({ message: `Hi ${sp.get('name')}!` })
-          },
-          method: 'get',
-          path: '/greet',
+    custom: { name: 'Customer portal' },
+    endpoints: [
+      {
+        custom: { description: 'Get the sanitized payload config' },
+        handler: (req) => {
+          return Response.json(req.payload.config)
         },
-      ],
-      fields: [
-        {
-          name: 'title',
-          type: 'text',
-          custom: {
-            description: 'The title of my global',
+        method: 'get',
+        path: '/config',
+      },
+    ],
+    globals: [
+      {
+        slug: 'my-global',
+        custom: { foo: 'bar' },
+        endpoints: [
+          {
+            custom: { params: [{ name: 'name', type: 'string', in: 'query' }] },
+            handler: (req) => {
+              const sp = new URL(req.url).searchParams
+              return Response.json({ message: `Hi ${sp.get('name')}!` })
+            },
+            method: 'get',
+            path: '/greet',
           },
-        },
-      ],
-      versions: false,
+        ],
+        fields: [
+          {
+            name: 'title',
+            type: 'text',
+            custom: {
+              description: 'The title of my global',
+            },
+          },
+        ],
+        versions: false,
+      },
+    ],
+    typescript: {
+      outputFile: path.resolve(dirname, 'payload-types.ts'),
     },
-  ],
-  onInit: async (payload) => {
+  },
+  seed: async (payload) => {
     const { totalDocs } = await payload.count({ collection: 'users' })
 
     if (totalDocs === 0) {
@@ -129,12 +139,5 @@ export default buildConfigWithDefaults({
         },
       })
     }
-  },
-  typescript: {
-    outputFile: path.resolve(dirname, 'payload-types.ts'),
-  },
-  cors: {
-    origins: '*',
-    headers: ['x-custom-header'],
   },
 })

--- a/test/config/int.spec.ts
+++ b/test/config/int.spec.ts
@@ -1,40 +1,28 @@
 import { execSync } from 'child_process'
 import { existsSync, readFileSync, rmSync } from 'fs'
 import path from 'path'
-import { type BlocksField, getPayload, type Payload } from 'payload'
+import { type BlocksField, getPayload } from 'payload'
 import { fileURLToPath } from 'url'
-import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { expect } from 'vitest'
 
-import type { NextRESTClient } from '../__helpers/shared/NextRESTClient.js'
-
+import { test } from '../__helpers/int/vitest.js'
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
-import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
+import testConfig from './config.js'
 import { testFilePath } from './testFilePath.js'
-
-let restClient: NextRESTClient
-let payload: Payload
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
-describe('Config', () => {
-  beforeAll(async () => {
-    ;({ payload, restClient } = await initPayloadInt(dirname))
-  })
-
-  afterAll(async () => {
-    await payload.destroy()
-  })
-
-  describe('payload config', () => {
-    it('allows a custom field at the config root', () => {
+test.suite({ config: testConfig })('Config', () => {
+  test.describe('payload config', () => {
+    test('allows a custom field at the config root', ({ payload }) => {
       const { config } = payload
       expect(config.custom).toEqual({
         name: 'Customer portal',
       })
     })
 
-    it('allows a custom field in the root endpoints', () => {
+    test('allows a custom field in the root endpoints', ({ payload }) => {
       const endpoints = payload.config.endpoints
       const customEndpoint = endpoints?.find((endpoint) => endpoint.path === '/config')
 
@@ -43,17 +31,20 @@ describe('Config', () => {
       })
     })
 
-    it('should allow multiple getPayload calls using different configs in same process', async () => {
+    test('should allow multiple getPayload calls using different configs in same process', async () => {
       const payload2 = await getPayload({
         key: 'payload2',
         config: await buildConfigWithDefaults({
-          collections: [
-            {
-              slug: 'payload2',
-              fields: [{ name: 'title2', type: 'text' }],
-              versions: false,
-            },
-          ],
+          suite: 'config-payload2',
+          config: {
+            collections: [
+              {
+                slug: 'payload2',
+                fields: [{ name: 'title2', type: 'text' }],
+                versions: false,
+              },
+            ],
+          },
         }),
       })
 
@@ -71,13 +62,16 @@ describe('Config', () => {
       const payload3 = await getPayload({
         key: 'payload3',
         config: await buildConfigWithDefaults({
-          collections: [
-            {
-              slug: 'payload3',
-              fields: [{ name: 'title3', type: 'text' }],
-              versions: false,
-            },
-          ],
+          suite: 'config-payload3',
+          config: {
+            collections: [
+              {
+                slug: 'payload3',
+                fields: [{ name: 'title3', type: 'text' }],
+                versions: false,
+              },
+            ],
+          },
         }),
       })
 
@@ -96,15 +90,15 @@ describe('Config', () => {
     })
   })
 
-  describe('collection config', () => {
-    it('allows a custom field in collections', () => {
+  test.describe('collection config', () => {
+    test('allows a custom field in collections', ({ payload }) => {
       const [collection] = payload.config.collections
       expect(collection.custom).toEqual({
         externalLink: 'https://foo.bar',
       })
     })
 
-    it('allows a custom field in collection endpoints', () => {
+    test('allows a custom field in collection endpoints', ({ payload }) => {
       const [collection] = payload.config.collections
       const [endpoint] = collection.endpoints || []
 
@@ -113,7 +107,7 @@ describe('Config', () => {
       })
     })
 
-    it('allows a custom field in collection fields', () => {
+    test('allows a custom field in collection fields', ({ payload }) => {
       const [collection] = payload.config.collections
       const [field] = collection.fields
 
@@ -122,7 +116,7 @@ describe('Config', () => {
       })
     })
 
-    it('allows a custom field in blocks in collection fields', () => {
+    test('allows a custom field in blocks in collection fields', ({ payload }) => {
       const [collection] = payload.config.collections
       const [, blocksField] = collection.fields
 
@@ -131,26 +125,26 @@ describe('Config', () => {
       })
     })
 
-    it('properly merges collection.labels with defaults', () => {
+    test('properly merges collection.labels with defaults', ({ payload }) => {
       const [collection] = payload.config.collections
       expect(collection?.labels).toEqual({ plural: 'Pages', singular: 'Page' })
     })
   })
 
-  describe('global config', () => {
-    it('allows a custom field in globals', () => {
+  test.describe('global config', () => {
+    test('allows a custom field in globals', ({ payload }) => {
       const [global] = payload.config.globals
       expect(global.custom).toEqual({ foo: 'bar' })
     })
 
-    it('allows a custom field in global endpoints', () => {
+    test('allows a custom field in global endpoints', ({ payload }) => {
       const [global] = payload.config.globals
       const [endpoint] = global.endpoints || []
 
       expect(endpoint.custom).toEqual({ params: [{ name: 'name', type: 'string', in: 'query' }] })
     })
 
-    it('allows a custom field in global fields', () => {
+    test('allows a custom field in global fields', ({ payload }) => {
       const [global] = payload.config.globals
       const [field] = global.fields
 
@@ -160,14 +154,14 @@ describe('Config', () => {
     })
   })
 
-  describe('cors config', () => {
-    it('includes a custom header in Access-Control-Allow-Headers', async () => {
+  test.describe('cors config', () => {
+    test('includes a custom header in Access-Control-Allow-Headers', async ({ restClient }) => {
       const response = await restClient.GET(`/pages`)
       expect(response.headers.get('Access-Control-Allow-Headers')).toContain('x-custom-header')
     })
   })
 
-  describe('bin config', () => {
+  test.describe('bin config', () => {
     const executeCLI = (command: string) => {
       execSync(`pnpm tsx "${path.resolve(dirname, 'bin.ts')}" ${command}`, {
         env: {
@@ -186,7 +180,7 @@ describe('Config', () => {
       }
     }
 
-    it.skip('should execute a custom script', () => {
+    test.skip('should execute a custom script', () => {
       deleteTestFile()
       executeCLI('start-server')
       expect(JSON.parse(readFileSync(testFilePath, 'utf-8')).docs).toHaveLength(1)

--- a/test/config/int.spec.ts
+++ b/test/config/int.spec.ts
@@ -7,13 +7,12 @@ import { expect } from 'vitest'
 
 import { test } from '../__helpers/int/vitest.js'
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
-import testConfig from './config.js'
 import { testFilePath } from './testFilePath.js'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
-test.suite({ config: testConfig })('Config', () => {
+test.suite({ config: './config.ts' })('Config', () => {
   test.describe('payload config', () => {
     test('allows a custom field at the config root', ({ payload }) => {
       const { config } = payload

--- a/test/create-payload-app/int.spec.ts
+++ b/test/create-payload-app/int.spec.ts
@@ -9,9 +9,10 @@ import path from 'path'
 import shelljs from 'shelljs'
 import tempy from 'tempy'
 import { promisify } from 'util'
-import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { expect } from 'vitest'
 
 import { configurePayloadConfig } from '../../packages/create-payload-app/src/lib/configure-payload-config.js'
+import { test } from '../__helpers/int/vitest.js'
 
 const readFile = promisify(fs.readFile)
 const writeFile = promisify(fs.writeFile)
@@ -45,15 +46,15 @@ const tanStackCreateArgs = [
   '--non-interactive',
 ]
 
-describe('create-payload-app', () => {
-  beforeAll(() => {
+test.suite({})('create-payload-app', () => {
+  test.beforeAll(() => {
     // Runs copyfiles copy app/(payload) -> dist/app/(payload)
     shelljs.exec('pnpm build:create-payload-app')
   })
 
-  describe.each(commandKeys)(`--init-next with %s`, (nextCmdKey) => {
+  test.describe.each(commandKeys)(`--init-next with %s`, (nextCmdKey) => {
     const projectDir = tempy.directory()
-    beforeEach(async () => {
+    test.beforeEach(async () => {
       if (fs.existsSync(projectDir)) {
         fs.rmSync(projectDir, { recursive: true })
       }
@@ -84,13 +85,13 @@ describe('create-payload-app', () => {
       await writeFile(tsConfigPath, userTsConfigContent, { encoding: 'utf8' })
     }, 90000)
 
-    afterEach(() => {
+    test.afterEach(() => {
       if (fs.existsSync(projectDir)) {
         fs.rmSync(projectDir, { recursive: true })
       }
     })
 
-    it('should install payload app in Next.js project', async () => {
+    test('should install payload app in Next.js project', async () => {
       expect(fs.existsSync(projectDir)).toBe(true)
 
       const firstResult = await initNext({
@@ -163,7 +164,7 @@ describe('create-payload-app', () => {
       })
     })
 
-    it('should install payload app with postgres adapter', async () => {
+    test('should install payload app with postgres adapter', async () => {
       expect(fs.existsSync(projectDir)).toBe(true)
 
       const firstResult = await initNext({
@@ -232,16 +233,16 @@ describe('create-payload-app', () => {
     })
   })
 
-  describe('official TanStack generator', () => {
+  test.describe('official TanStack generator', () => {
     let projectDir: string
 
-    afterEach(() => {
+    test.afterEach(() => {
       if (projectDir && fs.existsSync(projectDir)) {
         fs.rmSync(projectDir, { recursive: true })
       }
     })
 
-    it('should initialize and build a generated TanStack Start project', async () => {
+    test('should initialize and build a generated TanStack Start project', async () => {
       projectDir = tempy.directory()
       await createTanStackProject({ projectDir })
 
@@ -293,7 +294,7 @@ describe('create-payload-app', () => {
       await execa('pnpm', ['build'], { cwd: projectDir, stdio: 'inherit' })
     }, 300_000)
 
-    it('should initialize and build a generated TanStack Router-only project', async () => {
+    test('should initialize and build a generated TanStack Router-only project', async () => {
       projectDir = tempy.directory()
       await createTanStackProject({ projectDir, routerOnly: true })
 
@@ -360,10 +361,10 @@ describe('create-payload-app', () => {
     }, 300_000)
   })
 
-  describe('adapter replacement', () => {
+  test.describe('adapter replacement', () => {
     const projectDir = tempy.directory()
 
-    beforeEach(async () => {
+    test.beforeEach(async () => {
       if (fs.existsSync(projectDir)) {
         fs.rmSync(projectDir, { recursive: true })
       }
@@ -390,13 +391,13 @@ describe('create-payload-app', () => {
       await writeFile(tsConfigPath, userTsConfigContent, { encoding: 'utf8' })
     })
 
-    afterEach(() => {
+    test.afterEach(() => {
       if (fs.existsSync(projectDir)) {
         fs.rmSync(projectDir, { recursive: true })
       }
     })
 
-    it('should replace mongodb with postgres adapter', async () => {
+    test('should replace mongodb with postgres adapter', async () => {
       // First install with mongodb
       const firstResult = await initNext({
         '--debug': true,

--- a/test/custom-graphql/config.ts
+++ b/test/custom-graphql/config.ts
@@ -23,45 +23,51 @@ const resolveTransactionId = async (_obj, _args, context) => {
 }
 
 export default buildConfigWithDefaults({
-  admin: {
-    importMap: {
-      baseDir: path.resolve(dirname),
+  suite: 'custom-graphql',
+  config: {
+    admin: {
+      importMap: {
+        baseDir: path.resolve(dirname),
+      },
+    },
+    collections: [],
+    globals: [],
+    graphQL: {
+      mutations: (GraphQL) => {
+        return {
+          MutateTransactionID1: {
+            type: GraphQL.GraphQLString,
+            resolve: resolveTransactionId,
+          },
+          MutateTransactionID2: {
+            type: GraphQL.GraphQLString,
+            resolve: resolveTransactionId,
+          },
+        }
+      },
+      queries: (GraphQL) => {
+        return {
+          foo: {
+            type: GraphQLJSON,
+            args: {},
+            resolve: () => 'json test',
+          },
+          TransactionID1: {
+            type: GraphQL.GraphQLString,
+            resolve: resolveTransactionId,
+          },
+          TransactionID2: {
+            type: GraphQL.GraphQLString,
+            resolve: resolveTransactionId,
+          },
+        }
+      },
+    },
+    typescript: {
+      outputFile: path.resolve(dirname, 'payload-types.ts'),
     },
   },
-  collections: [],
-  globals: [],
-  graphQL: {
-    mutations: (GraphQL) => {
-      return {
-        MutateTransactionID1: {
-          type: GraphQL.GraphQLString,
-          resolve: resolveTransactionId,
-        },
-        MutateTransactionID2: {
-          type: GraphQL.GraphQLString,
-          resolve: resolveTransactionId,
-        },
-      }
-    },
-    queries: (GraphQL) => {
-      return {
-        TransactionID1: {
-          type: GraphQL.GraphQLString,
-          resolve: resolveTransactionId,
-        },
-        TransactionID2: {
-          type: GraphQL.GraphQLString,
-          resolve: resolveTransactionId,
-        },
-        foo: {
-          type: GraphQLJSON,
-          args: {},
-          resolve: () => 'json test',
-        },
-      }
-    },
-  },
-  onInit: async (payload) => {
+  seed: async (payload) => {
     await payload.create({
       collection: 'users',
       data: {
@@ -69,8 +75,5 @@ export default buildConfigWithDefaults({
         password: devUser.password,
       },
     })
-  },
-  typescript: {
-    outputFile: path.resolve(dirname, 'payload-types.ts'),
   },
 })

--- a/test/custom-graphql/int.spec.ts
+++ b/test/custom-graphql/int.spec.ts
@@ -2,9 +2,8 @@ import { fileURLToPath } from 'url'
 import { expect } from 'vitest'
 
 import { test } from '../__helpers/int/vitest.js'
-import testConfig from './config.js'
 
-test.suite({ config: testConfig })('Custom GraphQL', () => {
+test.suite({ config: './config.ts' })('Custom GraphQL', () => {
   if (
     !['cosmosdb', 'firestore', 'sqlite', 'sqlite-uuid', 'sqlite-uuidv7'].includes(
       process.env.PAYLOAD_DATABASE || '',

--- a/test/custom-graphql/int.spec.ts
+++ b/test/custom-graphql/int.spec.ts
@@ -1,35 +1,19 @@
-import type { Payload } from 'payload'
-
-import path from 'path'
 import { fileURLToPath } from 'url'
-import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { expect } from 'vitest'
 
-import type { NextRESTClient } from '../__helpers/shared/NextRESTClient.js'
+import { test } from '../__helpers/int/vitest.js'
+import testConfig from './config.js'
 
-import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
-
-let restClient: NextRESTClient
-let payload: Payload
-
-const filename = fileURLToPath(import.meta.url)
-const dirname = path.dirname(filename)
-
-describe('Custom GraphQL', () => {
-  beforeAll(async () => {
-    ;({ payload, restClient } = await initPayloadInt(dirname))
-  })
-
-  afterAll(async () => {
-    await payload.destroy()
-  })
-
+test.suite({ config: testConfig })('Custom GraphQL', () => {
   if (
     !['cosmosdb', 'firestore', 'sqlite', 'sqlite-uuid', 'sqlite-uuidv7'].includes(
       process.env.PAYLOAD_DATABASE || '',
     )
   ) {
-    describe('Isolated Transaction ID', () => {
-      it('should isolate transaction IDs between queries in the same request', async () => {
+    test.describe('Isolated Transaction ID', () => {
+      test('should isolate transaction IDs between queries in the same request', async ({
+        restClient,
+      }) => {
         const query = `query {
           TransactionID1
           TransactionID2
@@ -45,7 +29,9 @@ describe('Custom GraphQL', () => {
             data.TransactionID2 !== data.TransactionID1,
         ).toBe(true)
       })
-      it('should isolate transaction IDs between mutations in the same request', async () => {
+      test('should isolate transaction IDs between mutations in the same request', async ({
+        restClient,
+      }) => {
         const query = `mutation {
           MutateTransactionID1
           MutateTransactionID2
@@ -63,7 +49,7 @@ describe('Custom GraphQL', () => {
       })
     })
   } else {
-    it('should not run isolated transaction ID tests for sqlite (incl. uuid variants)/firestore/cosmosdb', () => {
+    test('should not run isolated transaction ID tests for sqlite (incl. uuid variants)/firestore/cosmosdb', () => {
       expect(true).toBe(true)
     })
   }

--- a/test/dashboard/config.ts
+++ b/test/dashboard/config.ts
@@ -13,273 +13,274 @@ const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
 export default buildConfigWithDefaults({
-  admin: {
-    components: {
-      afterDashboard: ['./components/BeforeOrAfterDashboard.js'],
-      beforeDashboard: ['./components/BeforeOrAfterDashboard.js'],
-      // views: {
-      //   dashboard: {
-      //     Component: {
-      //       path: './components/Revenue.tsx#default',
-      //     },
-      //   },
-      // },
-    },
-    dashboard: {
-      defaultLayout: ({ req: { user } }) => {
-        const baseWidgets: WidgetInstance[] = [
-          {
-            widgetSlug: 'collections',
-            width: 'full',
-          },
-          ...Array.from(
-            { length: 4 },
-            (_value, index): WidgetInstance<'count'> => ({
-              data: {
-                collection: index % 2 === 0 ? 'tickets' : 'events',
-                title: index % 2 === 0 ? 'Tickets' : 'Events',
-              },
-              widgetSlug: 'count',
-              width: 'x-small',
-            }),
-          ),
-          {
-            data: {
-              timeframe: 'monthly',
-              title: 'Revenue (Monthly)',
-            },
-            widgetSlug: 'revenue',
-            width: 'full',
-          },
-        ]
-
-        if (user?.email === 'dev@payloadcms.com') {
-          baseWidgets.push({
-            widgetSlug: 'private',
-            width: 'full',
-          })
-        }
-
-        const collectionQueryWidgets: WidgetInstance[] = [
-          {
-            data: {
-              limit: 3,
-              relatedCollection: 'revenue',
-              sortDirection: 'desc',
-              sortField: 'amount',
-              title: 'Top revenue entries',
-            },
-            widgetSlug: 'collection-query',
-            width: 'medium',
-          },
-          {
-            data: {
-              limit: 25,
-              relatedCollection: 'events',
-              sortDirection: 'asc',
-              sortField: 'startDate',
-              title: 'Event timeline',
-              where: {
-                location: {
-                  equals: 'Dashboard demo',
-                },
-              },
-            },
-            widgetSlug: 'collection-query',
-            width: 'medium',
-          },
-          // These intentionally stale widget configs simulate persisted JSON after migrations.
-          {
-            data: {
-              limit: 3,
-              relatedCollection: 'archived-posts',
-              sortDirection: 'desc',
-              sortField: 'updatedAt',
-              title: 'Missing collection',
-            },
-            widgetSlug: 'collection-query',
-            width: 'x-small',
-          } as unknown as WidgetInstance,
-          {
-            data: {
-              limit: 3,
-              relatedCollection: 'tickets',
-              sortDirection: 'desc',
-              sortField: 'assignee',
-              title: 'Non-sortable sort field',
-            },
-            widgetSlug: 'collection-query',
-            width: 'x-small',
-          },
-          {
-            data: {
-              limit: 3,
-              relatedCollection: 'events',
-              sortDirection: 'asc',
-              sortField: 'startDate',
-              title: 'Missing filter field',
-              where: {
-                visibility: {
-                  equals: 'public',
-                },
-              },
-            },
-            widgetSlug: 'collection-query',
-            width: 'x-small',
-          },
-          {
-            data: {
-              limit: 3,
-              relatedCollection: 'revenue',
-              sortDirection: 'desc',
-              sortField: 'total',
-              title: 'Multiple stale fields',
-              where: {
-                channel: {
-                  equals: 'enterprise',
-                },
-              },
-            },
-            widgetSlug: 'collection-query',
-            width: 'x-small',
-          },
-          // Sorts by a nested group field (`details.priority`) to exercise dot-path
-          // sorting/filtering in the widget.
-          {
-            data: {
-              limit: 5,
-              relatedCollection: 'events',
-              sortDirection: 'desc',
-              sortField: 'details.priority',
-              title: 'Events by priority',
-              where: {
-                location: {
-                  equals: 'Nested field demo',
-                },
-              },
-            },
-            widgetSlug: 'collection-query',
-            width: 'medium',
-          },
-        ]
-
-        baseWidgets.push(...collectionQueryWidgets)
-
-        baseWidgets.push({
-          data: {},
-          widgetSlug: 'activity',
-          width: 'medium',
-        })
-
-        return baseWidgets
+  suite: 'dashboard',
+  config: {
+    admin: {
+      components: {
+        afterDashboard: ['./components/BeforeOrAfterDashboard.js'],
+        beforeDashboard: ['./components/BeforeOrAfterDashboard.js'],
+        // views: {
+        //   dashboard: {
+        //     Component: {
+        //       path: './components/Revenue.tsx#default',
+        //     },
+        //   },
+        // },
       },
-      widgets: [
-        {
-          slug: 'count',
-          Component: './components/Count.tsx#default',
-          fields: [
+      dashboard: {
+        defaultLayout: ({ req: { user } }) => {
+          const baseWidgets: WidgetInstance[] = [
             {
-              name: 'title',
-              type: 'text',
-              required: true,
+              widgetSlug: 'collections',
+              width: 'full',
             },
-            {
-              name: 'collection',
-              type: 'select',
-              options: [
-                {
-                  label: 'Tickets',
-                  value: 'tickets',
+            ...Array.from(
+              { length: 4 },
+              (_value, index): WidgetInstance<'count'> => ({
+                data: {
+                  collection: index % 2 === 0 ? 'tickets' : 'events',
+                  title: index % 2 === 0 ? 'Tickets' : 'Events',
                 },
-                {
-                  label: 'Events',
-                  value: 'events',
-                },
-              ],
-            },
-          ],
-          label: {
-            en: 'Count Widget',
-            es: 'Widget de Conteo',
-          },
-          maxWidth: 'medium',
-        },
-        {
-          slug: 'private',
-          Component: './components/Private.tsx#default',
-          label: 'Private Widget',
-        },
-        {
-          slug: 'revenue',
-          Component: './components/Revenue.tsx#default',
-          // Demonstrates function form with i18n - returns localized label via t()
-          label: ({ i18n }) => (i18n.language === 'es' ? 'Gráfico de Ingresos' : 'Revenue Chart'),
-          minWidth: 'medium',
-        },
-        {
-          slug: 'page-query',
-          Component: './components/PageQuery.tsx#default',
-          label: 'Page Query Widget',
-        },
-        {
-          slug: 'configurable',
-          Component: './components/Configurable.tsx#default',
-          fields: [
+                widgetSlug: 'count',
+                width: 'x-small',
+              }),
+            ),
             {
-              name: 'title',
-              type: 'text',
-              localized: true,
-              required: true,
-            },
-            {
-              name: 'description',
-              type: 'textarea',
-              validate: (value) => {
-                if (value && value.length < 10) {
-                  return 'Description must be at least 10 characters'
-                }
-                return true
+              data: {
+                timeframe: 'monthly',
+                title: 'Revenue (Monthly)',
               },
+              widgetSlug: 'revenue',
+              width: 'full',
+            },
+          ]
+
+          if (user?.email === 'dev@payloadcms.com') {
+            baseWidgets.push({
+              widgetSlug: 'private',
+              width: 'full',
+            })
+          }
+
+          const collectionQueryWidgets: WidgetInstance[] = [
+            {
+              data: {
+                limit: 3,
+                relatedCollection: 'revenue',
+                sortDirection: 'desc',
+                sortField: 'amount',
+                title: 'Top revenue entries',
+              },
+              widgetSlug: 'collection-query',
+              width: 'medium',
             },
             {
-              name: 'relatedTicket',
-              type: 'relationship',
-              relationTo: 'tickets',
-            },
-            {
-              name: 'nestedGroup',
-              type: 'group',
-              fields: [
-                {
-                  name: 'nestedText',
-                  type: 'text',
-                  localized: true,
+              data: {
+                limit: 25,
+                relatedCollection: 'events',
+                sortDirection: 'asc',
+                sortField: 'startDate',
+                title: 'Event timeline',
+                where: {
+                  location: {
+                    equals: 'Dashboard demo',
+                  },
                 },
-              ],
+              },
+              widgetSlug: 'collection-query',
+              width: 'medium',
             },
-          ],
-          label: 'Configurable Widget',
+            // These intentionally stale widget configs simulate persisted JSON after migrations.
+            {
+              data: {
+                limit: 3,
+                relatedCollection: 'archived-posts',
+                sortDirection: 'desc',
+                sortField: 'updatedAt',
+                title: 'Missing collection',
+              },
+              widgetSlug: 'collection-query',
+              width: 'x-small',
+            } as unknown as WidgetInstance,
+            {
+              data: {
+                limit: 3,
+                relatedCollection: 'tickets',
+                sortDirection: 'desc',
+                sortField: 'assignee',
+                title: 'Non-sortable sort field',
+              },
+              widgetSlug: 'collection-query',
+              width: 'x-small',
+            },
+            {
+              data: {
+                limit: 3,
+                relatedCollection: 'events',
+                sortDirection: 'asc',
+                sortField: 'startDate',
+                title: 'Missing filter field',
+                where: {
+                  visibility: {
+                    equals: 'public',
+                  },
+                },
+              },
+              widgetSlug: 'collection-query',
+              width: 'x-small',
+            },
+            {
+              data: {
+                limit: 3,
+                relatedCollection: 'revenue',
+                sortDirection: 'desc',
+                sortField: 'total',
+                title: 'Multiple stale fields',
+                where: {
+                  channel: {
+                    equals: 'enterprise',
+                  },
+                },
+              },
+              widgetSlug: 'collection-query',
+              width: 'x-small',
+            },
+            // Sorts by a nested group field (`details.priority`) to exercise dot-path
+            // sorting/filtering in the widget.
+            {
+              data: {
+                limit: 5,
+                relatedCollection: 'events',
+                sortDirection: 'desc',
+                sortField: 'details.priority',
+                title: 'Events by priority',
+                where: {
+                  location: {
+                    equals: 'Nested field demo',
+                  },
+                },
+              },
+              widgetSlug: 'collection-query',
+              width: 'medium',
+            },
+          ]
+
+          baseWidgets.push(...collectionQueryWidgets)
+
+          baseWidgets.push({
+            data: {},
+            widgetSlug: 'activity',
+            width: 'medium',
+          })
+
+          return baseWidgets
         },
-      ],
+        widgets: [
+          {
+            slug: 'count',
+            Component: './components/Count.tsx#default',
+            fields: [
+              {
+                name: 'title',
+                type: 'text',
+                required: true,
+              },
+              {
+                name: 'collection',
+                type: 'select',
+                options: [
+                  {
+                    label: 'Tickets',
+                    value: 'tickets',
+                  },
+                  {
+                    label: 'Events',
+                    value: 'events',
+                  },
+                ],
+              },
+            ],
+            label: {
+              en: 'Count Widget',
+              es: 'Widget de Conteo',
+            },
+            maxWidth: 'medium',
+          },
+          {
+            slug: 'private',
+            Component: './components/Private.tsx#default',
+            label: 'Private Widget',
+          },
+          {
+            slug: 'revenue',
+            Component: './components/Revenue.tsx#default',
+            // Demonstrates function form with i18n - returns localized label via t()
+            label: ({ i18n }) => (i18n.language === 'es' ? 'Gráfico de Ingresos' : 'Revenue Chart'),
+            minWidth: 'medium',
+          },
+          {
+            slug: 'page-query',
+            Component: './components/PageQuery.tsx#default',
+            label: 'Page Query Widget',
+          },
+          {
+            slug: 'configurable',
+            Component: './components/Configurable.tsx#default',
+            fields: [
+              {
+                name: 'title',
+                type: 'text',
+                localized: true,
+                required: true,
+              },
+              {
+                name: 'description',
+                type: 'textarea',
+                validate: (value) => {
+                  if (value && value.length < 10) {
+                    return 'Description must be at least 10 characters'
+                  }
+                  return true
+                },
+              },
+              {
+                name: 'relatedTicket',
+                type: 'relationship',
+                relationTo: 'tickets',
+              },
+              {
+                name: 'nestedGroup',
+                type: 'group',
+                fields: [
+                  {
+                    name: 'nestedText',
+                    type: 'text',
+                    localized: true,
+                  },
+                ],
+              },
+            ],
+            label: 'Configurable Widget',
+          },
+        ],
+      },
+      importMap: {
+        baseDir: path.resolve(dirname),
+      },
     },
-    importMap: {
-      baseDir: path.resolve(dirname),
+    collections: [
+      Tickets,
+      Revenue,
+      Events,
+      // ...Array.from({ length: 35 }, () => ({
+      //   slug: `collection-${Math.random().toString(36).substring(2, 15)}`,
+      //   fields: [],
+      // })),
+    ],
+    localization: {
+      defaultLocale: 'en',
+      locales: ['en', 'es'],
     },
   },
-  collections: [
-    Tickets,
-    Revenue,
-    Events,
-    // ...Array.from({ length: 35 }, () => ({
-    //   slug: `collection-${Math.random().toString(36).substring(2, 15)}`,
-    //   fields: [],
-    // })),
-  ],
-  localization: {
-    defaultLocale: 'en',
-    locales: ['en', 'es'],
-  },
-  onInit: async (payload) => {
-    await seed(payload)
-  },
+  seed,
 })

--- a/test/dashboard/e2e.spec.ts
+++ b/test/dashboard/e2e.spec.ts
@@ -26,7 +26,6 @@ const url = new AdminUrlUtil(serverURL, 'users')
 describe('Dashboard', () => {
   beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
-    process.env.SEED_IN_CONFIG_ONINIT = 'false' // Makes it so the payload config onInit seed is not run. Otherwise, the seed would be run unnecessarily twice for the initial test run - once for beforeEach and once for onInit
     const page = await browser.newPage()
     await ensureCompilationIsDone({ page, serverURL })
     await page.close()
@@ -34,8 +33,6 @@ describe('Dashboard', () => {
   beforeEach(async ({ page }) => {
     await reInitializeDB({
       serverURL,
-      snapshotKey: 'lexicalTest',
-      uploadsDir: [path.resolve(dirname, './collections/Upload/uploads')],
     })
     await page.goto(url.admin)
   })

--- a/test/dashboard/int.spec.ts
+++ b/test/dashboard/int.spec.ts
@@ -1,5 +1,4 @@
-/* eslint-disable vitest/expect-expect */
-import { describe, expectTypeOf, it } from 'vitest'
+import { expectTypeOf } from 'vitest'
 
 import type {
   CollectionsWidget,
@@ -12,8 +11,10 @@ import type {
   Ticket,
 } from './payload-types.js'
 
-describe('Dashboard Widget Types', () => {
-  it('should add all widgets to Config', () => {
+import { test } from '../__helpers/int/vitest.js'
+
+test.suite({})('Dashboard Widget Types', () => {
+  test('should add all widgets to Config', () => {
     expectTypeOf<Config['widgets']>().toEqualTypeOf<{
       collections: CollectionsWidget
       configurable: ConfigurableWidget
@@ -24,14 +25,14 @@ describe('Dashboard Widget Types', () => {
     }>()
   })
 
-  it('should contain width and data on widget types', () => {
+  test('should contain width and data on widget types', () => {
     expectTypeOf<CountWidget>().toHaveProperty('data')
     expectTypeOf<CountWidget>().toHaveProperty('width')
     expectTypeOf<CountWidget['width']>().toEqualTypeOf<'medium' | 'small' | 'x-small'>()
     expectTypeOf<CollectionsWidget['width']>().toEqualTypeOf<'full'>()
   })
 
-  it('should mark widget data fields as required or optional', () => {
+  test('should mark widget data fields as required or optional', () => {
     type CountData = NonNullable<CountWidget['data']>
     type ConfigData = NonNullable<ConfigurableWidget['data']>
 

--- a/test/dataloader/config.ts
+++ b/test/dataloader/config.ts
@@ -10,118 +10,124 @@ import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
 import { devUser } from '../credentials.js'
 
 export default buildConfigWithDefaults({
-  admin: {
-    importMap: {
-      baseDir: path.resolve(dirname),
+  suite: 'dataloader',
+  config: {
+    admin: {
+      importMap: {
+        baseDir: path.resolve(dirname),
+      },
+    },
+    collections: [
+      {
+        slug: 'posts',
+        fields: [
+          {
+            name: 'title',
+            type: 'text',
+            required: true,
+          },
+          {
+            name: 'owner',
+            type: 'relationship',
+            hooks: {
+              beforeChange: [({ req: { user } }) => user?.id],
+            },
+            relationTo: 'users',
+          },
+        ],
+        versions: false,
+      },
+      {
+        slug: 'relation-a',
+        fields: [
+          {
+            name: 'relationship',
+            type: 'relationship',
+            relationTo: 'relation-b',
+          },
+          {
+            name: 'richText',
+            type: 'richText',
+            editor: lexicalEditor({}),
+          },
+        ],
+        labels: {
+          plural: 'Relation As',
+          singular: 'Relation A',
+        },
+        versions: false,
+      },
+      {
+        slug: 'relation-b',
+        fields: [
+          {
+            name: 'relationship',
+            type: 'relationship',
+            relationTo: 'relation-a',
+          },
+          {
+            name: 'richText',
+            type: 'richText',
+            editor: lexicalEditor({}),
+          },
+        ],
+        labels: {
+          plural: 'Relation Bs',
+          singular: 'Relation B',
+        },
+        versions: false,
+      },
+      {
+        slug: 'shops',
+        access: { read: () => true },
+        fields: [
+          {
+            name: 'name',
+            type: 'text',
+          },
+          {
+            name: 'items',
+            type: 'relationship',
+            hasMany: true,
+            relationTo: 'items',
+          },
+        ],
+        versions: false,
+      },
+      {
+        slug: 'items',
+        access: { read: () => true },
+        fields: [
+          {
+            name: 'name',
+            type: 'text',
+          },
+          {
+            name: 'itemTags',
+            type: 'relationship',
+            hasMany: true,
+            relationTo: 'itemTags',
+          },
+        ],
+        versions: false,
+      },
+      {
+        slug: 'itemTags',
+        access: { read: () => true },
+        fields: [
+          {
+            name: 'name',
+            type: 'text',
+          },
+        ],
+        versions: false,
+      },
+    ],
+    typescript: {
+      outputFile: path.resolve(dirname, 'payload-types.ts'),
     },
   },
-  collections: [
-    {
-      slug: 'posts',
-      fields: [
-        {
-          name: 'title',
-          type: 'text',
-          required: true,
-        },
-        {
-          name: 'owner',
-          type: 'relationship',
-          hooks: {
-            beforeChange: [({ req: { user } }) => user?.id],
-          },
-          relationTo: 'users',
-        },
-      ],
-      versions: false,
-    },
-    {
-      slug: 'relation-a',
-      fields: [
-        {
-          name: 'relationship',
-          type: 'relationship',
-          relationTo: 'relation-b',
-        },
-        {
-          name: 'richText',
-          type: 'richText',
-          editor: lexicalEditor({}),
-        },
-      ],
-      labels: {
-        plural: 'Relation As',
-        singular: 'Relation A',
-      },
-      versions: false,
-    },
-    {
-      slug: 'relation-b',
-      fields: [
-        {
-          name: 'relationship',
-          type: 'relationship',
-          relationTo: 'relation-a',
-        },
-        {
-          name: 'richText',
-          type: 'richText',
-          editor: lexicalEditor({}),
-        },
-      ],
-      labels: {
-        plural: 'Relation Bs',
-        singular: 'Relation B',
-      },
-      versions: false,
-    },
-    {
-      slug: 'shops',
-      access: { read: () => true },
-      fields: [
-        {
-          name: 'name',
-          type: 'text',
-        },
-        {
-          name: 'items',
-          type: 'relationship',
-          hasMany: true,
-          relationTo: 'items',
-        },
-      ],
-      versions: false,
-    },
-    {
-      slug: 'items',
-      access: { read: () => true },
-      fields: [
-        {
-          name: 'name',
-          type: 'text',
-        },
-        {
-          name: 'itemTags',
-          type: 'relationship',
-          hasMany: true,
-          relationTo: 'itemTags',
-        },
-      ],
-      versions: false,
-    },
-    {
-      slug: 'itemTags',
-      access: { read: () => true },
-      fields: [
-        {
-          name: 'name',
-          type: 'text',
-        },
-      ],
-      versions: false,
-    },
-  ],
-  onInit: async (payload) => {
+  seed: async (payload) => {
     const user = await payload.create({
       collection: 'users',
       data: {
@@ -148,9 +154,6 @@ export default buildConfigWithDefaults({
       collection: 'shops',
       data: { name: 'shop1', items: [item.id] },
     })
-  },
-  typescript: {
-    outputFile: path.resolve(dirname, 'payload-types.ts'),
   },
 })
 

--- a/test/dataloader/int.spec.ts
+++ b/test/dataloader/int.spec.ts
@@ -7,11 +7,11 @@ import { expect, vitest } from 'vitest'
 
 import { test } from '../__helpers/int/vitest.js'
 import { devUser } from '../credentials.js'
-import testConfig, { postDoc } from './config.js'
+import { postDoc } from './config.js'
 
 let token: string
 
-test.suite({ config: testConfig })('dataloader', () => {
+test.suite({ config: './config.ts' })('dataloader', () => {
   test.beforeEach(async ({ payload }) => {
     const loginResult = await payload.login({
       collection: 'users',

--- a/test/dataloader/int.spec.ts
+++ b/test/dataloader/int.spec.ts
@@ -1,28 +1,18 @@
-import type { CollectionSlug, Payload } from 'payload'
+import type { CollectionSlug } from 'payload'
 
 import { buildDefaultEditorState } from '@payloadcms/richtext-lexical'
-import path from 'path'
 import { createLocalReq } from 'payload'
 import { fileURLToPath } from 'url'
-import { afterAll, beforeAll, describe, expect, it, vitest } from 'vitest'
+import { expect, vitest } from 'vitest'
 
-import type { NextRESTClient } from '../__helpers/shared/NextRESTClient.js'
-
-import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
+import { test } from '../__helpers/int/vitest.js'
 import { devUser } from '../credentials.js'
-import { postDoc } from './config.js'
+import testConfig, { postDoc } from './config.js'
 
-let restClient: NextRESTClient
-let payload: Payload
 let token: string
 
-const filename = fileURLToPath(import.meta.url)
-const dirname = path.dirname(filename)
-
-describe('dataloader', () => {
-  beforeAll(async () => {
-    ;({ payload, restClient } = await initPayloadInt(dirname))
-
+test.suite({ config: testConfig })('dataloader', () => {
+  test.beforeEach(async ({ payload }) => {
     const loginResult = await payload.login({
       collection: 'users',
       data: {
@@ -36,12 +26,8 @@ describe('dataloader', () => {
     }
   })
 
-  afterAll(async () => {
-    await payload.destroy()
-  })
-
-  describe('graphql', () => {
-    it('should allow multiple parallel queries', async () => {
+  test.describe('graphql', () => {
+    test('should allow multiple parallel queries', async ({ restClient }) => {
       for (let i = 0; i < 100; i++) {
         const query = `
           query {
@@ -80,7 +66,7 @@ describe('dataloader', () => {
       }
     })
 
-    it('should allow querying via graphql', async () => {
+    test('should allow querying via graphql', async ({ restClient }) => {
       const query = `query {
         Posts {
           docs {
@@ -105,7 +91,7 @@ describe('dataloader', () => {
       expect(docs[0].title).toStrictEqual(postDoc.title)
     })
 
-    it('should avoid infinite loops', async () => {
+    test('should avoid infinite loops', async ({ payload }) => {
       const relationA = await payload.create({
         collection: 'relation-a',
         data: {
@@ -167,8 +153,8 @@ describe('dataloader', () => {
     })
   })
 
-  describe('find', () => {
-    it('should call the same query only once in a request', async () => {
+  test.describe('find', () => {
+    test('should call the same query only once in a request', async ({ payload }) => {
       const req = await createLocalReq({}, payload)
       const spy = vitest.spyOn(payload, 'find')
 

--- a/test/email-nodemailer/config.ts
+++ b/test/email-nodemailer/config.ts
@@ -29,12 +29,5 @@ export default buildConfigWithDefaults({
         password: devUser.password,
       },
     })
-
-    const email = await payload.sendEmail({
-      subject: 'This was sent while seeding',
-      to: 'test@example.com',
-    })
-
-    payload.logger.info({ email, msg: 'Email sent' })
   },
 })

--- a/test/email-nodemailer/config.ts
+++ b/test/email-nodemailer/config.ts
@@ -8,32 +8,33 @@ import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
 import { devUser } from '../credentials.js'
 
 export default buildConfigWithDefaults({
-  admin: {
-    importMap: {
-      baseDir: path.resolve(dirname),
+  suite: 'email-nodemailer',
+  config: {
+    admin: {
+      importMap: {
+        baseDir: path.resolve(dirname),
+      },
+    },
+    collections: [],
+    email: nodemailerAdapter(),
+    typescript: {
+      outputFile: path.resolve(dirname, 'payload-types.ts'),
     },
   },
-  collections: [],
-  email: nodemailerAdapter(),
-  onInit: async (payload) => {
-    if (process.env.SKIP_ON_INIT !== 'true') {
-      await payload.create({
-        collection: 'users',
-        data: {
-          email: devUser.email,
-          password: devUser.password,
-        },
-      })
+  seed: async (payload) => {
+    await payload.create({
+      collection: 'users',
+      data: {
+        email: devUser.email,
+        password: devUser.password,
+      },
+    })
 
-      const email = await payload.sendEmail({
-        subject: 'This was sent on init',
-        to: 'test@example.com',
-      })
+    const email = await payload.sendEmail({
+      subject: 'This was sent while seeding',
+      to: 'test@example.com',
+    })
 
-      payload.logger.info({ email, msg: 'Email sent' })
-    }
-  },
-  typescript: {
-    outputFile: path.resolve(dirname, 'payload-types.ts'),
+    payload.logger.info({ email, msg: 'Email sent' })
   },
 })

--- a/test/email-nodemailer/int.spec.ts
+++ b/test/email-nodemailer/int.spec.ts
@@ -1,7 +1,6 @@
 import type { NodemailerAdapterArgs } from '@payloadcms/email-nodemailer'
 
 import { nodemailerAdapter } from '@payloadcms/email-nodemailer'
-import { fileURLToPath } from 'url'
 import { expect, type Mock, vi } from 'vitest'
 
 import { test } from '../__helpers/int/vitest.js'
@@ -17,7 +16,7 @@ type EmailReturnType = {
 }
 
 test.suite({ config: './config.ts' })('@payloadcms/email-nodemailer', () => {
-  test.beforeEach(async () => {
+  test.beforeEach(() => {
     mockedSendEmail = vi.fn()
   })
 
@@ -25,7 +24,7 @@ test.suite({ config: './config.ts' })('@payloadcms/email-nodemailer', () => {
     test.beforeEach(async ({ payload }) => {
       // Partially mocked transport
       const mockedTransport = {
-        sendMail: async (message) => {
+        sendMail: (message) => {
           mockedSendEmail()
           return message
         },
@@ -58,7 +57,7 @@ test.suite({ config: './config.ts' })('@payloadcms/email-nodemailer', () => {
     test.beforeEach(async ({ payload }) => {
       // Partially mocked transport
       const mockedTransport = {
-        sendMail: async (message) => {
+        sendMail: (message) => {
           mockedSendEmail()
           return message
         },

--- a/test/email-nodemailer/int.spec.ts
+++ b/test/email-nodemailer/int.spec.ts
@@ -1,20 +1,15 @@
 import type { NodemailerAdapterArgs } from '@payloadcms/email-nodemailer'
-import type { Payload } from 'payload'
 
 import { nodemailerAdapter } from '@payloadcms/email-nodemailer'
-import path from 'path'
 import { fileURLToPath } from 'url'
-import { afterAll, beforeAll, beforeEach, describe, expect, it, type Mock, vi } from 'vitest'
+import { expect, type Mock, vi } from 'vitest'
 
-import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
+import { test } from '../__helpers/int/vitest.js'
+import testConfig from './config.js'
 
-let payload: Payload
 let mockedSendEmail: Mock
 
 const overrideRecipientAddress = 'overriden@example.com'
-
-const filename = fileURLToPath(import.meta.url)
-const dirname = path.dirname(filename)
 
 type EmailReturnType = {
   subject: string
@@ -22,25 +17,15 @@ type EmailReturnType = {
   to: string
 }
 
-describe('@payloadcms/email-nodemailer', () => {
-  beforeAll(async () => {
-    process.env.SKIP_ON_INIT = 'true'
-    ;({ payload } = await initPayloadInt(dirname))
-
+test.suite({ config: testConfig })('@payloadcms/email-nodemailer', () => {
+  test.beforeEach(async () => {
     mockedSendEmail = vi.fn()
   })
 
-  afterAll(async () => {
-    if (typeof payload?.db?.destroy === 'function') {
-      await payload.db.destroy()
-    }
-  })
-
-  describe('without basic config', () => {
-    beforeEach(async () => {
+  test.describe('without basic config', () => {
+    test.beforeEach(async ({ payload }) => {
       // Partially mocked transport
       const mockedTransport = {
-        // eslint-disable-next-line @typescript-eslint/require-await
         sendMail: async (message) => {
           mockedSendEmail()
           return message
@@ -59,7 +44,7 @@ describe('@payloadcms/email-nodemailer', () => {
       payload.email = mockedAdapter
     })
 
-    it('sends email with overrideRecipientAddress', async () => {
+    test('sends email with overrideRecipientAddress', async ({ payload }) => {
       const email = (await payload.email.sendEmail({
         to: 'dev@example.com',
         text: 'Hello, world!',
@@ -70,11 +55,10 @@ describe('@payloadcms/email-nodemailer', () => {
     })
   })
 
-  describe('with overrideRecipientAddress', () => {
-    beforeEach(async () => {
+  test.describe('with overrideRecipientAddress', () => {
+    test.beforeEach(async ({ payload }) => {
       // Partially mocked transport
       const mockedTransport = {
-        // eslint-disable-next-line @typescript-eslint/require-await
         sendMail: async (message) => {
           mockedSendEmail()
           return message
@@ -94,7 +78,7 @@ describe('@payloadcms/email-nodemailer', () => {
       payload.email = mockedAdapter
     })
 
-    it('sends email with overrideRecipientAddress', async () => {
+    test('sends email with overrideRecipientAddress', async ({ payload }) => {
       const email = (await payload.email.sendEmail({
         to: 'dev@example.com',
         text: 'Hello, world!',

--- a/test/email-nodemailer/int.spec.ts
+++ b/test/email-nodemailer/int.spec.ts
@@ -5,7 +5,6 @@ import { fileURLToPath } from 'url'
 import { expect, type Mock, vi } from 'vitest'
 
 import { test } from '../__helpers/int/vitest.js'
-import testConfig from './config.js'
 
 let mockedSendEmail: Mock
 
@@ -17,7 +16,7 @@ type EmailReturnType = {
   to: string
 }
 
-test.suite({ config: testConfig })('@payloadcms/email-nodemailer', () => {
+test.suite({ config: './config.ts' })('@payloadcms/email-nodemailer', () => {
   test.beforeEach(async () => {
     mockedSendEmail = vi.fn()
   })

--- a/test/email-resend/config.ts
+++ b/test/email-resend/config.ts
@@ -8,21 +8,27 @@ import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
 import { devUser } from '../credentials.js'
 
 export default buildConfigWithDefaults({
-  admin: {
-    importMap: {
-      baseDir: path.resolve(dirname),
+  suite: 'email-resend',
+  config: {
+    admin: {
+      importMap: {
+        baseDir: path.resolve(dirname),
+      },
+    },
+    collections: [],
+
+    // NOTE: The from address and api key should be properly set
+    // See email-resend README for more information
+    email: resendAdapter({
+      apiKey: process.env.RESEND_API_KEY || '',
+      defaultFromAddress: 'dev@payloadcms.com',
+      defaultFromName: 'Payload CMS',
+    }),
+    typescript: {
+      outputFile: path.resolve(dirname, 'payload-types.ts'),
     },
   },
-  collections: [],
-
-  // NOTE: The from address and api key should be properly set
-  // See email-resend README for more information
-  email: resendAdapter({
-    apiKey: process.env.RESEND_API_KEY || '',
-    defaultFromAddress: 'dev@payloadcms.com',
-    defaultFromName: 'Payload CMS',
-  }),
-  onInit: async (payload) => {
+  seed: async (payload) => {
     await payload.create({
       collection: 'users',
       data: {
@@ -38,8 +44,5 @@ export default buildConfigWithDefaults({
     })
 
     payload.logger.info({ email, msg: 'Email sent' })
-  },
-  typescript: {
-    outputFile: path.resolve(dirname, 'payload-types.ts'),
   },
 })

--- a/test/email/config.ts
+++ b/test/email/config.ts
@@ -13,15 +13,21 @@ const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
 export default buildConfigWithDefaults({
-  admin: {
-    importMap: {
-      baseDir: path.resolve(dirname),
+  suite: 'email',
+  config: {
+    admin: {
+      importMap: {
+        baseDir: path.resolve(dirname),
+      },
+    },
+    collections: [PostsCollection, MediaCollection],
+    email: nodemailerAdapter(),
+    globals: [MenuGlobal],
+    typescript: {
+      outputFile: path.resolve(dirname, 'payload-types.ts'),
     },
   },
-  collections: [PostsCollection, MediaCollection],
-  email: nodemailerAdapter(),
-  globals: [MenuGlobal],
-  onInit: async (payload) => {
+  seed: async (payload) => {
     await payload.create({
       collection: 'users',
       data: {
@@ -51,8 +57,5 @@ export default buildConfigWithDefaults({
       data: {},
       file: imageFile,
     })
-  },
-  typescript: {
-    outputFile: path.resolve(dirname, 'payload-types.ts'),
   },
 })

--- a/test/embed/config.ts
+++ b/test/embed/config.ts
@@ -10,15 +10,21 @@ const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
 export default buildConfigWithDefaults({
-  serverURL: `http://localhost:${process.env.PORT || 3000}`,
-  admin: {
-    importMap: {
-      baseDir: path.resolve(dirname),
+  suite: 'embed',
+  config: {
+    admin: {
+      importMap: {
+        baseDir: path.resolve(dirname),
+      },
+    },
+    cookiePrefix,
+    editor: lexicalEditor({}),
+    serverURL: `http://localhost:${process.env.PORT || 3000}`,
+    typescript: {
+      outputFile: path.resolve(dirname, 'payload-types.ts'),
     },
   },
-  cookiePrefix,
-  editor: lexicalEditor({}),
-  onInit: async (payload) => {
+  seed: async (payload) => {
     await payload.create({
       collection: 'users',
       data: {
@@ -26,8 +32,5 @@ export default buildConfigWithDefaults({
         password: devUser.password,
       },
     })
-  },
-  typescript: {
-    outputFile: path.resolve(dirname, 'payload-types.ts'),
   },
 })

--- a/test/endpoints/config.ts
+++ b/test/endpoints/config.ts
@@ -15,64 +15,70 @@ import {
 } from './shared.js'
 
 export default buildConfigWithDefaults({
-  admin: {
-    importMap: {
-      baseDir: path.resolve(dirname),
+  suite: 'endpoints',
+  config: {
+    admin: {
+      importMap: {
+        baseDir: path.resolve(dirname),
+      },
+    },
+    collections: [
+      {
+        slug: collectionSlug,
+        access: {
+          create: () => true,
+          delete: () => true,
+          read: () => true,
+          update: () => true,
+        },
+        endpoints: collectionEndpoints,
+        fields: [
+          {
+            name: 'title',
+            type: 'text',
+          },
+        ],
+        versions: false,
+      },
+      {
+        slug: noEndpointsCollectionSlug,
+        endpoints: false,
+        fields: [
+          {
+            name: 'name',
+            type: 'text',
+          },
+        ],
+        graphQL: false,
+        versions: false,
+      },
+    ],
+    endpoints,
+    globals: [
+      {
+        slug: globalSlug,
+        endpoints: globalEndpoints,
+        fields: [],
+        versions: false,
+      },
+      {
+        slug: noEndpointsGlobalSlug,
+        endpoints: false,
+        fields: [
+          {
+            name: 'name',
+            type: 'text',
+          },
+        ],
+        graphQL: false,
+        versions: false,
+      },
+    ],
+    typescript: {
+      outputFile: path.resolve(dirname, 'payload-types.ts'),
     },
   },
-  collections: [
-    {
-      slug: collectionSlug,
-      access: {
-        create: () => true,
-        delete: () => true,
-        read: () => true,
-        update: () => true,
-      },
-      endpoints: collectionEndpoints,
-      fields: [
-        {
-          name: 'title',
-          type: 'text',
-        },
-      ],
-      versions: false,
-    },
-    {
-      slug: noEndpointsCollectionSlug,
-      endpoints: false,
-      fields: [
-        {
-          name: 'name',
-          type: 'text',
-        },
-      ],
-      graphQL: false,
-      versions: false,
-    },
-  ],
-  endpoints,
-  globals: [
-    {
-      slug: globalSlug,
-      endpoints: globalEndpoints,
-      fields: [],
-      versions: false,
-    },
-    {
-      slug: noEndpointsGlobalSlug,
-      endpoints: false,
-      fields: [
-        {
-          name: 'name',
-          type: 'text',
-        },
-      ],
-      graphQL: false,
-      versions: false,
-    },
-  ],
-  onInit: async (payload) => {
+  seed: async (payload) => {
     await payload.create({
       collection: 'users',
       data: {
@@ -80,8 +86,5 @@ export default buildConfigWithDefaults({
         password: devUser.password,
       },
     })
-  },
-  typescript: {
-    outputFile: path.resolve(dirname, 'payload-types.ts'),
   },
 })

--- a/test/endpoints/int.spec.ts
+++ b/test/endpoints/int.spec.ts
@@ -2,7 +2,6 @@ import { fileURLToPath } from 'url'
 import { expect } from 'vitest'
 
 import { test } from '../__helpers/int/vitest.js'
-import testConfig from './config.js'
 import {
   applicationEndpoint,
   collectionSlug,
@@ -14,7 +13,7 @@ import {
   rootEndpoint,
 } from './shared.js'
 
-test.suite({ config: testConfig })('Endpoints', () => {
+test.suite({ config: './config.ts' })('Endpoints', () => {
   test.describe('Collections', () => {
     test('should GET a static endpoint', async ({ restClient }) => {
       const response = await restClient.GET(`/${collectionSlug}/say-hello/joe-bloggs`)

--- a/test/endpoints/int.spec.ts
+++ b/test/endpoints/int.spec.ts
@@ -1,11 +1,8 @@
-import path from 'path'
-import { type Payload } from 'payload'
 import { fileURLToPath } from 'url'
-import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { expect } from 'vitest'
 
-import type { NextRESTClient } from '../__helpers/shared/NextRESTClient.js'
-
-import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
+import { test } from '../__helpers/int/vitest.js'
+import testConfig from './config.js'
 import {
   applicationEndpoint,
   collectionSlug,
@@ -17,30 +14,16 @@ import {
   rootEndpoint,
 } from './shared.js'
 
-let payload: Payload
-let restClient: NextRESTClient
-
-const filename = fileURLToPath(import.meta.url)
-const dirname = path.dirname(filename)
-
-describe('Endpoints', () => {
-  beforeAll(async () => {
-    ;({ payload, restClient } = await initPayloadInt(dirname))
-  })
-
-  afterAll(async () => {
-    await payload.destroy()
-  })
-
-  describe('Collections', () => {
-    it('should GET a static endpoint', async () => {
+test.suite({ config: testConfig })('Endpoints', () => {
+  test.describe('Collections', () => {
+    test('should GET a static endpoint', async ({ restClient }) => {
       const response = await restClient.GET(`/${collectionSlug}/say-hello/joe-bloggs`)
       const data = await response.json()
       expect(response.status).toBe(200)
       expect(data.message).toStrictEqual('Hey Joey!')
     })
 
-    it('should GET an endpoint with a parameter', async () => {
+    test('should GET an endpoint with a parameter', async ({ restClient }) => {
       const name = 'George'
       const response = await restClient.GET(`/${collectionSlug}/say-hello/${name}`)
       const data = await response.json()
@@ -48,7 +31,7 @@ describe('Endpoints', () => {
       expect(data.message).toStrictEqual(`Hello ${name}!`)
     })
 
-    it('should POST an endpoint with data', async () => {
+    test('should POST an endpoint with data', async ({ restClient }) => {
       const params = { name: 'George', age: 29 }
       const response = await restClient.POST(`/${collectionSlug}/whoami`, {
         body: JSON.stringify(params),
@@ -59,14 +42,14 @@ describe('Endpoints', () => {
       expect(data.age).toStrictEqual(params.age)
     })
 
-    it('should disable built-in endpoints when false', async () => {
+    test('should disable built-in endpoints when false', async ({ restClient }) => {
       const response = await restClient.GET(`/${noEndpointsCollectionSlug}`)
       expect(response.status).toBe(501)
     })
   })
 
-  describe('Globals', () => {
-    it('should call custom endpoint', async () => {
+  test.describe('Globals', () => {
+    test('should call custom endpoint', async ({ restClient }) => {
       const params = { globals: 'response' }
       const response = await restClient.POST(`/globals/${globalSlug}/${globalEndpoint}`, {
         body: JSON.stringify(params),
@@ -76,14 +59,14 @@ describe('Endpoints', () => {
       expect(response.status).toBe(200)
       expect(params).toMatchObject(data)
     })
-    it('should disable built-in endpoints when false', async () => {
+    test('should disable built-in endpoints when false', async ({ restClient }) => {
       const response = await restClient.GET(`/globals/${noEndpointsGlobalSlug}`)
       expect(response.status).toBe(501)
     })
   })
 
-  describe('API', () => {
-    it('should call custom endpoint', async () => {
+  test.describe('API', () => {
+    test('should call custom endpoint', async ({ restClient }) => {
       const params = { app: 'response' }
       const response = await restClient.POST(`/${applicationEndpoint}`, {
         body: JSON.stringify(params),
@@ -94,7 +77,7 @@ describe('Endpoints', () => {
       expect(params).toMatchObject(data)
     })
 
-    it('should have i18n on req', async () => {
+    test('should have i18n on req', async ({ restClient }) => {
       const response = await restClient.GET(`/${applicationEndpoint}/i18n`)
       const data = await response.json()
 
@@ -103,8 +86,8 @@ describe('Endpoints', () => {
     })
   })
 
-  describe('Root', () => {
-    it('should call custom root endpoint', async () => {
+  test.describe('Root', () => {
+    test('should call custom root endpoint', async ({ restClient }) => {
       const params = { root: 'response' }
       const response = await restClient.POST(`/${rootEndpoint}`, {
         body: JSON.stringify(params),
@@ -115,7 +98,7 @@ describe('Endpoints', () => {
       expect(params).toMatchObject(data)
     })
 
-    it('should call custom OPTIONS endpoint with custom CORS headers', async () => {
+    test('should call custom OPTIONS endpoint with custom CORS headers', async ({ restClient }) => {
       const response = await restClient.OPTIONS(`/${customCorsEndpoint}`)
       const data = await response.json()
 

--- a/test/evals/config.ts
+++ b/test/evals/config.ts
@@ -9,31 +9,37 @@ const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
 export default buildConfigWithDefaults({
-  endpoints: [
-    {
-      // Serves eval-results/ static files so the Vitest HTML report's assets resolve correctly.
-      // Accessible at /api/eval-report/<filepath>
-      handler: evalReportHandler,
-      method: 'get',
-      path: '/eval-report/:filepath(.*)',
-    },
-  ],
-  admin: {
-    importMap: {
-      baseDir: path.resolve(dirname),
-    },
-    components: {
-      afterNavLinks: ['/components/EvalDashboard/NavLink.js#EvalDashboardNavLink'],
-      beforeDashboard: ['/components/DashboardInfo/index.js#DashboardInfo'],
-      views: {
-        evalDashboard: {
-          Component: '/components/EvalDashboard/index.js#EvalDashboardView',
-          path: '/eval-dashboard',
+  suite: 'evals',
+  config: {
+    admin: {
+      components: {
+        afterNavLinks: ['/components/EvalDashboard/NavLink.js#EvalDashboardNavLink'],
+        beforeDashboard: ['/components/DashboardInfo/index.js#DashboardInfo'],
+        views: {
+          evalDashboard: {
+            Component: '/components/EvalDashboard/index.js#EvalDashboardView',
+            path: '/eval-dashboard',
+          },
         },
       },
+      importMap: {
+        baseDir: path.resolve(dirname),
+      },
+    },
+    endpoints: [
+      {
+        // Serves eval-results/ static files so the Vitest HTML report's assets resolve correctly.
+        // Accessible at /api/eval-report/<filepath>
+        handler: evalReportHandler,
+        method: 'get',
+        path: '/eval-report/:filepath(.*)',
+      },
+    ],
+    typescript: {
+      outputFile: path.resolve(dirname, 'payload-types.ts'),
     },
   },
-  onInit: async (payload) => {
+  seed: async (payload) => {
     await payload.create({
       collection: 'users',
       data: {
@@ -41,8 +47,5 @@ export default buildConfigWithDefaults({
         password: devUser.password,
       },
     })
-  },
-  typescript: {
-    outputFile: path.resolve(dirname, 'payload-types.ts'),
   },
 })

--- a/test/evals/runCodegenDataset.ts
+++ b/test/evals/runCodegenDataset.ts
@@ -6,6 +6,7 @@ import path from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 import ts from 'typescript'
 import { expect as vitestExpect } from 'vitest'
+import { getPayload as getPayloadInstance } from 'payload'
 
 import type { MCPEvalDatabase } from './mcpDatabase.js'
 import type {
@@ -30,6 +31,7 @@ import { findReusableResult, recordRunResult, shouldRerun } from './runResults.j
 import { scoreConfigChange, scoreEvidence } from './scorer/index.js'
 import { accuracySummary, writeFailedCodegenAssertion } from './utils/index.js'
 import { validateConfigTypes } from './validate.js'
+import { runInit } from '../runInit.js'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const fixturesDir = path.join(__dirname, 'fixtures')
@@ -466,12 +468,15 @@ function createLazyPayload({
         }
 
         try {
-          const { initPayloadInt } = await import('../__helpers/shared/initPayloadInt.js')
-          payload = (
-            await initPayloadInt(configDir, suiteName, undefined, configFile, {
-              payloadKey: configFile,
-            })
-          ).payload
+          await runInit(suiteName, false, true, configFile)
+          const { default: configPromise } = (await import(pathToFileURL(configFilePath).href)) as {
+            default: Promise<import('payload').SanitizedConfig>
+          }
+          payload = await getPayloadInstance({
+            config: await configPromise,
+            cron: true,
+            key: configFile,
+          })
           return payload
         } finally {
           if (restoreMCPEnvironment) {

--- a/test/field-access-context/config.ts
+++ b/test/field-access-context/config.ts
@@ -11,14 +11,20 @@ const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
 export default buildConfigWithDefaults({
-  admin: {
-    importMap: {
-      baseDir: path.resolve(dirname),
+  suite: 'field-access-context',
+  config: {
+    admin: {
+      importMap: {
+        baseDir: path.resolve(dirname),
+      },
+    },
+    collections: [Parents, Children],
+    globals: [AccessContextGlobal],
+    typescript: {
+      outputFile: path.resolve(dirname, 'payload-types.ts'),
     },
   },
-  collections: [Parents, Children],
-  globals: [AccessContextGlobal],
-  onInit: async (payload) => {
+  seed: async (payload) => {
     await payload.create({
       collection: 'users',
       data: {
@@ -26,8 +32,5 @@ export default buildConfigWithDefaults({
         password: devUser.password,
       },
     })
-  },
-  typescript: {
-    outputFile: path.resolve(dirname, 'payload-types.ts'),
   },
 })

--- a/test/field-access-context/int.spec.ts
+++ b/test/field-access-context/int.spec.ts
@@ -1,30 +1,16 @@
-import type { Payload } from 'payload'
-
-import path from 'path'
 import { createLocalReq } from 'payload'
 import { fileURLToPath } from 'url'
-import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { expect } from 'vitest'
 
-import type { NextRESTClient } from '../__helpers/shared/NextRESTClient.js'
-
-import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
+import { test } from '../__helpers/int/vitest.js'
+import testConfig from './config.js'
 import { childrenSlug, globalSlug, parentsSlug, readAccessLog, resetAccessLog } from './shared.js'
-
-let payload: Payload
-let restClient: NextRESTClient
-
-const filename = fileURLToPath(import.meta.url)
-const dirname = path.dirname(filename)
 
 const childIDs: (number | string)[] = []
 const parentIDs: (number | string)[] = []
 
-describe('field access collection context', () => {
-  beforeAll(async () => {
-    ;({ payload, restClient } = await initPayloadInt(dirname))
-  })
-
-  afterEach(async () => {
+test.suite({ config: testConfig })('field access collection context', () => {
+  test.afterEach(async ({ payload }) => {
     for (const id of parentIDs) {
       await payload.delete({ id, collection: parentsSlug })
     }
@@ -38,11 +24,7 @@ describe('field access collection context', () => {
     resetAccessLog()
   })
 
-  afterAll(async () => {
-    await payload.destroy()
-  })
-
-  it('should pass collectionSlug to local create field access callbacks', async () => {
+  test('should pass collectionSlug to local create field access callbacks', async ({ payload }) => {
     const doc = await payload.create({
       collection: parentsSlug,
       data: {
@@ -62,7 +44,9 @@ describe('field access collection context', () => {
     ).toHaveLength(0)
   })
 
-  it('should pass collectionSlug to REST create field access callbacks', async () => {
+  test('should pass collectionSlug to REST create field access callbacks', async ({
+    restClient,
+  }) => {
     const response = await restClient.POST(`/${parentsSlug}`, {
       body: JSON.stringify({
         accessCreateProbe: 'rest create',
@@ -82,7 +66,7 @@ describe('field access collection context', () => {
     ).toHaveLength(0)
   })
 
-  it('should pass collectionSlug to local read field access callbacks', async () => {
+  test('should pass collectionSlug to local read field access callbacks', async ({ payload }) => {
     const doc = await payload.create({
       collection: parentsSlug,
       data: {
@@ -108,7 +92,10 @@ describe('field access collection context', () => {
     ).toHaveLength(0)
   })
 
-  it('should pass collectionSlug to REST read field access callbacks', async () => {
+  test('should pass collectionSlug to REST read field access callbacks', async ({
+    payload,
+    restClient,
+  }) => {
     const doc = await payload.create({
       collection: parentsSlug,
       data: {
@@ -131,7 +118,10 @@ describe('field access collection context', () => {
     ).toHaveLength(0)
   })
 
-  it('should pass collectionSlug to GraphQL read field access callbacks', async () => {
+  test('should pass collectionSlug to GraphQL read field access callbacks', async ({
+    payload,
+    restClient,
+  }) => {
     const doc = await payload.create({
       collection: parentsSlug,
       data: {
@@ -165,7 +155,9 @@ describe('field access collection context', () => {
     ).toHaveLength(0)
   })
 
-  it('should pass child collectionSlug when reading populated relationship children', async () => {
+  test('should pass child collectionSlug when reading populated relationship children', async ({
+    payload,
+  }) => {
     const child = await payload.create({
       collection: childrenSlug,
       data: {
@@ -202,7 +194,7 @@ describe('field access collection context', () => {
     ).toHaveLength(0)
   })
 
-  it('should pass collectionSlug to update field access callbacks', async () => {
+  test('should pass collectionSlug to update field access callbacks', async ({ payload }) => {
     const doc = await payload.create({
       collection: parentsSlug,
       data: {
@@ -230,7 +222,7 @@ describe('field access collection context', () => {
     ).toHaveLength(0)
   })
 
-  it('should pass collectionSlug to findDistinct field access callbacks', async () => {
+  test('should pass collectionSlug to findDistinct field access callbacks', async ({ payload }) => {
     const firstDoc = await payload.create({
       collection: parentsSlug,
       data: {
@@ -265,7 +257,9 @@ describe('field access collection context', () => {
     ).toHaveLength(0)
   })
 
-  it('should pass collectionSlug when building collection field permissions', async () => {
+  test('should pass collectionSlug when building collection field permissions', async ({
+    payload,
+  }) => {
     // payload.auth() calls getEntityPermissions for all registered collections,
     // which calls populateFieldPermissions → field.access[operation] for each field.
     const req = await createLocalReq({}, payload)
@@ -284,7 +278,9 @@ describe('field access collection context', () => {
     ).toHaveLength(0)
   })
 
-  it('should leave collectionSlug undefined and set globalSlug for global field access callbacks', async () => {
+  test('should leave collectionSlug undefined and set globalSlug for global field access callbacks', async ({
+    payload,
+  }) => {
     await payload.updateGlobal({
       slug: globalSlug,
       data: {
@@ -316,7 +312,9 @@ describe('field access collection context', () => {
     ).toHaveLength(0)
   })
 
-  it('should pass child collectionSlug when reading a populated relationship child from a global', async () => {
+  test('should pass child collectionSlug when reading a populated relationship child from a global', async ({
+    payload,
+  }) => {
     const child = await payload.create({
       collection: childrenSlug,
       data: {

--- a/test/field-access-context/int.spec.ts
+++ b/test/field-access-context/int.spec.ts
@@ -3,13 +3,12 @@ import { fileURLToPath } from 'url'
 import { expect } from 'vitest'
 
 import { test } from '../__helpers/int/vitest.js'
-import testConfig from './config.js'
 import { childrenSlug, globalSlug, parentsSlug, readAccessLog, resetAccessLog } from './shared.js'
 
 const childIDs: (number | string)[] = []
 const parentIDs: (number | string)[] = []
 
-test.suite({ config: testConfig })('field access collection context', () => {
+test.suite({ config: './config.ts' })('field access collection context', () => {
   test.afterEach(async ({ payload }) => {
     for (const id of parentIDs) {
       await payload.delete({ id, collection: parentsSlug })

--- a/test/field-error-states/config.ts
+++ b/test/field-error-states/config.ts
@@ -15,28 +15,27 @@ import { GlobalValidateDraftsOn } from './globals/ValidateDraftsOn/index.js'
 import { seed } from './seed.js'
 
 export default buildConfigWithDefaults({
-  admin: {
-    importMap: {
-      baseDir: path.resolve(dirname),
+  suite: 'field-error-states',
+  config: {
+    admin: {
+      importMap: {
+        baseDir: path.resolve(dirname),
+      },
+    },
+    collections: [
+      ErrorFieldsCollection,
+      Uploads,
+      ValidateDraftsOn,
+      ValidateDraftsOff,
+      ValidateDraftsOnAndAutosave,
+      PrevValue,
+      PrevValueRelation,
+      TabErrorReset,
+    ],
+    globals: [GlobalValidateDraftsOn],
+    typescript: {
+      outputFile: path.resolve(dirname, 'payload-types.ts'),
     },
   },
-  collections: [
-    ErrorFieldsCollection,
-    Uploads,
-    ValidateDraftsOn,
-    ValidateDraftsOff,
-    ValidateDraftsOnAndAutosave,
-    PrevValue,
-    PrevValueRelation,
-    TabErrorReset,
-  ],
-  globals: [GlobalValidateDraftsOn],
-  onInit: async (payload) => {
-    if (process.env.SEED_IN_CONFIG_ONINIT !== 'false') {
-      await seed(payload)
-    }
-  },
-  typescript: {
-    outputFile: path.resolve(dirname, 'payload-types.ts'),
-  },
+  seed,
 })

--- a/test/field-error-states/e2e.spec.ts
+++ b/test/field-error-states/e2e.spec.ts
@@ -58,7 +58,6 @@ describe('Field Error States', () => {
 
     await reInitializeDB({
       serverURL,
-      snapshotKey: 'fielderrorstates',
     })
   })
 

--- a/test/field-paths/config.ts
+++ b/test/field-paths/config.ts
@@ -9,13 +9,19 @@ import { devUser } from '../credentials.js'
 import { FieldPaths } from './collections/FieldPaths/index.js'
 
 export const HooksConfig: Promise<SanitizedConfig> = buildConfigWithDefaults({
-  admin: {
-    importMap: {
-      baseDir: path.resolve(dirname),
+  suite: 'field-paths',
+  config: {
+    admin: {
+      importMap: {
+        baseDir: path.resolve(dirname),
+      },
+    },
+    collections: [FieldPaths],
+    typescript: {
+      outputFile: path.resolve(dirname, 'payload-types.ts'),
     },
   },
-  collections: [FieldPaths],
-  onInit: async (payload) => {
+  seed: async (payload) => {
     await payload.create({
       collection: 'users',
       data: {
@@ -23,9 +29,6 @@ export const HooksConfig: Promise<SanitizedConfig> = buildConfigWithDefaults({
         password: devUser.password,
       },
     })
-  },
-  typescript: {
-    outputFile: path.resolve(dirname, 'payload-types.ts'),
   },
 })
 

--- a/test/field-paths/int.spec.ts
+++ b/test/field-paths/int.spec.ts
@@ -1,37 +1,17 @@
-import type { Payload, SanitizedConfig } from 'payload'
-
 import { initI18n } from '@payloadcms/translations'
-import path from 'path'
 import { fileURLToPath } from 'url'
-import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { expect } from 'vitest'
 
 // eslint-disable-next-line payload/no-relative-monorepo-imports
 import { buildFieldSchemaMap } from '../../packages/ui/src/utilities/buildFieldSchemaMap/index.js'
-import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
+import { test } from '../__helpers/int/vitest.js'
+import testConfig from './config.js'
 import { fieldPathsSlug } from './shared.js'
 import { testDoc } from './testDoc.js'
 
-let payload: Payload
-let config: SanitizedConfig
-
-const filename = fileURLToPath(import.meta.url)
-const dirname = path.dirname(filename)
-
-describe('Field Paths', () => {
-  beforeAll(async () => {
-    const initResult = await initPayloadInt(dirname)
-    config = initResult.config
-    payload = initResult.payload
-  })
-
-  afterAll(async () => {
-    if (typeof payload.db.destroy === 'function') {
-      await payload.db.destroy()
-    }
-  })
-
-  describe('hooks', () => {
-    it('should pass correct field paths through field hooks', async () => {
+test.suite({ config: testConfig })('Field Paths', () => {
+  test.describe('hooks', () => {
+    test('should pass correct field paths through field hooks', async ({ payload }) => {
       const formatExpectedFieldPaths = (
         fieldIdentifier: string,
         {
@@ -153,8 +133,8 @@ describe('Field Paths', () => {
     })
   })
 
-  describe('field schema map', () => {
-    it('should build a field schema map with correct field schema paths', async () => {
+  test.describe('field schema map', () => {
+    test('should build a field schema map with correct field schema paths', async ({ config }) => {
       const i18n = await initI18n({
         config: config.i18n,
         context: 'client',

--- a/test/field-paths/int.spec.ts
+++ b/test/field-paths/int.spec.ts
@@ -5,11 +5,10 @@ import { expect } from 'vitest'
 // eslint-disable-next-line payload/no-relative-monorepo-imports
 import { buildFieldSchemaMap } from '../../packages/ui/src/utilities/buildFieldSchemaMap/index.js'
 import { test } from '../__helpers/int/vitest.js'
-import testConfig from './config.js'
 import { fieldPathsSlug } from './shared.js'
 import { testDoc } from './testDoc.js'
 
-test.suite({ config: testConfig })('Field Paths', () => {
+test.suite({ config: './config.ts' })('Field Paths', () => {
   test.describe('hooks', () => {
     test('should pass correct field paths through field hooks', async ({ payload }) => {
       const formatExpectedFieldPaths = (

--- a/test/field-perf/config.ts
+++ b/test/field-perf/config.ts
@@ -6,71 +6,77 @@ import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
 import { devUser } from '../credentials.js'
 
 export default buildConfigWithDefaults({
-  admin: {
-    importMap: {
-      baseDir: path.resolve(dirname),
+  suite: 'field-perf',
+  config: {
+    admin: {
+      importMap: {
+        baseDir: path.resolve(dirname),
+      },
+    },
+    collections: [
+      {
+        slug: 'blocks-collection',
+        fields: [
+          {
+            name: 'layout',
+            type: 'blocks',
+            blocks: [
+              {
+                slug: 'content',
+                fields: [
+                  {
+                    name: 'richText',
+                    type: 'richText',
+                  },
+                  {
+                    name: 'field1',
+                    type: 'text',
+                  },
+                  {
+                    name: 'field2',
+                    type: 'text',
+                  },
+                  {
+                    name: 'field3',
+                    type: 'text',
+                  },
+                  {
+                    name: 'field4',
+                    type: 'text',
+                  },
+                  {
+                    name: 'field5',
+                    type: 'text',
+                  },
+                  {
+                    name: 'field6',
+                    type: 'text',
+                  },
+                  {
+                    name: 'field7',
+                    type: 'text',
+                  },
+                  {
+                    name: 'field8',
+                    type: 'text',
+                  },
+                  {
+                    name: 'field9',
+                    type: 'text',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+        versions: false,
+      },
+    ],
+    typescript: {
+      outputFile: path.resolve(dirname, 'payload-types.ts'),
     },
   },
-  collections: [
-    {
-      slug: 'blocks-collection',
-      fields: [
-        {
-          name: 'layout',
-          type: 'blocks',
-          blocks: [
-            {
-              slug: 'content',
-              fields: [
-                {
-                  name: 'richText',
-                  type: 'richText',
-                },
-                {
-                  name: 'field1',
-                  type: 'text',
-                },
-                {
-                  name: 'field2',
-                  type: 'text',
-                },
-                {
-                  name: 'field3',
-                  type: 'text',
-                },
-                {
-                  name: 'field4',
-                  type: 'text',
-                },
-                {
-                  name: 'field5',
-                  type: 'text',
-                },
-                {
-                  name: 'field6',
-                  type: 'text',
-                },
-                {
-                  name: 'field7',
-                  type: 'text',
-                },
-                {
-                  name: 'field8',
-                  type: 'text',
-                },
-                {
-                  name: 'field9',
-                  type: 'text',
-                },
-              ],
-            },
-          ],
-        },
-      ],
-      versions: false,
-    },
-  ],
-  onInit: async (payload) => {
+  seed: async (payload) => {
     await payload.create({
       collection: 'users',
       data: {
@@ -85,11 +91,6 @@ export default buildConfigWithDefaults({
         layout: [...Array(100)].map((row, i) => ({
           blockName: `Block ${i}`,
           blockType: 'content',
-          richText: [
-            {
-              children: [{ text: '' }],
-            },
-          ],
           field1: 'text field 1',
           field2: 'text field 2',
           field3: 'text field 3',
@@ -99,11 +100,13 @@ export default buildConfigWithDefaults({
           field7: 'text field 7',
           field8: 'text field 8',
           field9: 'text field 9',
+          richText: [
+            {
+              children: [{ text: '' }],
+            },
+          ],
         })),
       },
     })
-  },
-  typescript: {
-    outputFile: path.resolve(dirname, 'payload-types.ts'),
   },
 })

--- a/test/fields-relationship/config.ts
+++ b/test/fields-relationship/config.ts
@@ -21,38 +21,37 @@ import { Video } from './collections/Video/index.js'
 import { seed } from './seed.js'
 
 export default buildConfigWithDefaults({
-  admin: {
-    importMap: {
-      baseDir: path.resolve(dirname),
+  suite: 'fields-relationship',
+  config: {
+    admin: {
+      importMap: {
+        baseDir: path.resolve(dirname),
+      },
+    },
+    collections: [
+      Relationship,
+      RelationshipFilterFalse,
+      RelationshipFilterTrue,
+      Relation1,
+      Relation2,
+      Restricted,
+      RelationWithTitle,
+      RelationshipUpdatedExternally,
+      Collection1,
+      Collection2,
+      Video,
+      Podcast,
+      MixedMedia,
+      Versions,
+    ],
+    localization: {
+      defaultLocale: 'en',
+      fallback: true,
+      locales: ['en'],
+    },
+    typescript: {
+      outputFile: path.resolve(dirname, 'payload-types.ts'),
     },
   },
-  collections: [
-    Relationship,
-    RelationshipFilterFalse,
-    RelationshipFilterTrue,
-    Relation1,
-    Relation2,
-    Restricted,
-    RelationWithTitle,
-    RelationshipUpdatedExternally,
-    Collection1,
-    Collection2,
-    Video,
-    Podcast,
-    MixedMedia,
-    Versions,
-  ],
-  localization: {
-    locales: ['en'],
-    defaultLocale: 'en',
-    fallback: true,
-  },
-  onInit: async (payload) => {
-    if (process.env.SEED_IN_CONFIG_ONINIT !== 'false') {
-      await seed(payload)
-    }
-  },
-  typescript: {
-    outputFile: path.resolve(dirname, 'payload-types.ts'),
-  },
+  seed,
 })

--- a/test/fields-relationship/int.spec.ts
+++ b/test/fields-relationship/int.spec.ts
@@ -1,29 +1,17 @@
-import type { Payload } from 'payload'
-import { describe, beforeAll, afterAll, it, expect } from 'vitest'
-
-import path from 'path'
 import { fileURLToPath } from 'url'
+import { expect } from 'vitest'
 
-import type { NextRESTClient } from '../__helpers/shared/NextRESTClient.js'
 import type { Collection1 } from './payload-types.js'
 
+import { test } from '../__helpers/int/vitest.js'
 import { devUser } from '../credentials.js'
-import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
+import testConfig from './config.js'
 import { collection1Slug, versionedRelationshipFieldSlug } from './slugs.js'
-
-let payload: Payload
-let restClient: NextRESTClient
 
 const { email, password } = devUser
 
-const filename = fileURLToPath(import.meta.url)
-const dirname = path.dirname(filename)
-
-describe('Relationship Fields', () => {
-  beforeAll(async () => {
-    const initialized = await initPayloadInt(dirname)
-    ;({ payload, restClient } = initialized)
-
+test.suite({ config: testConfig })('Relationship Fields', () => {
+  test.beforeEach(async ({ restClient }) => {
     await restClient.login({
       slug: 'users',
       credentials: {
@@ -33,14 +21,10 @@ describe('Relationship Fields', () => {
     })
   })
 
-  afterAll(async () => {
-    await payload.destroy()
-  })
-
-  describe('Versioned Relationship Field', () => {
+  test.describe('Versioned Relationship Field', () => {
     let version2ID: string
     const relatedDocName = 'Related Doc'
-    beforeAll(async () => {
+    test.beforeEach(async ({ payload }) => {
       const relatedDoc = await payload.create({
         collection: collection1Slug,
         data: {
@@ -80,7 +64,9 @@ describe('Relationship Fields', () => {
 
       version2ID = versions.docs[0].id
     })
-    it('should return the correct versioned relationship field via REST', async () => {
+    test('should return the correct versioned relationship field via REST', async ({
+      restClient,
+    }) => {
       const version2Data = await restClient
         .GET(`/${versionedRelationshipFieldSlug}/versions/${version2ID}?locale=all`)
         .then((res) => res.json())
@@ -89,7 +75,9 @@ describe('Relationship Fields', () => {
       expect(version2Data.version.relationshipField[0].value.name).toEqual(relatedDocName)
     })
 
-    it('should return the correct versioned relationship field via LocalAPI', async () => {
+    test('should return the correct versioned relationship field via LocalAPI', async ({
+      payload,
+    }) => {
       const version2Data = await payload.findVersionByID({
         collection: versionedRelationshipFieldSlug,
         id: version2ID,

--- a/test/fields-relationship/int.spec.ts
+++ b/test/fields-relationship/int.spec.ts
@@ -5,12 +5,11 @@ import type { Collection1 } from './payload-types.js'
 
 import { test } from '../__helpers/int/vitest.js'
 import { devUser } from '../credentials.js'
-import testConfig from './config.js'
 import { collection1Slug, versionedRelationshipFieldSlug } from './slugs.js'
 
 const { email, password } = devUser
 
-test.suite({ config: testConfig })('Relationship Fields', () => {
+test.suite({ config: './config.ts' })('Relationship Fields', () => {
   test.beforeEach(async ({ restClient }) => {
     await restClient.login({
       slug: 'users',

--- a/test/folders/config.ts
+++ b/test/folders/config.ts
@@ -13,53 +13,59 @@ const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
 export default buildConfigWithDefaults({
-  admin: {
-    importMap: {
-      baseDir: path.resolve(dirname),
+  suite: 'folders',
+  config: {
+    admin: {
+      importMap: {
+        baseDir: path.resolve(dirname),
+      },
     },
-  },
-  collections: [
-    {
-      slug: folderSlug,
-      folders: {
+    collections: [
+      {
+        slug: folderSlug,
         admin: {
-          components: {
-            Icon: {
-              clientProps: { color: 'var(--theme-success-400)' },
-              path: './components/ColoredFolderIcon.tsx#ColoredFolderIcon',
+          useAsTitle: 'name',
+        },
+        fields: [
+          { name: 'name', type: 'text', required: true },
+          { name: 'folderSlug', type: 'text' },
+        ],
+        folders: {
+          admin: {
+            components: {
+              Icon: {
+                clientProps: { color: 'var(--theme-success-400)' },
+                path: './components/ColoredFolderIcon.tsx#ColoredFolderIcon',
+              },
             },
           },
+          collectionSpecific: { fieldName: 'folderType' },
+          joinField: { name: 'documentsAndFolders' },
+          parentFieldName: 'folder',
         },
-        collectionSpecific: { fieldName: 'folderType' },
-        joinField: { name: 'documentsAndFolders' },
-        parentFieldName: 'folder',
+        versions: false,
       },
-      admin: {
-        useAsTitle: 'name',
+      Posts,
+      Media,
+      TranslatedLabels,
+    ],
+    globals: [
+      {
+        slug: 'global',
+        fields: [
+          {
+            name: 'title',
+            type: 'text',
+          },
+        ],
+        versions: false,
       },
-      fields: [
-        { name: 'name', type: 'text', required: true },
-        { name: 'folderSlug', type: 'text' },
-      ],
-      versions: false,
+    ],
+    typescript: {
+      outputFile: path.resolve(dirname, 'payload-types.ts'),
     },
-    Posts,
-    Media,
-    TranslatedLabels,
-  ],
-  globals: [
-    {
-      slug: 'global',
-      fields: [
-        {
-          name: 'title',
-          type: 'text',
-        },
-      ],
-      versions: false,
-    },
-  ],
-  onInit: async (payload) => {
+  },
+  seed: async (payload) => {
     await payload.create({
       collection: 'users',
       data: {
@@ -68,8 +74,5 @@ export default buildConfigWithDefaults({
       },
     })
     await seed(payload)
-  },
-  typescript: {
-    outputFile: path.resolve(dirname, 'payload-types.ts'),
   },
 })

--- a/test/folders/int.spec.ts
+++ b/test/folders/int.spec.ts
@@ -1,35 +1,20 @@
-import type { Payload } from 'payload'
-
-import path from 'path'
 import { fileURLToPath } from 'url'
-import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { expect } from 'vitest'
 
-import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
+import { test } from '../__helpers/int/vitest.js'
+import testConfig from './config.js'
 import { folderSlug, postSlug } from './shared.js'
 
-let payload: Payload
-
-const filename = fileURLToPath(import.meta.url)
-const dirname = path.dirname(filename)
-
-describe('Folders Helpers', () => {
-  beforeAll(async () => {
-    ;({ payload } = await initPayloadInt(dirname))
-  })
-
-  afterAll(async () => {
-    await payload.destroy()
-  })
-
-  describe('createFoldersCollection', () => {
-    it('should create a collection with hierarchy enabled', () => {
+test.suite({ config: testConfig })('Folders Helpers', () => {
+  test.describe('createFoldersCollection', () => {
+    test('should create a collection with hierarchy enabled', ({ payload }) => {
       const foldersCollection = payload.collections[folderSlug].config
 
       expect(foldersCollection.hierarchy).toBeDefined()
       expect(foldersCollection.hierarchy).not.toBe(false)
     })
 
-    it('should add parent field with correct name', () => {
+    test('should add parent field with correct name', ({ payload }) => {
       const foldersCollection = payload.collections[folderSlug].config
       expect(foldersCollection.hierarchy).not.toBe(false)
 
@@ -39,9 +24,8 @@ describe('Folders Helpers', () => {
           (f: any) => f.name === parentFieldName && f.type === 'relationship',
         )
 
-        // eslint-disable-next-line vitest/no-conditional-expect
         expect(parentField).toBeDefined()
-        // eslint-disable-next-line vitest/no-conditional-expect
+
         expect(parentField).toMatchObject({
           type: 'relationship',
           relationTo: folderSlug,
@@ -49,7 +33,7 @@ describe('Folders Helpers', () => {
       }
     })
 
-    it('should add collectionSpecific field when configured', () => {
+    test('should add collectionSpecific field when configured', ({ payload }) => {
       const foldersCollection = payload.collections[folderSlug].config
 
       if (foldersCollection.hierarchy !== false && foldersCollection.hierarchy.collectionSpecific) {
@@ -58,12 +42,11 @@ describe('Folders Helpers', () => {
           (f: any) => f.name === fieldName,
         )
 
-        // eslint-disable-next-line vitest/no-conditional-expect
         expect(collectionSpecificField).toBeDefined()
       }
     })
 
-    it('should add join field when configured', () => {
+    test('should add join field when configured', ({ payload }) => {
       const foldersCollection = payload.collections[folderSlug].config
 
       if (foldersCollection.hierarchy !== false && foldersCollection.hierarchy.joinField) {
@@ -72,14 +55,13 @@ describe('Folders Helpers', () => {
           (f: any) => f.name === joinFieldName && f.type === 'join',
         )
 
-        // eslint-disable-next-line vitest/no-conditional-expect
         expect(joinField).toBeDefined()
-        // eslint-disable-next-line vitest/no-conditional-expect
+
         expect(joinField?.type).toBe('join')
       }
     })
 
-    it('should add virtual path fields', () => {
+    test('should add virtual path fields', ({ payload }) => {
       const foldersCollection = payload.collections[folderSlug].config
 
       const slugPathField = foldersCollection.fields.find((f: any) => f.name === '_h_slugPath')
@@ -92,8 +74,8 @@ describe('Folders Helpers', () => {
     })
   })
 
-  describe('createFolderField', () => {
-    it('should add folder relationship field to collection', () => {
+  test.describe('createFolderField', () => {
+    test('should add folder relationship field to collection', ({ payload }) => {
       const postsCollection = payload.collections[postSlug].config
       const folderField = postsCollection.fields.find(
         (f: any) => f.name === 'folder' && f.type === 'relationship',

--- a/test/folders/int.spec.ts
+++ b/test/folders/int.spec.ts
@@ -2,10 +2,9 @@ import { fileURLToPath } from 'url'
 import { expect } from 'vitest'
 
 import { test } from '../__helpers/int/vitest.js'
-import testConfig from './config.js'
 import { folderSlug, postSlug } from './shared.js'
 
-test.suite({ config: testConfig })('Folders Helpers', () => {
+test.suite({ config: './config.ts' })('Folders Helpers', () => {
   test.describe('createFoldersCollection', () => {
     test('should create a collection with hierarchy enabled', ({ payload }) => {
       const foldersCollection = payload.collections[folderSlug].config

--- a/test/form-state/config.ts
+++ b/test/form-state/config.ts
@@ -11,13 +11,19 @@ const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
 export default buildConfigWithDefaults({
-  collections: [PostsCollection, AutosavePostsCollection, ConditionsCollection],
-  admin: {
-    importMap: {
-      baseDir: path.resolve(dirname),
+  suite: 'form-state',
+  config: {
+    admin: {
+      importMap: {
+        baseDir: path.resolve(dirname),
+      },
+    },
+    collections: [PostsCollection, AutosavePostsCollection, ConditionsCollection],
+    typescript: {
+      outputFile: path.resolve(dirname, 'payload-types.ts'),
     },
   },
-  onInit: async (payload) => {
+  seed: async (payload) => {
     await payload.create({
       collection: 'users',
       data: {
@@ -32,8 +38,5 @@ export default buildConfigWithDefaults({
         title: 'example post',
       },
     })
-  },
-  typescript: {
-    outputFile: path.resolve(dirname, 'payload-types.ts'),
   },
 })

--- a/test/form-state/int.spec.ts
+++ b/test/form-state/int.spec.ts
@@ -1,29 +1,23 @@
-import type { FieldState, FormState, Payload, User } from 'payload'
+import type { FieldState, FormState, User } from 'payload'
 import type React from 'react'
 
 import { buildFormState } from '@payloadcms/ui/utilities/buildFormState'
-import path from 'path'
 import { createLocalReq } from 'payload'
 import { fileURLToPath } from 'url'
-import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { expect } from 'vitest'
 
-import type { NextRESTClient } from '../__helpers/shared/NextRESTClient.js'
-
-import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
 import { devUser } from '../credentials.js'
 import { conditionsSlug } from './collections/Conditions/index.js'
 import { postsSlug } from './collections/Posts/index.js'
 
 // eslint-disable-next-line payload/no-relative-monorepo-imports
 import { mergeServerFormState } from '../../packages/ui/src/forms/Form/mergeServerFormState.js'
+import { test } from '../__helpers/int/vitest.js'
+import testConfig from './config.js'
 
-let payload: Payload
-let restClient: NextRESTClient
 let user: User
 
 const { email, password } = devUser
-const filename = fileURLToPath(import.meta.url)
-const dirname = path.dirname(filename)
 
 const DummyReactComponent: React.ReactNode = {
   // @ts-expect-error - can ignore, needs to satisfy `typeof value.$$typeof === 'symbol'`
@@ -33,10 +27,8 @@ const DummyReactComponent: React.ReactNode = {
   key: null,
 }
 
-describe('Form State', () => {
-  beforeAll(async () => {
-    ;({ payload, restClient } = await initPayloadInt(dirname, undefined, true))
-
+test.suite({ config: testConfig })('Form State', () => {
+  test.beforeEach(async ({ restClient }) => {
     const data = await restClient
       .POST('/users/login', {
         body: JSON.stringify({
@@ -49,11 +41,7 @@ describe('Form State', () => {
     user = data.user
   })
 
-  afterAll(async () => {
-    await payload.destroy()
-  })
-
-  it('should build entire form state', async () => {
+  test('should build entire form state', async ({ payload }) => {
     const req = await createLocalReq({ user }, payload)
 
     const postData = await payload.create({
@@ -109,7 +97,9 @@ describe('Form State', () => {
     })
   })
 
-  it('should use `select` to build partial form state with only specified fields', async () => {
+  test('should use `select` to build partial form state with only specified fields', async ({
+    payload,
+  }) => {
     const req = await createLocalReq({ user }, payload)
 
     const postData = await payload.create({
@@ -154,7 +144,9 @@ describe('Form State', () => {
     })
   })
 
-  it('should not render custom components when `lastRenderedPath` exists', async () => {
+  test('should not render custom components when `lastRenderedPath` exists', async ({
+    payload,
+  }) => {
     const req = await createLocalReq({ user }, payload)
 
     const { state: stateWithRow } = await buildFormState({
@@ -237,7 +229,9 @@ describe('Form State', () => {
     expect(stateWithTitle?.['array.1.customTextField']?.customComponents?.Field).toBeDefined()
   })
 
-  it('should not render custom Field components for fields hidden by admin.condition', async () => {
+  test('should not render custom Field components for fields hidden by admin.condition', async ({
+    payload,
+  }) => {
     const req = await createLocalReq({ user }, payload)
 
     const hiddenDoc = await payload.create({
@@ -299,7 +293,9 @@ describe('Form State', () => {
     await payload.delete({ collection: conditionsSlug, id: visibleDoc.id })
   })
 
-  it('should preserve values of fields nested inside a row hidden by admin.condition', async () => {
+  test('should preserve values of fields nested inside a row hidden by admin.condition', async ({
+    payload,
+  }) => {
     const req = await createLocalReq({ user }, payload)
 
     const hiddenDoc = await payload.create({
@@ -336,7 +332,9 @@ describe('Form State', () => {
     await payload.delete({ collection: conditionsSlug, id: hiddenDoc.id })
   })
 
-  it('should preserve values of fields nested inside a collapsible hidden by admin.condition', async () => {
+  test('should preserve values of fields nested inside a collapsible hidden by admin.condition', async ({
+    payload,
+  }) => {
     const req = await createLocalReq({ user }, payload)
 
     const hiddenDoc = await payload.create({
@@ -370,7 +368,9 @@ describe('Form State', () => {
     await payload.delete({ collection: conditionsSlug, id: hiddenDoc.id })
   })
 
-  it('should render custom Field component when admin.condition flips from false to true via onChange', async () => {
+  test('should render custom Field component when admin.condition flips from false to true via onChange', async ({
+    payload,
+  }) => {
     const req = await createLocalReq({ user }, payload)
 
     const doc = await payload.create({
@@ -425,7 +425,9 @@ describe('Form State', () => {
     await payload.delete({ collection: conditionsSlug, id: doc.id })
   })
 
-  it('should add `addedByServer` flag to fields that originate on the server', async () => {
+  test('should add `addedByServer` flag to fields that originate on the server', async ({
+    payload,
+  }) => {
     const req = await createLocalReq({ user }, payload)
 
     const postData = await payload.create({
@@ -469,7 +471,7 @@ describe('Form State', () => {
     expect(newState.title?.addedByServer).toBeUndefined()
   })
 
-  it('should not omit value and initialValue from fields added by the server', () => {
+  test('should not omit value and initialValue from fields added by the server', () => {
     const currentState: FormState = {
       array: {
         rows: [
@@ -512,7 +514,7 @@ describe('Form State', () => {
     })
   })
 
-  it('should merge array rows without losing rows added to local state', () => {
+  test('should merge array rows without losing rows added to local state', () => {
     const currentState: FormState = {
       array: {
         errorPaths: [],
@@ -598,7 +600,7 @@ describe('Form State', () => {
     })
   })
 
-  it('should merge array rows without bringing back rows deleted from local state', () => {
+  test('should merge array rows without bringing back rows deleted from local state', () => {
     const currentState: FormState = {
       array: {
         rows: [
@@ -678,7 +680,7 @@ describe('Form State', () => {
     })
   })
 
-  it('should merge new fields returned from the server that do not yet exist in local state', () => {
+  test('should merge new fields returned from the server that do not yet exist in local state', () => {
     const currentState: FormState = {
       array: {
         rows: [
@@ -747,7 +749,7 @@ describe('Form State', () => {
     })
   })
 
-  it('should return the same object reference when only modifying a value', () => {
+  test('should return the same object reference when only modifying a value', () => {
     const currentState = {
       title: {
         value: 'Test Post',
@@ -772,7 +774,7 @@ describe('Form State', () => {
     expect(newState === currentState).toBe(true)
   })
 
-  it('should accept all values from the server regardless of local modifications, e.g. `acceptAllValues` on submit', () => {
+  test('should accept all values from the server regardless of local modifications, e.g. `acceptAllValues` on submit', () => {
     const title: FieldState = {
       value: 'Test Post (modified on the client)',
       initialValue: 'Test Post',
@@ -875,7 +877,7 @@ describe('Form State', () => {
     })
   })
 
-  it('should not accept values from the server if they have been modified locally since the request was made, e.g. `overrideLocalChanges: false` on autosave', () => {
+  test('should not accept values from the server if they have been modified locally since the request was made, e.g. `overrideLocalChanges: false` on autosave', () => {
     const title: FieldState = {
       value: 'Test Post (modified on the client 1)',
       initialValue: 'Test Post',
@@ -927,7 +929,7 @@ describe('Form State', () => {
     })
   })
 
-  it('should preserve client row data after reorder and delete during autosave', () => {
+  test('should preserve client row data after reorder and delete during autosave', () => {
     /**
      * Regression test for the "ghost item" bug.
      * User reorders [A, B, C] → [C, A, B], autosave fires, then user deletes A.
@@ -967,7 +969,7 @@ describe('Form State', () => {
     expect(newState['array.1.text']?.value).toBe('B text')
   })
 
-  it('should preserve client row data after reorder during autosave', () => {
+  test('should preserve client row data after reorder during autosave', () => {
     /**
      * User reorders [A, B] → [B, A] during autosave.
      * Server responds with stale [A, B]. Field values should remain with correct rows.
@@ -1003,7 +1005,7 @@ describe('Form State', () => {
     expect(newState['array.1.text']?.value).toBe('A text')
   })
 
-  it('should preserve nested array row data after reorder during autosave', () => {
+  test('should preserve nested array row data after reorder during autosave', () => {
     /**
      * User reorders nested array blocks[0].items from [A, B] → [B, A] during autosave.
      * Outer block unchanged. Server responds with stale inner array [A, B].
@@ -1050,7 +1052,7 @@ describe('Form State', () => {
     expect(newState['blocks.0.items.1.text']?.value).toBe('A text')
   })
 
-  it('should preserve nested array row data after reorder and delete during autosave', () => {
+  test('should preserve nested array row data after reorder and delete during autosave', () => {
     /**
      * User reorders nested array blocks[0].items from [A, B, C] → [C, A, B], then deletes A.
      * Outer block unchanged. Server responds with stale inner array [C, A, B].
@@ -1099,7 +1101,7 @@ describe('Form State', () => {
     expect(newState['blocks.0.items.1.text']?.value).toBe('B text')
   })
 
-  it('should accept server values on explicit save without row ID guard', () => {
+  test('should accept server values on explicit save without row ID guard', () => {
     /**
      * On explicit save (acceptValues: true), server values should be accepted
      * without the row ID guard interfering. This test ensures the guard is
@@ -1142,7 +1144,7 @@ describe('Form State', () => {
     expect(newState['array.1.text']?.value).toBe('B text from server')
   })
 
-  it('should preserve client-added row during autosave', () => {
+  test('should preserve client-added row during autosave', () => {
     /**
      * Client adds row D during autosave. Server responds with stale [A, B, C].
      * Row D should be preserved with its client value.
@@ -1180,7 +1182,7 @@ describe('Form State', () => {
     expect(newState['array.3.text']?.value).toBe('D text')
   })
 
-  it('should append server-added row with addedByServer flag', () => {
+  test('should append server-added row with addedByServer flag', () => {
     /**
      * Server adds a new row via hook with addedByServer: true.
      * Row should be appended and not blocked by row ID guard.
@@ -1218,7 +1220,7 @@ describe('Form State', () => {
     expect(newState['array.2.text']).not.toHaveProperty('addedByServer')
   })
 
-  it('should preserve empty client array when server has rows', () => {
+  test('should preserve empty client array when server has rows', () => {
     /**
      * Client deleted all rows during autosave. Server responds with [A, B].
      * Client should stay empty.
@@ -1251,7 +1253,7 @@ describe('Form State', () => {
     expect(newState['array.1.text']).toBeUndefined()
   })
 
-  it('should handle 3-level nested array reordering', () => {
+  test('should handle 3-level nested array reordering', () => {
     /**
      * Verify parseArrayFieldPath works at depth 3+.
      * blocks.0.items.1.subItems reordered from [X, Y] → [Y, X].
@@ -1303,7 +1305,7 @@ describe('Form State', () => {
     expect(newState['blocks.0.items.1.subItems.1.text']?.value).toBe('X text')
   })
 
-  it('should set rows to empty array for empty array fields', async () => {
+  test('should set rows to empty array for empty array fields', async ({ payload }) => {
     const req = await createLocalReq({ user }, payload)
 
     // Create a document with an empty array
@@ -1342,7 +1344,9 @@ describe('Form State', () => {
     expect(state?.array?.rows).toEqual([]) // should be [] not undefined
   })
 
-  it('should resolve a promise-returning `filterOptions` on a select field into `selectFilterOptions`', async () => {
+  test('should resolve a promise-returning `filterOptions` on a select field into `selectFilterOptions`', async ({
+    payload,
+  }) => {
     const req = await createLocalReq({ user }, payload)
 
     const postData = await payload.create({

--- a/test/form-state/int.spec.ts
+++ b/test/form-state/int.spec.ts
@@ -13,7 +13,6 @@ import { postsSlug } from './collections/Posts/index.js'
 // eslint-disable-next-line payload/no-relative-monorepo-imports
 import { mergeServerFormState } from '../../packages/ui/src/forms/Form/mergeServerFormState.js'
 import { test } from '../__helpers/int/vitest.js'
-import testConfig from './config.js'
 
 let user: User
 
@@ -27,7 +26,7 @@ const DummyReactComponent: React.ReactNode = {
   key: null,
 }
 
-test.suite({ config: testConfig })('Form State', () => {
+test.suite({ config: './config.ts' })('Form State', () => {
   test.beforeEach(async ({ restClient }) => {
     const data = await restClient
       .POST('/users/login', {

--- a/test/graphql-schema-gen/config.ts
+++ b/test/graphql-schema-gen/config.ts
@@ -6,177 +6,180 @@ const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
 export default buildConfigWithDefaults({
-  admin: {
-    importMap: {
-      baseDir: path.resolve(dirname),
+  suite: 'graphql-schema-gen',
+  config: {
+    admin: {
+      importMap: {
+        baseDir: path.resolve(dirname),
+      },
     },
+    typescript: {
+      outputFile: path.resolve(dirname, 'schema.ts'),
+    },
+    collections: [
+      {
+        slug: 'collection1',
+        fields: [
+          {
+            type: 'row',
+            fields: [{ type: 'text', required: true, name: 'testing' }],
+          },
+          {
+            type: 'tabs',
+            tabs: [
+              {
+                label: 'Tab 1',
+                fields: [
+                  {
+                    required: true,
+                    type: 'text',
+                    name: 'title',
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            type: 'array',
+            name: 'meta',
+            interfaceName: 'SharedMetaArray',
+            fields: [
+              {
+                name: 'title',
+                type: 'text',
+              },
+              {
+                name: 'description',
+                type: 'text',
+              },
+            ],
+          },
+          {
+            type: 'blocks',
+            name: 'blocks',
+            required: true,
+            blocks: [
+              {
+                slug: 'block1',
+                interfaceName: 'SharedMetaBlock',
+                fields: [
+                  {
+                    required: true,
+                    name: 'b1title',
+                    type: 'text',
+                  },
+                  {
+                    name: 'b1description',
+                    type: 'text',
+                  },
+                ],
+              },
+              {
+                slug: 'block2',
+                interfaceName: 'AnotherSharedBlock',
+                fields: [
+                  {
+                    name: 'b2title',
+                    type: 'text',
+                    required: true,
+                  },
+                  {
+                    name: 'b2description',
+                    type: 'text',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+        versions: false,
+      },
+      {
+        slug: 'collection2',
+        fields: [
+          {
+            type: 'array',
+            name: 'metaArray',
+            interfaceName: 'SharedMetaArray',
+            fields: [
+              {
+                name: 'title',
+                type: 'text',
+              },
+              {
+                name: 'description',
+                type: 'text',
+              },
+            ],
+          },
+          {
+            type: 'group',
+            name: 'metaGroup',
+            interfaceName: 'SharedMeta',
+            fields: [
+              {
+                name: 'title',
+                type: 'text',
+              },
+              {
+                name: 'description',
+                type: 'text',
+              },
+            ],
+          },
+          {
+            type: 'group',
+            name: 'nestedGroup',
+            fields: [
+              {
+                type: 'group',
+                name: 'meta',
+                interfaceName: 'SharedMeta',
+                fields: [
+                  {
+                    name: 'title',
+                    type: 'text',
+                  },
+                  {
+                    name: 'description',
+                    type: 'text',
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            name: 'some[text]',
+            type: 'text',
+          },
+          {
+            name: 'spaceBottom',
+            type: 'select',
+            required: false,
+            defaultValue: 'mb-0',
+            options: [
+              { label: 'None', value: 'mb-0' },
+              { label: 'Small', value: 'mb-8' },
+              { label: 'Medium', value: 'mb-16' },
+              { label: 'Large', value: 'mb-24' },
+              { label: 'Extra Large', value: 'mb-[150px]' },
+            ],
+          },
+        ],
+        versions: false,
+      },
+      {
+        // this should not be written to the generated schema
+        slug: 'no-graphql',
+        graphQL: false,
+        fields: [
+          {
+            name: 'name',
+            type: 'text',
+          },
+        ],
+        versions: false,
+      },
+    ],
   },
-  typescript: {
-    outputFile: path.resolve(dirname, 'schema.ts'),
-  },
-  collections: [
-    {
-      slug: 'collection1',
-      fields: [
-        {
-          type: 'row',
-          fields: [{ type: 'text', required: true, name: 'testing' }],
-        },
-        {
-          type: 'tabs',
-          tabs: [
-            {
-              label: 'Tab 1',
-              fields: [
-                {
-                  required: true,
-                  type: 'text',
-                  name: 'title',
-                },
-              ],
-            },
-          ],
-        },
-        {
-          type: 'array',
-          name: 'meta',
-          interfaceName: 'SharedMetaArray',
-          fields: [
-            {
-              name: 'title',
-              type: 'text',
-            },
-            {
-              name: 'description',
-              type: 'text',
-            },
-          ],
-        },
-        {
-          type: 'blocks',
-          name: 'blocks',
-          required: true,
-          blocks: [
-            {
-              slug: 'block1',
-              interfaceName: 'SharedMetaBlock',
-              fields: [
-                {
-                  required: true,
-                  name: 'b1title',
-                  type: 'text',
-                },
-                {
-                  name: 'b1description',
-                  type: 'text',
-                },
-              ],
-            },
-            {
-              slug: 'block2',
-              interfaceName: 'AnotherSharedBlock',
-              fields: [
-                {
-                  name: 'b2title',
-                  type: 'text',
-                  required: true,
-                },
-                {
-                  name: 'b2description',
-                  type: 'text',
-                },
-              ],
-            },
-          ],
-        },
-      ],
-      versions: false,
-    },
-    {
-      slug: 'collection2',
-      fields: [
-        {
-          type: 'array',
-          name: 'metaArray',
-          interfaceName: 'SharedMetaArray',
-          fields: [
-            {
-              name: 'title',
-              type: 'text',
-            },
-            {
-              name: 'description',
-              type: 'text',
-            },
-          ],
-        },
-        {
-          type: 'group',
-          name: 'metaGroup',
-          interfaceName: 'SharedMeta',
-          fields: [
-            {
-              name: 'title',
-              type: 'text',
-            },
-            {
-              name: 'description',
-              type: 'text',
-            },
-          ],
-        },
-        {
-          type: 'group',
-          name: 'nestedGroup',
-          fields: [
-            {
-              type: 'group',
-              name: 'meta',
-              interfaceName: 'SharedMeta',
-              fields: [
-                {
-                  name: 'title',
-                  type: 'text',
-                },
-                {
-                  name: 'description',
-                  type: 'text',
-                },
-              ],
-            },
-          ],
-        },
-        {
-          name: 'some[text]',
-          type: 'text',
-        },
-        {
-          name: 'spaceBottom',
-          type: 'select',
-          required: false,
-          defaultValue: 'mb-0',
-          options: [
-            { label: 'None', value: 'mb-0' },
-            { label: 'Small', value: 'mb-8' },
-            { label: 'Medium', value: 'mb-16' },
-            { label: 'Large', value: 'mb-24' },
-            { label: 'Extra Large', value: 'mb-[150px]' },
-          ],
-        },
-      ],
-      versions: false,
-    },
-    {
-      // this should not be written to the generated schema
-      slug: 'no-graphql',
-      graphQL: false,
-      fields: [
-        {
-          name: 'name',
-          type: 'text',
-        },
-      ],
-      versions: false,
-    },
-  ],
 })

--- a/test/plugin-cloud-storage/buildPluginCloudStorageIntConfig.ts
+++ b/test/plugin-cloud-storage/buildPluginCloudStorageIntConfig.ts
@@ -34,7 +34,6 @@ import {
   restrictedMediaSlug,
   testMetadataSlug,
 } from './shared.js'
-import { createTestBucket } from './utils.js'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
@@ -184,42 +183,35 @@ export function buildPluginCloudStorageIntConfig({
   })
 
   return buildConfigWithDefaults({
-    admin: {
-      importMap: {
-        baseDir: path.resolve(dirname),
+    suite: useCompositePrefixes
+      ? 'plugin-cloud-storage-composite-prefixes'
+      : 'plugin-cloud-storage',
+    config: {
+      admin: {
+        importMap: {
+          baseDir: path.resolve(dirname),
+        },
       },
+      collections: [
+        Media,
+        MediaWithCompositePrefixes,
+        MediaWithCustomURL,
+        MediaWithGenerateFileURL,
+        MediaWithOverwrite,
+        MediaWithPrefix,
+        MediaWithThrowingHook,
+        RestrictedMedia,
+        TestMetadata,
+        Users,
+      ],
+      plugins: [testMetadataPlugin],
+      storage: storagePlugin ? [storagePlugin] : [],
+      typescript: {
+        outputFile: path.resolve(dirname, 'payload-types.ts'),
+      },
+      upload: uploadOptions,
     },
-    collections: [
-      Media,
-      MediaWithCompositePrefixes,
-      MediaWithCustomURL,
-      MediaWithGenerateFileURL,
-      MediaWithOverwrite,
-      MediaWithPrefix,
-      MediaWithThrowingHook,
-      RestrictedMedia,
-      TestMetadata,
-      Users,
-    ],
-    onInit: async (payload) => {
-      /*const client = new AWS.S3({
-      endpoint: process.env.S3_ENDPOINT,
-      forcePathStyle: process.env.S3_FORCE_PATH_STYLE === 'true',
-      region: process.env.S3_REGION,
-      credentials: {
-        accessKeyId: process.env.S3_ACCESS_KEY_ID,
-        secretAccessKey: process.env.S3_SECRET_ACCESS_KEY,
-      },
-    })
-
-    const makeBucketRes = await client.send(
-      new AWS.CreateBucketCommand({ Bucket: 'payload-bucket' }),
-    )
-
-    if (makeBucketRes.$metadata.httpStatusCode !== 200) {
-      throw new Error(`Failed to create bucket. ${makeBucketRes.$metadata.httpStatusCode}`)
-    }*/
-
+    seed: async (payload) => {
       await payload.create({
         collection: 'users',
         data: {
@@ -228,17 +220,9 @@ export function buildPluginCloudStorageIntConfig({
         },
       })
 
-      await createTestBucket()
-
       payload.logger.info(
         `Using plugin-cloud-storage adapter: ${process.env.PAYLOAD_PUBLIC_CLOUD_STORAGE_ADAPTER}`,
       )
     },
-    plugins: [testMetadataPlugin],
-    storage: storagePlugin ? [storagePlugin] : [],
-    typescript: {
-      outputFile: path.resolve(dirname, 'payload-types.ts'),
-    },
-    upload: uploadOptions,
   })
 }

--- a/test/plugin-cloud-storage/config.compositePrefixes.ts
+++ b/test/plugin-cloud-storage/config.compositePrefixes.ts
@@ -1,5 +1,5 @@
 import { buildPluginCloudStorageIntConfig } from './buildPluginCloudStorageIntConfig.js'
 
-/** S3 `useCompositePrefixes: true` — use with `initPayloadInt(..., 'config.compositePrefixes.ts')` for composite key tests. */
+/** S3 `useCompositePrefixes: true` variant for the composite-key integration tests. */
 // eslint-disable-next-line no-restricted-exports
 export default buildPluginCloudStorageIntConfig({ useCompositePrefixes: true })

--- a/test/plugin-cloud-storage/e2e.spec.ts
+++ b/test/plugin-cloud-storage/e2e.spec.ts
@@ -1,6 +1,7 @@
 import type { Page } from '@playwright/test'
 
 import { expect, test } from '@playwright/test'
+import dotenv from 'dotenv'
 import * as path from 'path'
 import { fileURLToPath } from 'url'
 
@@ -10,9 +11,12 @@ import { initPayloadE2ENoConfig } from '../__helpers/shared/initPayloadE2ENoConf
 import { ensureCompilationIsDone } from '../__setup/e2e/ensureCompilationIsDone.js'
 import { TEST_TIMEOUT_LONG } from '../playwright.config.js'
 import { mediaSlug } from './shared.js'
+import { createTestBucket } from './utils.js'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
+
+dotenv.config({ path: path.resolve(dirname, './.env.emulated') })
 
 async function selectFile(page: Page, filePath: string) {
   await expect(async () => {
@@ -29,6 +33,7 @@ test.describe('Cloud Storage Plugin', () => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
     const { serverURL } = await initPayloadE2ENoConfig({ dirname })
     mediaURL = new AdminUrlUtil(serverURL, mediaSlug)
+    await createTestBucket()
 
     const context = await browser.newContext()
     page = await context.newPage()

--- a/test/plugin-cloud-storage/int.compositePrefixes.int.spec.ts
+++ b/test/plugin-cloud-storage/int.compositePrefixes.int.spec.ts
@@ -1,13 +1,13 @@
-import type { Payload } from 'payload'
 import type { SuiteAPI } from 'vitest'
 
 import * as AWS from '@aws-sdk/client-s3'
 import path from 'path'
 import shelljs from 'shelljs'
 import { fileURLToPath } from 'url'
-import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { expect } from 'vitest'
 
-import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
+import { test } from '../__helpers/int/vitest.js'
+import testConfig from './config.compositePrefixes.js'
 import { collectionPrefix, mediaWithCompositePrefixesSlug } from './shared.js'
 import { clearTestBucket, createTestBucket } from './utils.js'
 
@@ -16,39 +16,33 @@ const dirname = path.dirname(filename)
 
 function describeIfInCIOrHasLocalstack(): SuiteAPI | SuiteAPI['skip'] {
   if (process.env.CI) {
-    return describe
+    return test.describe
   }
 
   const { code } = shelljs.exec(`docker ps | grep localstack`)
 
   if (code !== 0) {
     console.warn('Localstack is not running. Skipping test suite.')
-    return describe.skip
+    return test.describe.skip
   }
 
   console.log('Localstack is running. Running test suite.')
 
-  return describe
+  return test.describe
 }
 
-describe('@payloadcms/plugin-cloud-storage (composite prefixes)', () => {
-  let payload: Payload
+test.suite({ config: testConfig })('@payloadcms/plugin-cloud-storage (composite prefixes)', () => {
   let TEST_BUCKET: string
 
-  beforeAll(async () => {
-    ;({ payload } = await initPayloadInt(dirname, undefined, true, 'config.compositePrefixes.ts'))
+  test.beforeEach(async () => {
     TEST_BUCKET = process.env.S3_BUCKET!
-  })
-
-  afterAll(async () => {
-    await payload.destroy()
   })
 
   let client: AWS.S3Client
 
   describeIfInCIOrHasLocalstack()('S3 composite prefixes', () => {
-    describe('S3', () => {
-      beforeAll(async () => {
+    test.describe('S3', () => {
+      test.beforeAll(async () => {
         client = new AWS.S3({
           credentials: {
             accessKeyId: process.env.S3_ACCESS_KEY_ID!,
@@ -63,11 +57,11 @@ describe('@payloadcms/plugin-cloud-storage (composite prefixes)', () => {
         await clearTestBucket(client)
       })
 
-      afterEach(async () => {
+      test.afterEach(async () => {
         await clearTestBucket(client)
       })
 
-      it('can upload with composite prefixes (collection + doc prefix)', async () => {
+      test('can upload with composite prefixes (collection + doc prefix)', async ({ payload }) => {
         const docPrefix = 'user-123'
 
         const upload = await payload.create({
@@ -93,7 +87,7 @@ describe('@payloadcms/plugin-cloud-storage (composite prefixes)', () => {
         )
       })
 
-      it('can upload with composite prefixes (collection prefix only)', async () => {
+      test('can upload with composite prefixes (collection prefix only)', async ({ payload }) => {
         const upload = await payload.create({
           collection: mediaWithCompositePrefixesSlug,
           data: {},

--- a/test/plugin-cloud-storage/int.compositePrefixes.int.spec.ts
+++ b/test/plugin-cloud-storage/int.compositePrefixes.int.spec.ts
@@ -7,7 +7,6 @@ import { fileURLToPath } from 'url'
 import { expect } from 'vitest'
 
 import { test } from '../__helpers/int/vitest.js'
-import testConfig from './config.compositePrefixes.js'
 import { collectionPrefix, mediaWithCompositePrefixesSlug } from './shared.js'
 import { clearTestBucket, createTestBucket } from './utils.js'
 
@@ -31,7 +30,9 @@ function describeIfInCIOrHasLocalstack(): SuiteAPI | SuiteAPI['skip'] {
   return test.describe
 }
 
-test.suite({ config: testConfig })('@payloadcms/plugin-cloud-storage (composite prefixes)', () => {
+const configPath = './config.compositePrefixes.ts'
+
+test.suite({ config: configPath })('@payloadcms/plugin-cloud-storage (composite prefixes)', () => {
   let TEST_BUCKET: string
 
   test.beforeEach(async () => {

--- a/test/plugin-cloud-storage/int.spec.ts
+++ b/test/plugin-cloud-storage/int.spec.ts
@@ -267,12 +267,14 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-cloud-storage', () => 
   })
 
   test.describe('integration (non-composite prefixes)', () => {
-    const TEST_BUCKET = process.env.S3_BUCKET!
-
     let client: AWS.S3Client
+    let TEST_BUCKET: string
+
     describeIfInCIOrHasLocalstack()('plugin-cloud-storage (non-composite prefixes)', () => {
       test.describe('S3', () => {
         test.beforeAll(async () => {
+          TEST_BUCKET = process.env.S3_BUCKET!
+
           client = new AWS.S3({
             credentials: {
               accessKeyId: process.env.S3_ACCESS_KEY_ID!,

--- a/test/plugin-cloud-storage/int.spec.ts
+++ b/test/plugin-cloud-storage/int.spec.ts
@@ -14,7 +14,6 @@ import { expect } from 'vitest'
 import type { Config } from './payload-types.js'
 
 import { test } from '../__helpers/int/vitest.js'
-import testConfig from './config.js'
 import {
   mediaSlug,
   mediaWithCustomURLSlug,
@@ -102,7 +101,7 @@ export function describeIfInCIOrHasLocalstack(): SuiteAPI | SuiteAPI['skip'] {
   return test.describe
 }
 
-test.suite({ config: testConfig })('@payloadcms/plugin-cloud-storage', () => {
+test.suite({ config: './config.ts' })('@payloadcms/plugin-cloud-storage', () => {
   test.describe('getFilePrefix', () => {
     const mockReq = {
       payload: {

--- a/test/plugin-cloud-storage/int.spec.ts
+++ b/test/plugin-cloud-storage/int.spec.ts
@@ -9,12 +9,12 @@ import { APIError } from 'payload'
 import { sanitizeFilename } from 'payload/shared'
 import shelljs from 'shelljs'
 import { fileURLToPath } from 'url'
-import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { expect } from 'vitest'
 
-import type { NextRESTClient } from '../__helpers/shared/NextRESTClient.js'
 import type { Config } from './payload-types.js'
 
-import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
+import { test } from '../__helpers/int/vitest.js'
+import testConfig from './config.js'
 import {
   mediaSlug,
   mediaWithCustomURLSlug,
@@ -86,7 +86,7 @@ async function verifyUploads({
 // needs to be here as it imports vitest functions and conflicts with playwright that uses jest
 export function describeIfInCIOrHasLocalstack(): SuiteAPI | SuiteAPI['skip'] {
   if (process.env.CI) {
-    return describe
+    return test.describe
   }
 
   // Check that localstack is running
@@ -94,16 +94,16 @@ export function describeIfInCIOrHasLocalstack(): SuiteAPI | SuiteAPI['skip'] {
 
   if (code !== 0) {
     console.warn('Localstack is not running. Skipping test suite.')
-    return describe.skip
+    return test.describe.skip
   }
 
   console.log('Localstack is running. Running test suite.')
 
-  return describe
+  return test.describe
 }
 
-describe('@payloadcms/plugin-cloud-storage', () => {
-  describe('getFilePrefix', () => {
+test.suite({ config: testConfig })('@payloadcms/plugin-cloud-storage', () => {
+  test.describe('getFilePrefix', () => {
     const mockReq = {
       payload: {
         find: () => ({ docs: [] }),
@@ -115,8 +115,8 @@ describe('@payloadcms/plugin-cloud-storage', () => {
       upload: {},
     } as any
 
-    describe('upload reference prefix sanitization', () => {
-      it('should return a valid prefix unchanged', async () => {
+    test.describe('upload reference prefix sanitization', () => {
+      test('should return a valid prefix unchanged', async () => {
         const result = await getFilePrefix({
           collection: mockCollection,
           uploadReference: { prefix: 'media/images' },
@@ -126,7 +126,7 @@ describe('@payloadcms/plugin-cloud-storage', () => {
         expect(result).toBe('media/images')
       })
 
-      it('should strip invalid segments from the prefix', async () => {
+      test('should strip invalid segments from the prefix', async () => {
         const result = await getFilePrefix({
           collection: mockCollection,
           uploadReference: { prefix: '../other-collection/private' },
@@ -137,7 +137,7 @@ describe('@payloadcms/plugin-cloud-storage', () => {
         expect(result).not.toContain('..')
       })
 
-      it('should handle deeply nested invalid segments', async () => {
+      test('should handle deeply nested invalid segments', async () => {
         const result = await getFilePrefix({
           collection: mockCollection,
           uploadReference: { prefix: 'a/../../outside' },
@@ -148,7 +148,7 @@ describe('@payloadcms/plugin-cloud-storage', () => {
         expect(result).not.toContain('..')
       })
 
-      it('should strip leading slashes from the prefix', async () => {
+      test('should strip leading slashes from the prefix', async () => {
         const result = await getFilePrefix({
           collection: mockCollection,
           uploadReference: { prefix: '/absolute/path' },
@@ -159,7 +159,7 @@ describe('@payloadcms/plugin-cloud-storage', () => {
         expect(result).not.toMatch(/^\//)
       })
 
-      it('should strip dot segments from the prefix', async () => {
+      test('should strip dot segments from the prefix', async () => {
         const result = await getFilePrefix({
           collection: mockCollection,
           uploadReference: { prefix: './relative/./path' },
@@ -169,7 +169,7 @@ describe('@payloadcms/plugin-cloud-storage', () => {
         expect(result).toBe('relative/path')
       })
 
-      it('should normalize backslash separators', async () => {
+      test('should normalize backslash separators', async () => {
         const result = await getFilePrefix({
           collection: mockCollection,
           uploadReference: { prefix: '..\\..\\outside' },
@@ -179,7 +179,7 @@ describe('@payloadcms/plugin-cloud-storage', () => {
         expect(result).not.toContain('..')
       })
 
-      it('should strip control characters from the prefix', async () => {
+      test('should strip control characters from the prefix', async () => {
         const result = await getFilePrefix({
           collection: mockCollection,
           uploadReference: { prefix: 'media\x00/images' },
@@ -189,7 +189,7 @@ describe('@payloadcms/plugin-cloud-storage', () => {
         expect(result).toBe('media/images')
       })
 
-      it('should return empty string for a prefix of only invalid segments', async () => {
+      test('should return empty string for a prefix of only invalid segments', async () => {
         const result = await getFilePrefix({
           collection: mockCollection,
           uploadReference: { prefix: '../../..' },
@@ -200,8 +200,8 @@ describe('@payloadcms/plugin-cloud-storage', () => {
       })
     })
 
-    describe('fallback to DB lookup', () => {
-      it('should return empty string when there is no upload reference or DB match', async () => {
+    test.describe('fallback to DB lookup', () => {
+      test('should return empty string when there is no upload reference or DB match', async () => {
         const result = await getFilePrefix({
           collection: mockCollection,
           filename: 'test.png',
@@ -210,7 +210,7 @@ describe('@payloadcms/plugin-cloud-storage', () => {
         expect(result).toBe('')
       })
 
-      it('should return prefix from DB when doc has a prefix', async () => {
+      test('should return prefix from DB when doc has a prefix', async () => {
         const reqWithDoc = {
           payload: {
             find: () => ({ docs: [{ prefix: 'db-prefix' }] }),
@@ -227,64 +227,53 @@ describe('@payloadcms/plugin-cloud-storage', () => {
     })
   })
 
-  describe('sanitizeFilename', () => {
-    it('should return a simple filename unchanged', () => {
+  test.describe('sanitizeFilename', () => {
+    test('should return a simple filename unchanged', () => {
       expect(sanitizeFilename('image.png')).toBe('image.png')
     })
 
-    it('should return only the base name from a path', () => {
+    test('should return only the base name from a path', () => {
       expect(sanitizeFilename('some/path/to/file.jpg')).toBe('file.jpg')
       expect(sanitizeFilename('a/b/../../c/d/../file.txt')).toBe('file.txt')
     })
 
-    it('should normalize backslash separators', () => {
+    test('should normalize backslash separators', () => {
       expect(sanitizeFilename('..\\..\\windows\\system32\\config')).toBe('config')
     })
 
-    it('should reject standalone dot filenames', () => {
+    test('should reject standalone dot filenames', () => {
       expect(() => sanitizeFilename('.')).toThrow(APIError)
       expect(() => sanitizeFilename('..')).toThrow(APIError)
     })
 
-    it('should reject empty filenames', () => {
+    test('should reject empty filenames', () => {
       expect(() => sanitizeFilename('')).toThrow(APIError)
       expect(() => sanitizeFilename('/')).toThrow(APIError)
       expect(() => sanitizeFilename('//')).toThrow(APIError)
     })
 
-    it('should strip control characters', () => {
+    test('should strip control characters', () => {
       expect(sanitizeFilename('file\x00name\x1f.txt')).toBe('filename.txt')
       expect(sanitizeFilename('file\x80name\x9f.txt')).toBe('filename.txt')
     })
 
-    it('should preserve unicode filenames', () => {
+    test('should preserve unicode filenames', () => {
       expect(sanitizeFilename('résumé.pdf')).toBe('résumé.pdf')
       expect(sanitizeFilename('日本語.txt')).toBe('日本語.txt')
     })
 
-    it('should treat percent-encoded strings as literal filenames', () => {
+    test('should treat percent-encoded strings as literal filenames', () => {
       expect(sanitizeFilename('%2e%2e%2f')).toBe('%2e%2e%2f')
     })
   })
 
-  describe('integration (non-composite prefixes)', () => {
-    let payload: Payload
-    let restClient: NextRESTClient
-    let TEST_BUCKET: string
-
-    beforeAll(async () => {
-      ;({ payload, restClient } = await initPayloadInt(dirname, undefined, true, 'config.ts'))
-      TEST_BUCKET = process.env.S3_BUCKET!
-    })
-
-    afterAll(async () => {
-      await payload.destroy()
-    })
+  test.describe('integration (non-composite prefixes)', () => {
+    const TEST_BUCKET = process.env.S3_BUCKET!
 
     let client: AWS.S3Client
     describeIfInCIOrHasLocalstack()('plugin-cloud-storage (non-composite prefixes)', () => {
-      describe('S3', () => {
-        beforeAll(async () => {
+      test.describe('S3', () => {
+        test.beforeAll(async () => {
           client = new AWS.S3({
             credentials: {
               accessKeyId: process.env.S3_ACCESS_KEY_ID!,
@@ -299,11 +288,11 @@ describe('@payloadcms/plugin-cloud-storage', () => {
           await clearTestBucket(client)
         })
 
-        afterEach(async () => {
+        test.afterEach(async () => {
           await clearTestBucket(client)
         })
 
-        it('can upload', async () => {
+        test('can upload', async ({ payload }) => {
           const upload = await payload.create({
             collection: mediaSlug,
             data: {},
@@ -323,7 +312,7 @@ describe('@payloadcms/plugin-cloud-storage', () => {
           expect(upload.url).toEqual(`/api/${mediaSlug}/file/${String(upload.filename)}`)
         })
 
-        it('can upload with prefix', async () => {
+        test('can upload with prefix', async ({ payload }) => {
           const upload = await payload.create({
             collection: mediaWithPrefixSlug,
             data: {},
@@ -345,7 +334,7 @@ describe('@payloadcms/plugin-cloud-storage', () => {
           )
         })
 
-        it('should not upload to S3 when mimeType validation fails', async () => {
+        test('should not upload to S3 when mimeType validation fails', async ({ payload }) => {
           // Get initial bucket contents
           const listBefore = await client.send(
             new AWS.ListObjectsV2Command({ Bucket: TEST_BUCKET }),
@@ -368,7 +357,7 @@ describe('@payloadcms/plugin-cloud-storage', () => {
           expect(fileCountAfter).toBe(fileCountBefore)
         })
 
-        it('should upload to S3 when mimeType validation passes', async () => {
+        test('should upload to S3 when mimeType validation passes', async ({ payload }) => {
           // Upload a valid PNG file
           const upload = await payload.create({
             collection: restrictedMediaSlug,
@@ -394,7 +383,7 @@ describe('@payloadcms/plugin-cloud-storage', () => {
           expect($metadata.httpStatusCode).toBe(200)
         })
 
-        it('should store correct URLs for sized images', async () => {
+        test('should store correct URLs for sized images', async ({ payload }) => {
           const upload = await payload.create({
             collection: mediaSlug,
             data: {},
@@ -440,7 +429,7 @@ describe('@payloadcms/plugin-cloud-storage', () => {
           }
         })
 
-        it('should handle collections without imageSizes correctly', async () => {
+        test('should handle collections without imageSizes correctly', async ({ payload }) => {
           const upload = await payload.create({
             collection: mediaWithPrefixSlug,
             data: {},
@@ -470,7 +459,9 @@ describe('@payloadcms/plugin-cloud-storage', () => {
           expect((rawDbData as any)?.sizes).toBeFalsy()
         })
 
-        it('should use custom generateFileURL in beforeChange when disablePayloadAccessControl is true', async () => {
+        test('should use custom generateFileURL in beforeChange when disablePayloadAccessControl is true', async ({
+          payload,
+        }) => {
           // This test verifies that custom generateFileURL is used in beforeChange hook
           // when disablePayloadAccessControl: true, preventing "undefined" from appearing in URLs
           const upload = await payload.create({
@@ -510,7 +501,9 @@ describe('@payloadcms/plugin-cloud-storage', () => {
           expect(apiResponse.url).toContain(prefix)
         })
 
-        it('should use custom generateFileURL even without disablePayloadAccessControl', async () => {
+        test('should use custom generateFileURL even without disablePayloadAccessControl', async ({
+          payload,
+        }) => {
           const upload = await payload.create({
             collection: mediaWithGenerateFileURLSlug,
             data: {},
@@ -548,10 +541,10 @@ describe('@payloadcms/plugin-cloud-storage', () => {
       })
     })
 
-    describe('External data persistence', () => {
+    test.describe('External data persistence', () => {
       const createdIDs: (number | string)[] = []
 
-      afterEach(async () => {
+      test.afterEach(async ({ payload }) => {
         for (const id of createdIDs) {
           try {
             await payload.delete({ id, collection: testMetadataSlug })
@@ -562,7 +555,9 @@ describe('@payloadcms/plugin-cloud-storage', () => {
         createdIDs.length = 0
       })
 
-      it('should automatically persist metadata returned by custom adapters', async () => {
+      test('should automatically persist metadata returned by custom adapters', async ({
+        payload,
+      }) => {
         const upload = await payload.create({
           collection: testMetadataSlug,
           data: {
@@ -598,7 +593,10 @@ describe('@payloadcms/plugin-cloud-storage', () => {
         })
       })
 
-      it('supports upload instructions when the adapter does not', async () => {
+      test('supports upload instructions when the adapter does not', async ({
+        payload,
+        restClient,
+      }) => {
         await restClient.login({ slug: 'users' })
 
         const file = fs.readFileSync(path.resolve(dirname, '../uploads/image.png'))
@@ -650,7 +648,7 @@ describe('@payloadcms/plugin-cloud-storage', () => {
         expect(doc.sizes.thumbnail.filename).toBeTruthy()
       })
 
-      it('should persist metadata on update operations', async () => {
+      test('should persist metadata on update operations', async ({ payload }) => {
         const upload = await payload.create({
           collection: testMetadataSlug,
           data: {
@@ -701,10 +699,10 @@ describe('@payloadcms/plugin-cloud-storage', () => {
       })
     })
 
-    describe('User afterChange hook propagation', () => {
+    test.describe('User afterChange hook propagation', () => {
       const createdIDs: (number | string)[] = []
 
-      afterEach(async () => {
+      test.afterEach(async ({ payload }) => {
         for (const id of createdIDs) {
           try {
             await payload.delete({ id, collection: mediaWithThrowingHookSlug })
@@ -715,7 +713,9 @@ describe('@payloadcms/plugin-cloud-storage', () => {
         createdIDs.length = 0
       })
 
-      it('should surface user afterChange errors that throw during the plugin internal update on create', async () => {
+      test('should surface user afterChange errors that throw during the plugin internal update on create', async ({
+        payload,
+      }) => {
         await expect(
           payload.create({
             collection: mediaWithThrowingHookSlug,
@@ -725,7 +725,9 @@ describe('@payloadcms/plugin-cloud-storage', () => {
         ).rejects.toThrow('User afterChange hook throws error')
       })
 
-      it('should surface user afterChange errors during reupload and preserve the previous file in S3', async () => {
+      test('should surface user afterChange errors during reupload and preserve the previous file in S3', async ({
+        payload,
+      }) => {
         const imagePath = path.resolve(dirname, '../uploads/image.png')
         const buildFile = (name: string) => ({
           name,
@@ -764,10 +766,10 @@ describe('@payloadcms/plugin-cloud-storage', () => {
       })
     })
 
-    describe('Reupload with overwriteExistingFiles', () => {
+    test.describe('Reupload with overwriteExistingFiles', () => {
       const createdIDs: (number | string)[] = []
 
-      afterEach(async () => {
+      test.afterEach(async ({ payload }) => {
         for (const id of createdIDs) {
           try {
             await payload.delete({ id, collection: mediaWithOverwriteSlug })
@@ -778,7 +780,9 @@ describe('@payloadcms/plugin-cloud-storage', () => {
         createdIDs.length = 0
       })
 
-      it('should preserve size variants in S3 when reupload reuses the same filename', async () => {
+      test('should preserve size variants in S3 when reupload reuses the same filename', async ({
+        payload,
+      }) => {
         const imagePath = path.resolve(dirname, '../uploads/image.png')
         const buildFile = (name: string) => ({
           name,
@@ -843,16 +847,16 @@ describe('@payloadcms/plugin-cloud-storage', () => {
       })
     })
 
-    describe('Azure', () => {
-      it.todo('can upload')
+    test.describe('Azure', () => {
+      test.todo('can upload')
     })
 
-    describe('GCS', () => {
-      it.todo('can upload')
+    test.describe('GCS', () => {
+      test.todo('can upload')
     })
 
-    describe('R2', () => {
-      it.todo('can upload')
+    test.describe('R2', () => {
+      test.todo('can upload')
     })
   })
 })

--- a/test/plugin-import-export/config.ts
+++ b/test/plugin-import-export/config.ts
@@ -51,329 +51,332 @@ dotenv.config({
 })
 
 export default buildConfigWithDefaults({
-  admin: {
-    importMap: {
-      baseDir: path.resolve(dirname),
+  suite: 'plugin-import-export',
+  config: {
+    admin: {
+      importMap: {
+        baseDir: path.resolve(dirname),
+      },
+      timezones: {
+        supportedTimezones: [...defaultTimezones, { label: 'UTC', value: 'UTC' }],
+      },
     },
-    timezones: {
-      supportedTimezones: [...defaultTimezones, { label: 'UTC', value: 'UTC' }],
-    },
-  },
-  collections: [
-    Users,
-    Pages,
-    Posts,
-    PostsExportsOnly,
-    PostsImportsOnly,
-    PostsNoJobsQueue,
-    PostsWithLimits,
-    PostsWithS3,
-    PostsWithHooks,
-    PostsWithFieldHooks,
-    PostsWithColumnMap,
-    Media,
-    CustomIdPages,
-  ],
-  localization: {
-    defaultLocale: 'en',
-    fallback: true,
-    locales: [
-      { code: 'en', label: 'English' },
-      { code: 'es', label: 'Spanish' },
-      { code: 'de', label: 'German' },
-      { code: 'he', label: 'Hebrew', rtl: true },
+    collections: [
+      Users,
+      Pages,
+      Posts,
+      PostsExportsOnly,
+      PostsImportsOnly,
+      PostsNoJobsQueue,
+      PostsWithLimits,
+      PostsWithS3,
+      PostsWithHooks,
+      PostsWithFieldHooks,
+      PostsWithColumnMap,
+      Media,
+      CustomIdPages,
     ],
-  },
-  i18n: {
-    supportedLanguages: {
-      en,
-      es,
-      he,
+    i18n: {
+      fallbackLanguage: 'en',
+      supportedLanguages: {
+        en,
+        es,
+        he,
+      },
     },
-    fallbackLanguage: 'en',
-  },
-  jobs: {
-    jobsCollectionOverrides: ({ defaultJobsCollection }) => {
-      if (defaultJobsCollection.admin) {
-        defaultJobsCollection.admin.group = 'Jobs'
-        defaultJobsCollection.admin.hidden = false
-      }
+    jobs: {
+      jobsCollectionOverrides: ({ defaultJobsCollection }) => {
+        if (defaultJobsCollection.admin) {
+          defaultJobsCollection.admin.group = 'Jobs'
+          defaultJobsCollection.admin.hidden = false
+        }
 
-      return defaultJobsCollection
+        return defaultJobsCollection
+      },
+    },
+    localization: {
+      defaultLocale: 'en',
+      fallback: true,
+      locales: [
+        { code: 'en', label: 'English' },
+        { code: 'es', label: 'Spanish' },
+        { code: 'de', label: 'German' },
+        { code: 'he', label: 'Hebrew', rtl: true },
+      ],
+    },
+    plugins: [
+      importExportPlugin({
+        collections: [
+          {
+            slug: 'pages',
+            export: {
+              overrideCollection: ({ collection }) => {
+                if (collection.admin) {
+                  collection.admin.group = 'System'
+                }
+                collection.upload.staticDir = path.resolve(dirname, 'uploads')
+                return collection
+              },
+            },
+            import: {
+              overrideCollection: ({ collection }) => {
+                if (collection.admin) {
+                  collection.admin.group = 'System'
+                }
+                collection.upload.staticDir = path.resolve(dirname, 'uploads')
+                return collection
+              },
+            },
+            versions: false,
+          },
+          {
+            slug: 'posts',
+            export: {
+              disableJobsQueue: true,
+              overrideCollection: ({ collection }) => {
+                collection.slug = 'posts-export'
+                if (collection.admin) {
+                  collection.admin.group = 'Posts'
+                }
+                collection.upload.staticDir = path.resolve(dirname, 'uploads')
+                return collection
+              },
+            },
+            import: {
+              disableJobsQueue: true,
+              overrideCollection: ({ collection }) => {
+                collection.slug = 'posts-import'
+                if (collection.admin) {
+                  collection.admin.group = 'Posts'
+                }
+                collection.upload.staticDir = path.resolve(dirname, 'uploads')
+                return collection
+              },
+            },
+            versions: false,
+          },
+          {
+            slug: 'posts-exports-only',
+            export: {
+              format: 'csv',
+            },
+            import: false,
+            versions: false,
+          },
+          {
+            slug: 'posts-imports-only',
+            export: false,
+            import: {
+              defaultVersionStatus: 'draft',
+              disableJobsQueue: true,
+            },
+            versions: false,
+          },
+          {
+            slug: 'posts-no-jobs-queue',
+            export: {
+              disableJobsQueue: true,
+              disableSave: true,
+              format: 'csv',
+              overrideCollection: ({ collection }) => {
+                collection.slug = 'posts-no-jobs-queue-export'
+                if (collection.admin) {
+                  collection.admin.group = 'Posts No Jobs Queue'
+                }
+                collection.upload.staticDir = path.resolve(dirname, 'uploads')
+                return collection
+              },
+            },
+            import: {
+              disableJobsQueue: true,
+            },
+            versions: false,
+          },
+          {
+            slug: postsWithS3Slug,
+            export: {
+              overrideCollection: ({ collection }) => {
+                collection.slug = 'posts-with-s3-export'
+                if (collection.admin) {
+                  collection.admin.group = 'S3 Tests'
+                }
+                return collection
+              },
+            },
+            import: {
+              overrideCollection: ({ collection }) => {
+                collection.slug = 'posts-with-s3-import'
+                if (collection.admin) {
+                  collection.admin.group = 'S3 Tests'
+                }
+                // The import task fetches the uploaded CSV back through Payload's
+                // file endpoint, which resolves to `localhost` under prod-server
+                // e2e and gets rejected by `safeFetch`'s SSRF guard.
+                collection.upload = typeof collection.upload === 'object' ? collection.upload : {}
+                collection.upload.skipSafeFetch = true
+                return collection
+              },
+            },
+            versions: false,
+          },
+          {
+            slug: 'posts-with-limits',
+            export: {
+              disableJobsQueue: true,
+              limit: ({ req }) => {
+                if (req.user?.limit) {
+                  return req.user.limit
+                }
+                return 5
+              },
+              overrideCollection: ({ collection }) => {
+                collection.slug = 'posts-with-limits-export'
+                collection.upload.staticDir = path.resolve(dirname, 'uploads')
+                return collection
+              },
+            },
+            import: {
+              disableJobsQueue: true,
+              limit: 5,
+              overrideCollection: ({ collection }) => {
+                collection.slug = 'posts-with-limits-import'
+                collection.upload.staticDir = path.resolve(dirname, 'uploads')
+                return collection
+              },
+            },
+            versions: false,
+          },
+          {
+            slug: 'media',
+            versions: false,
+          },
+          {
+            slug: customIdPagesSlug,
+            versions: false,
+          },
+          {
+            slug: postsWithHooksSlug,
+            export: {
+              batchSize: 2,
+              disableJobsQueue: true,
+              hooks: {
+                after: exportAfterHook,
+                before: exportBeforeHook,
+              },
+              overrideCollection: ({ collection }) => {
+                collection.slug = 'posts-with-hooks-export'
+                collection.upload.staticDir = path.resolve(dirname, 'uploads')
+                return collection
+              },
+            },
+            import: {
+              batchSize: 2,
+              disableJobsQueue: true,
+              hooks: {
+                after: importAfterHook,
+                before: importBeforeHook,
+              },
+              overrideCollection: ({ collection }) => {
+                collection.slug = 'posts-with-hooks-import'
+                collection.upload.staticDir = path.resolve(dirname, 'uploads')
+                return collection
+              },
+            },
+            versions: false,
+          },
+          {
+            slug: postsWithFieldHooksSlug,
+            export: {
+              disableJobsQueue: true,
+              overrideCollection: ({ collection }) => {
+                collection.slug = 'posts-with-field-hooks-export'
+                collection.upload.staticDir = path.resolve(dirname, 'uploads')
+                return collection
+              },
+            },
+            import: {
+              disableJobsQueue: true,
+              overrideCollection: ({ collection }) => {
+                collection.slug = 'posts-with-field-hooks-import'
+                collection.upload.staticDir = path.resolve(dirname, 'uploads')
+                return collection
+              },
+            },
+            versions: false,
+          },
+          {
+            slug: postsWithColumnMapSlug,
+            export: {
+              disableJobsQueue: true,
+              hooks: {
+                before: ({ data }) => {
+                  return data.map((row) => {
+                    const renamed: Record<string, unknown> = {}
+                    for (const [key, value] of Object.entries(row)) {
+                      renamed[exportRenameMap[key] ?? key] = value
+                    }
+                    return renamed
+                  })
+                },
+              },
+              overrideCollection: ({ collection }) => {
+                collection.slug = 'posts-with-column-map-export'
+                collection.upload.staticDir = path.resolve(dirname, 'uploads')
+                return collection
+              },
+            },
+            import: {
+              disableJobsQueue: true,
+              hooks: {
+                before: ({ data }) => {
+                  return data.map((doc) => {
+                    const renamed: Record<string, unknown> = {}
+                    for (const [key, value] of Object.entries(doc)) {
+                      const payloadKey = importRenameMap[key]
+                      if (payloadKey) {
+                        renamed[payloadKey] = value
+                      }
+                    }
+                    return renamed
+                  })
+                },
+              },
+              overrideCollection: ({ collection }) => {
+                collection.slug = 'posts-with-column-map-import'
+                collection.upload.staticDir = path.resolve(dirname, 'uploads')
+                return collection
+              },
+            },
+            versions: false,
+          },
+        ],
+        debug: true,
+      }),
+    ],
+    storage: [
+      s3Storage({
+        bucket: process.env.S3_BUCKET!,
+        collections: {
+          'posts-with-s3-export': true,
+          'posts-with-s3-import': true,
+        },
+        config: {
+          credentials: {
+            accessKeyId: process.env.S3_ACCESS_KEY_ID!,
+            secretAccessKey: process.env.S3_SECRET_ACCESS_KEY!,
+          },
+          endpoint: process.env.S3_ENDPOINT,
+          forcePathStyle: process.env.S3_FORCE_PATH_STYLE === 'true',
+          region: 'us-east-1',
+        },
+      }),
+    ],
+    typescript: {
+      outputFile: path.resolve(dirname, 'payload-types.ts'),
     },
   },
-  onInit: async (payload) => {
+  seed: async (payload) => {
     await createTestBucket()
     await seed(payload)
-  },
-  plugins: [
-    importExportPlugin({
-      debug: true,
-      collections: [
-        {
-          slug: 'pages',
-          export: {
-            overrideCollection: ({ collection }) => {
-              if (collection.admin) {
-                collection.admin.group = 'System'
-              }
-              collection.upload.staticDir = path.resolve(dirname, 'uploads')
-              return collection
-            },
-          },
-          import: {
-            overrideCollection: ({ collection }) => {
-              if (collection.admin) {
-                collection.admin.group = 'System'
-              }
-              collection.upload.staticDir = path.resolve(dirname, 'uploads')
-              return collection
-            },
-          },
-          versions: false,
-        },
-        {
-          slug: 'posts',
-          export: {
-            disableJobsQueue: true,
-            overrideCollection: ({ collection }) => {
-              collection.slug = 'posts-export'
-              if (collection.admin) {
-                collection.admin.group = 'Posts'
-              }
-              collection.upload.staticDir = path.resolve(dirname, 'uploads')
-              return collection
-            },
-          },
-          import: {
-            disableJobsQueue: true,
-            overrideCollection: ({ collection }) => {
-              collection.slug = 'posts-import'
-              if (collection.admin) {
-                collection.admin.group = 'Posts'
-              }
-              collection.upload.staticDir = path.resolve(dirname, 'uploads')
-              return collection
-            },
-          },
-          versions: false,
-        },
-        {
-          slug: 'posts-exports-only',
-          import: false,
-          export: {
-            format: 'csv',
-          },
-          versions: false,
-        },
-        {
-          slug: 'posts-imports-only',
-          export: false,
-          import: {
-            defaultVersionStatus: 'draft',
-            disableJobsQueue: true,
-          },
-          versions: false,
-        },
-        {
-          slug: 'posts-no-jobs-queue',
-          import: {
-            disableJobsQueue: true,
-          },
-          export: {
-            disableJobsQueue: true,
-            format: 'csv',
-            disableSave: true,
-            overrideCollection: ({ collection }) => {
-              collection.slug = 'posts-no-jobs-queue-export'
-              if (collection.admin) {
-                collection.admin.group = 'Posts No Jobs Queue'
-              }
-              collection.upload.staticDir = path.resolve(dirname, 'uploads')
-              return collection
-            },
-          },
-          versions: false,
-        },
-        {
-          slug: postsWithS3Slug,
-          export: {
-            overrideCollection: ({ collection }) => {
-              collection.slug = 'posts-with-s3-export'
-              if (collection.admin) {
-                collection.admin.group = 'S3 Tests'
-              }
-              return collection
-            },
-          },
-          import: {
-            overrideCollection: ({ collection }) => {
-              collection.slug = 'posts-with-s3-import'
-              if (collection.admin) {
-                collection.admin.group = 'S3 Tests'
-              }
-              // The import task fetches the uploaded CSV back through Payload's
-              // file endpoint, which resolves to `localhost` under prod-server
-              // e2e and gets rejected by `safeFetch`'s SSRF guard.
-              collection.upload = typeof collection.upload === 'object' ? collection.upload : {}
-              collection.upload.skipSafeFetch = true
-              return collection
-            },
-          },
-          versions: false,
-        },
-        {
-          slug: 'posts-with-limits',
-          export: {
-            disableJobsQueue: true,
-            limit: ({ req }) => {
-              if (req.user?.limit) {
-                return req.user.limit
-              }
-              return 5
-            },
-            overrideCollection: ({ collection }) => {
-              collection.slug = 'posts-with-limits-export'
-              collection.upload.staticDir = path.resolve(dirname, 'uploads')
-              return collection
-            },
-          },
-          import: {
-            disableJobsQueue: true,
-            limit: 5,
-            overrideCollection: ({ collection }) => {
-              collection.slug = 'posts-with-limits-import'
-              collection.upload.staticDir = path.resolve(dirname, 'uploads')
-              return collection
-            },
-          },
-          versions: false,
-        },
-        {
-          slug: 'media',
-          versions: false,
-        },
-        {
-          slug: customIdPagesSlug,
-          versions: false,
-        },
-        {
-          slug: postsWithHooksSlug,
-          export: {
-            batchSize: 2,
-            disableJobsQueue: true,
-            hooks: {
-              before: exportBeforeHook,
-              after: exportAfterHook,
-            },
-            overrideCollection: ({ collection }) => {
-              collection.slug = 'posts-with-hooks-export'
-              collection.upload.staticDir = path.resolve(dirname, 'uploads')
-              return collection
-            },
-          },
-          import: {
-            batchSize: 2,
-            disableJobsQueue: true,
-            hooks: {
-              before: importBeforeHook,
-              after: importAfterHook,
-            },
-            overrideCollection: ({ collection }) => {
-              collection.slug = 'posts-with-hooks-import'
-              collection.upload.staticDir = path.resolve(dirname, 'uploads')
-              return collection
-            },
-          },
-          versions: false,
-        },
-        {
-          slug: postsWithFieldHooksSlug,
-          export: {
-            disableJobsQueue: true,
-            overrideCollection: ({ collection }) => {
-              collection.slug = 'posts-with-field-hooks-export'
-              collection.upload.staticDir = path.resolve(dirname, 'uploads')
-              return collection
-            },
-          },
-          import: {
-            disableJobsQueue: true,
-            overrideCollection: ({ collection }) => {
-              collection.slug = 'posts-with-field-hooks-import'
-              collection.upload.staticDir = path.resolve(dirname, 'uploads')
-              return collection
-            },
-          },
-          versions: false,
-        },
-        {
-          slug: postsWithColumnMapSlug,
-          export: {
-            disableJobsQueue: true,
-            hooks: {
-              before: ({ data }) => {
-                return data.map((row) => {
-                  const renamed: Record<string, unknown> = {}
-                  for (const [key, value] of Object.entries(row)) {
-                    renamed[exportRenameMap[key] ?? key] = value
-                  }
-                  return renamed
-                })
-              },
-            },
-            overrideCollection: ({ collection }) => {
-              collection.slug = 'posts-with-column-map-export'
-              collection.upload.staticDir = path.resolve(dirname, 'uploads')
-              return collection
-            },
-          },
-          import: {
-            disableJobsQueue: true,
-            hooks: {
-              before: ({ data }) => {
-                return data.map((doc) => {
-                  const renamed: Record<string, unknown> = {}
-                  for (const [key, value] of Object.entries(doc)) {
-                    const payloadKey = importRenameMap[key]
-                    if (payloadKey) {
-                      renamed[payloadKey] = value
-                    }
-                  }
-                  return renamed
-                })
-              },
-            },
-            overrideCollection: ({ collection }) => {
-              collection.slug = 'posts-with-column-map-import'
-              collection.upload.staticDir = path.resolve(dirname, 'uploads')
-              return collection
-            },
-          },
-          versions: false,
-        },
-      ],
-    }),
-  ],
-  storage: [
-    s3Storage({
-      collections: {
-        'posts-with-s3-import': true,
-        'posts-with-s3-export': true,
-      },
-      bucket: process.env.S3_BUCKET!,
-      config: {
-        credentials: {
-          accessKeyId: process.env.S3_ACCESS_KEY_ID!,
-          secretAccessKey: process.env.S3_SECRET_ACCESS_KEY!,
-        },
-        endpoint: process.env.S3_ENDPOINT,
-        forcePathStyle: process.env.S3_FORCE_PATH_STYLE === 'true',
-        region: 'us-east-1',
-      },
-    }),
-  ],
-  typescript: {
-    outputFile: path.resolve(dirname, 'payload-types.ts'),
   },
 })

--- a/test/plugin-import-export/field-hooks.int.spec.ts
+++ b/test/plugin-import-export/field-hooks.int.spec.ts
@@ -1,26 +1,22 @@
-import type { AuthenticatedUser, Payload } from 'payload'
+import type { AuthenticatedUser } from 'payload'
 
 import path from 'path'
 import { fileURLToPath } from 'url'
-import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { expect } from 'vitest'
 
-import type { NextRESTClient } from '../__helpers/shared/NextRESTClient.js'
-
-import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
+import { test } from '../__helpers/int/vitest.js'
 import { devUser } from '../credentials.js'
+import testConfig from './config.js'
 import { readCSV, readJSON } from './helpers.js'
 import { postsWithFieldHooksSlug } from './shared.js'
 
-let payload: Payload
-let restClient: NextRESTClient
 let user: AuthenticatedUser
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
-describe('@payloadcms/plugin-import-export — field-level hooks', () => {
-  beforeAll(async () => {
-    ;({ payload, restClient } = await initPayloadInt(dirname))
+test.suite({ config: testConfig })('@payloadcms/plugin-import-export — field-level hooks', () => {
+  test.beforeEach(async ({ payload }) => {
     const loginResult = await payload.login({
       collection: 'users',
       data: { email: devUser.email, password: devUser.password },
@@ -29,11 +25,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
     user = loginResult.user!
   })
 
-  afterAll(async () => {
-    await payload.destroy()
-  })
-
-  afterEach(async () => {
+  test.afterEach(async ({ payload }) => {
     const existing = await payload.find({
       collection: postsWithFieldHooksSlug,
       limit: 1000,
@@ -48,8 +40,8 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
   // Field-level export hooks
   // ─────────────────────────────────────────────
 
-  describe('field-level export hooks', () => {
-    it('should transform CSV output using field-level export hook', async () => {
+  test.describe('field-level export hooks', () => {
+    test('should transform CSV output using field-level export hook', async ({ payload }) => {
       const post = await payload.create({
         collection: postsWithFieldHooksSlug,
         data: { customExport: 'raw value', title: 'Field Export Test' },
@@ -77,7 +69,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       expect(rows[0]!.customExport).toBe('raw value exported')
     })
 
-    it('should receive format: csv during CSV export', async () => {
+    test('should receive format: csv during CSV export', async ({ payload }) => {
       const post = await payload.create({
         collection: postsWithFieldHooksSlug,
         data: { customExport: 'test', title: 'Format CSV Test' },
@@ -105,7 +97,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       expect(rows[0]!.customExport_format).toBe('csv')
     })
 
-    it('should receive format: json during JSON export', async () => {
+    test('should receive format: json during JSON export', async ({ payload }) => {
       const post = await payload.create({
         collection: postsWithFieldHooksSlug,
         data: { customExport: 'test', title: 'Format JSON Test' },
@@ -133,7 +125,9 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       expect(docs[0]!.customExport).toBe('test exported')
     })
 
-    it('should transform deeply nested fields (group > named tab > field)', async () => {
+    test('should transform deeply nested fields (group > named tab > field)', async ({
+      payload,
+    }) => {
       const post = await payload.create({
         collection: postsWithFieldHooksSlug,
         data: {
@@ -164,7 +158,10 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       expect(rows[0]!.group_namedTab_deepField).toBe('deep value deep_exported')
     })
 
-    it('should transform deeply nested fields in CSV preview (group > named tab > field)', async () => {
+    test('should transform deeply nested fields in CSV preview (group > named tab > field)', async ({
+      payload,
+      restClient,
+    }) => {
       const post = await payload.create({
         collection: postsWithFieldHooksSlug,
         data: {
@@ -197,8 +194,10 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
   // Field-level import hooks
   // ─────────────────────────────────────────────
 
-  describe('field-level import hooks', () => {
-    it('should transform value during CSV import using field-level import hook', async () => {
+  test.describe('field-level import hooks', () => {
+    test('should transform value during CSV import using field-level import hook', async ({
+      payload,
+    }) => {
       const csvContent = `title,customImport\n"Import Hook Test","original_value"`
       const file = {
         name: 'field-hooks-import.csv',
@@ -229,7 +228,9 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       expect(imported.docs).toHaveLength(1)
     })
 
-    it('should transform value during JSON import using field-level import hook', async () => {
+    test('should transform value during JSON import using field-level import hook', async ({
+      payload,
+    }) => {
       const jsonContent = JSON.stringify([
         { customImport: 'json_value', title: 'JSON Import Hook Test' },
       ])
@@ -271,8 +272,10 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
   // Empty-cell preservation on update import
   // ─────────────────────────────────────────────
 
-  describe('synthetic import hooks should not clobber existing data with empty cells', () => {
-    it('should preserve existing number value when CSV update row has a blank count cell', async () => {
+  test.describe('synthetic import hooks should not clobber existing data with empty cells', () => {
+    test('should preserve existing number value when CSV update row has a blank count cell', async ({
+      payload,
+    }) => {
       const existing = await payload.create({
         collection: postsWithFieldHooksSlug,
         data: { count: 5, title: 'Empty Cell Update Number Test' },
@@ -317,8 +320,10 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
   // Execution order: field-level before collection-level
   // ─────────────────────────────────────────────
 
-  describe('execution order', () => {
-    it('should run field-level export hooks before collection-level hooks', async () => {
+  test.describe('execution order', () => {
+    test('should run field-level export hooks before collection-level hooks', async ({
+      payload,
+    }) => {
       // This test uses the postsWithFieldHooksSlug collection which has
       // field-level hooks on customExport AND collection-level hooks configured.
       // The field-level hook transforms the value first, then collection-level
@@ -356,8 +361,8 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
   // Reusable field config
   // ─────────────────────────────────────────────
 
-  describe('reusable field configs', () => {
-    it('should apply field-level hooks from a shared field definition', async () => {
+  test.describe('reusable field configs', () => {
+    test('should apply field-level hooks from a shared field definition', async ({ payload }) => {
       const post = await payload.create({
         collection: postsWithFieldHooksSlug,
         data: { email: 'USER@EXAMPLE.COM', title: 'Reusable Field Test' },
@@ -390,8 +395,10 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
   // Edge cases
   // ─────────────────────────────────────────────
 
-  describe('edge cases', () => {
-    it('should use default flattening when export hook returns undefined', async () => {
+  test.describe('edge cases', () => {
+    test('should use default flattening when export hook returns undefined', async ({
+      payload,
+    }) => {
       // A field without any hooks should flatten normally (default behavior)
       const post = await payload.create({
         collection: postsWithFieldHooksSlug,
@@ -425,8 +432,10 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
   // Field-level hooks inside arrays and blocks
   // ─────────────────────────────────────────────
 
-  describe('field-level hooks inside arrays', () => {
-    it('should run field-level export hook on array item sub-fields (CSV)', async () => {
+  test.describe('field-level hooks inside arrays', () => {
+    test('should run field-level export hook on array item sub-fields (CSV)', async ({
+      payload,
+    }) => {
       const post = await payload.create({
         collection: postsWithFieldHooksSlug,
         data: {
@@ -457,7 +466,9 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       expect(rows[0]!.items_1_note).toBe('second array_exported')
     })
 
-    it('should run field-level export hook on array item sub-fields (JSON)', async () => {
+    test('should run field-level export hook on array item sub-fields (JSON)', async ({
+      payload,
+    }) => {
       const post = await payload.create({
         collection: postsWithFieldHooksSlug,
         data: {
@@ -488,7 +499,9 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       expect(docs[0]!.items[1].note).toBe('beta array_exported')
     })
 
-    it('should run field-level import hook on array item sub-fields (CSV)', async () => {
+    test('should run field-level import hook on array item sub-fields (CSV)', async ({
+      payload,
+    }) => {
       const csvContent = `title,items_0_note,items_1_note\n"Array Import CSV","one","two"`
       const file = {
         name: 'array-items-import.csv',
@@ -520,7 +533,9 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       expect((imported.docs[0] as any).items[1].note).toBe('two_array_imported')
     })
 
-    it('should run field-level import hook on array item sub-fields (JSON)', async () => {
+    test('should run field-level import hook on array item sub-fields (JSON)', async ({
+      payload,
+    }) => {
       const jsonContent = JSON.stringify([
         { items: [{ note: 'uno' }, { note: 'dos' }], title: 'Array Import JSON' },
       ])
@@ -559,8 +574,8 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
     })
   })
 
-  describe('field-level hooks inside blocks', () => {
-    it('should run field-level export hook on block sub-fields (CSV)', async () => {
+  test.describe('field-level hooks inside blocks', () => {
+    test('should run field-level export hook on block sub-fields (CSV)', async ({ payload }) => {
       const post = await payload.create({
         collection: postsWithFieldHooksSlug,
         data: {
@@ -594,7 +609,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       expect(rows[0]!.content_1_textBlock_body).toBe('world block_exported')
     })
 
-    it('should run field-level export hook on block sub-fields (JSON)', async () => {
+    test('should run field-level export hook on block sub-fields (JSON)', async ({ payload }) => {
       const post = await payload.create({
         collection: postsWithFieldHooksSlug,
         data: {
@@ -624,7 +639,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       expect(docs[0]!.content[0].body).toBe('foo block_exported')
     })
 
-    it('should run field-level import hook on block sub-fields (CSV)', async () => {
+    test('should run field-level import hook on block sub-fields (CSV)', async ({ payload }) => {
       const csvContent = `title,content_0_textBlock_body\n"Blocks Import CSV","csv-body"`
       const file = {
         name: 'block-body-import.csv',
@@ -655,7 +670,7 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       expect((imported.docs[0] as any).content[0].body).toBe('csv-body_block_imported')
     })
 
-    it('should run field-level import hook on block sub-fields (JSON)', async () => {
+    test('should run field-level import hook on block sub-fields (JSON)', async ({ payload }) => {
       const jsonContent = JSON.stringify([
         {
           content: [{ blockType: 'textBlock', body: 'json-body' }],
@@ -700,8 +715,10 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
   // Hook receives the top-level document in `data` arg
   // ─────────────────────────────────────────────
 
-  describe('field-level import hook receives sibling-level data', () => {
-    it('should pass the nested parent object as siblingData to hooks inside a group (JSON)', async () => {
+  test.describe('field-level import hook receives sibling-level data', () => {
+    test('should pass the nested parent object as siblingData to hooks inside a group (JSON)', async ({
+      payload,
+    }) => {
       // The metadata.siblingEcho hook reads siblingData.slugFromTitle — that key
       // only exists on the parent-level `metadata` object, not on the top-level
       // document. If the hook received `data` (top-level) instead of `siblingData`,
@@ -751,8 +768,10 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
   // must not abort the whole batch.
   // ─────────────────────────────────────────────
 
-  describe('field-level hook error isolation', () => {
-    it('should isolate a thrown beforeImport hook to its row during CSV import', async () => {
+  test.describe('field-level hook error isolation', () => {
+    test('should isolate a thrown beforeImport hook to its row during CSV import', async ({
+      payload,
+    }) => {
       const csvContent = [
         'title,mayCrash',
         '"Crash Row 1","ok1"',
@@ -793,7 +812,9 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       expect(byTitle['Crash Row 3']!.mayCrash).toBe('ok3_imported')
     })
 
-    it('should isolate a thrown beforeImport hook to its row during JSON import', async () => {
+    test('should isolate a thrown beforeImport hook to its row during JSON import', async ({
+      payload,
+    }) => {
       const jsonContent = JSON.stringify([
         { mayCrash: 'json-ok-1', title: 'JSON Crash 1' },
         { mayCrash: 'CRASH', title: 'JSON Crash 2' },
@@ -837,7 +858,9 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       expect(byTitle['JSON Crash 3']!.mayCrash).toBe('json-ok-3_imported')
     })
 
-    it('should isolate a thrown beforeExport hook to its doc during CSV export', async () => {
+    test('should isolate a thrown beforeExport hook to its doc during CSV export', async ({
+      payload,
+    }) => {
       const docs = await Promise.all([
         payload.create({
           collection: postsWithFieldHooksSlug,
@@ -878,7 +901,9 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       expect(byTitle['Export Crash C']!.mayCrash).toBe('safe-c_exported')
     })
 
-    it('should isolate a thrown beforeExport hook to its doc during JSON export', async () => {
+    test('should isolate a thrown beforeExport hook to its doc during JSON export', async ({
+      payload,
+    }) => {
       const docs = await Promise.all([
         payload.create({
           collection: postsWithFieldHooksSlug,
@@ -929,8 +954,10 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
   // so child hooks should still register and fire.
   // ─────────────────────────────────────────────
 
-  describe('field-level hooks under unnamed presentational wrappers', () => {
-    it('should fire export hook on a field nested in a row wrapper (CSV)', async () => {
+  test.describe('field-level hooks under unnamed presentational wrappers', () => {
+    test('should fire export hook on a field nested in a row wrapper (CSV)', async ({
+      payload,
+    }) => {
       const post = await payload.create({
         collection: postsWithFieldHooksSlug,
         data: { rowField: 'inside-row', title: 'Row Wrapper Export' },
@@ -957,7 +984,9 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       expect(rows[0]!.rowField).toBe('inside-row_row_exported')
     })
 
-    it('should fire import hook on a field nested in a row wrapper (CSV)', async () => {
+    test('should fire import hook on a field nested in a row wrapper (CSV)', async ({
+      payload,
+    }) => {
       const csvContent = `title,rowField\n"Row Wrapper Import","incoming"`
       const file = {
         name: 'row-wrapper-import.csv',
@@ -988,7 +1017,9 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       expect((imported.docs[0] as any).rowField).toBe('incoming_row_imported')
     })
 
-    it('should fire export hook on a field nested in a collapsible wrapper (CSV)', async () => {
+    test('should fire export hook on a field nested in a collapsible wrapper (CSV)', async ({
+      payload,
+    }) => {
       const post = await payload.create({
         collection: postsWithFieldHooksSlug,
         data: { collapsibleField: 'inside-collapsible', title: 'Collapsible Wrapper Export' },
@@ -1015,7 +1046,9 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
       expect(rows[0]!.collapsibleField).toBe('inside-collapsible_collapsible_exported')
     })
 
-    it('should fire import hook on a field nested in a collapsible wrapper (CSV)', async () => {
+    test('should fire import hook on a field nested in a collapsible wrapper (CSV)', async ({
+      payload,
+    }) => {
       const csvContent = `title,collapsibleField\n"Collapsible Wrapper Import","incoming"`
       const file = {
         name: 'collapsible-wrapper-import.csv',
@@ -1047,8 +1080,10 @@ describe('@payloadcms/plugin-import-export — field-level hooks', () => {
     })
   })
 
-  describe('field-level import hook receives top-level data', () => {
-    it('should pass the full top-level doc to hooks on nested fields (JSON)', async () => {
+  test.describe('field-level import hook receives top-level data', () => {
+    test('should pass the full top-level doc to hooks on nested fields (JSON)', async ({
+      payload,
+    }) => {
       // The metadata.slugFromTitle hook reads data.title (top-level field)
       // and uses it to generate a slug when slugFromTitle is empty.
       const jsonContent = JSON.stringify([

--- a/test/plugin-import-export/field-hooks.int.spec.ts
+++ b/test/plugin-import-export/field-hooks.int.spec.ts
@@ -6,7 +6,6 @@ import { expect } from 'vitest'
 
 import { test } from '../__helpers/int/vitest.js'
 import { devUser } from '../credentials.js'
-import testConfig from './config.js'
 import { readCSV, readJSON } from './helpers.js'
 import { postsWithFieldHooksSlug } from './shared.js'
 
@@ -14,8 +13,9 @@ let user: AuthenticatedUser
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
+const configPath = './config.ts'
 
-test.suite({ config: testConfig })('@payloadcms/plugin-import-export — field-level hooks', () => {
+test.suite({ config: configPath })('@payloadcms/plugin-import-export — field-level hooks', () => {
   test.beforeEach(async ({ payload }) => {
     const loginResult = await payload.login({
       collection: 'users',

--- a/test/plugin-import-export/hooks.int.spec.ts
+++ b/test/plugin-import-export/hooks.int.spec.ts
@@ -1,19 +1,16 @@
-import type { AuthenticatedUser, Payload } from 'payload'
+import type { AuthenticatedUser } from 'payload'
 
 import path from 'path'
 import { fileURLToPath } from 'url'
-import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { expect } from 'vitest'
 
-import type { NextRESTClient } from '../__helpers/shared/NextRESTClient.js'
-
-import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
+import { test } from '../__helpers/int/vitest.js'
 import { devUser } from '../credentials.js'
+import testConfig from './config.js'
 import { readCSV, readJSON } from './helpers.js'
 import { hookCalls, resetHookSpies } from './hookSpies.js'
 import { postsWithColumnMapSlug, postsWithHooksSlug } from './shared.js'
 
-let payload: Payload
-let restClient: NextRESTClient
 let user: AuthenticatedUser
 
 const filename = fileURLToPath(import.meta.url)
@@ -21,9 +18,8 @@ const dirname = path.dirname(filename)
 
 const createdHookPostIDs: (number | string)[] = []
 
-describe('@payloadcms/plugin-import-export — hooks', () => {
-  beforeAll(async () => {
-    ;({ payload, restClient } = await initPayloadInt(dirname))
+test.suite({ config: testConfig })('@payloadcms/plugin-import-export — hooks', () => {
+  test.beforeEach(async ({ payload }) => {
     const loginResult = await payload.login({
       collection: 'users',
       data: { email: devUser.email, password: devUser.password },
@@ -32,11 +28,7 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
     user = loginResult.user!
   })
 
-  afterAll(async () => {
-    await payload.destroy()
-  })
-
-  afterEach(async () => {
+  test.afterEach(async ({ payload }) => {
     resetHookSpies()
     for (const id of createdHookPostIDs) {
       await payload
@@ -50,8 +42,10 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
   // Export hooks
   // ─────────────────────────────────────────────
 
-  describe('export hooks', () => {
-    it('should call export.hooks.before with correct args and apply its return value to CSV output', async () => {
+  test.describe('export hooks', () => {
+    test('should call export.hooks.before with correct args and apply its return value to CSV output', async ({
+      payload,
+    }) => {
       const post = await payload.create({
         collection: postsWithHooksSlug,
         data: { title: 'Hook Test', secret: 'top-secret', count: 1 },
@@ -94,7 +88,7 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
       expect(rows[0]!.title).toBe('Hook Test')
     })
 
-    it('should call export.hooks.after with correct args after write', async () => {
+    test('should call export.hooks.after with correct args after write', async ({ payload }) => {
       const post = await payload.create({
         collection: postsWithHooksSlug,
         data: { title: 'After Hook Test', secret: 'hidden', count: 2 },
@@ -127,7 +121,9 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
       expect(afterArgs.originalData).toBeDefined()
     })
 
-    it('should call export.hooks.before for JSON exports with nested docs', async () => {
+    test('should call export.hooks.before for JSON exports with nested docs', async ({
+      payload,
+    }) => {
       const post = await payload.create({
         collection: postsWithHooksSlug,
         data: { title: 'JSON Hook Test', secret: 'json-secret', count: 3 },
@@ -160,7 +156,9 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
       expect(jsonDocs[0]!.title).toBe('JSON Hook Test')
     })
 
-    it('should call export.hooks.before once per batch when multiple batches occur', async () => {
+    test('should call export.hooks.before once per batch when multiple batches occur', async ({
+      payload,
+    }) => {
       const posts = await Promise.all(
         Array.from({ length: 5 }, (_, i) =>
           payload.create({
@@ -194,7 +192,10 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
       expect(batchNumbers[1]).toBe(2)
     })
 
-    it('should call export.hooks.before via streaming download', async () => {
+    test('should call export.hooks.before via streaming download', async ({
+      payload,
+      restClient,
+    }) => {
       const post = await payload.create({
         collection: postsWithHooksSlug,
         data: { title: 'Download Hook Test', secret: 'streamed-secret', count: 4 },
@@ -224,8 +225,10 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
   // Import hooks
   // ─────────────────────────────────────────────
 
-  describe('import hooks', () => {
-    it('should call import.hooks.before with correct args and apply its return value to DB write', async () => {
+  test.describe('import hooks', () => {
+    test('should call import.hooks.before with correct args and apply its return value to DB write', async ({
+      payload,
+    }) => {
       const csvContent = `title,secret,count\n"Original Title","secret-val","10"`
       const file = {
         data: Buffer.from(csvContent),
@@ -269,7 +272,7 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
       importedDocs.docs.forEach((d) => createdHookPostIDs.push(d.id))
     })
 
-    it('should call import.hooks.after with per-batch ImportResult', async () => {
+    test('should call import.hooks.after with per-batch ImportResult', async ({ payload }) => {
       const csvContent = `title,count\n"After Hook Post","99"`
       const file = {
         data: Buffer.from(csvContent),
@@ -307,7 +310,9 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
       imported.docs.forEach((d) => createdHookPostIDs.push(d.id))
     })
 
-    it('should pass originalData (raw pre-transform rows) to import.hooks.after', async () => {
+    test('should pass originalData (raw pre-transform rows) to import.hooks.after', async ({
+      payload,
+    }) => {
       const csvContent = `title,count\n"OriginalData Post","42"`
       const file = {
         data: Buffer.from(csvContent),
@@ -343,7 +348,7 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
       imported.docs.forEach((d) => createdHookPostIDs.push(d.id))
     })
 
-    it('should call import.hooks.before for JSON imports', async () => {
+    test('should call import.hooks.before for JSON imports', async ({ payload }) => {
       const jsonContent = JSON.stringify([{ title: 'JSON Import Hook', count: 5 }])
       const file = {
         data: Buffer.from(jsonContent),
@@ -376,7 +381,9 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
       imported.docs.forEach((d) => createdHookPostIDs.push(d.id))
     })
 
-    it('should pass originalData as raw parsed JSON (before field hooks) to import hooks', async () => {
+    test('should pass originalData as raw parsed JSON (before field hooks) to import hooks', async ({
+      payload,
+    }) => {
       // The posts-with-hooks collection has an `email` field with a beforeImport field hook
       // that lowercases the value. This test verifies that originalData in both the before
       // and after collection hooks contains the raw parsed JSON value ('TEST@EXAMPLE.COM'),
@@ -427,7 +434,7 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
       imported.docs.forEach((d) => createdHookPostIDs.push(d.id))
     })
 
-    it('should call import.hooks.before once per batch', async () => {
+    test('should call import.hooks.before once per batch', async ({ payload }) => {
       const rows = Array.from({ length: 4 }, (_, i) => `"Batch Import ${i}","${i}"`).join('\n')
       const csvContent = `title,count\n${rows}`
       const file = {
@@ -468,17 +475,19 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
     })
   })
 
-  describe('column mapping — export', () => {
+  test.describe('column mapping — export', () => {
     const createdIDs: (number | string)[] = []
 
-    afterEach(async () => {
+    test.afterEach(async ({ payload }) => {
       for (const id of createdIDs) {
         await payload.delete({ collection: postsWithColumnMapSlug, id })
       }
       createdIDs.length = 0
     })
 
-    it('should rename CSV columns via collection-level export.hooks.before', async () => {
+    test('should rename CSV columns via collection-level export.hooks.before', async ({
+      payload,
+    }) => {
       const post = await payload.create({
         collection: postsWithColumnMapSlug,
         data: { title: 'Rename Me', excerpt: 'Original excerpt', count: 42 },
@@ -512,7 +521,9 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
       expect(rows[0]!.count).toBeUndefined()
     })
 
-    it('should rename a single CSV column via field-level beforeExport mutation', async () => {
+    test('should rename a single CSV column via field-level beforeExport mutation', async ({
+      payload,
+    }) => {
       const post = await payload.create({
         collection: postsWithColumnMapSlug,
         data: { title: 'Field Rename', excerpt: 'x', count: 1, sharedName: 'shared value' },
@@ -541,7 +552,10 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
       expect(rows[0]!.sharedName).toBeUndefined()
     })
 
-    it('should reflect collection-level export.hooks.before in CSV export preview', async () => {
+    test('should reflect collection-level export.hooks.before in CSV export preview', async ({
+      payload,
+      restClient,
+    }) => {
       const post = await payload.create({
         collection: postsWithColumnMapSlug,
         data: { title: 'Preview Rename', excerpt: 'preview excerpt', count: 11 },
@@ -578,7 +592,10 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
       expect(body.columns).not.toContain('count')
     })
 
-    it('should reflect collection-level export.hooks.before in JSON export preview', async () => {
+    test('should reflect collection-level export.hooks.before in JSON export preview', async ({
+      payload,
+      restClient,
+    }) => {
       const post = await payload.create({
         collection: postsWithColumnMapSlug,
         data: { title: 'JSON Preview Rename', excerpt: 'json preview', count: 22 },
@@ -606,7 +623,9 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
       expect(body.docs[0]!.title).toBeUndefined()
     })
 
-    it('should rename JSON keys via collection-level export.hooks.before', async () => {
+    test('should rename JSON keys via collection-level export.hooks.before', async ({
+      payload,
+    }) => {
       const post = await payload.create({
         collection: postsWithColumnMapSlug,
         data: { title: 'JSON Rename', excerpt: 'json excerpt', count: 7 },
@@ -639,10 +658,10 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
     })
   })
 
-  describe('column mapping — import', () => {
+  test.describe('column mapping — import', () => {
     const createdIDs: (number | string)[] = []
 
-    afterEach(async () => {
+    test.afterEach(async ({ payload }) => {
       for (const id of createdIDs) {
         await payload
           .delete({ collection: postsWithColumnMapSlug, id })
@@ -651,7 +670,9 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
       createdIDs.length = 0
     })
 
-    it('should import a CSV with foreign column names via collection-level import.hooks.before', async () => {
+    test('should import a CSV with foreign column names via collection-level import.hooks.before', async ({
+      payload,
+    }) => {
       const csv =
         '"Post Title","Summary","View Count","Ignored Column"\n' +
         '"Imported A","summary a","10","noise"\n' +
@@ -691,7 +712,9 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
       expect(imported.docs[1]!.count).toBe(20)
     })
 
-    it('should import a JSON file with foreign keys via collection-level import.hooks.before', async () => {
+    test('should import a JSON file with foreign keys via collection-level import.hooks.before', async ({
+      payload,
+    }) => {
       const content = JSON.stringify([
         {
           'Post Title': 'JSON A',
@@ -738,7 +761,9 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
       expect(imported.docs[1]!.count).toBe(6)
     })
 
-    it('should reflect collection-level import.hooks.before in CSV import preview', async () => {
+    test('should reflect collection-level import.hooks.before in CSV import preview', async ({
+      restClient,
+    }) => {
       const csv =
         '"Post Title","Summary","View Count","Ignored Column"\n' +
         '"Preview Imported","preview summary","30","noise"\n'
@@ -768,7 +793,9 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
       expect(body.docs[0]!['Ignored Column']).toBeUndefined()
     })
 
-    it('should reflect collection-level import.hooks.before in JSON import preview', async () => {
+    test('should reflect collection-level import.hooks.before in JSON import preview', async ({
+      restClient,
+    }) => {
       const content = JSON.stringify([
         {
           'Post Title': 'JSON Preview Imported',
@@ -801,7 +828,7 @@ describe('@payloadcms/plugin-import-export — hooks', () => {
       expect(body.docs[0]!['Post Title']).toBeUndefined()
     })
 
-    it('should drop foreign columns not present in the rename map', async () => {
+    test('should drop foreign columns not present in the rename map', async ({ payload }) => {
       const csv = '"Post Title","Ignored Column"\n' + '"Dropped Test","this should not survive"\n'
       const file = {
         data: Buffer.from(csv),

--- a/test/plugin-import-export/hooks.int.spec.ts
+++ b/test/plugin-import-export/hooks.int.spec.ts
@@ -6,7 +6,6 @@ import { expect } from 'vitest'
 
 import { test } from '../__helpers/int/vitest.js'
 import { devUser } from '../credentials.js'
-import testConfig from './config.js'
 import { readCSV, readJSON } from './helpers.js'
 import { hookCalls, resetHookSpies } from './hookSpies.js'
 import { postsWithColumnMapSlug, postsWithHooksSlug } from './shared.js'
@@ -18,7 +17,7 @@ const dirname = path.dirname(filename)
 
 const createdHookPostIDs: (number | string)[] = []
 
-test.suite({ config: testConfig })('@payloadcms/plugin-import-export — hooks', () => {
+test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export — hooks', () => {
   test.beforeEach(async ({ payload }) => {
     const loginResult = await payload.login({
       collection: 'users',

--- a/test/plugin-import-export/int.spec.ts
+++ b/test/plugin-import-export/int.spec.ts
@@ -1,32 +1,28 @@
-import type { AuthenticatedUser, CollectionSlug, Payload } from 'payload'
+import type { AuthenticatedUser, CollectionSlug } from 'payload'
 
 import fs from 'fs'
 import path from 'path'
 import { getFileByPath } from 'payload'
 import { extractID } from 'payload/shared'
 import { fileURLToPath } from 'url'
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { expect } from 'vitest'
 
-import type { NextRESTClient } from '../__helpers/shared/NextRESTClient.js'
-
-import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
+import { test } from '../__helpers/int/vitest.js'
 import { devUser, regularUser } from '../credentials.js'
 import { clearTestBucket, createTestBucket } from '../storage-s3/test-utils.js'
+import testConfig from './config.js'
 import { readCSV, readJSON } from './helpers.js'
 import { richTextData } from './seed/richTextData.js'
 import { customIdPagesSlug, postsWithS3Slug } from './shared.js'
 
-let payload: Payload
-let restClient: NextRESTClient
 let user: AuthenticatedUser
 let restrictedUser: any
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
-describe('@payloadcms/plugin-import-export', () => {
-  beforeAll(async () => {
-    ;({ payload, restClient } = await initPayloadInt(dirname))
+test.suite({ config: testConfig })('@payloadcms/plugin-import-export', () => {
+  test.beforeEach(async ({ payload }) => {
     const loginResult = await payload.login({
       collection: 'users',
       data: {
@@ -48,16 +44,12 @@ describe('@payloadcms/plugin-import-export', () => {
     }
   })
 
-  afterAll(async () => {
-    await payload.destroy()
-  })
-
-  describe('i18n scoping', () => {
-    it('should only merge plugin translations for supportedLanguages', () => {
+  test.describe('i18n scoping', () => {
+    test('should only merge plugin translations for supportedLanguages', ({ payload }) => {
       const supportedLangKeys = Object.keys(payload.config.i18n.supportedLanguages)
       expect(supportedLangKeys.sort()).toEqual(['en', 'es', 'he'])
 
-      // German is not in supportedLanguages — plugin-import-export must not contribute keys to it.
+      // German is not in supportedLanguages — plugin-import-export must not contribute keys to test.
       const deTranslations = payload.config.i18n.translations.de as
         | Record<string, unknown>
         | undefined
@@ -71,8 +63,8 @@ describe('@payloadcms/plugin-import-export', () => {
     })
   })
 
-  describe('graphql', () => {
-    it('should not break graphql', async () => {
+  test.describe('graphql', () => {
+    test('should not break graphql', async ({ restClient }) => {
       const query = `query {
         __schema {
           queryType {
@@ -90,8 +82,8 @@ describe('@payloadcms/plugin-import-export', () => {
     })
   })
 
-  describe('exports', () => {
-    it('should create a file for collection csv from defined fields', async () => {
+  test.describe('exports', () => {
+    test('should create a file for collection csv from defined fields', async ({ payload }) => {
       let doc = await payload.create({
         collection: 'exports',
         user,
@@ -127,7 +119,9 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(data[0].updatedAt).toBeDefined()
     })
 
-    it('should create a file for collection csv with all documents when limit 0', async () => {
+    test('should create a file for collection csv with all documents when limit 0', async ({
+      payload,
+    }) => {
       let doc = await payload.create({
         collection: 'exports',
         user,
@@ -156,7 +150,9 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(data).toHaveLength(totalNumberOfDocs)
     })
 
-    it('should create a file for collection csv with all documents when no limit', async () => {
+    test('should create a file for collection csv with all documents when no limit', async ({
+      payload,
+    }) => {
       let doc = await payload.create({
         collection: 'exports',
         user,
@@ -184,7 +180,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(data).toHaveLength(totalNumberOfDocs)
     })
 
-    it('should create a file for collection csv from limit and page 1', async () => {
+    test('should create a file for collection csv from limit and page 1', async ({ payload }) => {
       let doc = await payload.create({
         collection: 'exports',
         user,
@@ -219,7 +215,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(data[0].title).toStrictEqual(firstDocOnPage1?.title)
     })
 
-    it('should create a file for collection csv from limit and page 2', async () => {
+    test('should create a file for collection csv from limit and page 2', async ({ payload }) => {
       let doc = await payload.create({
         collection: 'exports',
         user,
@@ -254,7 +250,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(data[0].title).toStrictEqual(firstDocOnPage2?.title)
     })
 
-    it('should not create a file for collection csv when limit < 0', async () => {
+    test('should not create a file for collection csv when limit < 0', async ({ payload }) => {
       await expect(
         payload.create({
           collection: 'exports',
@@ -268,7 +264,9 @@ describe('@payloadcms/plugin-import-export', () => {
       ).rejects.toThrow(/Limit/)
     })
 
-    it('should create a file for collection csv with any positive limit value', async () => {
+    test('should create a file for collection csv with any positive limit value', async ({
+      payload,
+    }) => {
       let doc = await payload.create({
         collection: 'exports',
         user,
@@ -289,7 +287,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(doc.filename).toBeDefined()
     })
 
-    it('should export results sorted ASC by title when sort="title"', async () => {
+    test('should export results sorted ASC by title when sort="title"', async ({ payload }) => {
       let doc = await payload.create({
         collection: 'exports',
         user,
@@ -318,7 +316,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(data[0].title).toStrictEqual('Array 0')
     })
 
-    it('should export results sorted DESC by title when sort="-title"', async () => {
+    test('should export results sorted DESC by title when sort="-title"', async ({ payload }) => {
       let doc = await payload.create({
         collection: 'exports',
         user,
@@ -347,7 +345,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(data[0].title).toStrictEqual('Title 4')
     })
 
-    it('should create a file for collection csv with draft data', async () => {
+    test('should create a file for collection csv with draft data', async ({ payload }) => {
       const draftPage = await payload.create({
         collection: 'pages',
         user,
@@ -396,7 +394,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(data[0]._status).toStrictEqual('draft')
     })
 
-    it('should create a file for collection csv from one locale', async () => {
+    test('should create a file for collection csv from one locale', async ({ payload }) => {
       let doc = await payload.create({
         collection: 'exports',
         user,
@@ -426,7 +424,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(data[0].localized).toStrictEqual('en test')
     })
 
-    it('should create a file for collection csv from multiple locales', async () => {
+    test('should create a file for collection csv from multiple locales', async ({ payload }) => {
       let doc = await payload.create({
         collection: 'exports',
         user,
@@ -457,7 +455,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(data[0].localized_es).toStrictEqual('es test')
     })
 
-    it('should create a file for collection csv from array', async () => {
+    test('should create a file for collection csv from array', async ({ payload }) => {
       let doc = await payload.create({
         collection: 'exports',
         user,
@@ -488,7 +486,9 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(data[0].array_1_field2).toStrictEqual('baz')
     })
 
-    it('should create a CSV file with columns matching the order of the fields array', async () => {
+    test('should create a CSV file with columns matching the order of the fields array', async ({
+      payload,
+    }) => {
       const fields = ['id', 'group.value', 'group.array.field1', 'title', 'createdAt', 'updatedAt']
       const doc = await payload.create({
         collection: 'exports',
@@ -522,7 +522,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(str.indexOf('createdAt')).toBeLessThan(str.indexOf('updatedAt'))
     })
 
-    it('should create a CSV file with virtual fields', async () => {
+    test('should create a CSV file with virtual fields', async ({ payload }) => {
       const fields = ['id', 'virtual', 'virtualRelationship']
       const doc = await payload.create({
         collection: 'exports',
@@ -552,7 +552,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(data[0].virtualRelationship).toStrictEqual('name value')
     })
 
-    it('should create a file for collection csv from array.subfield', async () => {
+    test('should create a file for collection csv from array.subfield', async ({ payload }) => {
       let doc = await payload.create({
         collection: 'exports',
         user,
@@ -583,7 +583,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(data[0].array_1_field2).toBeUndefined()
     })
 
-    it('should create a file for collection csv from hasMany field', async () => {
+    test('should create a file for collection csv from hasMany field', async ({ payload }) => {
       let doc = await payload.create({
         collection: 'exports',
         user,
@@ -615,7 +615,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(data[0].hasManyNumber_4).toStrictEqual('3')
     })
 
-    it('should create a file for collection csv from blocks field', async () => {
+    test('should create a file for collection csv from blocks field', async ({ payload }) => {
       let doc = await payload.create({
         collection: 'exports',
         user,
@@ -644,7 +644,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(data[0].blocks_1_content_blockType).toStrictEqual('content')
     })
 
-    it('should create a csv of all fields when fields is empty', async () => {
+    test('should create a csv of all fields when fields is empty', async ({ payload }) => {
       const doc = await payload.create({
         collection: 'exports',
         user,
@@ -675,7 +675,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(data[0].createdAt).toBeDefined()
     })
 
-    it('should run beforeExport hook on a field', async () => {
+    test('should run beforeExport hook on a field', async ({ payload }) => {
       const fields = [
         'id',
         'custom',
@@ -718,7 +718,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(data[0].customRelationship).toBeUndefined()
     })
 
-    it('should create a JSON file for collection', async () => {
+    test('should create a JSON file for collection', async ({ payload }) => {
       let doc = await payload.create({
         collection: 'exports',
         user,
@@ -747,7 +747,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(data[0].title).toStrictEqual('JSON 0')
     })
 
-    it('should download an existing export JSON file', async () => {
+    test('should download an existing export JSON file', async ({ restClient }) => {
       const response = await restClient.POST('/exports/download', {
         body: JSON.stringify({
           data: {
@@ -774,7 +774,9 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(typeof data[0].title).toBe('string')
     })
 
-    it('should create an export with every field when no fields are defined', async () => {
+    test('should create an export with every field when no fields are defined', async ({
+      payload,
+    }) => {
       let doc = await payload.create({
         collection: 'exports',
         user,
@@ -802,7 +804,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(data[0].updatedAt).toBeDefined()
     })
 
-    it('should create jobs task for exports', async () => {
+    test('should create jobs task for exports', async ({ payload }) => {
       const doc = await payload.create({
         collection: 'exports' as CollectionSlug,
         user,
@@ -854,7 +856,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(data[0].title).toStrictEqual('Jobs 0')
     })
 
-    it('should export a large dataset without any duplicates', async () => {
+    test('should export a large dataset without any duplicates', async ({ payload }) => {
       const doc = await payload.create({
         collection: 'exports',
         user,
@@ -888,7 +890,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(duplicateIds).toHaveLength(0)
     })
 
-    it('should only include selected fields in CSV export, nothing else', async () => {
+    test('should only include selected fields in CSV export, nothing else', async ({ payload }) => {
       const doc = await payload.create({
         collection: 'posts-export',
         user,
@@ -916,7 +918,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(data[0].title).toBeDefined()
     })
 
-    it('should preserve user-specified field order in CSV export', async () => {
+    test('should preserve user-specified field order in CSV export', async ({ payload }) => {
       const doc = await payload.create({
         collection: 'posts-export',
         user,
@@ -943,7 +945,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(columns).toStrictEqual(['title', 'id', 'createdAt'])
     })
 
-    it('should export polymorphic relationship fields to CSV', async () => {
+    test('should export polymorphic relationship fields to CSV', async ({ payload }) => {
       const doc = await payload.create({
         collection: 'exports',
         user,
@@ -977,7 +979,9 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(data[0].hasManyPolymorphic_1_relationTo).toBe('posts')
     })
 
-    it('should not produce duplicate columns for hasOne polymorphic relationship export', async () => {
+    test('should not produce duplicate columns for hasOne polymorphic relationship export', async ({
+      payload,
+    }) => {
       const doc = await payload.create({
         collection: 'exports',
         user,
@@ -1014,7 +1018,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(leakedColumns).toEqual([])
     })
 
-    it('should export hasMany monomorphic relationship fields to CSV', async () => {
+    test('should export hasMany monomorphic relationship fields to CSV', async ({ payload }) => {
       const doc = await payload.create({
         collection: 'exports',
         user,
@@ -1045,7 +1049,9 @@ describe('@payloadcms/plugin-import-export', () => {
     })
 
     // disabled so we don't always run a massive test
-    it.skip('should create a file from a large set of collection documents', async () => {
+    test.skip('should create a file from a large set of collection documents', async ({
+      payload,
+    }) => {
       const allPromises = []
       let promises = []
       for (let i = 0; i < 100000; i++) {
@@ -1102,8 +1108,10 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(data[0].blocks_1_content_blockType).toStrictEqual('content')
     })
 
-    describe('schema-based column inference', () => {
-      it('should generate columns from schema without scanning documents', async () => {
+    test.describe('schema-based column inference', () => {
+      test('should generate columns from schema without scanning documents', async ({
+        payload,
+      }) => {
         let doc = await payload.create({
           collection: 'exports',
           user,
@@ -1138,7 +1146,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(headerLine).toContain('array_0_field2')
       })
 
-      it('should include all locale columns when locale is all', async () => {
+      test('should include all locale columns when locale is all', async ({ payload }) => {
         let doc = await payload.create({
           collection: 'exports',
           user,
@@ -1170,7 +1178,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(headerLine).toContain('localized_de')
       })
 
-      it('should generate correct columns for empty export', async () => {
+      test('should generate correct columns for empty export', async ({ payload }) => {
         let doc = await payload.create({
           collection: 'exports',
           user,
@@ -1201,7 +1209,9 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(content).toContain('excerpt')
       })
 
-      it('should include virtual fields in export columns (they have values)', async () => {
+      test('should include virtual fields in export columns (they have values)', async ({
+        payload,
+      }) => {
         let doc = await payload.create({
           collection: 'exports',
           user,
@@ -1231,8 +1241,10 @@ describe('@payloadcms/plugin-import-export', () => {
       })
     })
 
-    describe('beforeExport derived columns positioning', () => {
-      it('should position derived columns at the base field position and remove the original column', async () => {
+    test.describe('beforeExport derived columns positioning', () => {
+      test('should position derived columns at the base field position and remove the original column', async ({
+        payload,
+      }) => {
         const page = await payload.create({
           collection: 'pages',
           data: {
@@ -1280,7 +1292,9 @@ describe('@payloadcms/plugin-import-export', () => {
         await payload.delete({ collection: 'pages', id: page.id })
       })
 
-      it('should remove original column when beforeExport hook writes _name and _email (no _id)', async () => {
+      test('should remove original column when beforeExport hook writes _name and _email (no _id)', async ({
+        payload,
+      }) => {
         const page = await payload.create({
           collection: 'pages',
           data: {
@@ -1330,7 +1344,9 @@ describe('@payloadcms/plugin-import-export', () => {
         await payload.delete({ collection: 'pages', id: page.id })
       })
 
-      it('should remove original column when beforeExport hook writes _id and _locationName', async () => {
+      test('should remove original column when beforeExport hook writes _id and _locationName', async ({
+        payload,
+      }) => {
         const page = await payload.create({
           collection: 'pages',
           data: {
@@ -1380,7 +1396,10 @@ describe('@payloadcms/plugin-import-export', () => {
         await payload.delete({ collection: 'pages', id: page.id })
       })
 
-      it('should keep derived columns before trailing fields and match preview column order', async () => {
+      test('should keep derived columns before trailing fields and match preview column order', async ({
+        payload,
+        restClient,
+      }) => {
         const page = await payload.create({
           collection: 'pages',
           data: {
@@ -1442,7 +1461,10 @@ describe('@payloadcms/plugin-import-export', () => {
         await payload.delete({ collection: 'pages', id: page.id })
       })
 
-      it('should respect custom field order with beforeExport field first and match preview column order', async () => {
+      test('should respect custom field order with beforeExport field first and match preview column order', async ({
+        payload,
+        restClient,
+      }) => {
         const page = await payload.create({
           collection: 'pages',
           data: {
@@ -1507,8 +1529,8 @@ describe('@payloadcms/plugin-import-export', () => {
       })
     })
 
-    describe('date field export', () => {
-      it('should export date fields as ISO strings', async () => {
+    test.describe('date field export', () => {
+      test('should export date fields as ISO strings', async ({ payload }) => {
         const dateValue = '2026-01-22T00:00:00.000Z'
         const page = await payload.create({
           collection: 'pages',
@@ -1541,7 +1563,7 @@ describe('@payloadcms/plugin-import-export', () => {
         await payload.delete({ collection: 'pages', id: page.id })
       })
 
-      it('should handle null date values', async () => {
+      test('should handle null date values', async ({ payload }) => {
         const page = await payload.create({
           collection: 'pages',
           data: { title: 'Null Date Test', date: null, _status: 'published' },
@@ -1569,7 +1591,9 @@ describe('@payloadcms/plugin-import-export', () => {
         await payload.delete({ collection: 'pages', id: page.id })
       })
 
-      it('should not include timezone column when only date field is selected', async () => {
+      test('should not include timezone column when only date field is selected', async ({
+        payload,
+      }) => {
         const page = await payload.create({
           collection: 'pages',
           data: {
@@ -1604,7 +1628,9 @@ describe('@payloadcms/plugin-import-export', () => {
         await payload.delete({ collection: 'pages', id: page.id })
       })
 
-      it('should not create duplicate columns when selecting both date and timezone fields', async () => {
+      test('should not create duplicate columns when selecting both date and timezone fields', async ({
+        payload,
+      }) => {
         const page = await payload.create({
           collection: 'pages',
           data: {
@@ -1645,20 +1671,26 @@ describe('@payloadcms/plugin-import-export', () => {
       })
     })
 
-    describe('export collection config options', () => {
-      it('should apply per-collection overrideCollection to create custom export collection', () => {
+    test.describe('export collection config options', () => {
+      test('should apply per-collection overrideCollection to create custom export collection', ({
+        payload,
+      }) => {
         const customExportCollection = payload.collections['posts-no-jobs-queue-export']
         expect(customExportCollection).toBeDefined()
         expect(customExportCollection.config.admin?.group).toBe('Posts No Jobs Queue')
       })
 
-      it('should apply format and disableSave options to custom export collection', () => {
+      test('should apply format and disableSave options to custom export collection', ({
+        payload,
+      }) => {
         const customExportCollection = payload.collections['posts-no-jobs-queue-export']
         expect(customExportCollection.config.admin?.custom?.format).toBe('csv')
         expect(customExportCollection.config.admin?.custom?.disableSave).toBe(true)
       })
 
-      it('should reject download request with mismatched format when format is forced', async () => {
+      test('should reject download request with mismatched format when format is forced', async ({
+        restClient,
+      }) => {
         const response = await restClient.POST('/posts-no-jobs-queue-export/download', {
           body: JSON.stringify({
             data: {
@@ -1678,8 +1710,10 @@ describe('@payloadcms/plugin-import-export', () => {
       })
     })
 
-    describe('json and richText fields CSV serialization', () => {
-      it('should serialize json and richText fields as JSON strings in single columns', async () => {
+    test.describe('json and richText fields CSV serialization', () => {
+      test('should serialize json and richText fields as JSON strings in single columns', async ({
+        payload,
+      }) => {
         const jsonData = {
           key: 'value',
           nested: {
@@ -1764,7 +1798,9 @@ describe('@payloadcms/plugin-import-export', () => {
         })
       })
 
-      it('should roundtrip json and richText fields through CSV export/import', async () => {
+      test('should roundtrip json and richText fields through CSV export/import', async ({
+        payload,
+      }) => {
         const jsonData = {
           complex: {
             nested: {
@@ -1875,7 +1911,9 @@ describe('@payloadcms/plugin-import-export', () => {
         })
       })
 
-      it('should roundtrip a block containing a nested array with richText through CSV export/import', async () => {
+      test('should roundtrip a block containing a nested array with richText through CSV export/import', async ({
+        payload,
+      }) => {
         const testPage = await payload.create({
           collection: 'pages',
           data: {
@@ -1957,7 +1995,7 @@ describe('@payloadcms/plugin-import-export', () => {
         })
       })
 
-      it('should handle json fields in deeply nested array structures', async () => {
+      test('should handle json fields in deeply nested array structures', async ({ payload }) => {
         const jsonData = { level: 'nested', data: [1, 2, 3] }
 
         const testPage = await payload.create({
@@ -2074,7 +2112,7 @@ describe('@payloadcms/plugin-import-export', () => {
         })
       })
 
-      it('should update json and richText fields in update mode', async () => {
+      test('should update json and richText fields in update mode', async ({ payload }) => {
         const initialJson = { version: 1, data: 'initial' }
         const updatedJson = { version: 2, data: 'updated', extra: [1, 2, 3] }
 
@@ -2136,7 +2174,7 @@ describe('@payloadcms/plugin-import-export', () => {
         })
       })
 
-      it('should handle json and richText fields in upsert mode', async () => {
+      test('should handle json and richText fields in upsert mode', async ({ payload }) => {
         const timestamp = Date.now()
         const existingJson = { id: 'existing', value: 100 }
         const newJson = { id: 'new', value: 200, nested: { key: 'value' } }
@@ -2215,7 +2253,7 @@ describe('@payloadcms/plugin-import-export', () => {
         })
       })
 
-      it('should import json fields from manually created CSV', async () => {
+      test('should import json fields from manually created CSV', async ({ payload }) => {
         const manualJson = {
           settings: {
             theme: 'dark',
@@ -2273,7 +2311,7 @@ describe('@payloadcms/plugin-import-export', () => {
         })
       })
 
-      it('should handle multiple imports updating the same json fields', async () => {
+      test('should handle multiple imports updating the same json fields', async ({ payload }) => {
         const jsonV1 = { version: 1, items: ['a'] }
         const jsonV2 = { version: 2, items: ['a', 'b'] }
         const jsonV3 = { version: 3, items: ['a', 'b', 'c'] }
@@ -2353,8 +2391,8 @@ describe('@payloadcms/plugin-import-export', () => {
       })
     })
 
-    describe('Excel compatibility', () => {
-      it('should include UTF-8 BOM at the start of CSV files', async () => {
+    test.describe('Excel compatibility', () => {
+      test('should include UTF-8 BOM at the start of CSV files', async ({ payload }) => {
         const page = await payload.create({
           collection: 'pages',
           data: {
@@ -2388,7 +2426,7 @@ describe('@payloadcms/plugin-import-export', () => {
         await payload.delete({ collection: 'pages', id: page.id })
       })
 
-      it('should correctly encode UTF-8 characters for Excel', async () => {
+      test('should correctly encode UTF-8 characters for Excel', async ({ payload }) => {
         const unicodeTitle = 'Ümlauts, émojis 🎉, 日本語, and spëcial çharacters'
         const unicodeExcerpt = 'Ñoño señor • bullet points • áéíóú'
 
@@ -2430,7 +2468,9 @@ describe('@payloadcms/plugin-import-export', () => {
         await payload.delete({ collection: 'pages', id: page.id })
       })
 
-      it('should handle special CSV characters that could break Excel parsing', async () => {
+      test('should handle special CSV characters that could break Excel parsing', async ({
+        payload,
+      }) => {
         const specialCharsTitle = 'Title with "quotes" and, commas'
         const specialCharsExcerpt = 'Line1\nLine2\nLine3 with\ttabs'
 
@@ -2466,7 +2506,10 @@ describe('@payloadcms/plugin-import-export', () => {
         await payload.delete({ collection: 'pages', id: page.id })
       })
 
-      it('should preserve Hebrew characters in CSV download via streaming endpoint', async () => {
+      test('should preserve Hebrew characters in CSV download via streaming endpoint', async ({
+        payload,
+        restClient,
+      }) => {
         const hebrewTitle = 'Hebrew BOM Test'
         const hebrewLocalized = 'בדיקה עברית'
 
@@ -2514,7 +2557,7 @@ describe('@payloadcms/plugin-import-export', () => {
         await payload.delete({ collection: 'pages', id: page.id })
       })
 
-      it('should preserve Hebrew characters in job-created CSV export', async () => {
+      test('should preserve Hebrew characters in job-created CSV export', async ({ payload }) => {
         const hebrewTitle = 'Hebrew Jobs Test'
         const hebrewLocalized = 'שלום עולם'
 
@@ -2568,7 +2611,9 @@ describe('@payloadcms/plugin-import-export', () => {
         await payload.delete({ collection: 'pages', id: page.id })
       })
 
-      it('should preserve Hebrew characters in hook-created CSV export (no jobs queue)', async () => {
+      test('should preserve Hebrew characters in hook-created CSV export (no jobs queue)', async ({
+        payload,
+      }) => {
         const hebrewTitle = 'Hebrew Hooks Test'
         const hebrewContent = 'טקסט בעברית'
 
@@ -2622,8 +2667,8 @@ describe('@payloadcms/plugin-import-export', () => {
       })
     })
 
-    describe('fields', () => {
-      it('should export checkbox field as true/false strings', async () => {
+    test.describe('fields', () => {
+      test('should export checkbox field as true/false strings', async ({ payload }) => {
         let doc = await payload.create({
           collection: 'exports',
           user,
@@ -2648,7 +2693,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(['false', '0', '']).toContain(falseDoc?.checkbox)
       })
 
-      it('should export select field values', async () => {
+      test('should export select field values', async ({ payload }) => {
         let doc = await payload.create({
           collection: 'exports',
           user,
@@ -2671,7 +2716,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(data.find((d) => d.title === 'Select 2')?.select).toBe('option3')
       })
 
-      it('should export select hasMany field values', async () => {
+      test('should export select hasMany field values', async ({ payload }) => {
         let doc = await payload.create({
           collection: 'exports',
           user,
@@ -2693,7 +2738,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(selectManyDoc).toBeDefined()
       })
 
-      it('should export radio field values', async () => {
+      test('should export radio field values', async ({ payload }) => {
         let doc = await payload.create({
           collection: 'exports',
           user,
@@ -2716,7 +2761,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(data.find((d) => d.title === 'Radio 2')?.radio).toBe('radio3')
       })
 
-      it('should export email field values', async () => {
+      test('should export email field values', async ({ payload }) => {
         let doc = await payload.create({
           collection: 'exports',
           user,
@@ -2738,7 +2783,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(data.find((d) => d.title === 'Email 1')?.email).toBe('test1@example.com')
       })
 
-      it('should export textarea field with multiline content', async () => {
+      test('should export textarea field with multiline content', async ({ payload }) => {
         let doc = await payload.create({
           collection: 'exports',
           user,
@@ -2761,7 +2806,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(textarea0?.textarea).toContain('Line 2')
       })
 
-      it('should export code field values', async () => {
+      test('should export code field values', async ({ payload }) => {
         let doc = await payload.create({
           collection: 'exports',
           user,
@@ -2782,7 +2827,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(data.find((d) => d.title === 'Code 0')?.code).toContain('function test0')
       })
 
-      it('should export point field values', async () => {
+      test('should export point field values', async ({ payload }) => {
         let doc = await payload.create({
           collection: 'exports',
           user,
@@ -2803,7 +2848,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(data.find((d) => d.title === 'Point 0')).toBeDefined()
       })
 
-      it('should export hasMany text field values', async () => {
+      test('should export hasMany text field values', async ({ payload }) => {
         let doc = await payload.create({
           collection: 'exports',
           user,
@@ -2824,7 +2869,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(data.find((d) => d.title === 'TextMany 0')).toBeDefined()
       })
 
-      it('should export upload field values as IDs', async () => {
+      test('should export upload field values as IDs', async ({ payload }) => {
         let doc = await payload.create({
           collection: 'exports',
           user,
@@ -2849,10 +2894,10 @@ describe('@payloadcms/plugin-import-export', () => {
       })
     })
 
-    describe('custom ID exports', () => {
+    test.describe('custom ID exports', () => {
       const createdCustomIdPages: string[] = []
 
-      afterEach(async () => {
+      test.afterEach(async ({ payload }) => {
         for (const id of createdCustomIdPages) {
           try {
             await payload.delete({
@@ -2866,7 +2911,7 @@ describe('@payloadcms/plugin-import-export', () => {
         createdCustomIdPages.length = 0
       })
 
-      it('should export documents with custom text IDs to CSV', async () => {
+      test('should export documents with custom text IDs to CSV', async ({ payload }) => {
         await payload.create({
           collection: customIdPagesSlug as CollectionSlug,
           data: {
@@ -2920,7 +2965,7 @@ describe('@payloadcms/plugin-import-export', () => {
         )
       })
 
-      it('should export documents with custom text IDs to JSON', async () => {
+      test('should export documents with custom text IDs to JSON', async ({ payload }) => {
         await payload.create({
           collection: customIdPagesSlug as CollectionSlug,
           data: {
@@ -2976,8 +3021,8 @@ describe('@payloadcms/plugin-import-export', () => {
     })
   })
 
-  describe('imports', () => {
-    beforeEach(async () => {
+  test.describe('imports', () => {
+    test.beforeEach(async ({ payload }) => {
       await payload.delete({
         collection: 'pages',
         where: {
@@ -2993,7 +3038,7 @@ describe('@payloadcms/plugin-import-export', () => {
       })
     })
 
-    it('should import collection documents from CSV with defined fields', async () => {
+    test('should import collection documents from CSV with defined fields', async ({ payload }) => {
       const createdPages = []
       for (let i = 0; i < 3; i++) {
         const page = await payload.create({
@@ -3085,7 +3130,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(importedPages.docs[0]?.group?.array?.[0]?.field1).toBe('test 0')
     })
 
-    it('should import collection documents from JSON', async () => {
+    test('should import collection documents from JSON', async ({ payload }) => {
       const testData = [
         {
           title: 'JSON Import 1',
@@ -3142,7 +3187,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(importedPages.docs[0]?.group?.value).toBe('json group 1')
     })
 
-    it('should update existing documents in update mode', async () => {
+    test('should update existing documents in update mode', async ({ payload }) => {
       const page1 = await payload.create({
         collection: 'pages',
         data: {
@@ -3219,7 +3264,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(updatedPage1.group?.value).toBe('updated value 1')
     })
 
-    it('should handle upsert mode correctly', async () => {
+    test('should handle upsert mode correctly', async ({ payload }) => {
       const timestamp = Date.now()
       const existingPage = await payload.create({
         collection: 'pages',
@@ -3308,7 +3353,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(newPages.docs[0]?.excerpt).toBe('new')
     })
 
-    it('should import localized fields from CSV with single locale', async () => {
+    test('should import localized fields from CSV with single locale', async ({ payload }) => {
       const csvContent =
         'title,localized\n' +
         '"Localized Import 1","en single locale test 1"\n' +
@@ -3355,7 +3400,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(importedPages.docs[0]?.localized).toBe('en single locale test 1')
     })
 
-    it('should import localized fields from CSV with multiple locales', async () => {
+    test('should import localized fields from CSV with multiple locales', async ({ payload }) => {
       await payload.delete({
         collection: 'pages',
         where: {
@@ -3421,7 +3466,9 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(importedPagesEs.docs[0]?.localized).toBe('Spanish text 1')
     })
 
-    it('should import localized fields correctly regardless of CSV column order', async () => {
+    test('should import localized fields correctly regardless of CSV column order', async ({
+      payload,
+    }) => {
       // CSV columns intentionally put 'de' before 'en' (the defaultLocale)
       // to verify the import uses defaultLocale, not CSV column order
       const csvContent =
@@ -3508,7 +3555,7 @@ describe('@payloadcms/plugin-import-export', () => {
       })
     })
 
-    it('should import array fields from CSV', async () => {
+    test('should import array fields from CSV', async ({ payload }) => {
       const csvContent =
         'title,array_0_field1,array_0_field2,array_1_field1,array_1_field2\n' +
         '"Array Import 1","foo1","bar1","foo2","bar2"\n' +
@@ -3558,7 +3605,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(importedPages.docs[0]?.array?.[1]?.field2).toBe('bar2')
     })
 
-    it('should import blocks fields from CSV', async () => {
+    test('should import blocks fields from CSV', async ({ payload }) => {
       const csvContent =
         'title,blocks_0_hero_blockType,blocks_0_hero_title,blocks_1_content_blockType,blocks_1_content_richText\n' +
         '"Blocks Import 1","hero","Hero Title 1","content","{""root"":{""children"":[{""children"":[{""text"":""Sample content""}],""type"":""paragraph""}],""type"":""root""}}"'
@@ -3604,13 +3651,14 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(blocks?.[0]?.blockType).toBe('hero')
       const heroBlock = blocks?.[0]
       if (heroBlock?.blockType === 'hero') {
-        // eslint-disable-next-line vitest/no-conditional-expect
         expect((heroBlock as { blockType: 'hero'; title?: string })?.title).toBe('Hero Title 1')
       }
       expect(blocks?.[1]?.blockType).toBe('content')
     })
 
-    it('should import hasMany number fields from CSV with various formats', async () => {
+    test('should import hasMany number fields from CSV with various formats', async ({
+      payload,
+    }) => {
       const csvContent =
         'title,hasManyNumber\n' +
         '"HasMany Comma-Separated","1,2,3,5,8"\n' + // Comma-separated format
@@ -3674,10 +3722,8 @@ describe('@payloadcms/plugin-import-export', () => {
       const empty = importedPages.docs.find((d) => d?.title === 'HasMany Empty')
 
       if (empty?.hasManyNumber) {
-        // eslint-disable-next-line vitest/no-conditional-expect
         expect(empty?.hasManyNumber).toEqual([])
       } else {
-        // eslint-disable-next-line vitest/no-conditional-expect
         expect(empty?.hasManyNumber).not.toBeTruthy()
       }
 
@@ -3688,7 +3734,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(mixedEmpty?.hasManyNumber).toEqual([1, 3, 5])
     })
 
-    it('should import relationship fields from CSV', async () => {
+    test('should import relationship fields from CSV', async ({ payload }) => {
       const users = await payload.find({
         collection: 'users',
         limit: 3,
@@ -3749,7 +3795,9 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(extractID(page2?.author)).toBe(userId2)
     })
 
-    it('should handle explicit null vs empty polymorphic relationships in import', async () => {
+    test('should handle explicit null vs empty polymorphic relationships in import', async ({
+      payload,
+    }) => {
       const users = await payload.find({ collection: 'users', limit: 1 })
       const posts = await payload.find({ collection: 'posts', limit: 1 })
       const userId = users.docs[0]?.id
@@ -3819,7 +3867,7 @@ describe('@payloadcms/plugin-import-export', () => {
       })
     })
 
-    it('should import polymorphic relationship fields from CSV', async () => {
+    test('should import polymorphic relationship fields from CSV', async ({ payload }) => {
       const users = await payload.find({
         collection: 'users',
         limit: 1,
@@ -3889,7 +3937,7 @@ describe('@payloadcms/plugin-import-export', () => {
       })
     })
 
-    it('should skip virtual fields during import', async () => {
+    test('should skip virtual fields during import', async ({ payload }) => {
       const csvContent =
         'title,virtual,virtualRelationship\n' +
         '"Virtual Import Test","ignored value","ignored relationship"'
@@ -3933,7 +3981,9 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(importedPages.docs[0]?.virtual).toBe('virtual value')
     })
 
-    it('should correctly handle draft/published status when creating documents', async () => {
+    test('should correctly handle draft/published status when creating documents', async ({
+      payload,
+    }) => {
       const csvContent =
         'title,_status\n' +
         '"Draft Import 1","draft"\n' +
@@ -3990,7 +4040,9 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(publishedPages.docs).toHaveLength(1)
     })
 
-    it('should default to creating published documents when no _status specified', async () => {
+    test('should default to creating published documents when no _status specified', async ({
+      payload,
+    }) => {
       payload.config.debug = true
 
       const csvContent =
@@ -4039,7 +4091,7 @@ describe('@payloadcms/plugin-import-export', () => {
       payload.config.debug = false
     })
 
-    it('should handle error scenarios gracefully', async () => {
+    test('should handle error scenarios gracefully', async ({ payload }) => {
       const missingFieldCsv = ''
       const missingFieldBuffer = Buffer.from(missingFieldCsv)
 
@@ -4129,7 +4181,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(importDoc3.summary?.updated).toBe(0)
     })
 
-    it('should handle partial import success correctly', async () => {
+    test('should handle partial import success correctly', async ({ payload }) => {
       const timestamp = Date.now()
       const mixedCsv =
         'title,hasManyNumber_0,_status\n' +
@@ -4214,7 +4266,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(validPage2.docs).toHaveLength(1)
     })
 
-    it('should import nested group fields correctly', async () => {
+    test('should import nested group fields correctly', async ({ payload }) => {
       const csvContent =
         'title,group_value,group_ignore,group_array_0_field1,group_array_0_field2\n' +
         '"Nested Group Import","nested value","ignore value","array field 1","array field 2"'
@@ -4263,7 +4315,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(page?.group?.array?.[0]?.field2).toBe('array field 2')
     })
 
-    it('should handle tabs and collapsible fields during import', async () => {
+    test('should handle tabs and collapsible fields during import', async ({ payload }) => {
       const csvContent =
         'title,tabToCSV,namedTab_tabToCSV,textFieldInCollapsible\n' +
         '"Tab Import Test","tab value 1","named tab value","collapsible value"'
@@ -4310,7 +4362,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(page?.textFieldInCollapsible).toBe('collapsible value')
     })
 
-    it('should skip disabled fields during import', async () => {
+    test('should skip disabled fields during import', async ({ payload }) => {
       const pagesCollection = payload.config.collections.find((c) => c.slug === 'pages')
       if (pagesCollection && pagesCollection.admin) {
         pagesCollection.admin.custom = {
@@ -4373,7 +4425,7 @@ describe('@payloadcms/plugin-import-export', () => {
       }
     })
 
-    it('should create jobs task for imports', async () => {
+    test('should create jobs task for imports', async ({ payload }) => {
       const csvContent =
         'title,excerpt\n' + '"Jobs Import 1","excerpt 1"\n' + '"Jobs Import 2","excerpt 2"'
 
@@ -4448,7 +4500,9 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(importedPages.docs[0]?.excerpt).toBe('excerpt 1')
     })
 
-    it('should successfully roundtrip export and import with beforeExport/beforeImport hooks', async () => {
+    test('should successfully roundtrip export and import with beforeExport/beforeImport hooks', async ({
+      payload,
+    }) => {
       const createdPages = []
       for (let i = 0; i < 3; i++) {
         const page = await payload.create({
@@ -4551,7 +4605,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(importedPages.docs[0]?.group?.custom).toBe('group custom value toCSV')
     })
 
-    it('should handle all field types in export/import roundtrip', async () => {
+    test('should handle all field types in export/import roundtrip', async ({ payload }) => {
       const testUser = await payload.find({
         collection: 'users',
         limit: 1,
@@ -4698,8 +4752,8 @@ describe('@payloadcms/plugin-import-export', () => {
       })
     })
 
-    describe('batch processing', () => {
-      it('should process large imports in batches', async () => {
+    test.describe('batch processing', () => {
+      test('should process large imports in batches', async ({ payload }) => {
         const rows = ['title,excerpt']
         for (let i = 0; i < 250; i++) {
           rows.push(`"Batch Test ${i}","Excerpt ${i}"`)
@@ -4751,7 +4805,7 @@ describe('@payloadcms/plugin-import-export', () => {
         })
       })
 
-      it('should handle errors in batch processing and continue', async () => {
+      test('should handle errors in batch processing and continue', async ({ payload }) => {
         const csvContent = `title,excerpt,relationship
 "Valid Doc 1","Excerpt 1",""
 "Valid Doc 2","Excerpt 2","invalid-id"
@@ -4795,7 +4849,7 @@ describe('@payloadcms/plugin-import-export', () => {
         })
       })
 
-      it('should report row numbers in errors correctly', async () => {
+      test('should report row numbers in errors correctly', async ({ payload }) => {
         const testUser = await payload.find({
           collection: 'users',
           limit: 1,
@@ -4836,9 +4890,9 @@ describe('@payloadcms/plugin-import-export', () => {
 
         if (importDoc.summary?.issueDetails && Array.isArray(importDoc.summary.issueDetails)) {
           const issues = importDoc.summary.issueDetails as Array<{ error: string; row: number }>
-          // eslint-disable-next-line vitest/no-conditional-expect
+
           expect(issues).toHaveLength(1)
-          // eslint-disable-next-line vitest/no-conditional-expect
+
           expect(issues[0]?.row).toBe(3)
         }
 
@@ -4850,7 +4904,7 @@ describe('@payloadcms/plugin-import-export', () => {
         })
       })
 
-      it('should handle batch processing with localized fields', async () => {
+      test('should handle batch processing with localized fields', async ({ payload }) => {
         const rows = ['title,localized_en,localized_es']
         for (let i = 0; i < 150; i++) {
           rows.push(`"Batch Localized ${i}","English ${i}","Spanish ${i}"`)
@@ -4915,7 +4969,9 @@ describe('@payloadcms/plugin-import-export', () => {
         })
       })
 
-      it('should respect defaultVersionStatus configuration and create published documents', async () => {
+      test('should respect defaultVersionStatus configuration and create published documents', async ({
+        payload,
+      }) => {
         const csvContent =
           'title,excerpt\n"Default Status Test 1","Test excerpt 1"\n"Default Status Test 2","Test excerpt 2"'
         const csvBuffer = Buffer.from(csvContent)
@@ -4967,7 +5023,9 @@ describe('@payloadcms/plugin-import-export', () => {
         })
       })
 
-      it('should create draft documents when explicit _status:draft is in CSV', async () => {
+      test('should create draft documents when explicit _status:draft is in CSV', async ({
+        payload,
+      }) => {
         const csvContent =
           'title,excerpt,_status\n"Explicit Draft Test 1","Test excerpt 1","draft"\n"Explicit Draft Test 2","Test excerpt 2","draft"'
         const csvBuffer = Buffer.from(csvContent)
@@ -5019,7 +5077,9 @@ describe('@payloadcms/plugin-import-export', () => {
         })
       })
 
-      it('should create published documents in upsert mode when document does not exist', async () => {
+      test('should create published documents in upsert mode when document does not exist', async ({
+        payload,
+      }) => {
         const csvContent =
           'title,excerpt\n"Upsert New Published Test 1","Test excerpt 1"\n"Upsert New Published Test 2","Test excerpt 2"'
         const csvBuffer = Buffer.from(csvContent)
@@ -5072,7 +5132,9 @@ describe('@payloadcms/plugin-import-export', () => {
         })
       })
 
-      it('should handle manual CSV with localized fields without locale suffix', async () => {
+      test('should handle manual CSV with localized fields without locale suffix', async ({
+        payload,
+      }) => {
         const csvContent =
           'title,localized\n"Manual Locale Test 1","Default locale content 1"\n"Manual Locale Test 2","Default locale content 2"'
         const csvBuffer = Buffer.from(csvContent)
@@ -5127,8 +5189,8 @@ describe('@payloadcms/plugin-import-export', () => {
       })
     })
 
-    describe('fields', () => {
-      it('should import checkbox field from CSV', async () => {
+    test.describe('fields', () => {
+      test('should import checkbox field from CSV', async ({ payload }) => {
         const csvContent =
           'title,checkbox\n' +
           '"Checkbox Import True","true"\n' +
@@ -5184,7 +5246,7 @@ describe('@payloadcms/plugin-import-export', () => {
         })
       })
 
-      it('should import select field from CSV', async () => {
+      test('should import select field from CSV', async ({ payload }) => {
         const csvContent =
           'title,select\n' +
           '"Select Import 1","option1"\n' +
@@ -5238,7 +5300,7 @@ describe('@payloadcms/plugin-import-export', () => {
         })
       })
 
-      it('should import radio field from CSV', async () => {
+      test('should import radio field from CSV', async ({ payload }) => {
         const csvContent =
           'title,radio\n' +
           '"Radio Import 1","radio1"\n' +
@@ -5286,7 +5348,7 @@ describe('@payloadcms/plugin-import-export', () => {
         })
       })
 
-      it('should import email field from CSV', async () => {
+      test('should import email field from CSV', async ({ payload }) => {
         const csvContent =
           'title,email\n' +
           '"Email Import 1","user1@example.com"\n' +
@@ -5336,7 +5398,7 @@ describe('@payloadcms/plugin-import-export', () => {
         })
       })
 
-      it('should import textarea field with multiline content from CSV', async () => {
+      test('should import textarea field with multiline content from CSV', async ({ payload }) => {
         const csvContent = 'title,textarea\n' + '"Textarea Import 1","Line 1\nLine 2\nLine 3"'
 
         const csvBuffer = Buffer.from(csvContent)
@@ -5378,7 +5440,7 @@ describe('@payloadcms/plugin-import-export', () => {
         })
       })
 
-      it('should import code field from CSV', async () => {
+      test('should import code field from CSV', async ({ payload }) => {
         const csvContent = 'title,code\n' + '"Code Import 1","function hello() { return 42; }"'
 
         const csvBuffer = Buffer.from(csvContent)
@@ -5419,7 +5481,7 @@ describe('@payloadcms/plugin-import-export', () => {
         })
       })
 
-      it('should import point field from CSV', async () => {
+      test('should import point field from CSV', async ({ payload }) => {
         const csvContent =
           'title,point_0,point_1\n' +
           '"Point Import SF","-122.4194","37.7749"\n' +
@@ -5469,7 +5531,9 @@ describe('@payloadcms/plugin-import-export', () => {
         })
       })
 
-      it('should import selectHasMany field from CSV with indexed format', async () => {
+      test('should import selectHasMany field from CSV with indexed format', async ({
+        payload,
+      }) => {
         const csvContent =
           'title,selectHasMany_0,selectHasMany_1,selectHasMany_2\n' +
           '"SelectHasMany Import 1","tagA","tagB",""\n' +
@@ -5523,7 +5587,7 @@ describe('@payloadcms/plugin-import-export', () => {
         })
       })
 
-      it('should import textHasMany field from CSV with indexed format', async () => {
+      test('should import textHasMany field from CSV with indexed format', async ({ payload }) => {
         const csvContent =
           'title,textHasMany_0,textHasMany_1,textHasMany_2\n' +
           '"TextHasMany Import 1","value1","value2",""\n' +
@@ -5577,7 +5641,7 @@ describe('@payloadcms/plugin-import-export', () => {
         })
       })
 
-      it('should import upload field from CSV with media ID', async () => {
+      test('should import upload field from CSV with media ID', async ({ payload }) => {
         const imageFilePath = path.resolve(dirname, './image.png')
         const imageFile = await getFileByPath(imageFilePath)
 
@@ -5640,10 +5704,10 @@ describe('@payloadcms/plugin-import-export', () => {
       })
     })
 
-    describe('custom ID imports', () => {
+    test.describe('custom ID imports', () => {
       const createdCustomIdPages: string[] = []
 
-      afterEach(async () => {
+      test.afterEach(async ({ payload }) => {
         for (const id of createdCustomIdPages) {
           try {
             await payload.delete({
@@ -5657,7 +5721,7 @@ describe('@payloadcms/plugin-import-export', () => {
         createdCustomIdPages.length = 0
       })
 
-      it('should import documents with custom text IDs in create mode', async () => {
+      test('should import documents with custom text IDs in create mode', async ({ payload }) => {
         const testData = [
           { id: 'custom-page-1', title: 'Custom ID Page 1' },
           { id: 'custom-page-2', title: 'Custom ID Page 2' },
@@ -5706,7 +5770,7 @@ describe('@payloadcms/plugin-import-export', () => {
         createdCustomIdPages.push('custom-page-1', 'custom-page-2', 'custom-page-3')
       })
 
-      it('should import documents with custom text IDs from CSV', async () => {
+      test('should import documents with custom text IDs from CSV', async ({ payload }) => {
         const csvContent = `id,title\ncustom-csv-1,CSV Custom Page 1\ncustom-csv-2,CSV Custom Page 2`
         const csvBuffer = Buffer.from(csvContent)
 
@@ -5750,7 +5814,9 @@ describe('@payloadcms/plugin-import-export', () => {
         createdCustomIdPages.push('custom-csv-1', 'custom-csv-2')
       })
 
-      it('should preserve custom IDs in upsert mode when creating new documents', async () => {
+      test('should preserve custom IDs in upsert mode when creating new documents', async ({
+        payload,
+      }) => {
         const testData = [
           { id: 'upsert-custom-1', title: 'Upsert Custom Page 1' },
           { id: 'upsert-custom-2', title: 'Upsert Custom Page 2' },
@@ -5799,7 +5865,9 @@ describe('@payloadcms/plugin-import-export', () => {
         createdCustomIdPages.push('upsert-custom-1', 'upsert-custom-2')
       })
 
-      it('should update existing documents with custom IDs in upsert mode', async () => {
+      test('should update existing documents with custom IDs in upsert mode', async ({
+        payload,
+      }) => {
         await payload.create({
           collection: customIdPagesSlug,
           data: {
@@ -5848,7 +5916,9 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(updatedPage.title).toBe('Updated Title via Upsert')
       })
 
-      it('should update existing documents with custom IDs in update mode', async () => {
+      test('should update existing documents with custom IDs in update mode', async ({
+        payload,
+      }) => {
         await payload.create({
           collection: customIdPagesSlug as CollectionSlug,
           data: {
@@ -5897,7 +5967,9 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(updatedPage.title).toBe('Updated via Update Mode')
       })
 
-      it('should report issue for non-existing documents in update mode with custom IDs', async () => {
+      test('should report issue for non-existing documents in update mode with custom IDs', async ({
+        payload,
+      }) => {
         const testData = [{ id: 'non-existing-custom-id', title: 'This should fail' }]
 
         const jsonBuffer = Buffer.from(JSON.stringify(testData))
@@ -5932,8 +6004,10 @@ describe('@payloadcms/plugin-import-export', () => {
     })
   })
 
-  describe('collection configuration', () => {
-    it('should exclude collections with custom export collections from base exports', () => {
+  test.describe('collection configuration', () => {
+    test('should exclude collections with custom export collections from base exports', ({
+      payload,
+    }) => {
       const exportsConfig = payload.collections['exports'].config
       const validSlugs =
         exportsConfig.admin?.custom?.['plugin-import-export']?.collectionSlugs || []
@@ -5948,7 +6022,9 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(validSlugs).toContain(customIdPagesSlug)
     })
 
-    it('should exclude collections with custom import collections from base imports', () => {
+    test('should exclude collections with custom import collections from base imports', ({
+      payload,
+    }) => {
       const importsConfig = payload.collections['imports'].config
       const validSlugs =
         importsConfig.admin?.custom?.['plugin-import-export']?.collectionSlugs || []
@@ -5962,7 +6038,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(validSlugs).toContain(customIdPagesSlug)
     })
 
-    it('custom export collection should only have its target collection slug', () => {
+    test('custom export collection should only have its target collection slug', ({ payload }) => {
       const postsExportConfig = payload.collections['posts-export'].config
       const validSlugs =
         postsExportConfig.admin?.custom?.['plugin-import-export']?.collectionSlugs || []
@@ -5971,7 +6047,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(validSlugs).toEqual(['posts'])
     })
 
-    it('custom import collection should only have its target collection slug', () => {
+    test('custom import collection should only have its target collection slug', ({ payload }) => {
       const postsImportConfig = payload.collections['posts-import'].config
       const validSlugs =
         postsImportConfig.admin?.custom?.['plugin-import-export']?.collectionSlugs || []
@@ -5981,9 +6057,11 @@ describe('@payloadcms/plugin-import-export', () => {
     })
   })
 
-  describe('posts-exports-only and posts-imports-only collections', () => {
-    describe('posts-exports-only', () => {
-      it('should export from posts-exports-only collection (no jobs queue)', async () => {
+  test.describe('posts-exports-only and posts-imports-only collections', () => {
+    test.describe('posts-exports-only', () => {
+      test('should export from posts-exports-only collection (no jobs queue)', async ({
+        payload,
+      }) => {
         const doc = await payload.create({
           collection: 'exports',
           user,
@@ -6009,7 +6087,9 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(data[0].title).toContain('Export Only Post')
       })
 
-      it('should not allow restricted user to export from posts-exports-only (access control)', async () => {
+      test('should not allow restricted user to export from posts-exports-only (access control)', async ({
+        payload,
+      }) => {
         const doc = await payload.create({
           collection: 'exports',
           user: restrictedUser,
@@ -6043,8 +6123,10 @@ describe('@payloadcms/plugin-import-export', () => {
       })
     })
 
-    describe('posts-imports-only', () => {
-      it('should import to posts-imports-only collection (no jobs queue, synchronous)', async () => {
+    test.describe('posts-imports-only', () => {
+      test('should import to posts-imports-only collection (no jobs queue, synchronous)', async ({
+        payload,
+      }) => {
         const csvContent = 'title\n"Sync Import Test 1"\n"Sync Import Test 2"\n"Sync Import Test 3"'
         const csvBuffer = Buffer.from(csvContent)
 
@@ -6091,7 +6173,9 @@ describe('@payloadcms/plugin-import-export', () => {
         })
       })
 
-      it('should not allow restricted user to import to posts-imports-only (access control)', async () => {
+      test('should not allow restricted user to import to posts-imports-only (access control)', async ({
+        payload,
+      }) => {
         const csvContent = 'title\n"Restricted Import Test 1"\n"Restricted Import Test 2"'
         const csvBuffer = Buffer.from(csvContent)
 
@@ -6132,7 +6216,9 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(importedDocs.totalDocs).toBe(0)
       })
 
-      it('should create draft documents when defaultVersionStatus is draft in plugin config', async () => {
+      test('should create draft documents when defaultVersionStatus is draft in plugin config', async ({
+        payload,
+      }) => {
         const csvContent =
           'title,_status\n"Default Draft Config Test 1",""\n"Default Draft Config Test 2",""\n"Default Draft Config Override Test","published"'
         const csvBuffer = Buffer.from(csvContent)
@@ -6200,8 +6286,8 @@ describe('@payloadcms/plugin-import-export', () => {
     })
   })
 
-  describe('access control with jobs queue', () => {
-    it('should respect access control when export uses jobs queue', async () => {
+  test.describe('access control with jobs queue', () => {
+    test('should respect access control when export uses jobs queue', async ({ payload }) => {
       for (let i = 0; i < 3; i++) {
         await payload.create({
           collection: 'pages',
@@ -6235,7 +6321,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(data.length).toBeGreaterThan(0)
     })
 
-    it('should respect access control when import uses jobs queue', async () => {
+    test('should respect access control when import uses jobs queue', async ({ payload }) => {
       const csvContent = 'title\n"Jobs Queue Import 1"\n"Jobs Queue Import 2"'
       const csvBuffer = Buffer.from(csvContent)
 
@@ -6282,8 +6368,8 @@ describe('@payloadcms/plugin-import-export', () => {
     })
   })
 
-  describe('preview endpoints', () => {
-    it('should return export preview data for CSV format', async () => {
+  test.describe('preview endpoints', () => {
+    test('should return export preview data for CSV format', async ({ payload, restClient }) => {
       await payload.create({
         collection: 'pages',
         data: {
@@ -6333,7 +6419,7 @@ describe('@payloadcms/plugin-import-export', () => {
       })
     })
 
-    it('should return export preview data for JSON format', async () => {
+    test('should return export preview data for JSON format', async ({ payload, restClient }) => {
       await payload.create({
         collection: 'pages',
         data: {
@@ -6375,7 +6461,7 @@ describe('@payloadcms/plugin-import-export', () => {
       })
     })
 
-    it('should return import preview data for CSV', async () => {
+    test('should return import preview data for CSV', async ({ restClient }) => {
       const csvContent =
         'title,excerpt\n"Import Preview Test 1","Excerpt 1"\n"Import Preview Test 2","Excerpt 2"'
       const base64Data = Buffer.from(csvContent).toString('base64')
@@ -6399,7 +6485,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(response.totalDocs).toBe(2)
     })
 
-    it('should return import preview data for JSON', async () => {
+    test('should return import preview data for JSON', async ({ restClient }) => {
       const jsonContent = JSON.stringify([
         { title: 'JSON Import Preview 1', excerpt: 'Excerpt 1' },
         { title: 'JSON Import Preview 2', excerpt: 'Excerpt 2' },
@@ -6424,7 +6510,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(response.totalDocs).toBe(2)
     })
 
-    it('should handle invalid collection slug in export preview', async () => {
+    test('should handle invalid collection slug in export preview', async ({ restClient }) => {
       const response = await restClient.POST('/exports/export-preview', {
         body: JSON.stringify({
           collectionSlug: 'nonexistent-collection',
@@ -6440,7 +6526,10 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(data.error).toContain('not found')
     })
 
-    it('rejects an invalid preview field path and keeps collection access unchanged', async () => {
+    test('rejects an invalid preview field path and keeps collection access unchanged', async ({
+      payload,
+      restClient,
+    }) => {
       const post = await payload.create({
         collection: 'posts-imports-only',
         data: {
@@ -6482,7 +6571,10 @@ describe('@payloadcms/plugin-import-export', () => {
       }
     })
 
-    it('should apply beforeExport hook customizations in export preview and remove replaced columns', async () => {
+    test('should apply beforeExport hook customizations in export preview and remove replaced columns', async ({
+      payload,
+      restClient,
+    }) => {
       const page = await payload.create({
         collection: 'pages',
         data: {
@@ -6547,7 +6639,10 @@ describe('@payloadcms/plugin-import-export', () => {
       await payload.delete({ collection: 'pages', id: page.id })
     })
 
-    it('should remove replaced columns from preview when no fields are selected', async () => {
+    test('should remove replaced columns from preview when no fields are selected', async ({
+      payload,
+      restClient,
+    }) => {
       const page = await payload.create({
         collection: 'pages',
         data: {
@@ -6599,7 +6694,7 @@ describe('@payloadcms/plugin-import-export', () => {
       await payload.delete({ collection: 'pages', id: page.id })
     })
 
-    it('should handle invalid collection slug in import preview', async () => {
+    test('should handle invalid collection slug in import preview', async ({ restClient }) => {
       const csvContent = 'title\n"Test"'
       const base64Data = Buffer.from(csvContent).toString('base64')
 
@@ -6619,7 +6714,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(data.error).toContain('not found')
     })
 
-    it('should handle missing file data in import preview', async () => {
+    test('should handle missing file data in import preview', async ({ restClient }) => {
       const response = await restClient.POST('/imports/preview-data', {
         body: JSON.stringify({
           collectionSlug: 'pages',
@@ -6635,7 +6730,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(data.error).toContain('No file data')
     })
 
-    it('should paginate import preview data for CSV', async () => {
+    test('should paginate import preview data for CSV', async ({ restClient }) => {
       const rows = ['title,excerpt']
       for (let i = 0; i < 15; i++) {
         rows.push(`"Import Pagination Test ${i}","Excerpt ${i}"`)
@@ -6702,7 +6797,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(responsePage2.hasPrevPage).toBe(true)
     })
 
-    it('should paginate import preview data for JSON', async () => {
+    test('should paginate import preview data for JSON', async ({ restClient }) => {
       const items = []
       for (let i = 0; i < 11; i++) {
         items.push({ title: `JSON Import Test ${i}`, excerpt: `Excerpt ${i}` })
@@ -6768,7 +6863,9 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(responsePage2.hasPrevPage).toBe(true)
     })
 
-    it('should default to previewLimit 10 and previewPage 1 for import preview', async () => {
+    test('should default to previewLimit 10 and previewPage 1 for import preview', async ({
+      restClient,
+    }) => {
       const rows = ['title,excerpt']
       for (let i = 0; i < 25; i++) {
         rows.push(`"Default Pagination Test ${i}","Excerpt ${i}"`)
@@ -6802,7 +6899,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(response.totalPages).toBe(3)
     })
 
-    it('should respect preview limit (max 10)', async () => {
+    test('should respect preview limit (max 10)', async ({ payload, restClient }) => {
       for (let i = 0; i < 15; i++) {
         await payload.create({
           collection: 'pages',
@@ -6839,7 +6936,10 @@ describe('@payloadcms/plugin-import-export', () => {
       })
     })
 
-    it('should respect export limit when paginating preview (limit 11, per page 10)', async () => {
+    test('should respect export limit when paginating preview (limit 11, per page 10)', async ({
+      payload,
+      restClient,
+    }) => {
       for (let i = 0; i < 15; i++) {
         await payload.create({
           collection: 'pages',
@@ -6922,7 +7022,10 @@ describe('@payloadcms/plugin-import-export', () => {
       })
     })
 
-    it('should return empty docs when preview page exceeds export limit boundary', async () => {
+    test('should return empty docs when preview page exceeds export limit boundary', async ({
+      payload,
+      restClient,
+    }) => {
       for (let i = 0; i < 5; i++) {
         await payload.create({
           collection: 'pages',
@@ -6971,7 +7074,10 @@ describe('@payloadcms/plugin-import-export', () => {
       })
     })
 
-    it('should have matching column order between preview and export when no fields selected', async () => {
+    test('should have matching column order between preview and export when no fields selected', async ({
+      payload,
+      restClient,
+    }) => {
       const previewResponse: { columns: string[]; docs: unknown[] } = await restClient
         .POST('/posts-export/export-preview', {
           body: JSON.stringify({
@@ -7011,7 +7117,10 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(previewResponse.columns).toStrictEqual(exportColumns)
     })
 
-    it('should have matching column order between preview and export with selected fields', async () => {
+    test('should have matching column order between preview and export with selected fields', async ({
+      payload,
+      restClient,
+    }) => {
       const selectedFields = ['title', 'id', 'createdAt']
 
       const previewResponse: { columns: string[]; docs: unknown[] } = await restClient
@@ -7057,8 +7166,10 @@ describe('@payloadcms/plugin-import-export', () => {
     })
   })
 
-  describe('rich text field handling', () => {
-    it('should preserve Lexical numeric properties on JSON export/import', async () => {
+  test.describe('rich text field handling', () => {
+    test('should preserve Lexical numeric properties on JSON export/import', async ({
+      payload,
+    }) => {
       const page = await payload.create({
         collection: 'pages',
         data: {
@@ -7151,7 +7262,7 @@ describe('@payloadcms/plugin-import-export', () => {
       })
     })
 
-    it('should export rich text inside blocks to CSV and import back', async () => {
+    test('should export rich text inside blocks to CSV and import back', async ({ payload }) => {
       const page = await payload.create({
         collection: 'pages',
         data: {
@@ -7240,8 +7351,8 @@ describe('@payloadcms/plugin-import-export', () => {
     })
   })
 
-  describe('error recovery', () => {
-    it('should continue processing after individual document errors', async () => {
+  test.describe('error recovery', () => {
+    test('should continue processing after individual document errors', async ({ payload }) => {
       const csvContent =
         'title\n' +
         '"Error Recovery Test 1"\n' +
@@ -7293,7 +7404,7 @@ describe('@payloadcms/plugin-import-export', () => {
       })
     })
 
-    it('should report accurate error counts on partial failure', async () => {
+    test('should report accurate error counts on partial failure', async ({ payload }) => {
       const csvContent =
         'title\n' +
         '"Partial Fail Test 1"\n' +
@@ -7338,7 +7449,7 @@ describe('@payloadcms/plugin-import-export', () => {
       })
     })
 
-    it('should handle malformed CSV gracefully', async () => {
+    test('should handle malformed CSV gracefully', async ({ payload }) => {
       const malformedCSV = 'title,excerpt\n"Unclosed quote,Value'
       const csvBuffer = Buffer.from(malformedCSV)
 
@@ -7368,8 +7479,8 @@ describe('@payloadcms/plugin-import-export', () => {
     })
   })
 
-  describe('custom field functions edge cases', () => {
-    it('should handle beforeExport hook that returns undefined', async () => {
+  test.describe('custom field functions edge cases', () => {
+    test('should handle beforeExport hook that returns undefined', async ({ payload }) => {
       const page = await payload.create({
         collection: 'pages',
         data: {
@@ -7412,7 +7523,7 @@ describe('@payloadcms/plugin-import-export', () => {
       })
     })
 
-    it('should apply beforeImport hook to reconstruct relationships', async () => {
+    test('should apply beforeImport hook to reconstruct relationships', async ({ payload }) => {
       const page = await payload.create({
         collection: 'pages',
         data: {
@@ -7498,8 +7609,8 @@ describe('@payloadcms/plugin-import-export', () => {
     })
   })
 
-  describe('disabled fields in complex structures', () => {
-    it('should exclude disabled fields from export', async () => {
+  test.describe('disabled fields in complex structures', () => {
+    test('should exclude disabled fields from export', async ({ payload }) => {
       const page = await payload.create({
         collection: 'pages',
         data: {
@@ -7546,8 +7657,8 @@ describe('@payloadcms/plugin-import-export', () => {
     })
   })
 
-  describe('JSON-specific tests', () => {
-    it('should import deeply nested JSON objects', async () => {
+  test.describe('JSON-specific tests', () => {
+    test('should import deeply nested JSON objects', async ({ payload }) => {
       const nestedData = [
         {
           title: 'Deeply Nested Test',
@@ -7618,7 +7729,9 @@ describe('@payloadcms/plugin-import-export', () => {
       })
     })
 
-    it('should handle JSON export and import roundtrip with all field types', async () => {
+    test('should handle JSON export and import roundtrip with all field types', async ({
+      payload,
+    }) => {
       const page = await payload.create({
         collection: 'pages',
         data: {
@@ -7719,8 +7832,8 @@ describe('@payloadcms/plugin-import-export', () => {
     })
   })
 
-  describe('limit and pagination edge cases', () => {
-    it('should handle page exceeding total pages', async () => {
+  test.describe('limit and pagination edge cases', () => {
+    test('should handle page exceeding total pages', async ({ payload }) => {
       await payload.create({
         collection: 'pages',
         data: { title: 'Pagination Test 1', _status: 'published' },
@@ -7765,7 +7878,7 @@ describe('@payloadcms/plugin-import-export', () => {
       })
     })
 
-    it('should handle very large limit values', async () => {
+    test('should handle very large limit values', async ({ payload }) => {
       for (let i = 0; i < 5; i++) {
         await payload.create({
           collection: 'pages',
@@ -7807,7 +7920,7 @@ describe('@payloadcms/plugin-import-export', () => {
       })
     })
 
-    it('should export correctly with limit=1', async () => {
+    test('should export correctly with limit=1', async ({ payload }) => {
       await payload.create({
         collection: 'pages',
         data: { title: 'Single Limit Test 1' },
@@ -7851,8 +7964,8 @@ describe('@payloadcms/plugin-import-export', () => {
     })
   })
 
-  describe('streaming export edge cases', () => {
-    it('should stream large exports without memory issues', async () => {
+  test.describe('streaming export edge cases', () => {
+    test('should stream large exports without memory issues', async ({ payload }) => {
       const promises = []
       for (let i = 0; i < 100; i++) {
         promises.push(
@@ -7901,7 +8014,7 @@ describe('@payloadcms/plugin-import-export', () => {
       })
     })
 
-    it('should handle empty result set in streaming export', async () => {
+    test('should handle empty result set in streaming export', async ({ payload }) => {
       const exportDoc = await payload.create({
         collection: 'exports',
         user,
@@ -7925,8 +8038,8 @@ describe('@payloadcms/plugin-import-export', () => {
     })
   })
 
-  describe('concurrent operations', () => {
-    it('should handle multiple simultaneous imports', async () => {
+  test.describe('concurrent operations', () => {
+    test('should handle multiple simultaneous imports', async ({ payload }) => {
       const timestamp = Date.now()
 
       const csv1 = `title\n"Concurrent Import A1 ${timestamp}"\n"Concurrent Import A2 ${timestamp}"`
@@ -7994,7 +8107,7 @@ describe('@payloadcms/plugin-import-export', () => {
       })
     })
 
-    it('should handle export during active import', async () => {
+    test('should handle export during active import', async ({ payload }) => {
       for (let i = 0; i < 5; i++) {
         await payload.create({
           collection: 'pages',
@@ -8044,7 +8157,7 @@ describe('@payloadcms/plugin-import-export', () => {
       if (finalExport.filename) {
         const csvPath = path.join(dirname, './uploads', finalExport.filename)
         const exportedData = await readCSV(csvPath)
-        // eslint-disable-next-line vitest/no-conditional-expect
+
         expect(exportedData).toHaveLength(5)
       }
 
@@ -8060,10 +8173,10 @@ describe('@payloadcms/plugin-import-export', () => {
     })
   })
 
-  describe('max limit enforcement', () => {
+  test.describe('max limit enforcement', () => {
     const createdPostIds: (number | string)[] = []
 
-    beforeEach(async () => {
+    test.beforeEach(async ({ payload }) => {
       // Create 10 test documents (more than the limit of 5)
       for (let i = 0; i < 10; i++) {
         const doc = await payload.create({
@@ -8074,12 +8187,12 @@ describe('@payloadcms/plugin-import-export', () => {
       }
     })
 
-    afterAll(async () => {
+    test.afterAll(async ({ payloadInstance }) => {
       // Clean up all test documents
       if (createdPostIds.length > 0) {
         for (const id of createdPostIds) {
           try {
-            await payload.delete({
+            await payloadInstance.delete({
               collection: 'posts-with-limits',
               id,
             })
@@ -8091,8 +8204,8 @@ describe('@payloadcms/plugin-import-export', () => {
       }
     })
 
-    describe('export max limit', () => {
-      it('should limit export to maxLimit when no user limit specified', async () => {
+    test.describe('export max limit', () => {
+      test('should limit export to maxLimit when no user limit specified', async ({ payload }) => {
         const exportDoc = await payload.create({
           collection: 'posts-with-limits-export',
           user,
@@ -8110,7 +8223,9 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(data).toHaveLength(5)
       })
 
-      it('should clamp user limit to maxLimit when user limit exceeds maxLimit', async () => {
+      test('should clamp user limit to maxLimit when user limit exceeds maxLimit', async ({
+        payload,
+      }) => {
         const exportDoc = await payload.create({
           collection: 'posts-with-limits-export',
           user,
@@ -8129,7 +8244,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(data).toHaveLength(5)
       })
 
-      it('should use user limit when it is below maxLimit', async () => {
+      test('should use user limit when it is below maxLimit', async ({ payload }) => {
         const exportDoc = await payload.create({
           collection: 'posts-with-limits-export',
           user,
@@ -8148,7 +8263,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(data).toHaveLength(3)
       })
 
-      it('should include maxLimit in export preview response', async () => {
+      test('should include maxLimit in export preview response', async ({ restClient }) => {
         const response = await restClient.POST(`/posts-with-limits-export/export-preview`, {
           body: JSON.stringify({
             collectionSlug: 'posts-with-limits',
@@ -8165,7 +8280,10 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(result.totalDocs).toBe(5)
       })
 
-      it('should have preview match exactly what is exported', async () => {
+      test('should have preview match exactly what is exported', async ({
+        payload,
+        restClient,
+      }) => {
         const previewResponse = await restClient.POST(`/posts-with-limits-export/export-preview`, {
           body: JSON.stringify({
             collectionSlug: 'posts-with-limits',
@@ -8202,7 +8320,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(exportedData).toHaveLength(5)
       })
 
-      it('should have preview pagination respect maxLimit', async () => {
+      test('should have preview pagination respect maxLimit', async ({ restClient }) => {
         const page1Response = await restClient.POST(`/posts-with-limits-export/export-preview`, {
           body: JSON.stringify({
             collectionSlug: 'posts-with-limits',
@@ -8246,8 +8364,8 @@ describe('@payloadcms/plugin-import-export', () => {
       })
     })
 
-    describe('import max limit', () => {
-      it('should reject import when document count exceeds maxLimit', async () => {
+    test.describe('import max limit', () => {
+      test('should reject import when document count exceeds maxLimit', async ({ payload }) => {
         const csvContent = Array.from({ length: 10 }, (_, i) => `"Exceed Limit Import ${i}"`).join(
           '\n',
         )
@@ -8283,7 +8401,7 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(importedDocs.totalDocs).toBe(0)
       })
 
-      it('should allow import when document count equals maxLimit', async () => {
+      test('should allow import when document count equals maxLimit', async ({ payload }) => {
         const csvContent = Array.from({ length: 5 }, (_, i) => `"Exact Limit Import ${i}"`).join(
           '\n',
         )
@@ -8317,7 +8435,7 @@ describe('@payloadcms/plugin-import-export', () => {
         })
       })
 
-      it('should allow import when document count is below maxLimit', async () => {
+      test('should allow import when document count is below maxLimit', async ({ payload }) => {
         const csvContent = Array.from({ length: 3 }, (_, i) => `"Below Limit Import ${i}"`).join(
           '\n',
         )
@@ -8351,7 +8469,9 @@ describe('@payloadcms/plugin-import-export', () => {
         })
       })
 
-      it('should include maxLimit and limitExceeded in import preview response', async () => {
+      test('should include maxLimit and limitExceeded in import preview response', async ({
+        restClient,
+      }) => {
         const csvContent = Array.from({ length: 10 }, (_, i) => `"Preview Limit Test ${i}"`).join(
           '\n',
         )
@@ -8376,7 +8496,10 @@ describe('@payloadcms/plugin-import-export', () => {
         expect(result.totalDocs).toBe(10)
       })
 
-      it('should have import preview accurately predict import outcome', async () => {
+      test('should have import preview accurately predict import outcome', async ({
+        payload,
+        restClient,
+      }) => {
         const exceedsLimitCsv = `title\n${Array.from({ length: 10 }, (_, i) => `"Predict Fail ${i}"`).join('\n')}`
         const exceedsBuffer = Buffer.from(exceedsLimitCsv)
 
@@ -8460,11 +8583,11 @@ describe('@payloadcms/plugin-import-export', () => {
         })
       })
     })
-    describe('dynamic user-based export limits', () => {
+    test.describe('dynamic user-based export limits', () => {
       const createdPostIds: (number | string)[] = []
       let userWithDynamicLimit: any
 
-      beforeAll(async () => {
+      test.beforeEach(async ({ payload }) => {
         // Find the dev user and set their limit to 7
         const devUserDocs = await payload.find({
           collection: 'users',
@@ -8493,23 +8616,23 @@ describe('@payloadcms/plugin-import-export', () => {
         }
       })
 
-      afterAll(async () => {
+      test.afterAll(async ({ payloadInstance }) => {
         // Reset the dev user's limit
-        const devUserDocs = await payload.find({
+        const devUserDocs = await payloadInstance.find({
           collection: 'users',
           where: { email: { equals: devUser.email } },
         })
 
         const devUserId = devUserDocs.docs[0]?.id
 
-        await payload.update({
+        await payloadInstance.update({
           id: devUserId,
           collection: 'users',
           data: { limit: null as unknown as number },
         })
 
         // Restore the original user login state
-        const loginResult = await payload.login({
+        const loginResult = await payloadInstance.login({
           collection: 'users',
           data: {
             email: devUser.email,
@@ -8522,7 +8645,7 @@ describe('@payloadcms/plugin-import-export', () => {
         // Clean up test documents
         for (const id of createdPostIds) {
           try {
-            await payload.delete({
+            await payloadInstance.delete({
               id,
               collection: 'posts-with-limits',
             })
@@ -8533,8 +8656,8 @@ describe('@payloadcms/plugin-import-export', () => {
         createdPostIds.length = 0
       })
 
-      describe('export with dynamic user limit of 7', () => {
-        it('should export up to 7 documents when user limit is set to 7', async () => {
+      test.describe('export with dynamic user limit of 7', () => {
+        test('should export up to 7 documents when user limit is set to 7', async ({ payload }) => {
           const exportDoc = await payload.create({
             collection: 'posts-with-limits-export',
             data: {
@@ -8552,7 +8675,7 @@ describe('@payloadcms/plugin-import-export', () => {
           expect(data).toHaveLength(7)
         })
 
-        it('should clamp request limit to dynamic maxLimit of 7', async () => {
+        test('should clamp request limit to dynamic maxLimit of 7', async ({ payload }) => {
           const exportDoc = await payload.create({
             collection: 'posts-with-limits-export',
             data: {
@@ -8571,7 +8694,7 @@ describe('@payloadcms/plugin-import-export', () => {
           expect(data).toHaveLength(7)
         })
 
-        it('should allow export with limit below dynamic maxLimit of 7', async () => {
+        test('should allow export with limit below dynamic maxLimit of 7', async ({ payload }) => {
           const exportDoc = await payload.create({
             collection: 'posts-with-limits-export',
             data: {
@@ -8590,7 +8713,7 @@ describe('@payloadcms/plugin-import-export', () => {
           expect(data).toHaveLength(4)
         })
 
-        it('should reflect dynamic maxLimit of 7 in export preview', async () => {
+        test('should reflect dynamic maxLimit of 7 in export preview', async ({ restClient }) => {
           const response = await restClient.POST(`/posts-with-limits-export/export-preview`, {
             body: JSON.stringify({
               collectionSlug: 'posts-with-limits',
@@ -8607,7 +8730,10 @@ describe('@payloadcms/plugin-import-export', () => {
           expect(result.totalDocs).toBe(7)
         })
 
-        it('should have preview match exactly what is exported with dynamic limit', async () => {
+        test('should have preview match exactly what is exported with dynamic limit', async ({
+          payload,
+          restClient,
+        }) => {
           const previewResponse = await restClient.POST(
             `/posts-with-limits-export/export-preview`,
             {
@@ -8645,7 +8771,9 @@ describe('@payloadcms/plugin-import-export', () => {
           expect(exportedData).toHaveLength(7)
         })
 
-        it('should have preview pagination respect dynamic maxLimit of 7', async () => {
+        test('should have preview pagination respect dynamic maxLimit of 7', async ({
+          restClient,
+        }) => {
           const page1Response = await restClient.POST(`/posts-with-limits-export/export-preview`, {
             body: JSON.stringify({
               collectionSlug: 'posts-with-limits',
@@ -8689,8 +8817,10 @@ describe('@payloadcms/plugin-import-export', () => {
         })
       })
 
-      describe('import limit remains static despite user limit change', () => {
-        it('should reject import with 7 documents when static import limit is 5', async () => {
+      test.describe('import limit remains static despite user limit change', () => {
+        test('should reject import with 7 documents when static import limit is 5', async ({
+          payload,
+        }) => {
           const csvContent = Array.from(
             { length: 7 },
             (_, i) => `"Dynamic Import Exceed ${i}"`,
@@ -8724,7 +8854,9 @@ describe('@payloadcms/plugin-import-export', () => {
           })
         })
 
-        it('should allow import within static limit of 5 even with user limit of 7', async () => {
+        test('should allow import within static limit of 5 even with user limit of 7', async ({
+          payload,
+        }) => {
           const csvContent = Array.from(
             { length: 5 },
             (_, i) => `"Dynamic Import Within ${i}"`,
@@ -8758,7 +8890,9 @@ describe('@payloadcms/plugin-import-export', () => {
           })
         })
 
-        it('should show static maxLimit of 5 in import preview despite user limit of 7', async () => {
+        test('should show static maxLimit of 5 in import preview despite user limit of 7', async ({
+          restClient,
+        }) => {
           const csvContent = Array.from(
             { length: 10 },
             (_, i) => `"Dynamic Preview Import ${i}"`,
@@ -8791,15 +8925,15 @@ describe('@payloadcms/plugin-import-export', () => {
   // The int test environment uses in-process route handlers, but getFileFromDoc uses
   // fetch() which requires a real HTTP server. See e2e.spec.ts for S3 tests that run
   // with a real server.
-  describe.skip('S3 storage', () => {
+  test.describe.skip('S3 storage', () => {
     const createdPostIDs: (number | string)[] = []
 
-    beforeAll(async () => {
+    test.beforeAll(async () => {
       await createTestBucket()
       await clearTestBucket()
     })
 
-    afterEach(async () => {
+    test.afterEach(async ({ payload }) => {
       for (const id of createdPostIDs) {
         try {
           await payload.delete({
@@ -8814,7 +8948,7 @@ describe('@payloadcms/plugin-import-export', () => {
       await clearTestBucket()
     })
 
-    it('should import CSV file stored in S3', async () => {
+    test('should import CSV file stored in S3', async ({ payload }) => {
       const csvContent = `title\n"S3 Import Test 1"\n"S3 Import Test 2"\n"S3 Import Test 3"`
       const csvBuffer = Buffer.from(csvContent)
 
@@ -8848,7 +8982,7 @@ describe('@payloadcms/plugin-import-export', () => {
       posts.docs.forEach((post) => createdPostIDs.push(post.id))
     })
 
-    it('should export to S3 and verify file is accessible', async () => {
+    test('should export to S3 and verify file is accessible', async ({ payload, restClient }) => {
       const testPosts = await Promise.all([
         payload.create({
           collection: postsWithS3Slug as CollectionSlug,
@@ -8890,7 +9024,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect(exportedCSV).toContain('S3 Export Test 2')
     })
 
-    it('should handle import errors gracefully when file is in S3', async () => {
+    test('should handle import errors gracefully when file is in S3', async ({ payload }) => {
       const csvContent = `wrongfield\n"Some Value"`
       const csvBuffer = Buffer.from(csvContent)
 
@@ -8913,7 +9047,7 @@ describe('@payloadcms/plugin-import-export', () => {
       expect((importDoc as any).summary?.issues).toBeGreaterThan(0)
     })
 
-    it('should import JSON file stored in S3', async () => {
+    test('should import JSON file stored in S3', async ({ payload }) => {
       const jsonContent = JSON.stringify([
         { title: 'S3 JSON Import 1' },
         { title: 'S3 JSON Import 2' },

--- a/test/plugin-import-export/int.spec.ts
+++ b/test/plugin-import-export/int.spec.ts
@@ -10,7 +10,6 @@ import { expect } from 'vitest'
 import { test } from '../__helpers/int/vitest.js'
 import { devUser, regularUser } from '../credentials.js'
 import { clearTestBucket, createTestBucket } from '../storage-s3/test-utils.js'
-import testConfig from './config.js'
 import { readCSV, readJSON } from './helpers.js'
 import { richTextData } from './seed/richTextData.js'
 import { customIdPagesSlug, postsWithS3Slug } from './shared.js'
@@ -21,7 +20,7 @@ let restrictedUser: any
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
-test.suite({ config: testConfig })('@payloadcms/plugin-import-export', () => {
+test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => {
   test.beforeEach(async ({ payload }) => {
     const loginResult = await payload.login({
       collection: 'users',


### PR DESCRIPTION
## What?

Migrates 19 integration suites from a mix of module-scoped `initPayloadInt`, config `onInit` seeding, and manual lifecycle hooks to explicit Vitest fixtures:

- configs move test seeding out of `onInit` and register `{ suite, config, seed }` with `buildConfigWithDefaults`
- root `describe` blocks become `test.suite({ config })`
- lifecycle-only `beforeAll`, `beforeEach`, and `afterAll` hooks are removed where the fixture now owns initialization, reset/seed, and teardown

For these suites, Payload is created once per file, reset and optionally seeded once before each test that requests `payload`, `restClient`, or `sdk`, and destroyed after the file.

## Why?

This makes test isolation consistent and removes reliance on config `onInit` hooks for seeding.

Migration batch 3/5 in stack #17993. Depends on #17989.
