### PR TITLE
test: migrate integration suites (4/5)

### DIFF
--- a/test/__helpers/int/vitest.ts
+++ b/test/__helpers/int/vitest.ts
@@ -186,15 +186,12 @@ export const test = Object.assign(testWithFixtures, {
       describe: testWithFixtures.describe.runIf(shouldRun),
     })
   },
-  suite: ({ config, cron = true, db }: TestSuiteOptions) => {
-    testWithFixtures.override(
-      'configPath',
-      config ? path.resolve(getTestDirectory(), config) : null,
-    )
-    testWithFixtures.override('testCron', cron)
-    testWithFixtures.override('testSuiteConfigured', true)
+  suite(this: typeof testWithFixtures, { config, cron = true, db }: TestSuiteOptions) {
+    this.override('configPath', config ? path.resolve(getTestDirectory(), config) : null)
+    this.override('testCron', cron)
+    this.override('testSuiteConfigured', true)
 
-    return testWithFixtures.describe.runIf(matchesDatabase({ db }))
+    return this.describe.runIf(matchesDatabase({ db }))
   },
 })
 

--- a/test/fields/baseConfig.ts
+++ b/test/fields/baseConfig.ts
@@ -100,7 +100,27 @@ export const collections: CollectionConfig[] = [
 ]
 
 export const baseConfig: Partial<Config> = {
-  collections,
+  admin: {
+    components: {
+      afterNavLinks: ['/components/AfterNavLinks.js#AfterNavLinks'],
+    },
+    custom: {
+      client: {
+        'new-value': 'client available',
+      },
+    },
+    importMap: {
+      baseDir: path.resolve(dirname),
+    },
+    timezones: {
+      defaultTimezone: 'America/Monterrey',
+      supportedTimezones: ({ defaultTimezones }) => [
+        ...defaultTimezones,
+        { label: '(GMT-6) Monterrey, Nuevo Leon', value: 'America/Monterrey' },
+        { label: 'Custom UTC', value: 'UTC' },
+      ],
+    },
+  },
   blocks: [
     {
       slug: 'ConfigBlockTest',
@@ -132,6 +152,7 @@ export const baseConfig: Partial<Config> = {
       ],
     },
   ],
+  collections,
   custom: {
     client: {
       'new-value': 'client available',
@@ -140,38 +161,14 @@ export const baseConfig: Partial<Config> = {
       'new-server-value': 'only available on server',
     },
   },
-  admin: {
-    importMap: {
-      baseDir: path.resolve(dirname),
-    },
-    components: {
-      afterNavLinks: ['/components/AfterNavLinks.js#AfterNavLinks'],
-    },
-    custom: {
-      client: {
-        'new-value': 'client available',
-      },
-    },
-    timezones: {
-      supportedTimezones: ({ defaultTimezones }) => [
-        ...defaultTimezones,
-        { label: '(GMT-6) Monterrey, Nuevo Leon', value: 'America/Monterrey' },
-        { label: 'Custom UTC', value: 'UTC' },
-      ],
-      defaultTimezone: 'America/Monterrey',
-    },
-  },
   localization: {
     defaultLocale: 'en',
     fallback: true,
     locales: ['en', 'es'],
   },
-  onInit: async (payload) => {
-    if (process.env.SEED_IN_CONFIG_ONINIT !== 'false') {
-      await seed(payload)
-    }
-  },
   typescript: {
     outputFile: path.resolve(dirname, 'payload-types.ts'),
   },
 }
+
+export { seed }

--- a/test/fields/collections/Array/e2e.spec.ts
+++ b/test/fields/collections/Array/e2e.spec.ts
@@ -39,8 +39,6 @@ let serverURL: string
 describe('Array', () => {
   beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
-
-    process.env.SEED_IN_CONFIG_ONINIT = 'false' // Makes it so the payload config onInit seed is not run. Otherwise, the seed would be run unnecessarily twice for the initial test run - once for beforeEach and once for onInit
     ;({ payload, serverURL } = await initPayloadE2ENoConfig<Config>({
       dirname,
     }))
@@ -51,8 +49,6 @@ describe('Array', () => {
   beforeEach(async () => {
     await reInitializeDB({
       serverURL,
-      snapshotKey: 'fieldsTest',
-      uploadsDir: path.resolve(dirname, './collections/Upload/uploads'),
     })
 
     if (client) {

--- a/test/fields/collections/Blocks/e2e.spec.ts
+++ b/test/fields/collections/Blocks/e2e.spec.ts
@@ -47,8 +47,6 @@ let context: BrowserContext
 describe('Block fields', () => {
   beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
-
-    process.env.SEED_IN_CONFIG_ONINIT = 'false' // Makes it so the payload config onInit seed is not run. Otherwise, the seed would be run unnecessarily twice for the initial test run - once for beforeEach and once for onInit
     ;({ serverURL } = await initPayloadE2ENoConfig({
       dirname,
     }))
@@ -65,8 +63,6 @@ describe('Block fields', () => {
     })*/
     await reInitializeDB({
       serverURL,
-      snapshotKey: 'fieldsTest',
-      uploadsDir: path.resolve(dirname, './collections/Upload/uploads'),
     })
 
     if (client) {

--- a/test/fields/collections/Checkbox/e2e.spec.ts
+++ b/test/fields/collections/Checkbox/e2e.spec.ts
@@ -30,7 +30,6 @@ let url: AdminUrlUtil
 describe('Checkboxes', () => {
   beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
-    process.env.SEED_IN_CONFIG_ONINIT = 'false' // Makes it so the payload config onInit seed is not run. Otherwise, the seed would be run unnecessarily twice for the initial test run - once for beforeEach and once for onInit
     ;({ serverURL } = await initPayloadE2ENoConfig({
       dirname,
       // prebuild,
@@ -45,8 +44,6 @@ describe('Checkboxes', () => {
   beforeEach(async () => {
     await reInitializeDB({
       serverURL,
-      snapshotKey: 'fieldsTest',
-      uploadsDir: path.resolve(dirname, './collections/Upload/uploads'),
     })
     if (client) {
       await client.logout()

--- a/test/fields/collections/Code/e2e.spec.ts
+++ b/test/fields/collections/Code/e2e.spec.ts
@@ -27,7 +27,6 @@ let url: AdminUrlUtil
 test.describe('Code', () => {
   test.beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
-    process.env.SEED_IN_CONFIG_ONINIT = 'false'
     ;({ serverURL } = await initPayloadE2ENoConfig<Config>({
       dirname,
     }))
@@ -41,8 +40,6 @@ test.describe('Code', () => {
   test.beforeEach(async () => {
     await reInitializeDB({
       serverURL,
-      snapshotKey: 'fieldsTest',
-      uploadsDir: path.resolve(dirname, './collections/Upload/uploads'),
     })
 
     if (client) {

--- a/test/fields/collections/Collapsible/e2e.spec.ts
+++ b/test/fields/collections/Collapsible/e2e.spec.ts
@@ -35,7 +35,6 @@ let url: AdminUrlUtil
 describe('Collapsibles', () => {
   beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
-    process.env.SEED_IN_CONFIG_ONINIT = 'false' // Makes it so the payload config onInit seed is not run. Otherwise, the seed would be run unnecessarily twice for the initial test run - once for beforeEach and once for onInit
     ;({ payload, serverURL } = await initPayloadE2ENoConfig<Config>({
       dirname,
       // prebuild,
@@ -50,8 +49,6 @@ describe('Collapsibles', () => {
   beforeEach(async () => {
     await reInitializeDB({
       serverURL,
-      snapshotKey: 'fieldsTest',
-      uploadsDir: path.resolve(dirname, './collections/Upload/uploads'),
     })
     if (client) {
       await client.logout()

--- a/test/fields/collections/ConditionalLogic/e2e.spec.ts
+++ b/test/fields/collections/ConditionalLogic/e2e.spec.ts
@@ -53,7 +53,6 @@ const toggleConditionAndCheckField = async (toggleLocator: string, fieldLocator:
 describe('Conditional Logic', () => {
   beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
-    process.env.SEED_IN_CONFIG_ONINIT = 'false' // Makes it so the payload config onInit seed is not run. Otherwise, the seed would be run unnecessarily twice for the initial test run - once for beforeEach and once for onInit
     ;({ payload, serverURL } = await initPayloadE2ENoConfig<Config>({
       dirname,
       // prebuild,
@@ -74,8 +73,6 @@ describe('Conditional Logic', () => {
 
     await reInitializeDB({
       serverURL,
-      snapshotKey: 'fieldsTest',
-      uploadsDir: path.resolve(dirname, './collections/Upload/uploads'),
     })
 
     if (client) {

--- a/test/fields/collections/CustomID/e2e.spec.ts
+++ b/test/fields/collections/CustomID/e2e.spec.ts
@@ -35,7 +35,6 @@ let customRowIDURL: AdminUrlUtil
 describe('Custom IDs', () => {
   beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
-    process.env.SEED_IN_CONFIG_ONINIT = 'false' // Makes it so the payload config onInit seed is not run. Otherwise, the seed would be run unnecessarily twice for the initial test run - once for beforeEach and once for onInit
     ;({ payload, serverURL } = await initPayloadE2ENoConfig<Config>({
       dirname,
       // prebuild,
@@ -52,8 +51,6 @@ describe('Custom IDs', () => {
   beforeEach(async () => {
     await reInitializeDB({
       serverURL,
-      snapshotKey: 'fieldsTest',
-      uploadsDir: path.resolve(dirname, './collections/Upload/uploads'),
     })
     if (client) {
       await client.logout()

--- a/test/fields/collections/Date/e2e.spec.ts
+++ b/test/fields/collections/Date/e2e.spec.ts
@@ -58,7 +58,6 @@ const getTimezoneOptionSelector = ({
 describe('Date', () => {
   beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
-    process.env.SEED_IN_CONFIG_ONINIT = 'false' // Makes it so the payload config onInit seed is not run. Otherwise, the seed would be run unnecessarily twice for the initial test run - once for beforeEach and once for onInit
     ;({ payload, serverURL } = await initPayloadE2ENoConfig<Config>({
       dirname,
       // prebuild,
@@ -71,8 +70,6 @@ describe('Date', () => {
   beforeEach(async () => {
     await reInitializeDB({
       serverURL,
-      snapshotKey: 'fieldsTest',
-      uploadsDir: path.resolve(dirname, './collections/Upload/uploads'),
     })
 
     if (client) {
@@ -749,7 +746,6 @@ const createTimezoneContextTests = (contextName: string, timezoneId: string) => 
   describe(`Date with TZ - Context: ${contextName}`, () => {
     beforeAll(async ({ browser }, testInfo) => {
       testInfo.setTimeout(TEST_TIMEOUT_LONG)
-      process.env.SEED_IN_CONFIG_ONINIT = 'false'
       ;({ payload, serverURL } = await initPayloadE2ENoConfig<Config>({
         dirname,
       }))
@@ -762,8 +758,6 @@ const createTimezoneContextTests = (contextName: string, timezoneId: string) => 
     beforeEach(async () => {
       await reInitializeDB({
         serverURL,
-        snapshotKey: 'fieldsTest',
-        uploadsDir: path.resolve(dirname, './collections/Upload/uploads'),
       })
 
       if (client) {

--- a/test/fields/collections/Email/e2e.spec.ts
+++ b/test/fields/collections/Email/e2e.spec.ts
@@ -35,7 +35,6 @@ let url: AdminUrlUtil
 describe('Email', () => {
   beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
-    process.env.SEED_IN_CONFIG_ONINIT = 'false' // Makes it so the payload config onInit seed is not run. Otherwise, the seed would be run unnecessarily twice for the initial test run - once for beforeEach and once for onInit
     ;({ payload, serverURL } = await initPayloadE2ENoConfig<Config>({
       dirname,
       // prebuild,
@@ -48,8 +47,6 @@ describe('Email', () => {
   beforeEach(async () => {
     await reInitializeDB({
       serverURL,
-      snapshotKey: 'fieldsTest',
-      uploadsDir: path.resolve(dirname, './collections/Upload/uploads'),
     })
 
     if (client) {

--- a/test/fields/collections/Group/e2e.spec.ts
+++ b/test/fields/collections/Group/e2e.spec.ts
@@ -34,7 +34,6 @@ let url: AdminUrlUtil
 describe('Group', () => {
   beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
-    process.env.SEED_IN_CONFIG_ONINIT = 'false' // Makes it so the payload config onInit seed is not run. Otherwise, the seed would be run unnecessarily twice for the initial test run - once for beforeEach and once for onInit
     ;({ payload, serverURL } = await initPayloadE2ENoConfig<Config>({
       dirname,
       // prebuild,
@@ -48,8 +47,6 @@ describe('Group', () => {
   beforeEach(async () => {
     await reInitializeDB({
       serverURL,
-      snapshotKey: 'fieldsTest',
-      uploadsDir: path.resolve(dirname, './collections/Upload/uploads'),
     })
     if (client) {
       await client.logout()

--- a/test/fields/collections/Indexed/e2e.spec.ts
+++ b/test/fields/collections/Indexed/e2e.spec.ts
@@ -34,7 +34,6 @@ let url: AdminUrlUtil
 describe('Radio', () => {
   beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
-    process.env.SEED_IN_CONFIG_ONINIT = 'false' // Makes it so the payload config onInit seed is not run. Otherwise, the seed would be run unnecessarily twice for the initial test run - once for beforeEach and once for onInit
     ;({ payload, serverURL } = await initPayloadE2ENoConfig<Config>({
       dirname,
       // prebuild,
@@ -49,8 +48,6 @@ describe('Radio', () => {
   beforeEach(async () => {
     await reInitializeDB({
       serverURL,
-      snapshotKey: 'fieldsTest',
-      uploadsDir: path.resolve(dirname, './collections/Upload/uploads'),
     })
     if (client) {
       await client.logout()

--- a/test/fields/collections/JSON/e2e.spec.ts
+++ b/test/fields/collections/JSON/e2e.spec.ts
@@ -35,7 +35,6 @@ let url: AdminUrlUtil
 describe('JSON', () => {
   beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
-    process.env.SEED_IN_CONFIG_ONINIT = 'false' // Makes it so the payload config onInit seed is not run. Otherwise, the seed would be run unnecessarily twice for the initial test run - once for beforeEach and once for onInit
     ;({ payload, serverURL } = await initPayloadE2ENoConfig<Config>({
       dirname,
       // prebuild,
@@ -50,8 +49,6 @@ describe('JSON', () => {
   beforeEach(async () => {
     await reInitializeDB({
       serverURL,
-      snapshotKey: 'fieldsTest',
-      uploadsDir: path.resolve(dirname, './collections/Upload/uploads'),
     })
     if (client) {
       await client.logout()

--- a/test/fields/collections/Number/e2e.spec.ts
+++ b/test/fields/collections/Number/e2e.spec.ts
@@ -38,7 +38,6 @@ let url: AdminUrlUtil
 describe('Number', () => {
   beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
-    process.env.SEED_IN_CONFIG_ONINIT = 'false' // Makes it so the payload config onInit seed is not run. Otherwise, the seed would be run unnecessarily twice for the initial test run - once for beforeEach and once for onInit
     ;({ payload, serverURL } = await initPayloadE2ENoConfig<Config>({
       dirname,
       // prebuild,
@@ -52,8 +51,6 @@ describe('Number', () => {
   beforeEach(async () => {
     await reInitializeDB({
       serverURL,
-      snapshotKey: 'fieldsTest',
-      uploadsDir: path.resolve(dirname, './collections/Upload/uploads'),
     })
     if (client) {
       await client.logout()

--- a/test/fields/collections/Point/e2e.spec.ts
+++ b/test/fields/collections/Point/e2e.spec.ts
@@ -36,7 +36,6 @@ let emptyGroupPoint
 describe('Point', () => {
   beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
-    process.env.SEED_IN_CONFIG_ONINIT = 'false' // Makes it so the payload config onInit seed is not run. Otherwise, the seed would be run unnecessarily twice for the initial test run - once for beforeEach and once for onInit
     ;({ payload, serverURL } = await initPayloadE2ENoConfig<Config>({
       dirname,
       // prebuild,
@@ -49,8 +48,6 @@ describe('Point', () => {
   beforeEach(async () => {
     await reInitializeDB({
       serverURL,
-      snapshotKey: 'fieldsTest',
-      uploadsDir: path.resolve(dirname, './collections/Upload/uploads'),
     })
 
     if (client) {

--- a/test/fields/collections/Radio/e2e.spec.ts
+++ b/test/fields/collections/Radio/e2e.spec.ts
@@ -33,7 +33,6 @@ let url: AdminUrlUtil
 describe('Radio', () => {
   beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
-    process.env.SEED_IN_CONFIG_ONINIT = 'false' // Makes it so the payload config onInit seed is not run. Otherwise, the seed would be run unnecessarily twice for the initial test run - once for beforeEach and once for onInit
     ;({ payload, serverURL } = await initPayloadE2ENoConfig<Config>({
       dirname,
       // prebuild,
@@ -48,8 +47,6 @@ describe('Radio', () => {
   beforeEach(async () => {
     await reInitializeDB({
       serverURL,
-      snapshotKey: 'fieldsTest',
-      uploadsDir: path.resolve(dirname, './collections/Upload/uploads'),
     })
     if (client) {
       await client.logout()

--- a/test/fields/collections/Relationship/e2e.spec.ts
+++ b/test/fields/collections/Relationship/e2e.spec.ts
@@ -48,7 +48,6 @@ let serverURL: string
 describe('relationship', () => {
   beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
-    process.env.SEED_IN_CONFIG_ONINIT = 'false' // Makes it so the payload config onInit seed is not run. Otherwise, the seed would be run unnecessarily twice for the initial test run - once for beforeEach and once for onInit
     ;({ payload, serverURL } = await initPayloadE2ENoConfig<Config>({
       dirname,
     }))
@@ -59,8 +58,6 @@ describe('relationship', () => {
   beforeEach(async () => {
     await reInitializeDB({
       serverURL,
-      snapshotKey: 'fieldsTest',
-      uploadsDir: path.resolve(dirname, './collections/Upload/uploads'),
     })
 
     await ensureCompilationIsDone({ page, serverURL })

--- a/test/fields/collections/Row/e2e.spec.ts
+++ b/test/fields/collections/Row/e2e.spec.ts
@@ -32,7 +32,6 @@ let url: AdminUrlUtil
 describe('Row', () => {
   beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
-    process.env.SEED_IN_CONFIG_ONINIT = 'false' // Makes it so the payload config onInit seed is not run. Otherwise, the seed would be run unnecessarily twice for the initial test run - once for beforeEach and once for onInit
     ;({ payload, serverURL } = await initPayloadE2ENoConfig<Config>({
       dirname,
       // prebuild,
@@ -47,8 +46,6 @@ describe('Row', () => {
   beforeEach(async () => {
     await reInitializeDB({
       serverURL,
-      snapshotKey: 'fieldsTest',
-      uploadsDir: path.resolve(dirname, './collections/Upload/uploads'),
     })
     if (client) {
       await client.logout()

--- a/test/fields/collections/Select/e2e.spec.ts
+++ b/test/fields/collections/Select/e2e.spec.ts
@@ -36,7 +36,6 @@ let url: AdminUrlUtil
 describe('Select', () => {
   beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
-    process.env.SEED_IN_CONFIG_ONINIT = 'false' // Makes it so the payload config onInit seed is not run. Otherwise, the seed would be run unnecessarily twice for the initial test run - once for beforeEach and once for onInit
     ;({ payload, serverURL } = await initPayloadE2ENoConfig<Config>({
       dirname,
       // prebuild,
@@ -51,8 +50,6 @@ describe('Select', () => {
   beforeEach(async () => {
     await reInitializeDB({
       serverURL,
-      snapshotKey: 'fieldsTest',
-      uploadsDir: path.resolve(dirname, './collections/Upload/uploads'),
     })
     if (client) {
       await client.logout()

--- a/test/fields/collections/SlugField/e2e.spec.ts
+++ b/test/fields/collections/SlugField/e2e.spec.ts
@@ -49,7 +49,6 @@ const regenerateSlug = async (fieldName: string = 'slug') => {
 describe('SlugField', () => {
   beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
-    process.env.SEED_IN_CONFIG_ONINIT = 'false' // Makes it so the payload config onInit seed is not run. Otherwise, the seed would be run unnecessarily twice for the initial test run - once for beforeEach and once for onInit
     ;({ payload, serverURL } = await initPayloadE2ENoConfig<Config>({
       dirname,
       // prebuild,
@@ -63,8 +62,6 @@ describe('SlugField', () => {
   beforeEach(async () => {
     await reInitializeDB({
       serverURL,
-      snapshotKey: 'fieldsTest',
-      uploadsDir: path.resolve(dirname, './collections/Upload/uploads'),
     })
 
     if (client) {

--- a/test/fields/collections/Tabs/e2e.spec.ts
+++ b/test/fields/collections/Tabs/e2e.spec.ts
@@ -37,7 +37,6 @@ let url: AdminUrlUtil
 describe('Tabs', () => {
   beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
-    process.env.SEED_IN_CONFIG_ONINIT = 'false' // Makes it so the payload config onInit seed is not run. Otherwise, the seed would be run unnecessarily twice for the initial test run - once for beforeEach and once for onInit
     ;({ payload, serverURL } = await initPayloadE2ENoConfig<Config>({
       dirname,
       // prebuild,
@@ -50,8 +49,6 @@ describe('Tabs', () => {
   beforeEach(async () => {
     await reInitializeDB({
       serverURL,
-      snapshotKey: 'fieldsTest',
-      uploadsDir: path.resolve(dirname, './collections/Upload/uploads'),
     })
 
     if (client) {

--- a/test/fields/collections/Tabs2/e2e.spec.ts
+++ b/test/fields/collections/Tabs2/e2e.spec.ts
@@ -34,7 +34,6 @@ let url: AdminUrlUtil
 describe('Tabs', () => {
   beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
-    process.env.SEED_IN_CONFIG_ONINIT = 'false' // Makes it so the payload config onInit seed is not run. Otherwise, the seed would be run unnecessarily twice for the initial test run - once for beforeEach and once for onInit
     ;({ payload, serverURL } = await initPayloadE2ENoConfig<Config>({
       dirname,
       // prebuild,
@@ -47,8 +46,6 @@ describe('Tabs', () => {
   beforeEach(async () => {
     await reInitializeDB({
       serverURL,
-      snapshotKey: 'fieldsTest',
-      uploadsDir: path.resolve(dirname, './collections/Upload/uploads'),
     })
 
     if (client) {

--- a/test/fields/collections/Text/e2e.spec.ts
+++ b/test/fields/collections/Text/e2e.spec.ts
@@ -44,7 +44,6 @@ let url: AdminUrlUtil
 describe('Text', () => {
   beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
-    process.env.SEED_IN_CONFIG_ONINIT = 'false' // Makes it so the payload config onInit seed is not run. Otherwise, the seed would be run unnecessarily twice for the initial test run - once for beforeEach and once for onInit
     ;({ payload, serverURL } = await initPayloadE2ENoConfig<Config>({
       dirname,
       // prebuild,
@@ -57,8 +56,6 @@ describe('Text', () => {
   beforeEach(async () => {
     await reInitializeDB({
       serverURL,
-      snapshotKey: 'fieldsTest',
-      uploadsDir: path.resolve(dirname, './collections/Upload/uploads'),
     })
 
     if (client) {

--- a/test/fields/collections/Textarea/e2e.spec.ts
+++ b/test/fields/collections/Textarea/e2e.spec.ts
@@ -45,7 +45,6 @@ let url: AdminUrlUtil
 describe('Textarea', () => {
   beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
-    process.env.SEED_IN_CONFIG_ONINIT = 'false' // Makes it so the payload config onInit seed is not run. Otherwise, the seed would be run unnecessarily twice for the initial test run - once for beforeEach and once for onInit
     ;({ payload, serverURL } = await initPayloadE2ENoConfig<Config>({
       dirname,
       // prebuild,
@@ -58,8 +57,6 @@ describe('Textarea', () => {
   beforeEach(async () => {
     await reInitializeDB({
       serverURL,
-      snapshotKey: 'fieldsTest',
-      uploadsDir: path.resolve(dirname, './collections/Upload/uploads'),
     })
 
     if (client) {

--- a/test/fields/collections/UI/e2e.spec.ts
+++ b/test/fields/collections/UI/e2e.spec.ts
@@ -32,7 +32,6 @@ let url: AdminUrlUtil
 describe('Radio', () => {
   beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
-    process.env.SEED_IN_CONFIG_ONINIT = 'false' // Makes it so the payload config onInit seed is not run. Otherwise, the seed would be run unnecessarily twice for the initial test run - once for beforeEach and once for onInit
     ;({ payload, serverURL } = await initPayloadE2ENoConfig<Config>({
       dirname,
       // prebuild,
@@ -47,8 +46,6 @@ describe('Radio', () => {
   beforeEach(async () => {
     await reInitializeDB({
       serverURL,
-      snapshotKey: 'fieldsTest',
-      uploadsDir: path.resolve(dirname, './collections/Upload/uploads'),
     })
     if (client) {
       await client.logout()

--- a/test/fields/collections/Upload/e2e.spec.ts
+++ b/test/fields/collections/Upload/e2e.spec.ts
@@ -35,7 +35,6 @@ let url: AdminUrlUtil
 describe('Upload', () => {
   beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
-    process.env.SEED_IN_CONFIG_ONINIT = 'false' // Makes it so the payload config onInit seed is not run. Otherwise, the seed would be run unnecessarily twice for the initial test run - once for beforeEach and once for onInit
     ;({ payload, serverURL } = await initPayloadE2ENoConfig<Config>({
       dirname,
       // prebuild,
@@ -49,8 +48,6 @@ describe('Upload', () => {
   beforeEach(async () => {
     await reInitializeDB({
       serverURL,
-      snapshotKey: 'fieldsTest',
-      uploadsDir: path.resolve(dirname, './collections/Upload/uploads'),
     })
 
     await ensureCompilationIsDone({ page, serverURL })

--- a/test/fields/collections/UploadMulti/e2e.spec.ts
+++ b/test/fields/collections/UploadMulti/e2e.spec.ts
@@ -33,7 +33,6 @@ let url: AdminUrlUtil
 describe('Upload with hasMany', () => {
   beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
-    process.env.SEED_IN_CONFIG_ONINIT = 'false' // Makes it so the payload config onInit seed is not run. Otherwise, the seed would be run unnecessarily twice for the initial test run - once for beforeEach and once for onInit
     ;({ payload, serverURL } = await initPayloadE2ENoConfig<Config>({
       dirname,
       // prebuild,
@@ -46,8 +45,6 @@ describe('Upload with hasMany', () => {
   beforeEach(async () => {
     await reInitializeDB({
       serverURL,
-      snapshotKey: 'fieldsTest',
-      uploadsDir: path.resolve(dirname, './collections/Upload/uploads'),
     })
 
     await ensureCompilationIsDone({ page, serverURL })

--- a/test/fields/collections/UploadMultiPoly/e2e.spec.ts
+++ b/test/fields/collections/UploadMultiPoly/e2e.spec.ts
@@ -34,15 +34,12 @@ let url: AdminUrlUtil
 describe('Upload polymorphic with hasMany', () => {
   beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
-    process.env.SEED_IN_CONFIG_ONINIT = 'false' // Makes it so the payload config onInit seed is not run. Otherwise, the seed would be run unnecessarily twice for the initial test run - once for beforeEach and once for onInit
     ;({ payload, serverURL } = await initPayloadE2ENoConfig<Config>({ dirname }))
     url = new AdminUrlUtil(serverURL, uploadsMultiPoly)
   })
   beforeEach(async ({ page }) => {
     await reInitializeDB({
       serverURL,
-      snapshotKey: 'fieldsTest',
-      uploadsDir: path.resolve(dirname, './collections/Upload/uploads'),
     })
     await initPage({ page, serverURL })
   })

--- a/test/fields/collections/UploadPoly/e2e.spec.ts
+++ b/test/fields/collections/UploadPoly/e2e.spec.ts
@@ -34,7 +34,6 @@ let url: AdminUrlUtil
 describe('Upload polymorphic', () => {
   beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
-    process.env.SEED_IN_CONFIG_ONINIT = 'false' // Makes it so the payload config onInit seed is not run. Otherwise, the seed would be run unnecessarily twice for the initial test run - once for beforeEach and once for onInit
     ;({ payload, serverURL } = await initPayloadE2ENoConfig<Config>({
       dirname,
       // prebuild,
@@ -47,8 +46,6 @@ describe('Upload polymorphic', () => {
   beforeEach(async () => {
     await reInitializeDB({
       serverURL,
-      snapshotKey: 'fieldsTest',
-      uploadsDir: path.resolve(dirname, './collections/Upload/uploads'),
     })
 
     await ensureCompilationIsDone({ page, serverURL })

--- a/test/fields/collections/UploadRestricted/e2e.spec.ts
+++ b/test/fields/collections/UploadRestricted/e2e.spec.ts
@@ -33,7 +33,6 @@ let url: AdminUrlUtil
 describe('Upload with restrictions', () => {
   beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
-    process.env.SEED_IN_CONFIG_ONINIT = 'false' // Makes it so the payload config onInit seed is not run. Otherwise, the seed would be run unnecessarily twice for the initial test run - once for beforeEach and once for onInit
     ;({ payload, serverURL } = await initPayloadE2ENoConfig<Config>({
       dirname,
       // prebuild,
@@ -46,8 +45,6 @@ describe('Upload with restrictions', () => {
   beforeEach(async () => {
     await reInitializeDB({
       serverURL,
-      snapshotKey: 'fieldsTest',
-      uploadsDir: path.resolve(dirname, './collections/Upload/uploads'),
     })
 
     if (client) {

--- a/test/fields/config.blockreferences.ts
+++ b/test/fields/config.blockreferences.ts
@@ -2,9 +2,13 @@
 
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
 import { autoDedupeBlocksPlugin } from '../__helpers/shared/autoDedupeBlocksPlugin/index.js'
-import { baseConfig } from './baseConfig.js'
+import { baseConfig, seed } from './baseConfig.js'
 
 export default buildConfigWithDefaults({
-  ...baseConfig,
-  plugins: [autoDedupeBlocksPlugin({ silent: true })],
+  suite: 'fields-blockreferences',
+  config: {
+    ...baseConfig,
+    plugins: [autoDedupeBlocksPlugin({ silent: true })],
+  },
+  seed,
 })

--- a/test/fields/config.ts
+++ b/test/fields/config.ts
@@ -1,6 +1,6 @@
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
-import { baseConfig } from './baseConfig.js'
+import { baseConfig, seed } from './baseConfig.js'
 
-export default buildConfigWithDefaults(baseConfig)
+export default buildConfigWithDefaults({ suite: 'fields', config: baseConfig, seed })
 
 export { collections } from './baseConfig.js'

--- a/test/fields/int.spec.ts
+++ b/test/fields/int.spec.ts
@@ -26,7 +26,6 @@ import {
 } from './collections/Tabs/constants.js'
 import { tabsDoc } from './collections/Tabs/shared.js'
 import { defaultText } from './collections/Text/shared.js'
-import testConfig from './config.js'
 import {
   arrayFieldsSlug,
   blockFieldsSlug,
@@ -43,7 +42,7 @@ import {
 
 let user: any
 
-test.suite({ config: testConfig })('Fields', () => {
+test.suite({ config: './config.ts' })('Fields', () => {
   test.beforeEach(async ({ payload, restClient }) => {
     await restClient.login({
       slug: 'users',

--- a/test/fields/int.spec.ts
+++ b/test/fields/int.spec.ts
@@ -1,19 +1,15 @@
 import type { MongooseAdapter } from '@payloadcms/db-mongodb'
 import type { IndexDirection, IndexOptions } from 'mongoose'
-import type { Payload, ValidationError } from 'payload'
+import type { ValidationError } from 'payload'
 
 import { slugifyHandler } from '@payloadcms/ui/utilities/slugify'
-import path from 'path'
 import { createLocalReq, reload } from 'payload'
 import { fileURLToPath } from 'url'
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { expect } from 'vitest'
 
-import type { NextRESTClient } from '../__helpers/shared/NextRESTClient.js'
 import type { BlockField, GroupField } from './payload-types.js'
 
 import { test } from '../__helpers/int/vitest.js'
-import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
-import { isMongoose } from '../__helpers/shared/isMongoose.js'
 import { devUser } from '../credentials.js'
 import { arrayDefaultValue } from './collections/Array/index.js'
 import { blocksDoc } from './collections/Blocks/shared.js'
@@ -30,7 +26,7 @@ import {
 } from './collections/Tabs/constants.js'
 import { tabsDoc } from './collections/Tabs/shared.js'
 import { defaultText } from './collections/Text/shared.js'
-import { clearAndSeedEverything } from './seed.js'
+import testConfig from './config.js'
 import {
   arrayFieldsSlug,
   blockFieldsSlug,
@@ -44,21 +40,11 @@ import {
   tabsFieldsSlug,
   textFieldsSlug,
 } from './slugs.js'
-let restClient: NextRESTClient
+
 let user: any
-let payload: Payload
 
-const filename = fileURLToPath(import.meta.url)
-const dirname = path.dirname(filename)
-
-describe('Fields', () => {
-  beforeAll(async () => {
-    process.env.SEED_IN_CONFIG_ONINIT = 'false' // Makes it so the payload config onInit seed is not run. Otherwise, the seed would be run unnecessarily twice for the initial test run - once for beforeEach and once for onInit
-    ;({ payload, restClient } = await initPayloadInt(dirname))
-
-    // Seed ONCE for all tests
-    await clearAndSeedEverything(payload)
-
+test.suite({ config: testConfig })('Fields', () => {
+  test.beforeEach(async ({ payload, restClient }) => {
     await restClient.login({
       slug: 'users',
       credentials: devUser,
@@ -72,21 +58,17 @@ describe('Fields', () => {
     })
   })
 
-  afterAll(async () => {
-    await payload.destroy()
-  })
-
-  describe('slug field', () => {
+  test.describe('slug field', () => {
     const created: (number | string)[] = []
 
-    afterEach(async () => {
+    test.afterEach(async ({ payload }) => {
       for (const id of created) {
         await payload.delete({ collection: 'slug-fields', id })
       }
       created.length = 0
     })
 
-    it('should generate a slug from the source field on create', async () => {
+    test('should generate a slug from the source field on create', async ({ payload }) => {
       const doc = await payload.create({
         collection: 'slug-fields',
         data: { title: 'My First Post' },
@@ -95,7 +77,7 @@ describe('Fields', () => {
       expect(doc.slug).toBe('my-first-post')
     })
 
-    it('should keep a user-provided slug on create', async () => {
+    test('should keep a user-provided slug on create', async ({ payload }) => {
       const doc = await payload.create({
         collection: 'slug-fields',
         data: { title: 'My First Post', slug: 'custom-slug' },
@@ -104,7 +86,7 @@ describe('Fields', () => {
       expect(doc.slug).toBe('custom-slug')
     })
 
-    it('should slugify an unnormalized explicit value', async () => {
+    test('should slugify an unnormalized explicit value', async ({ payload }) => {
       const doc = await payload.create({
         collection: 'slug-fields',
         data: { title: 'My First Post', slug: 'Hello World' },
@@ -113,7 +95,7 @@ describe('Fields', () => {
       expect(doc.slug).toBe('hello-world')
     })
 
-    it('should freeze a diverged slug on update', async () => {
+    test('should freeze a diverged slug on update', async ({ payload }) => {
       const doc = await payload.create({
         collection: 'slug-fields',
         data: { title: 'Original Title' },
@@ -135,7 +117,7 @@ describe('Fields', () => {
       expect(again.slug).toBe('manual-value')
     })
 
-    it('should fill every locale of a localized slug on create', async () => {
+    test('should fill every locale of a localized slug on create', async ({ payload }) => {
       const doc = await payload.create({
         collection: 'slug-fields',
         data: { title: 'Title', localizedTitle: 'English Title' },
@@ -156,7 +138,9 @@ describe('Fields', () => {
       expect(localizedSlug.es).toMatch(/^slug-field-\d+$/)
     })
 
-    it('should derive every locale of a localized slug from a shared non-localized source', async () => {
+    test('should derive every locale of a localized slug from a shared non-localized source', async ({
+      payload,
+    }) => {
       const doc = await payload.create({
         collection: 'slug-fields',
         data: { title: 'Hello World' },
@@ -176,7 +160,9 @@ describe('Fields', () => {
       expect(shared.es).toBe('hello-world')
     })
 
-    it('should keep localized slugs independent when one locale is changed', async () => {
+    test('should keep localized slugs independent when one locale is changed', async ({
+      payload,
+    }) => {
       const doc = await payload.create({
         collection: 'slug-fields',
         data: { title: 'Title', localizedTitle: 'English Title' },
@@ -202,7 +188,9 @@ describe('Fields', () => {
       expect(localizedSlug.es).toBe('titulo-espanol')
     })
 
-    it('should fall back to <singular>-N for a slug field with no useAsSlug source', async () => {
+    test('should fall back to <singular>-N for a slug field with no useAsSlug source', async ({
+      payload,
+    }) => {
       const doc = await payload.create({
         collection: 'slug-fields',
         data: { title: 'No Source' },
@@ -211,7 +199,9 @@ describe('Fields', () => {
       expect(doc.sourcelessSlug).toMatch(/^slug-field-\d+$/)
     })
 
-    it('should keep an explicit value on a slug field with no useAsSlug source', async () => {
+    test('should keep an explicit value on a slug field with no useAsSlug source', async ({
+      payload,
+    }) => {
       const doc = await payload.create({
         collection: 'slug-fields',
         data: { title: 'No Source', sourcelessSlug: 'Manual Value' },
@@ -220,7 +210,7 @@ describe('Fields', () => {
       expect(doc.sourcelessSlug).toBe('manual-value')
     })
 
-    it('should allow the same localized slug value in different locales', async () => {
+    test('should allow the same localized slug value in different locales', async ({ payload }) => {
       const en = await payload.create({
         collection: 'slug-fields',
         data: { title: 'Title', localizedSlug: 'shared' },
@@ -238,7 +228,9 @@ describe('Fields', () => {
       expect(es.localizedSlug).toBe('shared')
     })
 
-    it('should allow one document to reuse the same slug across its own locales', async () => {
+    test('should allow one document to reuse the same slug across its own locales', async ({
+      payload,
+    }) => {
       const doc = await payload.create({
         collection: 'slug-fields',
         data: { title: 'Title', localizedSlug: 'shared-across-self' },
@@ -265,7 +257,9 @@ describe('Fields', () => {
       expect(localizedSlug.es).toBe('shared-across-self')
     })
 
-    it('should reject a localized slug that collides within the same locale', async () => {
+    test('should reject a localized slug that collides within the same locale', async ({
+      payload,
+    }) => {
       const first = await payload.create({
         collection: 'slug-fields',
         data: { title: 'First', localizedSlug: 'shared-localized' },
@@ -283,7 +277,7 @@ describe('Fields', () => {
       ).rejects.toThrow()
     })
 
-    it('should scope localized uniqueness per locale across documents', async () => {
+    test('should scope localized uniqueness per locale across documents', async ({ payload }) => {
       // Doc A: en `my-slug`, es `my-slugo`.
       const a = await payload.create({
         collection: 'slug-fields',
@@ -326,7 +320,9 @@ describe('Fields', () => {
       ).rejects.toThrow()
     })
 
-    it('should auto-increment a derived localized slug that collides within the same locale', async () => {
+    test('should auto-increment a derived localized slug that collides within the same locale', async ({
+      payload,
+    }) => {
       const first = await payload.create({
         collection: 'slug-fields',
         data: { title: 'First', localizedTitle: 'Shared Derived' },
@@ -344,7 +340,9 @@ describe('Fields', () => {
       expect(second.localizedSlug).toBe('shared-derived-1')
     })
 
-    it('should not increment a derived localized slug shared across different locales', async () => {
+    test('should not increment a derived localized slug shared across different locales', async ({
+      payload,
+    }) => {
       const en = await payload.create({
         collection: 'slug-fields',
         data: { title: 'English', localizedTitle: 'Cross Locale' },
@@ -362,7 +360,9 @@ describe('Fields', () => {
       expect(es.localizedSlug).toBe('cross-locale')
     })
 
-    it('should give a duplicate a fresh fallback slug instead of drifting from the original', async () => {
+    test('should give a duplicate a fresh fallback slug instead of drifting from the original', async ({
+      payload,
+    }) => {
       const original = await payload.create({
         collection: 'slug-fields',
         data: { title: 'My First Post' },
@@ -387,7 +387,9 @@ describe('Fields', () => {
       expect(secondDuplicate.slug).toBe('slug-field-2')
     })
 
-    it('should derive from the source when an explicit value slugifies to nothing', async () => {
+    test('should derive from the source when an explicit value slugifies to nothing', async ({
+      payload,
+    }) => {
       const doc = await payload.create({
         collection: 'slug-fields',
         data: { title: 'Fallthrough Title', slug: '!!!' },
@@ -396,7 +398,7 @@ describe('Fields', () => {
       expect(doc.slug).toBe('fallthrough-title')
     })
 
-    it('should reject a slug that collides with another document', async () => {
+    test('should reject a slug that collides with another document', async ({ payload }) => {
       const first = await payload.create({
         collection: 'slug-fields',
         data: { title: 'First', slug: 'shared-slug' },
@@ -412,7 +414,7 @@ describe('Fields', () => {
       ).rejects.toThrow()
     })
 
-    it('should reject updating a slug to collide with another document', async () => {
+    test('should reject updating a slug to collide with another document', async ({ payload }) => {
       const a = await payload.create({
         collection: 'slug-fields',
         data: { title: 'Doc A', slug: 'doc-a' },
@@ -429,7 +431,7 @@ describe('Fields', () => {
       ).rejects.toThrow()
     })
 
-    it('should allow re-saving a document with its own unchanged slug', async () => {
+    test('should allow re-saving a document with its own unchanged slug', async ({ payload }) => {
       const doc = await payload.create({
         collection: 'slug-fields',
         data: { title: 'Stable', slug: 'stable-slug' },
@@ -449,7 +451,9 @@ describe('Fields', () => {
     // The regen button calls the slugify server function directly, which has its own fallback path
     // separate from the beforeChange hook. It must scope the source-less `<singular>-N` fallback to
     // the active locale, or it hands back a slug already taken in that locale.
-    it('should regenerate a source-less localized slug to a locale-unique fallback', async () => {
+    test('should regenerate a source-less localized slug to a locale-unique fallback', async ({
+      payload,
+    }) => {
       const taken = await payload.create({
         collection: 'slug-fields',
         data: { title: 'Taken' },
@@ -474,7 +478,9 @@ describe('Fields', () => {
       expect(regenerated).not.toBe(takenSlug)
     })
 
-    it('should dedupe a source-derived slug on regenerate, matching the next save', async () => {
+    test('should dedupe a source-derived slug on regenerate, matching the next save', async ({
+      payload,
+    }) => {
       const first = await payload.create({
         collection: 'slug-fields',
         data: { title: 'Shared Regen' },
@@ -497,7 +503,9 @@ describe('Fields', () => {
       expect(regenerated).toBe('shared-regen-1')
     })
 
-    it('should let a document reuse its own slug on regenerate via the excluded id', async () => {
+    test('should let a document reuse its own slug on regenerate via the excluded id', async ({
+      payload,
+    }) => {
       const doc = await payload.create({
         collection: 'slug-fields',
         data: { title: 'Own Slug' },
@@ -508,7 +516,7 @@ describe('Fields', () => {
       const req = await createLocalReq({ user: user.user }, payload)
 
       // Excluding the current doc means regenerating its own unchanged source reuses the value rather
-      // than bumping past it.
+      // than bumping past test.
       const regenerated = await slugifyHandler({
         id: doc.id,
         collectionSlug: 'slug-fields',
@@ -521,17 +529,17 @@ describe('Fields', () => {
       expect(regenerated).toBe('own-slug')
     })
 
-    describe('autosave drafts', () => {
+    test.describe('autosave drafts', () => {
       const created: (number | string)[] = []
 
-      afterEach(async () => {
+      test.afterEach(async ({ payload }) => {
         for (const id of created) {
           await payload.delete({ collection: 'slug-autosave', id })
         }
         created.length = 0
       })
 
-      it('should generate the slug from the source on a draft create', async () => {
+      test('should generate the slug from the source on a draft create', async ({ payload }) => {
         const draft = await payload.create({
           collection: 'slug-autosave',
           draft: true,
@@ -541,7 +549,9 @@ describe('Fields', () => {
         expect(draft.slug).toBe('draft-one')
       })
 
-      it('should fall back to <singular>-N when a draft is created with no source', async () => {
+      test('should fall back to <singular>-N when a draft is created with no source', async ({
+        payload,
+      }) => {
         const draft = await payload.create({
           collection: 'slug-autosave',
           draft: true,
@@ -560,7 +570,9 @@ describe('Fields', () => {
         expect(latestDraft.slug).toBe('slug-autosave-1')
       })
 
-      it('should fall back when the explicit value slugifies to nothing and there is no source', async () => {
+      test('should fall back when the explicit value slugifies to nothing and there is no source', async ({
+        payload,
+      }) => {
         const draft = await payload.create({
           collection: 'slug-autosave',
           draft: true,
@@ -570,7 +582,9 @@ describe('Fields', () => {
         expect(draft.slug).toBe('slug-autosave-1')
       })
 
-      it('should give each source-less draft the next fallback without colliding', async () => {
+      test('should give each source-less draft the next fallback without colliding', async ({
+        payload,
+      }) => {
         const first = await payload.create({
           collection: 'slug-autosave',
           draft: true,
@@ -589,7 +603,7 @@ describe('Fields', () => {
         expect(second.slug).toBe('slug-autosave-2')
       })
 
-      it('should reject a draft slug that collides with another draft', async () => {
+      test('should reject a draft slug that collides with another draft', async ({ payload }) => {
         const first = await payload.create({
           collection: 'slug-autosave',
           draft: true,
@@ -607,7 +621,9 @@ describe('Fields', () => {
         ).rejects.toThrow()
       })
 
-      it('should reject updating a draft slug to collide with another draft', async () => {
+      test('should reject updating a draft slug to collide with another draft', async ({
+        payload,
+      }) => {
         const a = await payload.create({
           collection: 'slug-autosave',
           draft: true,
@@ -631,7 +647,9 @@ describe('Fields', () => {
         ).rejects.toThrow()
       })
 
-      it('should allow the same localized draft slug across locales but reject within a locale', async () => {
+      test('should allow the same localized draft slug across locales but reject within a locale', async ({
+        payload,
+      }) => {
         const en = await payload.create({
           collection: 'slug-autosave',
           draft: true,
@@ -662,7 +680,9 @@ describe('Fields', () => {
         ).rejects.toThrow()
       })
 
-      it('should fall back to <singular>-N for a source-less localized slug on a draft', async () => {
+      test('should fall back to <singular>-N for a source-less localized slug on a draft', async ({
+        payload,
+      }) => {
         const draft = await payload.create({
           collection: 'slug-autosave',
           draft: true,
@@ -690,7 +710,9 @@ describe('Fields', () => {
         expect(published.localizedSlug).toBe('slug-autosave-1')
       })
 
-      it('should fill every locale of a localized slug on a draft create', async () => {
+      test('should fill every locale of a localized slug on a draft create', async ({
+        payload,
+      }) => {
         const draft = await payload.create({
           collection: 'slug-autosave',
           draft: true,
@@ -710,7 +732,9 @@ describe('Fields', () => {
         expect(localizedSlug.es).toMatch(/^slug-autosave-\d+$/)
       })
 
-      it('should fall back to a per-locale <singular>-N for localized slugs on a draft', async () => {
+      test('should fall back to a per-locale <singular>-N for localized slugs on a draft', async ({
+        payload,
+      }) => {
         const en = await payload.create({
           collection: 'slug-autosave',
           draft: true,
@@ -731,7 +755,7 @@ describe('Fields', () => {
         expect(es.localizedSlug).toBe('slug-autosave-1')
       })
 
-      it('should give a duplicated draft its own unique slug', async () => {
+      test('should give a duplicated draft its own unique slug', async ({ payload }) => {
         const original = await payload.create({
           collection: 'slug-autosave',
           draft: true,
@@ -747,7 +771,9 @@ describe('Fields', () => {
         expect(duplicate.slug).toMatch(/^slug-autosave-\d+$/)
       })
 
-      it('should keep an explicit slug the user typed on the initial draft', async () => {
+      test('should keep an explicit slug the user typed on the initial draft', async ({
+        payload,
+      }) => {
         const draft = await payload.create({
           collection: 'slug-autosave',
           draft: true,
@@ -757,7 +783,7 @@ describe('Fields', () => {
         expect(draft.slug).toBe('user-typed')
       })
 
-      it('should freeze the slug across subsequent autosaves once set', async () => {
+      test('should freeze the slug across subsequent autosaves once set', async ({ payload }) => {
         const draft = await payload.create({
           collection: 'slug-autosave',
           draft: true,
@@ -775,7 +801,7 @@ describe('Fields', () => {
         expect(updated.slug).toBe('draft-one')
       })
 
-      it('should keep an admin overwrite across subsequent autosaves', async () => {
+      test('should keep an admin overwrite across subsequent autosaves', async ({ payload }) => {
         const draft = await payload.create({
           collection: 'slug-autosave',
           draft: true,
@@ -807,7 +833,7 @@ describe('Fields', () => {
         expect(afterMoreEdits.slug).toBe('human-chosen-slug')
       })
 
-      it('should not change an already-set slug on publish or after', async () => {
+      test('should not change an already-set slug on publish or after', async ({ payload }) => {
         const draft = await payload.create({
           collection: 'slug-autosave',
           draft: true,
@@ -840,18 +866,21 @@ describe('Fields', () => {
     })
   })
 
-  describe('slug field read access', () => {
+  test.describe('slug field read access', () => {
     const collection = 'slug-field-access'
     const created: (number | string)[] = []
 
-    afterEach(async () => {
+    test.afterEach(async ({ payload }) => {
       for (const id of created) {
         await payload.delete({ collection, id })
       }
       created.length = 0
     })
 
-    it('should apply read access when a REST create omits overrideAccess', async () => {
+    test('should apply read access when a REST create omits overrideAccess', async ({
+      payload,
+      restClient,
+    }) => {
       const hidden = await payload.create({
         collection,
         data: { title: 'REST shared title' },
@@ -868,7 +897,9 @@ describe('Fields', () => {
       expect(doc.slug).toBe('rest-shared-title')
     })
 
-    it('should apply read access when checking a generated slug during create', async () => {
+    test('should apply read access when checking a generated slug during create', async ({
+      payload,
+    }) => {
       const hidden = await payload.create({
         collection,
         data: { title: 'Shared title' },
@@ -887,7 +918,9 @@ describe('Fields', () => {
       expect(createdWithAccess.slug).toBe('shared-title')
     })
 
-    it('should apply read access when checking an explicit slug during update', async () => {
+    test('should apply read access when checking an explicit slug during update', async ({
+      payload,
+    }) => {
       const hidden = await payload.create({
         collection,
         data: { slug: 'shared-slug', title: 'Hidden' },
@@ -910,7 +943,7 @@ describe('Fields', () => {
       expect(updated.slug).toBe('shared-slug')
     })
 
-    it('should apply read access while filling localized slugs', async () => {
+    test('should apply read access while filling localized slugs', async ({ payload }) => {
       const hidden = await payload.create({
         collection,
         data: { localizedTitle: 'Localized title', title: 'Hidden' },
@@ -945,7 +978,7 @@ describe('Fields', () => {
       expect(localizedSlug.es).toBe(hiddenLocalizedSlug.es)
     })
 
-    it('should apply read access when choosing a source-less fallback', async () => {
+    test('should apply read access when choosing a source-less fallback', async ({ payload }) => {
       const hidden = await payload.create({
         collection,
         data: { title: 'Hidden' },
@@ -964,7 +997,9 @@ describe('Fields', () => {
       expect(createdWithAccess.sourcelessSlug).toBe(hidden.sourcelessSlug)
     })
 
-    it('should retain elevated slug probes for explicitly elevated Local API creates', async () => {
+    test('should retain elevated slug probes for explicitly elevated Local API creates', async ({
+      payload,
+    }) => {
       const hidden = await payload.create({
         collection,
         data: { title: 'Shared title' },
@@ -982,17 +1017,17 @@ describe('Fields', () => {
     })
   })
 
-  describe('text', () => {
+  test.describe('text', () => {
     let doc
     const text = 'text field'
-    beforeEach(async () => {
+    test.beforeEach(async ({ payload }) => {
       doc = await payload.create({
         collection: 'text-fields',
         data: { text },
       })
     })
 
-    it('creates with default values', () => {
+    test('creates with default values', () => {
       expect(doc.text).toStrictEqual(text)
       expect(doc.defaultString).toStrictEqual(defaultText)
       expect(doc.defaultEmptyString).toStrictEqual('')
@@ -1000,7 +1035,7 @@ describe('Fields', () => {
       expect(doc.defaultAsync).toStrictEqual(defaultText)
     })
 
-    it('should populate default values in beforeValidate hook', async () => {
+    test('should populate default values in beforeValidate hook', async ({ payload }) => {
       const { dependentOnFieldWithDefaultValue, fieldWithDefaultValue } = await payload.create({
         collection: 'text-fields',
         data: { text },
@@ -1009,7 +1044,7 @@ describe('Fields', () => {
       expect(fieldWithDefaultValue).toEqual(dependentOnFieldWithDefaultValue)
     })
 
-    it('should populate function default values from req', async () => {
+    test('should populate function default values from req', async ({ payload }) => {
       const text = await payload.create({
         req: {
           context: {
@@ -1023,7 +1058,7 @@ describe('Fields', () => {
       expect(text.defaultValueFromReq).toBe('from-context')
     })
 
-    it('should localize an array of strings using hasMany', async () => {
+    test('should localize an array of strings using hasMany', async ({ payload }) => {
       const localizedHasMany = ['hello', 'world']
       const { id } = await payload.create({
         collection: 'text-fields',
@@ -1043,7 +1078,7 @@ describe('Fields', () => {
       expect(localizedDoc.localizedHasMany.en).toEqual(localizedHasMany)
     })
 
-    it('should validate localized required text field with locale all', async () => {
+    test('should validate localized required text field with locale all', async ({ payload }) => {
       const doc = await payload.create({
         collection: 'text-fields',
         data: {
@@ -1071,7 +1106,7 @@ describe('Fields', () => {
       await payload.delete({ collection: 'text-fields', id: doc.id })
     })
 
-    it('should query hasMany in', async () => {
+    test('should query hasMany in', async ({ payload }) => {
       const hit = await payload.create({
         collection: 'text-fields',
         data: {
@@ -1104,7 +1139,7 @@ describe('Fields', () => {
       expect(missResult).toBeFalsy()
     })
 
-    it('should query multiple hasMany fields', async () => {
+    test('should query multiple hasMany fields', async ({ payload }) => {
       await payload.delete({ collection: 'text-fields', where: {} })
       const hit = await payload.create({
         collection: 'text-fields',
@@ -1141,7 +1176,7 @@ describe('Fields', () => {
       expect(missResult).toBeFalsy()
     })
 
-    it('should query hasMany with contains operator - string value', async () => {
+    test('should query hasMany with contains operator - string value', async ({ payload }) => {
       const hit = await payload.create({
         collection: 'text-fields',
         data: {
@@ -1177,7 +1212,7 @@ describe('Fields', () => {
       await payload.delete({ collection: 'text-fields', id: miss.id })
     })
 
-    it('should query hasMany with contains operator - array value', async () => {
+    test('should query hasMany with contains operator - array value', async ({ payload }) => {
       const hit1 = await payload.create({
         collection: 'text-fields',
         data: {
@@ -1224,7 +1259,7 @@ describe('Fields', () => {
       await payload.delete({ collection: 'text-fields', id: miss.id })
     })
 
-    it('should query like on value', async () => {
+    test('should query like on value', async ({ payload }) => {
       const miss = await payload.create({
         collection: 'text-fields',
         data: {
@@ -1255,7 +1290,7 @@ describe('Fields', () => {
       expect(missResult).toBeFalsy()
     })
 
-    it('should query not_like on value', async () => {
+    test('should query not_like on value', async ({ payload }) => {
       const hit = await payload.create({
         collection: 'text-fields',
         data: {
@@ -1286,7 +1321,7 @@ describe('Fields', () => {
       expect(missResult).toBeFalsy()
     })
 
-    it('should query hasMany within an array', async () => {
+    test('should query hasMany within an array', async ({ payload }) => {
       const docFirst = await payload.create({
         collection: 'text-fields',
         data: {
@@ -1372,7 +1407,7 @@ describe('Fields', () => {
       expect(resInSecond.totalDocs).toBe(1)
     })
 
-    it('should query hasMany within blocks', async () => {
+    test('should query hasMany within blocks', async ({ payload }) => {
       const docFirst = await payload.create({
         collection: 'text-fields',
         data: {
@@ -1460,7 +1495,7 @@ describe('Fields', () => {
       expect(resInSecond.totalDocs).toBe(1)
     })
 
-    it('should delete rows when updating hasMany with empty array', async () => {
+    test('should delete rows when updating hasMany with empty array', async ({ payload }) => {
       const { id: createdDocId } = await payload.create({
         collection: textFieldsSlug,
         data: {
@@ -1486,7 +1521,7 @@ describe('Fields', () => {
     })
   })
 
-  describe('relationship', () => {
+  test.describe('relationship', () => {
     let textDoc
     let otherTextDoc
     let selfReferencing
@@ -1498,7 +1533,7 @@ describe('Fields', () => {
     const otherTextDocText = 'alt text'
     const relationshipText = 'relationship text'
 
-    beforeEach(async () => {
+    test.beforeEach(async ({ payload }) => {
       textDoc = await payload.create({
         collection: 'text-fields',
         data: {
@@ -1559,7 +1594,7 @@ describe('Fields', () => {
       })
     })
 
-    it('should query parent self-reference', async () => {
+    test('should query parent self-reference', async ({ payload }) => {
       const childResult = await payload.find({
         collection: relationshipFieldsSlug,
         where: {
@@ -1589,7 +1624,7 @@ describe('Fields', () => {
       expect(allChildren.docs).toHaveLength(2)
     })
 
-    it('should query relationship inside array', async () => {
+    test('should query relationship inside array', async ({ payload }) => {
       const result = await payload.find({
         collection: relationshipFieldsSlug,
         where: {
@@ -1608,7 +1643,7 @@ describe('Fields', () => {
       expect(result.docs[0]).toMatchObject(relationshipInArray)
     })
 
-    it('should query text in row after relationship', async () => {
+    test('should query text in row after relationship', async ({ payload }) => {
       const row = await payload.create({
         collection: 'row-fields',
         data: { title: 'some-title', id: 'custom-row-id' },
@@ -1640,8 +1675,10 @@ describe('Fields', () => {
     })
   })
 
-  describe('rows', () => {
-    it('should show proper validation error message on text field within row field', async () => {
+  test.describe('rows', () => {
+    test('should show proper validation error message on text field within row field', async ({
+      payload,
+    }) => {
       await expect(async () =>
         payload.create({
           collection: 'row-fields',
@@ -1654,18 +1691,18 @@ describe('Fields', () => {
     })
   })
 
-  describe('timestamps', () => {
+  test.describe('timestamps', () => {
     const tenMinutesAgo = new Date(Date.now() - 1000 * 60 * 10)
     const tenMinutesLater = new Date(Date.now() + 1000 * 60 * 10)
     let doc
-    beforeEach(async () => {
+    test.beforeEach(async ({ payload }) => {
       doc = await payload.create({
         collection: 'date-fields',
         data: dateDoc,
       })
     })
 
-    it('should query updatedAt', async () => {
+    test('should query updatedAt', async ({ payload }) => {
       const { docs } = await payload.find({
         collection: 'date-fields',
         depth: 0,
@@ -1679,7 +1716,7 @@ describe('Fields', () => {
       expect(docs.map(({ id }) => id)).toContain(doc.id)
     })
 
-    it('should query createdAt (greater_than_equal with results)', async () => {
+    test('should query createdAt (greater_than_equal with results)', async ({ payload }) => {
       const result = await payload.find({
         collection: 'date-fields',
         depth: 0,
@@ -1693,7 +1730,7 @@ describe('Fields', () => {
       expect(result.docs[0].id).toEqual(doc.id)
     })
 
-    it('should query createdAt (greater_than_equal with no results)', async () => {
+    test('should query createdAt (greater_than_equal with no results)', async ({ payload }) => {
       const result = await payload.find({
         collection: 'date-fields',
         depth: 0,
@@ -1707,7 +1744,7 @@ describe('Fields', () => {
       expect(result.totalDocs).toBe(0)
     })
 
-    it('should query createdAt (less_than with results)', async () => {
+    test('should query createdAt (less_than with results)', async ({ payload }) => {
       const result = await payload.find({
         collection: 'date-fields',
         depth: 0,
@@ -1721,7 +1758,7 @@ describe('Fields', () => {
       expect(result.docs[0].id).toEqual(doc.id)
     })
 
-    it('should query createdAt (less_than with no results)', async () => {
+    test('should query createdAt (less_than with no results)', async ({ payload }) => {
       const result = await payload.find({
         collection: 'date-fields',
         depth: 0,
@@ -1735,7 +1772,7 @@ describe('Fields', () => {
       expect(result.totalDocs).toBe(0)
     })
 
-    it('should query createdAt (in with results)', async () => {
+    test('should query createdAt (in with results)', async ({ payload }) => {
       const result = await payload.find({
         collection: 'date-fields',
         depth: 0,
@@ -1749,7 +1786,7 @@ describe('Fields', () => {
       expect(result.docs[0].id).toBe(doc.id)
     })
 
-    it('should query createdAt (in without results)', async () => {
+    test('should query createdAt (in without results)', async ({ payload }) => {
       const result = await payload.find({
         collection: 'date-fields',
         depth: 0,
@@ -1784,7 +1821,7 @@ describe('Fields', () => {
       }
     })
 
-    it('should query a date field inside an array field', async () => {
+    test('should query a date field inside an array field', async ({ payload }) => {
       await payload.delete({ collection: 'date-fields', where: {} })
       for (const doc of dataSample) {
         await payload.create({
@@ -1806,18 +1843,17 @@ describe('Fields', () => {
       if (res.totalDocs > 10) {
         // This is where postgres might fail! selectDistinct actually removed some rows here, because it distincts by:
         // not only ID, but also created_at, updated_at, items_date
-        // eslint-disable-next-line vitest/no-conditional-expect
+
         expect(res.docs).toHaveLength(10)
       } else {
-        // eslint-disable-next-line vitest/no-conditional-expect
         expect(res.docs.length).toBeLessThanOrEqual(res.totalDocs)
       }
     })
   })
 
-  describe('select', () => {
+  test.describe('select', () => {
     let doc
-    beforeEach(async () => {
+    test.beforeEach(async ({ payload }) => {
       const { id } = await payload.create({
         collection: 'select-fields',
         data: {
@@ -1832,11 +1868,11 @@ describe('Fields', () => {
       })
     })
 
-    it('creates with hasMany localized', () => {
+    test('creates with hasMany localized', () => {
       expect(doc.selectHasManyLocalized.en).toEqual(['one', 'two'])
     })
 
-    it('retains hasMany updates', async () => {
+    test('retains hasMany updates', async ({ payload }) => {
       const { id } = await payload.create({
         collection: 'select-fields',
         data: {
@@ -1856,7 +1892,7 @@ describe('Fields', () => {
       expect(updatedDoc.selectHasMany).toEqual(['one', 'two'])
     })
 
-    it('should clear select hasMany field', async () => {
+    test('should clear select hasMany field', async ({ payload }) => {
       const { id } = await payload.create({
         collection: 'select-fields',
         data: {
@@ -1875,7 +1911,7 @@ describe('Fields', () => {
       expect(updatedDoc.selectHasMany).toHaveLength(0)
     })
 
-    it('should query hasMany in', async () => {
+    test('should query hasMany in', async ({ payload }) => {
       const hit = await payload.create({
         collection: 'select-fields',
         data: {
@@ -1906,7 +1942,7 @@ describe('Fields', () => {
       expect(missResult).toBeFalsy()
     })
 
-    it('should CRUD within array hasMany', async () => {
+    test('should CRUD within array hasMany', async ({ payload }) => {
       const doc = await payload.create({
         collection: 'select-fields',
         data: { array: [{ selectHasMany: ['one', 'two'] }] },
@@ -1930,7 +1966,7 @@ describe('Fields', () => {
       expect(upd.array[0].selectHasMany).toStrictEqual(['six'])
     })
 
-    it('should CRUD within array + group hasMany', async () => {
+    test('should CRUD within array + group hasMany', async ({ payload }) => {
       const doc = await payload.create({
         collection: 'select-fields',
         data: { array: [{ group: { selectHasMany: ['one', 'two'] } }] },
@@ -1954,7 +1990,7 @@ describe('Fields', () => {
       expect(upd.array[0].group.selectHasMany).toStrictEqual(['six'])
     })
 
-    it('should work with versions', async () => {
+    test('should work with versions', async ({ payload }) => {
       const base = await payload.create({
         collection: 'select-versions-fields',
         data: { hasMany: ['a', 'b'] },
@@ -1978,7 +2014,7 @@ describe('Fields', () => {
       expect(block.blocks[0]?.hasManyBlocks).toStrictEqual(['a', 'b'])
     })
 
-    it('should work with autosave', async () => {
+    test('should work with autosave', async ({ payload }) => {
       let data = await payload.create({
         collection: 'select-versions-fields',
         data: { hasMany: ['a', 'b', 'c'] },
@@ -2012,7 +2048,9 @@ describe('Fields', () => {
       expect(data.hasMany).toStrictEqual(['a'])
     })
 
-    it('should prevent against saving a value excluded by `filterOptions`', async () => {
+    test('should prevent against saving a value excluded by `filterOptions`', async ({
+      payload,
+    }) => {
       try {
         const result = await payload.create({
           collection: 'select-fields',
@@ -2024,7 +2062,6 @@ describe('Fields', () => {
 
         expect(result).toBeFalsy()
       } catch (error) {
-        // eslint-disable-next-line vitest/no-conditional-expect
         expect((error as Error).message).toBe(
           'The following field is invalid: Select with filtered options',
         )
@@ -2041,7 +2078,9 @@ describe('Fields', () => {
       expect(result).toBeTruthy()
     })
 
-    it('should prevent against saving a value excluded by an async `filterOptions`', async () => {
+    test('should prevent against saving a value excluded by an async `filterOptions`', async ({
+      payload,
+    }) => {
       await expect(
         payload.create({
           collection: 'select-fields',
@@ -2063,7 +2102,9 @@ describe('Fields', () => {
       expect(result).toBeTruthy()
     })
 
-    it('should throw field error when duplicate values in hasMany select field', async () => {
+    test('should throw field error when duplicate values in hasMany select field', async ({
+      payload,
+    }) => {
       let error: undefined | ValidationError
 
       try {
@@ -2083,16 +2124,16 @@ describe('Fields', () => {
     })
   })
 
-  describe('number', () => {
+  test.describe('number', () => {
     let doc
-    beforeEach(async () => {
+    test.beforeEach(async ({ payload }) => {
       doc = await payload.create({
         collection: 'number-fields',
         data: numberDoc,
       })
     })
 
-    it('creates with default values', () => {
+    test('creates with default values', () => {
       expect(doc.number).toEqual(numberDoc.number)
       expect(doc.min).toEqual(numberDoc.min)
       expect(doc.max).toEqual(numberDoc.max)
@@ -2103,7 +2144,7 @@ describe('Fields', () => {
       expect(doc.defaultNumber).toEqual(defaultNumber)
     })
 
-    it('should not create number below minimum', async () => {
+    test('should not create number below minimum', async ({ payload }) => {
       await expect(async () =>
         payload.create({
           collection: 'number-fields',
@@ -2113,7 +2154,7 @@ describe('Fields', () => {
         }),
       ).rejects.toThrow('The following field is invalid: Min')
     })
-    it('should not create number above max', async () => {
+    test('should not create number above max', async ({ payload }) => {
       await expect(async () =>
         payload.create({
           collection: 'number-fields',
@@ -2124,7 +2165,7 @@ describe('Fields', () => {
       ).rejects.toThrow('The following field is invalid: Max')
     })
 
-    it('should not create number below 0', async () => {
+    test('should not create number below 0', async ({ payload }) => {
       await expect(async () =>
         payload.create({
           collection: 'number-fields',
@@ -2135,7 +2176,7 @@ describe('Fields', () => {
       ).rejects.toThrow('The following field is invalid: Positive Number')
     })
 
-    it('should not create number above 0', async () => {
+    test('should not create number above 0', async ({ payload }) => {
       await expect(async () =>
         payload.create({
           collection: 'number-fields',
@@ -2145,7 +2186,7 @@ describe('Fields', () => {
         }),
       ).rejects.toThrow('The following field is invalid: Negative Number')
     })
-    it('should not create a decimal number below min', async () => {
+    test('should not create a decimal number below min', async ({ payload }) => {
       await expect(async () =>
         payload.create({
           collection: 'number-fields',
@@ -2156,7 +2197,7 @@ describe('Fields', () => {
       ).rejects.toThrow('The following field is invalid: Decimal Min')
     })
 
-    it('should not create a decimal number above max', async () => {
+    test('should not create a decimal number above max', async ({ payload }) => {
       await expect(async () =>
         payload.create({
           collection: 'number-fields',
@@ -2166,7 +2207,7 @@ describe('Fields', () => {
         }),
       ).rejects.toThrow('The following field is invalid: Decimal Max')
     })
-    it('should localize an array of numbers using hasMany', async () => {
+    test('should localize an array of numbers using hasMany', async ({ payload }) => {
       const localizedHasMany = [5, 10]
       const { id } = await payload.create({
         collection: 'number-fields',
@@ -2185,7 +2226,7 @@ describe('Fields', () => {
       expect(localizedDoc.localizedHasMany.en).toEqual(localizedHasMany)
     })
 
-    it('should query hasMany in', async () => {
+    test('should query hasMany in', async ({ payload }) => {
       const hit = await payload.create({
         collection: 'number-fields',
         data: {
@@ -2216,7 +2257,7 @@ describe('Fields', () => {
       expect(missResult).toBeFalsy()
     })
 
-    it('should properly query numbers with exists operator', async () => {
+    test('should properly query numbers with exists operator', async ({ payload }) => {
       const docWithNull = await payload.create({
         collection: 'number-fields',
         data: {
@@ -2250,7 +2291,7 @@ describe('Fields', () => {
       expect(numbersNotExists.docs.find((doc) => doc.id === docWithNull.id)).toBeDefined()
     })
 
-    it('should delete rows when updating hasMany with empty array', async () => {
+    test('should delete rows when updating hasMany with empty array', async ({ payload }) => {
       const { id: createdDocId } = await payload.create({
         collection: numberFieldsSlug,
         data: {
@@ -2275,7 +2316,7 @@ describe('Fields', () => {
     })
   })
 
-  it('should query hasMany within an array', async () => {
+  test('should query hasMany within an array', async ({ payload }) => {
     const docFirst = await payload.create({
       collection: 'number-fields',
       data: {
@@ -2341,7 +2382,7 @@ describe('Fields', () => {
     expect(resInSecond.totalDocs).toBe(1)
   })
 
-  it('should query hasMany within blocks', async () => {
+  test('should query hasMany within blocks', async ({ payload }) => {
     const docFirst = await payload.create({
       collection: 'number-fields',
       data: {
@@ -2409,96 +2450,95 @@ describe('Fields', () => {
     expect(resInSecond.totalDocs).toBe(1)
   })
 
-  if (isMongoose(payload)) {
-    describe('indexes', () => {
-      let indexes
-      const definitions: Record<string, IndexDirection> = {}
-      const options: Record<string, IndexOptions> = {}
+  test.options({ db: 'mongo' }).describe('indexes', () => {
+    let indexes
+    const definitions: Record<string, IndexDirection> = {}
+    const options: Record<string, IndexOptions> = {}
 
-      beforeAll(() => {
-        indexes = (payload.db as MongooseAdapter).collections[
-          'indexed-fields'
-        ].schema.indexes() as [Record<string, IndexDirection>, IndexOptions]
+    test.beforeEach(({ payload }) => {
+      indexes = (payload.db as MongooseAdapter).collections['indexed-fields'].schema.indexes() as [
+        Record<string, IndexDirection>,
+        IndexOptions,
+      ]
 
-        indexes.forEach((index) => {
-          const field = Object.keys(index[0])[0]
-          definitions[field] = index[0][field]
+      indexes.forEach((index) => {
+        const field = Object.keys(index[0])[0]
+        definitions[field] = index[0][field]
 
-          options[field] = index[1]
-        })
-      })
-
-      it('should have indexes', () => {
-        expect(definitions.text).toEqual(1)
-      })
-
-      it('should have unique sparse indexes when field is not required', () => {
-        expect(definitions.uniqueText).toEqual(1)
-        expect(options.uniqueText).toMatchObject({ sparse: true, unique: true })
-      })
-
-      it('should have unique indexes that are not sparse when field is required', () => {
-        expect(definitions.uniqueRequiredText).toEqual(1)
-        expect(options.uniqueText).toMatchObject({ unique: true })
-      })
-
-      it('should have 2dsphere indexes on point fields', () => {
-        expect(definitions.point).toEqual('2dsphere')
-      })
-
-      it('should have 2dsphere indexes on point fields in groups', () => {
-        expect(definitions['group.point']).toEqual('2dsphere')
-      })
-
-      it('should have a sparse index on a unique localized field in a group', () => {
-        expect(definitions['group.localizedUnique.en']).toEqual(1)
-        expect(options['group.localizedUnique.en']).toMatchObject({ sparse: true, unique: true })
-        expect(definitions['group.localizedUnique.es']).toEqual(1)
-        expect(options['group.localizedUnique.es']).toMatchObject({ sparse: true, unique: true })
-      })
-
-      it('should have unique indexes in a collapsible', () => {
-        expect(definitions['collapsibleLocalizedUnique.en']).toEqual(1)
-        expect(options['collapsibleLocalizedUnique.en']).toMatchObject({
-          sparse: true,
-          unique: true,
-        })
-        expect(definitions.collapsibleTextUnique).toEqual(1)
-        expect(options.collapsibleTextUnique).toMatchObject({ unique: true })
+        options[field] = index[1]
       })
     })
 
-    describe('version indexes', () => {
-      let indexes
-      const definitions: Record<string, IndexDirection> = {}
-      const options: Record<string, IndexOptions> = {}
+    test('should have indexes', () => {
+      expect(definitions.text).toEqual(1)
+    })
 
-      beforeEach(() => {
-        indexes = (payload.db as MongooseAdapter).versions['indexed-fields'].schema.indexes() as [
-          Record<string, IndexDirection>,
-          IndexOptions,
-        ]
-        indexes.forEach((index) => {
-          const field = Object.keys(index[0])[0]
-          definitions[field] = index[0][field]
+    test('should have unique sparse indexes when field is not required', () => {
+      expect(definitions.uniqueText).toEqual(1)
+      expect(options.uniqueText).toMatchObject({ sparse: true, unique: true })
+    })
 
-          options[field] = index[1]
-        })
+    test('should have unique indexes that are not sparse when field is required', () => {
+      expect(definitions.uniqueRequiredText).toEqual(1)
+      expect(options.uniqueText).toMatchObject({ unique: true })
+    })
+
+    test('should have 2dsphere indexes on point fields', () => {
+      expect(definitions.point).toEqual('2dsphere')
+    })
+
+    test('should have 2dsphere indexes on point fields in groups', () => {
+      expect(definitions['group.point']).toEqual('2dsphere')
+    })
+
+    test('should have a sparse index on a unique localized field in a group', () => {
+      expect(definitions['group.localizedUnique.en']).toEqual(1)
+      expect(options['group.localizedUnique.en']).toMatchObject({ sparse: true, unique: true })
+      expect(definitions['group.localizedUnique.es']).toEqual(1)
+      expect(options['group.localizedUnique.es']).toMatchObject({ sparse: true, unique: true })
+    })
+
+    test('should have unique indexes in a collapsible', () => {
+      expect(definitions['collapsibleLocalizedUnique.en']).toEqual(1)
+      expect(options['collapsibleLocalizedUnique.en']).toMatchObject({
+        sparse: true,
+        unique: true,
       })
+      expect(definitions.collapsibleTextUnique).toEqual(1)
+      expect(options.collapsibleTextUnique).toMatchObject({ unique: true })
+    })
+  })
 
-      it('should have versions indexes', () => {
-        expect(definitions['version.text']).toEqual(1)
+  test.options({ db: 'mongo' }).describe('version indexes', () => {
+    let indexes
+    const definitions: Record<string, IndexDirection> = {}
+    const options: Record<string, IndexOptions> = {}
+
+    test.beforeEach(({ payload }) => {
+      indexes = (payload.db as MongooseAdapter).versions['indexed-fields'].schema.indexes() as [
+        Record<string, IndexDirection>,
+        IndexOptions,
+      ]
+      indexes.forEach((index) => {
+        const field = Object.keys(index[0])[0]
+        definitions[field] = index[0][field]
+
+        options[field] = index[1]
       })
     })
-  }
 
-  describe('point', () => {
+    test('should have versions indexes', () => {
+      expect(definitions['version.text']).toEqual(1)
+    })
+  })
+
+  test.describe('point', () => {
     let doc
     const point = [7, -7]
     const localized = [5, -2]
     const group = { point: [1, 9] }
 
-    beforeEach(async () => {
+    test.beforeEach(async ({ payload }) => {
       const findDoc = await payload.find({
         collection: 'point-fields',
         pagination: false,
@@ -2506,7 +2546,7 @@ describe('Fields', () => {
       ;[doc] = findDoc.docs
     })
 
-    it('should read', async () => {
+    test('should read', async ({ payload }) => {
       if (payload.db.name === 'sqlite') {
         return
       }
@@ -2522,7 +2562,7 @@ describe('Fields', () => {
       expect(doc.group).toMatchObject(pointDoc.group)
     })
 
-    it('should create', async () => {
+    test('should create', async ({ payload }) => {
       if (payload.db.name === 'sqlite') {
         return
       }
@@ -2540,7 +2580,7 @@ describe('Fields', () => {
       expect(doc.group).toMatchObject(group)
     })
 
-    it('should not create duplicate point when unique', async () => {
+    test('should not create duplicate point when unique', async ({ payload }) => {
       if (payload.db.name === 'sqlite') {
         return
       }
@@ -2585,7 +2625,9 @@ describe('Fields', () => {
       expect(doc.group).toMatchObject(uniqueGroup)
     })
 
-    it('should throw validation error when "required" field is set to null', async () => {
+    test('should throw validation error when "required" field is set to null', async ({
+      payload,
+    }) => {
       if (payload.db.name === 'sqlite') {
         return
       }
@@ -2614,7 +2656,9 @@ describe('Fields', () => {
       ).rejects.toThrow('The following field is invalid: Location')
     })
 
-    it('should not throw validation error when non-"required" field is set to null', async () => {
+    test('should not throw validation error when non-"required" field is set to null', async ({
+      payload,
+    }) => {
       if (payload.db.name === 'sqlite') {
         return
       }
@@ -2645,7 +2689,7 @@ describe('Fields', () => {
       expect(updatedDoc.localized).toEqual(undefined)
     })
 
-    it('should not error with camel case name point field', async () => {
+    test('should not error with camel case name point field', async ({ payload }) => {
       if (payload.db.name === 'sqlite') {
         return
       }
@@ -2658,8 +2702,8 @@ describe('Fields', () => {
     })
   })
 
-  describe('checkbox', () => {
-    beforeEach(async () => {
+  test.describe('checkbox', () => {
+    test.beforeEach(async ({ payload }) => {
       await payload.delete({
         collection: checkboxFieldsSlug,
         where: {
@@ -2670,7 +2714,7 @@ describe('Fields', () => {
       })
     })
 
-    it('should query checkbox fields with exists operator', async () => {
+    test('should query checkbox fields with exists operator', async ({ payload }) => {
       const existsTrueDoc = await payload.create({
         collection: checkboxFieldsSlug,
         data: {
@@ -2710,8 +2754,8 @@ describe('Fields', () => {
     })
   })
 
-  describe('unique indexes', () => {
-    beforeEach(async () => {
+  test.describe('unique indexes', () => {
+    test.beforeEach(async ({ payload }) => {
       // Clean up indexed-fields to avoid unique constraint violations
       // This ensures each test starts with a clean slate
       await payload.delete({
@@ -2724,7 +2768,7 @@ describe('Fields', () => {
       })
     })
 
-    it('should throw validation error saving on unique fields', async () => {
+    test('should throw validation error saving on unique fields', async ({ payload }) => {
       const timestamp = Date.now() + Math.random()
       const data = {
         text: 'a-' + timestamp,
@@ -2743,7 +2787,9 @@ describe('Fields', () => {
       }).toBeDefined()
     })
 
-    it('should throw validation error saving on unique relationship fields hasMany: false non polymorphic', async () => {
+    test('should throw validation error saving on unique relationship fields hasMany: false non polymorphic', async ({
+      payload,
+    }) => {
       const textDoc = await payload.create({
         collection: 'text-fields',
         data: { text: 'unique-test-hasMany-false-' + Date.now() },
@@ -2782,7 +2828,9 @@ describe('Fields', () => {
       ).rejects.toBeTruthy()
     })
 
-    it('should throw validation error saving on unique relationship fields hasMany: true', async () => {
+    test('should throw validation error saving on unique relationship fields hasMany: true', async ({
+      payload,
+    }) => {
       const textDoc = await payload.create({
         collection: 'text-fields',
         data: { text: 'unique-test-hasMany-true-' + Date.now() },
@@ -2842,7 +2890,9 @@ describe('Fields', () => {
       ).rejects.toBeTruthy()
     })
 
-    it('should throw validation error saving on unique relationship fields polymorphic not hasMany', async () => {
+    test('should throw validation error saving on unique relationship fields polymorphic not hasMany', async ({
+      payload,
+    }) => {
       const textDoc = await payload.create({
         collection: 'text-fields',
         data: { text: 'unique-test-poly-' + Date.now() },
@@ -2902,7 +2952,9 @@ describe('Fields', () => {
       ).rejects.toBeTruthy()
     })
 
-    it('should throw validation error saving on unique relationship fields polymorphic hasMany: true', async () => {
+    test('should throw validation error saving on unique relationship fields polymorphic hasMany: true', async ({
+      payload,
+    }) => {
       const textDoc = await payload.create({
         collection: 'text-fields',
         data: { text: 'unique-test-poly-hasMany-' + Date.now() },
@@ -2967,7 +3019,9 @@ describe('Fields', () => {
       ).rejects.toBeTruthy()
     })
 
-    it('should not throw validation error saving multiple null values for unique fields', async () => {
+    test('should not throw validation error saving multiple null values for unique fields', async ({
+      payload,
+    }) => {
       const timestamp = Date.now()
       const data = {
         localizedUniqueRequiredText: 'en1-' + timestamp,
@@ -2997,7 +3051,7 @@ describe('Fields', () => {
       expect(result.id).toBeDefined()
     })
 
-    it('should duplicate with unique fields', async () => {
+    test('should duplicate with unique fields', async ({ payload }) => {
       const timestamp = Date.now()
       const data = {
         text: 'duplicate-' + timestamp,
@@ -3017,18 +3071,18 @@ describe('Fields', () => {
     })
   })
 
-  describe('array', () => {
+  test.describe('array', () => {
     let doc
     const collection = arrayFieldsSlug
 
-    beforeEach(async () => {
+    test.beforeEach(async ({ payload }) => {
       doc = await payload.create({
         collection,
         data: {},
       })
     })
 
-    it('should create with ids and nested ids', async () => {
+    test('should create with ids and nested ids', async ({ payload }) => {
       const docWithIDs = (await payload.create({
         collection: groupFieldsSlug,
         data: namedGroupDoc,
@@ -3036,12 +3090,12 @@ describe('Fields', () => {
       expect(docWithIDs.group.subGroup.arrayWithinGroup[0].id).toBeDefined()
     })
 
-    it('should create with defaultValue', () => {
+    test('should create with defaultValue', () => {
       expect(doc.items).toMatchObject(arrayDefaultValue)
       expect(doc.localized).toMatchObject(arrayDefaultValue)
     })
 
-    it('should create and update localized subfields with versions', async () => {
+    test('should create and update localized subfields with versions', async ({ payload }) => {
       const doc = await payload.create({
         collection,
         data: {
@@ -3086,7 +3140,9 @@ describe('Fields', () => {
       expect(result.items[0].localizedText.es).toStrictEqual('spanish')
     })
 
-    it('should create and append localized items to nested array with versions', async () => {
+    test('should create and append localized items to nested array with versions', async ({
+      payload,
+    }) => {
       const doc = await payload.create({
         collection,
         data: {
@@ -3141,7 +3197,7 @@ describe('Fields', () => {
       expect(res.nestedArrayLocalized[2].array[0].text).toBe('amigo')
     })
 
-    it('should create with nested array', async () => {
+    test('should create with nested array', async ({ payload }) => {
       const subArrayText = 'something expected'
       const doc = await payload.create({
         collection,
@@ -3175,7 +3231,9 @@ describe('Fields', () => {
       expect(result.items[0].subArray[0].text).toStrictEqual(subArrayText)
     })
 
-    it('should update without overwriting other locales with defaultValue', async () => {
+    test('should update without overwriting other locales with defaultValue', async ({
+      payload,
+    }) => {
       const localized = [{ text: 'unique' }]
       const enText = 'english'
       const esText = 'spanish'
@@ -3221,7 +3279,7 @@ describe('Fields', () => {
       expect(allLocales.localized.es[0].text).toStrictEqual(esText)
     })
 
-    it('should query by the same array', async () => {
+    test('should query by the same array', async ({ payload }) => {
       const doc = await payload.create({
         collection,
         data: {
@@ -3265,7 +3323,9 @@ describe('Fields', () => {
       expect(res.id).toBe(doc.id)
     })
 
-    it('should show proper validation error on text field in nested array', async () => {
+    test('should show proper validation error on text field in nested array', async ({
+      payload,
+    }) => {
       await expect(async () =>
         payload.create({
           collection,
@@ -3285,7 +3345,9 @@ describe('Fields', () => {
       ).rejects.toThrow('The following field is invalid: Items 1 > Sub Array 1 > Second text field')
     })
 
-    it('should show proper validation error on text field in row field in nested array', async () => {
+    test('should show proper validation error on text field in row field in nested array', async ({
+      payload,
+    }) => {
       await expect(async () =>
         payload.create({
           collection,
@@ -3305,7 +3367,9 @@ describe('Fields', () => {
       ).rejects.toThrow('The following field is invalid: Items 1 > Sub Array 1 > Text In Row')
     })
 
-    it('should not have multiple instances of the id field in an array with a nested custom id field', () => {
+    test('should not have multiple instances of the id field in an array with a nested custom id field', ({
+      payload,
+    }) => {
       const arraysCollection = payload.config.collections.find(
         (collection) => collection.slug === arrayFieldsSlug,
       )
@@ -3320,7 +3384,7 @@ describe('Fields', () => {
       expect((idFields[0].admin?.disabled as { filter?: boolean })?.filter).toBe(true)
     })
 
-    test.options({ db: 'mongo' })('should query exists true', async () => {
+    test.options({ db: 'mongo' })('should query exists true', async ({ payload }) => {
       await payload.delete({ collection: 'array-fields', where: {} })
 
       const withoutCollapsed = await payload.create({
@@ -3368,7 +3432,7 @@ describe('Fields', () => {
       expect(res.docs[0].id).toBe(withCollapsed.id)
     })
 
-    test.options({ db: 'mongo' })('should query exists false', async () => {
+    test.options({ db: 'mongo' })('should query exists false', async ({ payload }) => {
       await payload.delete({ collection: 'array-fields', where: {} })
 
       const withoutCollapsed = await payload.create({
@@ -3416,7 +3480,7 @@ describe('Fields', () => {
       expect(res.docs[0].id).toBe(withoutCollapsed.id)
     })
 
-    it('should properly handle richText inside array', async () => {
+    test('should properly handle richText inside array', async ({ payload }) => {
       const richTextValue = {
         root: {
           type: 'root',
@@ -3458,7 +3522,7 @@ describe('Fields', () => {
       expect(found.items[0].richTextField).toEqual(richTextValue)
     })
 
-    it('should not crash when array contains a null element', async () => {
+    test('should not crash when array contains a null element', async ({ payload }) => {
       const doc = await payload.create({
         collection,
         data: {
@@ -3473,22 +3537,22 @@ describe('Fields', () => {
     })
   })
 
-  describe('group', () => {
+  test.describe('group', () => {
     let document
 
-    beforeEach(async () => {
+    test.beforeEach(async ({ payload }) => {
       document = await payload.create({
         collection: groupFieldsSlug,
         data: {},
       })
     })
 
-    it('should create with defaultValue', () => {
+    test('should create with defaultValue', () => {
       expect(document.group.defaultParent).toStrictEqual(groupDefaultValue)
       expect(document.group.defaultChild).toStrictEqual(groupDefaultChild)
     })
 
-    it('should not have duplicate keys', () => {
+    test('should not have duplicate keys', () => {
       expect(document.arrayOfGroups[0]).toMatchObject({
         id: expect.any(String),
         groupItem: {
@@ -3497,7 +3561,7 @@ describe('Fields', () => {
       })
     })
 
-    it('should work with unnamed group', async () => {
+    test('should work with unnamed group', async ({ payload }) => {
       const groupDoc = await payload.create({
         collection: groupFieldsSlug,
         data: {
@@ -3514,7 +3578,7 @@ describe('Fields', () => {
       })
     })
 
-    it('should work with unnamed group - graphql', async () => {
+    test('should work with unnamed group - graphql', async ({ restClient }) => {
       const mutation = `mutation {
               createGroupField(
                 data: {
@@ -3544,7 +3608,7 @@ describe('Fields', () => {
       })
     })
 
-    it('should query a subfield within a localized group', async () => {
+    test('should query a subfield within a localized group', async ({ payload }) => {
       const text = 'find this'
       const hit = await payload.create({
         collection: groupFieldsSlug,
@@ -3575,7 +3639,9 @@ describe('Fields', () => {
       expect(resultIDs).not.toContain(miss.id)
     })
 
-    it('should insert/read camelCase group with nested arrays + localized', async () => {
+    test('should insert/read camelCase group with nested arrays + localized', async ({
+      payload,
+    }) => {
       const res = await payload.create({
         collection: 'group-fields',
         data: {
@@ -3599,7 +3665,7 @@ describe('Fields', () => {
       expect(res.camelCaseGroup.array[0].array[0].text).toBe('nested')
     })
 
-    it('should insert/update/read localized group with array inside', async () => {
+    test('should insert/update/read localized group with array inside', async ({ payload }) => {
       const doc = await payload.create({
         collection: 'group-fields',
         locale: 'en',
@@ -3636,7 +3702,9 @@ describe('Fields', () => {
       expect(allDoc.localizedGroupArr.es.array[0].text).toBe('text-es')
     })
 
-    it('should insert/update/read localized group with select hasMany inside', async () => {
+    test('should insert/update/read localized group with select hasMany inside', async ({
+      payload,
+    }) => {
       const doc = await payload.create({
         collection: 'group-fields',
         locale: 'en',
@@ -3673,7 +3741,9 @@ describe('Fields', () => {
       expect(allDoc.localizedGroupSelect.es.select).toStrictEqual(['one'])
     })
 
-    it('should insert/update/read localized group with relationship inside', async () => {
+    test('should insert/update/read localized group with relationship inside', async ({
+      payload,
+    }) => {
       const rel_1 = await payload.create({
         collection: 'email-fields',
         data: { email: 'pro123@gmail.com' },
@@ -3722,7 +3792,9 @@ describe('Fields', () => {
       expect(docAll.localizedGroupRel.es.email).toBe(rel_2.id)
     })
 
-    it('should insert/update/read localized group with hasMany relationship inside', async () => {
+    test('should insert/update/read localized group with hasMany relationship inside', async ({
+      payload,
+    }) => {
       const rel_1 = await payload.create({
         collection: 'email-fields',
         data: { email: 'pro123@gmail.com' },
@@ -3771,7 +3843,9 @@ describe('Fields', () => {
       expect(docAll.localizedGroupManyRel.es.email).toStrictEqual([rel_2.id])
     })
 
-    it('should insert/update/read localized group with poly relationship inside', async () => {
+    test('should insert/update/read localized group with poly relationship inside', async ({
+      payload,
+    }) => {
       const rel_1 = await payload.create({
         collection: 'email-fields',
         data: { email: 'pro123@gmail.com' },
@@ -3838,7 +3912,9 @@ describe('Fields', () => {
       })
     })
 
-    it('should insert/update/read localized group with poly hasMany relationship inside', async () => {
+    test('should insert/update/read localized group with poly hasMany relationship inside', async ({
+      payload,
+    }) => {
       const rel_1 = await payload.create({
         collection: 'email-fields',
         data: { email: 'pro123@gmail.com' },
@@ -3918,17 +3994,17 @@ describe('Fields', () => {
     })
   })
 
-  describe('tabs', () => {
+  test.describe('tabs', () => {
     let document
 
-    beforeEach(async () => {
+    test.beforeEach(async ({ payload }) => {
       document = await payload.create({
         collection: tabsFieldsSlug,
         data: tabsDoc,
       })
     })
 
-    it('should hot module reload and still be able to create', async () => {
+    test('should hot module reload and still be able to create', async ({ payload }) => {
       const testDoc1 = await payload.findByID({
         id: document.id,
         collection: tabsFieldsSlug,
@@ -3944,19 +4020,19 @@ describe('Fields', () => {
       expect(testDoc1.id).toStrictEqual(testDoc2.id)
     })
 
-    it('should create with fields inside a named tab', () => {
+    test('should create with fields inside a named tab', () => {
       expect(document.tab.text).toStrictEqual(namedTabText)
     })
 
-    it('should create with defaultValue inside a named tab', () => {
+    test('should create with defaultValue inside a named tab', () => {
       expect(document.tab.defaultValue).toStrictEqual(namedTabDefaultValue)
     })
 
-    it('should create with defaultValue inside a named tab with no other values', () => {
+    test('should create with defaultValue inside a named tab with no other values', () => {
       expect(document.namedTabWithDefaultValue.defaultValue).toStrictEqual(namedTabDefaultValue)
     })
 
-    it('should create with localized text inside a named tab', async () => {
+    test('should create with localized text inside a named tab', async ({ payload }) => {
       document = await payload.findByID({
         id: document.id,
         collection: tabsFieldsSlug,
@@ -3965,7 +4041,7 @@ describe('Fields', () => {
       expect(document.localizedTab.en.text).toStrictEqual(localizedTextValue)
     })
 
-    it('should allow access control on a named tab', async () => {
+    test('should allow access control on a named tab', async ({ payload }) => {
       document = await payload.findByID({
         id: document.id,
         collection: tabsFieldsSlug,
@@ -3974,7 +4050,7 @@ describe('Fields', () => {
       expect(document.accessControlTab).toBeUndefined()
     })
 
-    it('should allow hooks on a named tab', async () => {
+    test('should allow hooks on a named tab', async ({ payload }) => {
       const newDocument = await payload.create({
         collection: tabsFieldsSlug,
         data: tabsDoc,
@@ -3985,7 +4061,7 @@ describe('Fields', () => {
       expect(newDocument.hooksTab.afterRead).toBe(true)
     })
 
-    it('should return empty object for groups when no data present', async () => {
+    test('should return empty object for groups when no data present', async ({ payload }) => {
       const doc = await payload.create({
         collection: groupFieldsSlug,
         data: namedGroupDoc,
@@ -3994,7 +4070,7 @@ describe('Fields', () => {
       expect(doc.potentiallyEmptyGroup).toBeDefined()
     })
 
-    it('should insert/read camelCase tab with nested arrays + localized', async () => {
+    test('should insert/read camelCase tab with nested arrays + localized', async ({ payload }) => {
       const res = await payload.create({
         collection: 'tabs-fields',
         data: {
@@ -4025,7 +4101,9 @@ describe('Fields', () => {
       expect(res.camelCaseTab.array[0].array[0].text).toBe('nested')
     })
 
-    it('should show proper validation error message on text field within array within tab', async () => {
+    test('should show proper validation error message on text field within array within tab', async ({
+      payload,
+    }) => {
       await expect(async () =>
         payload.update({
           id: document.id,
@@ -4048,8 +4126,8 @@ describe('Fields', () => {
     })
   })
 
-  describe('blocks', () => {
-    it('should retrieve doc with blocks', async () => {
+  test.describe('blocks', () => {
+    test('should retrieve doc with blocks', async ({ payload }) => {
       const blockFields = await payload.find({
         collection: 'block-fields',
       })
@@ -4071,7 +4149,7 @@ describe('Fields', () => {
     // lexical's `{root: {children: [...]}}` shape
     test.options({ db: (adapter) => adapter.startsWith('sqlite') === false })(
       'should query based on richtext data within a block',
-      async () => {
+      async ({ payload }) => {
         const blockFieldsSuccess = await payload.find({
           collection: 'block-fields',
           where: {
@@ -4099,7 +4177,7 @@ describe('Fields', () => {
     // TODO: re-enable on sqlite — see note above.
     test.options({ db: (adapter) => adapter.startsWith('sqlite') === false })(
       'should query based on richtext data within a localized block, specifying locale',
-      async () => {
+      async ({ payload }) => {
         const blockFieldsSuccess = await payload.find({
           collection: 'block-fields',
           where: {
@@ -4127,7 +4205,7 @@ describe('Fields', () => {
     // TODO: re-enable on sqlite — see note above.
     test.options({ db: (adapter) => adapter.startsWith('sqlite') === false })(
       'should query based on richtext data within a localized block, without specifying locale',
-      async () => {
+      async ({ payload }) => {
         const blockFieldsSuccess = await payload.find({
           collection: 'block-fields',
           where: {
@@ -4152,7 +4230,7 @@ describe('Fields', () => {
       },
     )
 
-    it('should filter based on nested block fields', async () => {
+    test('should filter based on nested block fields', async ({ payload }) => {
       await payload.create({
         collection: 'block-fields',
         data: {
@@ -4206,7 +4284,7 @@ describe('Fields', () => {
       expect(docs).toHaveLength(2)
     })
 
-    it('should query blocks with nested relationship', async () => {
+    test('should query blocks with nested relationship', async ({ payload }) => {
       const textDoc = await payload.create({
         collection: textFieldsSlug,
         data: {
@@ -4235,7 +4313,7 @@ describe('Fields', () => {
       expect(result.docs[0]).toMatchObject(blockDoc)
     })
 
-    it('should query by blockType', async () => {
+    test('should query by blockType', async ({ payload }) => {
       const text = 'blockType query test'
 
       const hit = await payload.create({
@@ -4299,7 +4377,7 @@ describe('Fields', () => {
       expect(inMissResult).toBeUndefined()
     })
 
-    it('should allow localized array of blocks', async () => {
+    test('should allow localized array of blocks', async ({ payload }) => {
       const result = await payload.create({
         collection: blockFieldsSlug,
         data: {
@@ -4319,7 +4397,9 @@ describe('Fields', () => {
       expect(result.blocksWithLocalizedArray[0].array[0].text).toEqual('localized')
     })
 
-    it('ensure localized field within block reference is saved correctly', async () => {
+    test('ensure localized field within block reference is saved correctly', async ({
+      payload,
+    }) => {
       const blockFields = await payload.find({
         collection: 'block-fields',
         locale: 'all',
@@ -4336,7 +4416,9 @@ describe('Fields', () => {
       expect(doc?.localizedReferences?.[0]?.text).toEqual({ en: 'localized text' })
     })
 
-    it('ensure localized property is stripped from localized field within localized block reference', async () => {
+    test('ensure localized property is stripped from localized field within localized block reference', async ({
+      payload,
+    }) => {
       const blockFields = await payload.find({
         collection: 'block-fields',
         locale: 'all',
@@ -4355,7 +4437,7 @@ describe('Fields', () => {
       expect(doc?.localizedReferencesLocalizedBlock?.en?.[0]?.text).toEqual('localized text')
     })
 
-    it('should not crash when blocks array contains a null element', async () => {
+    test('should not crash when blocks array contains a null element', async ({ payload }) => {
       const doc = await payload.create({
         collection: blockFieldsSlug,
         data: {
@@ -4377,8 +4459,10 @@ describe('Fields', () => {
     })
   })
 
-  describe('collapsible', () => {
-    it('should show proper validation error message for fields nested in collapsible', async () => {
+  test.describe('collapsible', () => {
+    test('should show proper validation error message for fields nested in collapsible', async ({
+      payload,
+    }) => {
       await expect(async () =>
         payload.create({
           collection: collapsibleFieldsSlug,
@@ -4397,8 +4481,8 @@ describe('Fields', () => {
     })
   })
 
-  describe('json', () => {
-    it('should save json data', async () => {
+  test.describe('json', () => {
+    test('should save json data', async ({ payload }) => {
       const json = { foo: 'bar' }
       const doc = await payload.create({
         collection: 'json-fields',
@@ -4410,7 +4494,7 @@ describe('Fields', () => {
       expect(doc.json).toStrictEqual({ foo: 'bar' })
     })
 
-    it('should validate json', async () => {
+    test('should validate json', async ({ payload }) => {
       await expect(async () =>
         payload.create({
           collection: 'json-fields',
@@ -4421,7 +4505,7 @@ describe('Fields', () => {
       ).rejects.toThrow('The following field is invalid: Json')
     })
 
-    it('should validate json schema', async () => {
+    test('should validate json schema', async ({ payload }) => {
       await expect(async () =>
         payload.create({
           collection: 'json-fields',
@@ -4432,7 +4516,7 @@ describe('Fields', () => {
       ).rejects.toThrow('The following field is invalid: Json')
     })
 
-    it('should save empty json objects', async () => {
+    test('should save empty json objects', async ({ payload }) => {
       const jsonFieldsDoc = await payload.create({
         collection: 'json-fields',
         data: {
@@ -4457,11 +4541,11 @@ describe('Fields', () => {
       expect(updatedJsonFieldsDoc.json.state).toEqual({})
     })
 
-    describe('querying', () => {
+    test.describe('querying', () => {
       let fooBar
       let bazBar
 
-      beforeEach(async () => {
+      test.beforeEach(async ({ payload }) => {
         // Clean up all json-fields documents to have a clean slate
         // This ensures each test has predictable data and query results
         await payload.delete({
@@ -4501,7 +4585,7 @@ describe('Fields', () => {
         }
       })
 
-      it('should query nested properties - like', async () => {
+      test('should query nested properties - like', async ({ payload }) => {
         const { docs } = await payload.find({
           collection: 'json-fields',
           where: {
@@ -4515,7 +4599,7 @@ describe('Fields', () => {
         expect(docIDs).not.toContain(bazBar.id)
       })
 
-      it('should query nested properties - not_like', async () => {
+      test('should query nested properties - not_like', async ({ payload }) => {
         const { docs } = await payload.find({
           collection: 'json-fields',
           where: {
@@ -4529,7 +4613,7 @@ describe('Fields', () => {
         expect(docIDs).not.toContain(bazBar.id)
       })
 
-      it('should query nested properties - equals', async () => {
+      test('should query nested properties - equals', async ({ payload }) => {
         const { docs } = await payload.find({
           collection: 'json-fields',
           where: {
@@ -4551,7 +4635,7 @@ describe('Fields', () => {
         expect(notEquals.docs).toHaveLength(0)
       })
 
-      it('should query nested numbers - equals', async () => {
+      test('should query nested numbers - equals', async ({ payload }) => {
         const { docs } = await payload.find({
           collection: 'json-fields',
           where: {
@@ -4565,7 +4649,7 @@ describe('Fields', () => {
         expect(docIDs).not.toContain(bazBar.id)
       })
 
-      it('should query nested properties - exists', async () => {
+      test('should query nested properties - exists', async ({ payload }) => {
         const { docs } = await payload.find({
           collection: 'json-fields',
           where: {
@@ -4579,7 +4663,7 @@ describe('Fields', () => {
         expect(docIDs).not.toContain(bazBar.id)
       })
 
-      it('should query - exists', async () => {
+      test('should query - exists', async ({ payload }) => {
         const nullJSON = await payload.create({
           collection: 'json-fields',
           data: {},
@@ -4614,7 +4698,7 @@ describe('Fields', () => {
         expect(existFalseIDs).not.toContain(hasJSON.id)
       })
 
-      it('exists should not return null values', async () => {
+      test('exists should not return null values', async ({ payload }) => {
         const { id } = await payload.create({
           collection: 'select-fields',
           data: {
@@ -4671,7 +4755,7 @@ describe('Fields', () => {
         expect(result.docs).toHaveLength(1)
       })
 
-      it('should query nested numbers - in', async () => {
+      test('should query nested numbers - in', async ({ payload }) => {
         const { docs } = await payload.find({
           collection: 'json-fields',
           where: {
@@ -4686,7 +4770,7 @@ describe('Fields', () => {
         expect(docIDs).not.toContain(2)
       })
 
-      it('should query nested numbers - not_in', async () => {
+      test('should query nested numbers - not_in', async ({ payload }) => {
         const { docs } = await payload.find({
           collection: 'json-fields',
           where: {
@@ -4701,7 +4785,9 @@ describe('Fields', () => {
         expect(docIDs).toContain(2)
       })
 
-      it('should query nested numbers with multiple clauses - equals_and_in', async () => {
+      test('should query nested numbers with multiple clauses - equals_and_in', async ({
+        payload,
+      }) => {
         const { docs } = await payload.find({
           collection: 'json-fields',
           where: {
@@ -4725,7 +4811,7 @@ describe('Fields', () => {
         expect(docIDs).toContain(4)
       })
 
-      it('should query deeply', async () => {
+      test('should query deeply', async ({ payload }) => {
         if (payload.db.name === 'sqlite') {
           return
         }
@@ -4784,7 +4870,7 @@ describe('Fields', () => {
         expect(docs[0].id).toBe(json_1.id)
       })
 
-      it('should query 2-level nested object properties', async () => {
+      test('should query 2-level nested object properties', async ({ payload }) => {
         const docId = '42'
         const collectionSlug = 'posts'
 
@@ -4846,7 +4932,7 @@ describe('Fields', () => {
         expect(andDocs[0]?.id).toBe(matchingDoc.id)
       })
 
-      it('should disallow unsafe query paths', async () => {
+      test('should disallow unsafe query paths', async ({ payload }) => {
         await expect(
           payload.find({
             collection: 'json-fields',
@@ -4884,54 +4970,59 @@ describe('Fields', () => {
         ).rejects.toBeTruthy()
       })
 
-      test.options({ db: 'drizzle' })('should disallow unsafe query values', async () => {
-        await expect(
-          payload.find({
-            collection: 'json-fields',
-            where: {
-              'json.value': { equals: 'select(' },
-            },
-          }),
-        ).rejects.toBeTruthy()
+      test.options({ db: 'drizzle' })(
+        'should disallow unsafe query values',
+        async ({ payload }) => {
+          await expect(
+            payload.find({
+              collection: 'json-fields',
+              where: {
+                'json.value': { equals: 'select(' },
+              },
+            }),
+          ).rejects.toBeTruthy()
 
-        await expect(
-          payload.find({
-            collection: 'json-fields',
-            where: {
-              'json.value': { equals: '"unsafe' },
-            },
-          }),
-        ).rejects.toBeTruthy()
+          await expect(
+            payload.find({
+              collection: 'json-fields',
+              where: {
+                'json.value': { equals: '"unsafe' },
+              },
+            }),
+          ).rejects.toBeTruthy()
 
-        await expect(
-          payload.find({
-            collection: 'json-fields',
-            where: {
-              'json.value': { equals: `'unsafe` },
-            },
-          }),
-        ).rejects.toBeTruthy()
+          await expect(
+            payload.find({
+              collection: 'json-fields',
+              where: {
+                'json.value': { equals: `'unsafe` },
+              },
+            }),
+          ).rejects.toBeTruthy()
 
-        await expect(
-          payload.find({
-            collection: 'json-fields',
-            where: {
-              'json.value': { equals: `unsafe\\` },
-            },
-          }),
-        ).rejects.toBeTruthy()
+          await expect(
+            payload.find({
+              collection: 'json-fields',
+              where: {
+                'json.value': { equals: `unsafe\\` },
+              },
+            }),
+          ).rejects.toBeTruthy()
 
-        await expect(
-          payload.find({
-            collection: 'json-fields',
-            where: {
-              'json.value': { equals: `unsafe=` },
-            },
-          }),
-        ).rejects.toBeTruthy()
-      })
+          await expect(
+            payload.find({
+              collection: 'json-fields',
+              where: {
+                'json.value': { equals: `unsafe=` },
+              },
+            }),
+          ).rejects.toBeTruthy()
+        },
+      )
 
-      it('should reject disallowed characters in JSON field path segments', async () => {
+      test('should reject disallowed characters in JSON field path segments', async ({
+        payload,
+      }) => {
         // Path segments in JSON queries must only contain word characters.
         const badPaths = [
           "json.key'bad",
@@ -4953,7 +5044,7 @@ describe('Fields', () => {
         }
       })
 
-      it('should accept valid path segments in JSON field queries', async () => {
+      test('should accept valid path segments in JSON field queries', async ({ payload }) => {
         const result = await payload.find({
           collection: 'json-fields',
           where: {
@@ -4966,8 +5057,8 @@ describe('Fields', () => {
     })
   })
 
-  describe('relationships', () => {
-    it('should not crash if querying with empty in operator', async () => {
+  test.describe('relationships', () => {
+    test('should not crash if querying with empty in operator', async ({ payload }) => {
       const query = await payload.find({
         collection: 'relationship-fields',
         where: {
@@ -4980,17 +5071,17 @@ describe('Fields', () => {
       expect(query.docs).toBeDefined()
     })
 
-    describe('querying', () => {
+    test.describe('querying', () => {
       const createdIDs: (number | string)[] = []
 
-      afterEach(async () => {
+      test.afterEach(async ({ payload }) => {
         for (const id of createdIDs) {
           await payload.delete({ collection: 'relationship-fields', id })
         }
         createdIDs.length = 0
       })
 
-      it('should query non-polymorphic hasMany - equals', async () => {
+      test('should query non-polymorphic hasMany - equals', async ({ payload }) => {
         // TODO: Remove this check once we implement exact array equality for SQL adapters
         // Currently only MongoDB supports array equals/not_equals on hasMany relationships
         if (payload.db.name !== 'mongoose') {
@@ -5042,7 +5133,7 @@ describe('Fields', () => {
         expect(noMatchResult.docs).toHaveLength(0)
       })
 
-      it('should query polymorphic hasMany - equals', async () => {
+      test('should query polymorphic hasMany - equals', async ({ payload }) => {
         // TODO: Remove this check once we implement exact array equality for SQL adapters
         // Currently only MongoDB supports array equals/not_equals on hasMany relationships
         if (payload.db.name !== 'mongoose') {
@@ -5101,7 +5192,7 @@ describe('Fields', () => {
         expect(noMatchResult.docs).toHaveLength(0)
       })
 
-      it('should query non-polymorphic hasMany - not_equals', async () => {
+      test('should query non-polymorphic hasMany - not_equals', async ({ payload }) => {
         // TODO: Remove this check once we implement exact array equality for SQL adapters
         // Currently only MongoDB supports array equals/not_equals on hasMany relationships
         if (payload.db.name !== 'mongoose') {
@@ -5172,7 +5263,7 @@ describe('Fields', () => {
         expect(noMatchDocIDs).not.toContain(relDoc2.id)
       })
 
-      it('should query polymorphic hasMany - not_equals', async () => {
+      test('should query polymorphic hasMany - not_equals', async ({ payload }) => {
         // TODO: Remove this check once we implement exact array equality for SQL adapters
         // Currently only MongoDB supports array equals/not_equals on hasMany relationships
         if (payload.db.name !== 'mongoose') {
@@ -5250,7 +5341,9 @@ describe('Fields', () => {
         expect(noMatchDocIDs).not.toContain(relDoc2.id)
       })
 
-      it('should not throw when querying hasMany relationship with equals array', async () => {
+      test('should not throw when querying hasMany relationship with equals array', async ({
+        payload,
+      }) => {
         const text1 = await payload.create({
           collection: 'text-fields',
           data: { text: 'Text 1' },
@@ -5292,7 +5385,9 @@ describe('Fields', () => {
         }
       })
 
-      it('should include docs with null relationship when using not_equals with array on non-hasMany field', async () => {
+      test('should include docs with null relationship when using not_equals with array on non-hasMany field', async ({
+        payload,
+      }) => {
         // Only SQL adapters are affected - MongoDB handles NOT IN / NULL differently
         if (payload.db.name === 'mongoose') {
           return
@@ -5340,8 +5435,8 @@ describe('Fields', () => {
     })
   })
 
-  describe('clearable fields - exists', () => {
-    it('exists should not return null values', async () => {
+  test.describe('clearable fields - exists', () => {
+    test('exists should not return null values', async ({ payload }) => {
       const { id } = await payload.create({
         collection: 'select-fields',
         data: {
@@ -5399,10 +5494,10 @@ describe('Fields', () => {
     })
   })
 
-  describe('Custom ID Nested', () => {
+  test.describe('Custom ID Nested', () => {
     const createdIDs: number[] = []
 
-    afterEach(async () => {
+    test.afterEach(async ({ payload }) => {
       for (const id of createdIDs) {
         await payload.delete({
           collection: customIDNestedSlug,
@@ -5412,7 +5507,7 @@ describe('Fields', () => {
       createdIDs.length = 0
     })
 
-    it('should create document with numeric custom ID nested in tabs', async () => {
+    test('should create document with numeric custom ID nested in tabs', async ({ payload }) => {
       const customID = 12345
       createdIDs.push(customID)
 
@@ -5429,7 +5524,7 @@ describe('Fields', () => {
       expect(doc.title).toBe('Test Document')
     })
 
-    it('should retrieve document by numeric custom ID', async () => {
+    test('should retrieve document by numeric custom ID', async ({ payload }) => {
       const customID = 67890
       createdIDs.push(customID)
 
@@ -5450,7 +5545,7 @@ describe('Fields', () => {
       expect(retrieved.title).toBe('Another Test')
     })
 
-    it('should update document with numeric custom ID', async () => {
+    test('should update document with numeric custom ID', async ({ payload }) => {
       const customID = 99999
       createdIDs.push(customID)
 
@@ -5475,8 +5570,8 @@ describe('Fields', () => {
     })
   })
 
-  describe('date fields with timezones', () => {
-    it('should create document with UTC offset timezone', async () => {
+  test.describe('date fields with timezones', () => {
+    test('should create document with UTC offset timezone', async ({ payload }) => {
       const doc = await payload.create({
         collection: dateFieldsSlug,
         data: {
@@ -5491,7 +5586,7 @@ describe('Fields', () => {
       expect(doc.dateWithOffsetTimezone_tz).toEqual('+05:30')
     })
 
-    it('should update timezone from IANA to offset', async () => {
+    test('should update timezone from IANA to offset', async ({ payload }) => {
       const doc = await payload.create({
         collection: dateFieldsSlug,
         data: {
@@ -5515,7 +5610,7 @@ describe('Fields', () => {
       expect(updated.dateWithMixedTimezones_tz).toEqual('+05:30')
     })
 
-    it('should query documents by timezone field', async () => {
+    test('should query documents by timezone field', async ({ payload }) => {
       await payload.create({
         collection: dateFieldsSlug,
         data: {
@@ -5551,7 +5646,7 @@ describe('Fields', () => {
       ).toBe(true)
     })
 
-    it('should store mixed IANA and offset timezones correctly', async () => {
+    test('should store mixed IANA and offset timezones correctly', async ({ payload }) => {
       const doc = await payload.create({
         collection: dateFieldsSlug,
         data: {
@@ -5578,7 +5673,7 @@ describe('Fields', () => {
       expect(doc2.dateWithMixedTimezones_tz).toEqual('+05:30')
     })
 
-    it('should handle different offset formats consistently', async () => {
+    test('should handle different offset formats consistently', async ({ payload }) => {
       // Test HH:mm format
       const doc1 = await payload.create({
         collection: dateFieldsSlug,
@@ -5619,12 +5714,12 @@ describe('Fields', () => {
       expect(doc3.dateWithOffsetTimezone_tz).toEqual('+00:00')
     })
 
-    describe('GraphQL timezone operations', () => {
+    test.describe('GraphQL timezone operations', () => {
       // Note: GraphQL enums serialize to their NAME (e.g., '_TZOFFSET_PLUS_05_30'), not their VALUE (e.g., '+05:30')
       // This is standard GraphQL behavior. UTC offsets are transformed to GraphQL-safe names:
       // +05:30 → _TZOFFSET_PLUS_05_30, -08:00 → _TZOFFSET_MINUS_08_00, America/New_York → America_New_York
 
-      it('should read UTC offset timezone via GraphQL query', async () => {
+      test('should read UTC offset timezone via GraphQL query', async ({ payload, restClient }) => {
         const doc = await payload.create({
           collection: dateFieldsSlug,
           data: {
@@ -5656,7 +5751,10 @@ describe('Fields', () => {
         expect(result.data.DateField.dateWithOffsetTimezone_tz).toEqual('_TZOFFSET_PLUS_05_30')
       })
 
-      it('should read negative UTC offset timezone via GraphQL query', async () => {
+      test('should read negative UTC offset timezone via GraphQL query', async ({
+        payload,
+        restClient,
+      }) => {
         const doc = await payload.create({
           collection: dateFieldsSlug,
           data: {
@@ -5682,7 +5780,10 @@ describe('Fields', () => {
         expect(result.data.DateField.dateWithOffsetTimezone_tz).toEqual('_TZOFFSET_MINUS_08_00')
       })
 
-      it('should read mixed IANA and offset timezones via GraphQL query', async () => {
+      test('should read mixed IANA and offset timezones via GraphQL query', async ({
+        payload,
+        restClient,
+      }) => {
         const doc = await payload.create({
           collection: dateFieldsSlug,
           data: {
@@ -5710,7 +5811,9 @@ describe('Fields', () => {
         expect(result.data.DateField.dateWithMixedTimezones_tz).toEqual('America_New_York')
       })
 
-      it('should create document with UTC offset timezone via GraphQL mutation', async () => {
+      test('should create document with UTC offset timezone via GraphQL mutation', async ({
+        restClient,
+      }) => {
         const mutation = `
           mutation {
             createDateField(
@@ -5744,7 +5847,9 @@ describe('Fields', () => {
         )
       })
 
-      it('should create document with negative UTC offset via GraphQL mutation', async () => {
+      test('should create document with negative UTC offset via GraphQL mutation', async ({
+        restClient,
+      }) => {
         const mutation = `
           mutation {
             createDateField(
@@ -5777,7 +5882,10 @@ describe('Fields', () => {
         )
       })
 
-      it('should update timezone from one offset to another via GraphQL mutation', async () => {
+      test('should update timezone from one offset to another via GraphQL mutation', async ({
+        payload,
+        restClient,
+      }) => {
         const doc = await payload.create({
           collection: dateFieldsSlug,
           data: {
@@ -5812,7 +5920,10 @@ describe('Fields', () => {
         )
       })
 
-      it('should update mixed timezone field from IANA to offset via GraphQL mutation', async () => {
+      test('should update mixed timezone field from IANA to offset via GraphQL mutation', async ({
+        payload,
+        restClient,
+      }) => {
         const doc = await payload.create({
           collection: dateFieldsSlug,
           data: {
@@ -5846,7 +5957,10 @@ describe('Fields', () => {
         )
       })
 
-      it('should update mixed timezone field from offset to IANA via GraphQL mutation', async () => {
+      test('should update mixed timezone field from offset to IANA via GraphQL mutation', async ({
+        payload,
+        restClient,
+      }) => {
         const doc = await payload.create({
           collection: dateFieldsSlug,
           data: {
@@ -5879,7 +5993,10 @@ describe('Fields', () => {
         expect(result.data.updateDateField.dateWithMixedTimezones_tz).toEqual('America_New_York')
       })
 
-      it('should query documents by offset timezone field via GraphQL', async () => {
+      test('should query documents by offset timezone field via GraphQL', async ({
+        payload,
+        restClient,
+      }) => {
         // Create documents with different timezones
         await payload.create({
           collection: dateFieldsSlug,
@@ -5924,7 +6041,7 @@ describe('Fields', () => {
         ).toBe(true)
       })
 
-      it('should handle UTC+00:00 offset via GraphQL', async () => {
+      test('should handle UTC+00:00 offset via GraphQL', async ({ restClient }) => {
         const mutation = `
           mutation {
             createDateField(
@@ -5958,7 +6075,7 @@ describe('Fields', () => {
       })
     })
 
-    it('should apply timezone override function to customize the field', async () => {
+    test('should apply timezone override function to customize the field', async ({ payload }) => {
       // The dateWithTimezoneWithDisabledColumns field has an override that sets disabled.column: true
       // We can verify this by checking the collection config has the modified field
       const dateCollection = payload.collections[dateFieldsSlug]
@@ -5986,7 +6103,7 @@ describe('Fields', () => {
       expect(doc.dateWithTimezoneWithDisabledColumns_tz).toEqual('America/New_York')
     })
 
-    it('should generate timezone field label from parent date field label', () => {
+    test('should generate timezone field label from parent date field label', ({ payload }) => {
       const dateCollection = payload.collections[dateFieldsSlug]
       const fields = dateCollection.config.flattenedFields
 
@@ -6001,7 +6118,9 @@ describe('Fields', () => {
       expect(disabledColumnsTzField?.label).toEqual('Date With Timezone With Disabled Columns Tz')
     })
 
-    it('should not silently default timezone to UTC when no defaultTimezone is configured', async () => {
+    test('should not silently default timezone to UTC when no defaultTimezone is configured', async ({
+      payload,
+    }) => {
       const { dateWithTimezoneNoDefault_tz: _, ...dataWithoutNoDefaultTz } = dateDoc
 
       const doc = await payload.create({
@@ -6016,7 +6135,7 @@ describe('Fields', () => {
       expect(doc.dateWithTimezoneNoDefault_tz).toBeFalsy()
     })
 
-    it('should use configured defaultTimezone when set', async () => {
+    test('should use configured defaultTimezone when set', async ({ payload }) => {
       const { dateWithMixedTimezones_tz: _, ...dataWithoutMixedTz } = dateDoc
 
       const doc = await payload.create({

--- a/test/lexical-mdx/config.ts
+++ b/test/lexical-mdx/config.ts
@@ -12,30 +12,36 @@ const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
 export default buildConfigWithDefaults({
-  // ...extend config here
-  collections: [
-    PostsCollection,
-    {
-      slug: 'simple',
-      fields: [
-        {
-          name: 'text',
-          type: 'text',
-        },
-      ],
-      versions: false,
+  suite: 'lexical-mdx',
+  config: {
+    // ...extend config here
+    admin: {
+      importMap: {
+        baseDir: path.resolve(dirname),
+      },
     },
-    MediaCollection,
-  ],
-  admin: {
-    importMap: {
-      baseDir: path.resolve(dirname),
+    collections: [
+      PostsCollection,
+      {
+        slug: 'simple',
+        fields: [
+          {
+            name: 'text',
+            type: 'text',
+          },
+        ],
+        versions: false,
+      },
+      MediaCollection,
+    ],
+    cors: [`http://localhost:${process.env.PORT || 3000}`, 'http://localhost:3001'],
+    editor: lexicalEditor({}),
+    globals: [],
+    typescript: {
+      outputFile: path.resolve(dirname, 'payload-types.ts'),
     },
   },
-  editor: lexicalEditor({}),
-  cors: [`http://localhost:${process.env.PORT || 3000}`, 'http://localhost:3001'],
-  globals: [],
-  onInit: async (payload) => {
+  seed: async (payload) => {
     await payload.create({
       collection: 'users',
       data: {
@@ -66,17 +72,14 @@ export default buildConfigWithDefaults({
     for (const file of mdxFiles) {
       await payload.create({
         collection: 'posts',
-        depth: 0,
         context: {
           seed: true,
         },
         data: {
           docPath: file,
         },
+        depth: 0,
       })
     }
-  },
-  typescript: {
-    outputFile: path.resolve(dirname, 'payload-types.ts'),
   },
 })

--- a/test/lexical-mdx/int.spec.ts
+++ b/test/lexical-mdx/int.spec.ts
@@ -4,23 +4,23 @@ import type {
   SanitizedServerEditorConfig,
   SerializedBlockNode,
 } from '@payloadcms/richtext-lexical'
-import type { RichTextField, SanitizedConfig } from 'payload'
+import type { RichTextField } from 'payload'
 import type { MarkOptional } from 'ts-essentials'
 
 import { writeFileSync } from 'fs'
 import path from 'path'
 import { fileURLToPath } from 'url'
-import { beforeAll, describe, expect, it } from 'vitest'
+import { expect } from 'vitest'
 
-import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
+import { test } from '../__helpers/int/vitest.js'
 import { postsSlug } from './collections/Posts/index.js'
+import testConfig from './config.js'
 import { editorJSONToMDX, mdxToEditorJSON } from './mdx/hooks.js'
 import { codeTest1 } from './tests/code1.test.js'
 import { defaultTests } from './tests/default.test.js'
 import { restExamplesTest1 } from './tests/restExamples.test.js'
 import { restExamplesTest2 } from './tests/restExamples2.test.js'
 
-let config: SanitizedConfig
 let editorConfig: SanitizedServerEditorConfig
 
 const filename = fileURLToPath(import.meta.url)
@@ -44,14 +44,11 @@ export type Test = {
 }
 type Tests = Array<Test>
 
-describe('Lexical MDX', () => {
+test.suite({ config: testConfig })('Lexical MDX', () => {
   // --__--__--__--__--__--__--__--__--__
   // Boilerplate test setup/teardown
   // --__--__--__--__--__--__--__--__--__
-  beforeAll(async () => {
-    const { config: incomingConfig } = await initPayloadInt(dirname, undefined, false)
-    config = incomingConfig
-
+  test.beforeEach(async ({ config }) => {
     const richTextField: RichTextField = config.collections
       .find((collection) => collection.slug === postsSlug)
       .fields.find(
@@ -106,7 +103,7 @@ describe('Lexical MDX', () => {
     }
 
     if (convertToEditorJSON !== false) {
-      it(`can convert to editor JSON: ${description ?? sanitizedInput}"`, () => {
+      test(`can convert to editor JSON: ${description ?? sanitizedInput}"`, () => {
         const result = mdxToEditorJSON({
           mdxWithFrontmatter: sanitizedInput,
           editorConfig,
@@ -119,7 +116,7 @@ describe('Lexical MDX', () => {
         if (blockNode) {
           const receivedBlockNode: SerializedBlockNode = result.editorState.root
             .children[0] as unknown as SerializedBlockNode
-          // eslint-disable-next-line vitest/no-conditional-expect
+
           expect(receivedBlockNode).not.toBeNull()
 
           // By doing it like this, the blockNode defined in the test does not need to have all the top-level properties. We only wanna compare keys that are defined in the test
@@ -131,14 +128,12 @@ describe('Lexical MDX', () => {
           removeUndefinedAndIDRecursively(receivedBlockNodeToTest)
           removeUndefinedAndIDRecursively(blockNode)
 
-          // eslint-disable-next-line vitest/no-conditional-expect
           expect(receivedBlockNodeToTest).toStrictEqual(blockNode)
         } else if (rootChildren) {
           const receivedRootChildren = result.editorState.root.children
           removeUndefinedAndIDRecursively(receivedRootChildren)
           removeUndefinedAndIDRecursively(rootChildren)
 
-          // eslint-disable-next-line vitest/no-conditional-expect
           expect(receivedRootChildren).toStrictEqual(rootChildren)
         } else {
           throw new Error('Test not configured properly')
@@ -147,7 +142,7 @@ describe('Lexical MDX', () => {
     }
 
     if (convertFromEditorJSON !== false) {
-      it(`can convert from editor JSON: ${description ?? sanitizedInput}"`, () => {
+      test(`can convert from editor JSON: ${description ?? sanitizedInput}"`, () => {
         const editorState = {
           root: {
             children: blockNode
@@ -181,7 +176,7 @@ describe('Lexical MDX', () => {
     }
   }
 
-  describe('upload markdown: Markdown → Lexical (import)', () => {
+  test.describe('upload markdown: Markdown → Lexical (import)', () => {
     function countUploadNodes(node: {
       [key: string]: unknown
       children?: unknown[]
@@ -219,7 +214,7 @@ describe('Lexical MDX', () => {
       return out
     }
 
-    it('imports upload placeholder as upload node and verifies it is there', () => {
+    test('imports upload placeholder as upload node and verifies it is there', () => {
       const markdown = '![uploads:123]()'
       const result = mdxToEditorJSON({ mdxWithFrontmatter: markdown, editorConfig })
       const rootChildren = result.editorState.root?.children ?? []
@@ -233,7 +228,7 @@ describe('Lexical MDX', () => {
       expect(uploads[0].value).toBe(123)
     })
 
-    it('imports image markdown without creating upload node and preserves content', () => {
+    test('imports image markdown without creating upload node and preserves content', () => {
       const markdown = '![alt](/uploads/image.jpg)'
       const result = mdxToEditorJSON({ mdxWithFrontmatter: markdown, editorConfig })
       const rootChildren = result.editorState.root?.children ?? []
@@ -252,8 +247,8 @@ describe('Lexical MDX', () => {
     })
   })
 
-  describe('link markdown: should not match image markdown', () => {
-    it('should not parse image markdown as a link node', () => {
+  test.describe('link markdown: should not match image markdown', () => {
+    test('should not parse image markdown as a link node', () => {
       const markdown = '![Alt text](https://example.com/image.jpg)'
       const result = mdxToEditorJSON({ mdxWithFrontmatter: markdown, editorConfig })
       const serialized = JSON.stringify(result.editorState)

--- a/test/lexical-mdx/int.spec.ts
+++ b/test/lexical-mdx/int.spec.ts
@@ -14,7 +14,6 @@ import { expect } from 'vitest'
 
 import { test } from '../__helpers/int/vitest.js'
 import { postsSlug } from './collections/Posts/index.js'
-import testConfig from './config.js'
 import { editorJSONToMDX, mdxToEditorJSON } from './mdx/hooks.js'
 import { codeTest1 } from './tests/code1.test.js'
 import { defaultTests } from './tests/default.test.js'
@@ -44,7 +43,7 @@ export type Test = {
 }
 type Tests = Array<Test>
 
-test.suite({ config: testConfig })('Lexical MDX', () => {
+test.suite({ config: './config.ts' })('Lexical MDX', () => {
   // --__--__--__--__--__--__--__--__--__
   // Boilerplate test setup/teardown
   // --__--__--__--__--__--__--__--__--__

--- a/test/lexical/baseConfig.ts
+++ b/test/lexical/baseConfig.ts
@@ -118,13 +118,9 @@ export const baseConfig: Partial<Config> = {
     fallback: true,
     locales: ['en', 'es', 'he'],
   },
-  onInit: async (payload) => {
-    // IMPORTANT: This should only seed, not clear the database.
-    if (process.env.SEED_IN_CONFIG_ONINIT !== 'false') {
-      await seed(payload)
-    }
-  },
   typescript: {
     outputFile: path.resolve(dirname, 'payload-types.ts'),
   },
 }
+
+export { seed }

--- a/test/lexical/collections/Lexical/e2e/blocks/e2e.spec.ts
+++ b/test/lexical/collections/Lexical/e2e/blocks/e2e.spec.ts
@@ -59,7 +59,6 @@ let serverURL: string
 describe('lexicalBlocks', () => {
   beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
-    process.env.SEED_IN_CONFIG_ONINIT = 'false' // Makes it so the payload config onInit seed is not run. Otherwise, the seed would be run unnecessarily twice for the initial test run - once for beforeEach and once for onInit
     ;({ payload, serverURL } = await initPayloadE2ENoConfig<Config>({ dirname }))
 
     context = await browser.newContext()
@@ -73,8 +72,6 @@ describe('lexicalBlocks', () => {
     // })
     await reInitializeDB({
       serverURL,
-      snapshotKey: 'lexicalTest',
-      uploadsDir: [path.resolve(dirname, './collections/Upload/uploads')],
     })
 
     if (client) {

--- a/test/lexical/collections/Lexical/e2e/main/e2e.spec.ts
+++ b/test/lexical/collections/Lexical/e2e/main/e2e.spec.ts
@@ -77,7 +77,6 @@ async function navigateToLexicalFields(
 describe('lexicalMain', () => {
   beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
-    process.env.SEED_IN_CONFIG_ONINIT = 'false' // Makes it so the payload config onInit seed is not run. Otherwise, the seed would be run unnecessarily twice for the initial test run - once for beforeEach and once for onInit
     ;({ payload, serverURL } = await initPayloadE2ENoConfig<Config>({ dirname }))
 
     context = await browser.newContext()
@@ -91,8 +90,6 @@ describe('lexicalMain', () => {
     })*/
     await reInitializeDB({
       serverURL,
-      snapshotKey: 'lexicalTest',
-      uploadsDir: [path.resolve(dirname, './collections/Upload/uploads')],
     })
 
     if (client) {

--- a/test/lexical/collections/LexicalAutosaveBlock/e2e.spec.ts
+++ b/test/lexical/collections/LexicalAutosaveBlock/e2e.spec.ts
@@ -30,7 +30,6 @@ describe('Lexical: nested richText loses focus on parent autosave', () => {
 
   beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
-    process.env.SEED_IN_CONFIG_ONINIT = 'false'
     ;({ payload, serverURL } = await initPayloadE2ENoConfig<Config>({ dirname }))
 
     const page = await browser.newPage()

--- a/test/lexical/collections/LexicalHeadingFeature/e2e.spec.ts
+++ b/test/lexical/collections/LexicalHeadingFeature/e2e.spec.ts
@@ -29,7 +29,6 @@ describe('Lexical Heading Feature', () => {
   let lexical: LexicalHelpers
   beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
-    process.env.SEED_IN_CONFIG_ONINIT = 'false' // Makes it so the payload config onInit seed is not run. Otherwise, the seed would be run unnecessarily twice for the initial test run - once for beforeEach and once for onInit
     const page = await browser.newPage()
     await ensureCompilationIsDone({ page, serverURL })
     await page.close()

--- a/test/lexical/collections/LexicalJSXConverter/e2e.spec.ts
+++ b/test/lexical/collections/LexicalJSXConverter/e2e.spec.ts
@@ -30,7 +30,6 @@ const { serverURL } = await initPayloadE2ENoConfig({
 describe('Lexical JSX Converter', () => {
   beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
-    process.env.SEED_IN_CONFIG_ONINIT = 'false' // Makes it so the payload config onInit seed is not run. Otherwise, the seed would be run unnecessarily twice for the initial test run - once for beforeEach and once for onInit
     const page = await browser.newPage()
     await ensureCompilationIsDone({ page, serverURL })
     await page.close()

--- a/test/lexical/collections/LexicalLinkFeature/e2e.spec.ts
+++ b/test/lexical/collections/LexicalLinkFeature/e2e.spec.ts
@@ -28,7 +28,6 @@ const { serverURL } = await initPayloadE2ENoConfig({
 describe('Lexical Link Feature', () => {
   beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
-    process.env.SEED_IN_CONFIG_ONINIT = 'false' // Makes it so the payload config onInit seed is not run. Otherwise, the seed would be run unnecessarily twice for the initial test run - once for beforeEach and once for onInit
 
     await ensureCompilationIsDone({ browser, serverURL })
   })

--- a/test/lexical/collections/LexicalListsFeature/e2e.spec.ts
+++ b/test/lexical/collections/LexicalListsFeature/e2e.spec.ts
@@ -31,7 +31,6 @@ describe('Lexical Lists Features', () => {
   let lexical: LexicalHelpers
   beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
-    process.env.SEED_IN_CONFIG_ONINIT = 'false' // Makes it so the payload config onInit seed is not run. Otherwise, the seed would be run unnecessarily twice for the initial test run - once for beforeEach and once for onInit
     ;({ payload, serverURL } = await initPayloadE2ENoConfig<Config>({ dirname }))
 
     const page = await browser.newPage()

--- a/test/lexical/collections/LexicalSlugFieldNameCollision/e2e.spec.ts
+++ b/test/lexical/collections/LexicalSlugFieldNameCollision/e2e.spec.ts
@@ -28,7 +28,6 @@ describe('Lexical: collection slug equals top-level field name', () => {
 
   beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
-    process.env.SEED_IN_CONFIG_ONINIT = 'false'
     ;({ payload, serverURL } = await initPayloadE2ENoConfig<Config>({ dirname }))
 
     const page = await browser.newPage()

--- a/test/lexical/collections/LexicalViewsFrontend/e2e.spec.ts
+++ b/test/lexical/collections/LexicalViewsFrontend/e2e.spec.ts
@@ -31,7 +31,6 @@ const { beforeAll, beforeEach, describe } = test
 describe('Lexical Views', () => {
   beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
-    process.env.SEED_IN_CONFIG_ONINIT = 'false' // Makes it so the payload config onInit seed is not run. Otherwise, the seed would be run unnecessarily twice for the initial test run - once for beforeEach and once for onInit
     ;({ payload: _payload, serverURL } = await initPayloadE2ENoConfig<Config>({ dirname }))
 
     const page = await browser.newPage()

--- a/test/lexical/collections/LexicalViewsNested/e2e.spec.ts
+++ b/test/lexical/collections/LexicalViewsNested/e2e.spec.ts
@@ -26,7 +26,6 @@ describe('Lexical Views Nested', () => {
 
   beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
-    process.env.SEED_IN_CONFIG_ONINIT = 'false'
     ;({ payload: _payload, serverURL } = await initPayloadE2ENoConfig<Config>({ dirname }))
 
     const page = await browser.newPage()

--- a/test/lexical/collections/LexicalViewsProvider/e2e.spec.ts
+++ b/test/lexical/collections/LexicalViewsProvider/e2e.spec.ts
@@ -27,7 +27,6 @@ describe('Lexical Views Provider', () => {
 
   beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
-    process.env.SEED_IN_CONFIG_ONINIT = 'false'
     ;({ payload: _payload, serverURL } = await initPayloadE2ENoConfig<Config>({ dirname }))
 
     const page = await browser.newPage()

--- a/test/lexical/collections/LexicalViewsProviderDefault/e2e.spec.ts
+++ b/test/lexical/collections/LexicalViewsProviderDefault/e2e.spec.ts
@@ -26,7 +26,6 @@ describe('Lexical Views Provider Default', () => {
 
   beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
-    process.env.SEED_IN_CONFIG_ONINIT = 'false'
     ;({ payload: _payload, serverURL } = await initPayloadE2ENoConfig<Config>({ dirname }))
 
     const page = await browser.newPage()

--- a/test/lexical/collections/LexicalViewsProviderFallback/e2e.spec.ts
+++ b/test/lexical/collections/LexicalViewsProviderFallback/e2e.spec.ts
@@ -26,7 +26,6 @@ describe('Lexical Views Provider Fallback', () => {
 
   beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
-    process.env.SEED_IN_CONFIG_ONINIT = 'false'
     ;({ payload: _payload, serverURL } = await initPayloadE2ENoConfig<Config>({ dirname }))
 
     const page = await browser.newPage()

--- a/test/lexical/collections/OnDemandForm/e2e.spec.ts
+++ b/test/lexical/collections/OnDemandForm/e2e.spec.ts
@@ -25,7 +25,6 @@ describe('Lexical On Demand', () => {
   let lexical: LexicalHelpers
   beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
-    process.env.SEED_IN_CONFIG_ONINIT = 'false' // Makes it so the payload config onInit seed is not run. Otherwise, the seed would be run unnecessarily twice for the initial test run - once for beforeEach and once for onInit
     const page = await browser.newPage()
     await ensureCompilationIsDone({ page, serverURL })
     await page.close()
@@ -35,8 +34,6 @@ describe('Lexical On Demand', () => {
     beforeEach(async ({ page }) => {
       await reInitializeDB({
         serverURL,
-        snapshotKey: 'lexicalTest',
-        uploadsDir: [path.resolve(dirname, './collections/Upload/uploads')],
       })
       const url = new AdminUrlUtil(serverURL, 'OnDemandForm')
       lexical = new LexicalHelpers(page)
@@ -73,8 +70,6 @@ describe('Lexical On Demand', () => {
     beforeEach(async ({ page }) => {
       await reInitializeDB({
         serverURL,
-        snapshotKey: 'lexicalTest',
-        uploadsDir: [path.resolve(dirname, './collections/Upload/uploads')],
       })
       const url = new AdminUrlUtil(serverURL, 'OnDemandOutsideForm')
       lexical = new LexicalHelpers(page)

--- a/test/lexical/collections/_LexicalFullyFeatured/db/e2e.spec.ts
+++ b/test/lexical/collections/_LexicalFullyFeatured/db/e2e.spec.ts
@@ -40,7 +40,6 @@ describe('Lexical Fully Featured - database', () => {
   let url: AdminUrlUtil
   beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
-    process.env.SEED_IN_CONFIG_ONINIT = 'false' // Makes it so the payload config onInit seed is not run. Otherwise, the seed would be run unnecessarily twice for the initial test run - once for beforeEach and once for onInit
     ;({ payload, serverURL } = await initPayloadE2ENoConfig<Config>({ dirname }))
 
     const page = await browser.newPage()
@@ -50,8 +49,6 @@ describe('Lexical Fully Featured - database', () => {
   beforeEach(async ({ page }) => {
     await reInitializeDB({
       serverURL,
-      snapshotKey: 'lexicalTest',
-      uploadsDir: [path.resolve(dirname, './collections/Upload/uploads')],
     })
     url = new AdminUrlUtil(serverURL, lexicalFullyFeaturedSlug)
     lexical = new LexicalHelpers(page)

--- a/test/lexical/collections/_LexicalFullyFeatured/e2e.spec.ts
+++ b/test/lexical/collections/_LexicalFullyFeatured/e2e.spec.ts
@@ -31,7 +31,6 @@ describe('Lexical Fully Featured', () => {
   let lexical: LexicalHelpers
   beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
-    process.env.SEED_IN_CONFIG_ONINIT = 'false' // Makes it so the payload config onInit seed is not run. Otherwise, the seed would be run unnecessarily twice for the initial test run - once for beforeEach and once for onInit
     ;({ payload, serverURL } = await initPayloadE2ENoConfig<Config>({ dirname }))
 
     await ensureCompilationIsDone({ browser, serverURL })
@@ -408,7 +407,6 @@ describe('Lexical Fully Featured, admin panel in RTL', () => {
   let lexical: LexicalHelpers
   beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
-    process.env.SEED_IN_CONFIG_ONINIT = 'false' // Makes it so the payload config onInit seed is not run. Otherwise, the seed would be run unnecessarily twice for the initial test run - once for beforeEach and once for onInit
     ;({ payload, serverURL } = await initPayloadE2ENoConfig<Config>({ dirname }))
 
     await ensureCompilationIsDone({ browser, serverURL })

--- a/test/lexical/config.blockreferences.ts
+++ b/test/lexical/config.blockreferences.ts
@@ -4,7 +4,7 @@ import type { BlockSlug } from 'payload'
 
 import { autoDedupeBlocksPlugin } from '../__helpers/shared/autoDedupeBlocksPlugin/index.js'
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
-import { baseConfig } from './baseConfig.js'
+import { baseConfig, seed } from './baseConfig.js'
 import {
   getLexicalFieldsCollection,
   lexicalBlocks,
@@ -13,24 +13,28 @@ import {
 import { lexicalFieldsSlug } from './slugs.js'
 
 export default buildConfigWithDefaults({
-  ...baseConfig,
-  blocks: [
-    ...(baseConfig.blocks ?? []),
-    ...lexicalBlocks.filter((block) => typeof block !== 'string'),
-    ...lexicalInlineBlocks.filter((block) => typeof block !== 'string'),
-  ],
-  collections: baseConfig.collections?.map((collection) => {
-    if (collection.slug === lexicalFieldsSlug) {
-      return getLexicalFieldsCollection({
-        blocks: lexicalBlocks.map((block) =>
-          typeof block === 'string' ? block : block.slug,
-        ) as BlockSlug[],
-        inlineBlocks: lexicalInlineBlocks.map((block) =>
-          typeof block === 'string' ? block : block.slug,
-        ) as BlockSlug[],
-      })
-    }
-    return collection
-  }),
-  plugins: [autoDedupeBlocksPlugin({ silent: false })],
+  suite: 'lexical-blockreferences',
+  config: {
+    ...baseConfig,
+    blocks: [
+      ...(baseConfig.blocks ?? []),
+      ...lexicalBlocks.filter((block) => typeof block !== 'string'),
+      ...lexicalInlineBlocks.filter((block) => typeof block !== 'string'),
+    ],
+    collections: baseConfig.collections?.map((collection) => {
+      if (collection.slug === lexicalFieldsSlug) {
+        return getLexicalFieldsCollection({
+          blocks: lexicalBlocks.map((block) =>
+            typeof block === 'string' ? block : block.slug,
+          ) as BlockSlug[],
+          inlineBlocks: lexicalInlineBlocks.map((block) =>
+            typeof block === 'string' ? block : block.slug,
+          ) as BlockSlug[],
+        })
+      }
+      return collection
+    }),
+    plugins: [autoDedupeBlocksPlugin({ silent: false })],
+  },
+  seed,
 })

--- a/test/lexical/config.ts
+++ b/test/lexical/config.ts
@@ -1,4 +1,4 @@
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
-import { baseConfig } from './baseConfig.js'
+import { baseConfig, seed } from './baseConfig.js'
 
-export default buildConfigWithDefaults(baseConfig)
+export default buildConfigWithDefaults({ suite: 'lexical', config: baseConfig, seed })

--- a/test/lexical/lexical.int.spec.ts
+++ b/test/lexical/lexical.int.spec.ts
@@ -54,7 +54,7 @@ import { richTextDocData } from './collections/RichText/data.js'
 import { generateLexicalRichText } from './collections/RichText/generateLexicalRichText.js'
 import { textDoc } from './collections/Text/shared.js'
 import { uploadsDoc } from './collections/Upload/shared.js'
-import { clearAndSeedEverything } from './seed.js'
+import testConfig from './config.js'
 import {
   arrayFieldsSlug,
   lexicalFieldsSlug,
@@ -68,13 +68,8 @@ let createdJPGDocID: number | string = null
 let createdTextDocID: number | string = null
 let createdRichTextDocID: number | string = null
 
-test.describe('Lexical', () => {
-  test.beforeAll(() => {
-    process.env.SEED_IN_CONFIG_ONINIT = 'false' // Makes it so the payload config onInit seed is not run. Otherwise, the seed would be run unnecessarily twice for the initial test run - once for beforeEach and once for onInit
-  })
-
+test.suite({ config: testConfig })('Lexical', () => {
   test.beforeEach(async ({ payload, restClient }) => {
-    await clearAndSeedEverything(payload)
     await restClient.login({
       slug: 'users',
       credentials: devUser,

--- a/test/lexical/lexical.int.spec.ts
+++ b/test/lexical/lexical.int.spec.ts
@@ -54,7 +54,6 @@ import { richTextDocData } from './collections/RichText/data.js'
 import { generateLexicalRichText } from './collections/RichText/generateLexicalRichText.js'
 import { textDoc } from './collections/Text/shared.js'
 import { uploadsDoc } from './collections/Upload/shared.js'
-import testConfig from './config.js'
 import {
   arrayFieldsSlug,
   lexicalFieldsSlug,
@@ -68,7 +67,7 @@ let createdJPGDocID: number | string = null
 let createdTextDocID: number | string = null
 let createdRichTextDocID: number | string = null
 
-test.suite({ config: testConfig })('Lexical', () => {
+test.suite({ config: './config.ts' })('Lexical', () => {
   test.beforeEach(async ({ payload, restClient }) => {
     await restClient.login({
       slug: 'users',

--- a/test/live-preview/config.ts
+++ b/test/live-preview/config.ts
@@ -32,50 +32,53 @@ import {
 import { formatLivePreviewURL } from './utilities/formatLivePreviewURL.js'
 
 export default buildConfigWithDefaults({
-  localization: {
-    defaultLocale: 'en',
-    locales: ['en', 'es'],
-  },
-  admin: {
-    importMap: {
-      baseDir: path.resolve(dirname),
+  suite: 'live-preview',
+  config: {
+    admin: {
+      importMap: {
+        baseDir: path.resolve(dirname),
+      },
+      livePreview: {
+        // You can define any of these properties on a per collection or global basis
+        // The Live Preview config cascades from the top down, properties are inherited from here
+        breakpoints: [mobileBreakpoint, desktopBreakpoint],
+        collections: [
+          pagesSlug,
+          postsSlug,
+          ssrPagesSlug,
+          ssrAutosavePagesSlug,
+          customLivePreviewSlug,
+        ],
+        globals: ['header', 'footer'],
+        url: formatLivePreviewURL,
+      },
     },
-    livePreview: {
-      // You can define any of these properties on a per collection or global basis
-      // The Live Preview config cascades from the top down, properties are inherited from here
-      url: formatLivePreviewURL,
-      breakpoints: [mobileBreakpoint, desktopBreakpoint],
-      collections: [
-        pagesSlug,
-        postsSlug,
-        ssrPagesSlug,
-        ssrAutosavePagesSlug,
-        customLivePreviewSlug,
-      ],
-      globals: ['header', 'footer'],
+    blocks: [MediaBlock],
+    collections: [
+      Users,
+      Pages,
+      Posts,
+      SSR,
+      SSRAutosave,
+      Tenants,
+      Categories,
+      Media,
+      CollectionLevelConfig,
+      OpenByDefault,
+      StaticURLCollection,
+      CustomLivePreview,
+      ConditionalURL,
+    ],
+    cors: [`http://localhost:${process.env.PORT || 3000}`, 'http://localhost:3001'],
+    csrf: [`http://localhost:${process.env.PORT || 3000}`, 'http://localhost:3001'],
+    globals: [Header, Footer],
+    localization: {
+      defaultLocale: 'en',
+      locales: ['en', 'es'],
+    },
+    typescript: {
+      outputFile: path.resolve(dirname, 'payload-types.ts'),
     },
   },
-  cors: [`http://localhost:${process.env.PORT || 3000}`, 'http://localhost:3001'],
-  csrf: [`http://localhost:${process.env.PORT || 3000}`, 'http://localhost:3001'],
-  collections: [
-    Users,
-    Pages,
-    Posts,
-    SSR,
-    SSRAutosave,
-    Tenants,
-    Categories,
-    Media,
-    CollectionLevelConfig,
-    OpenByDefault,
-    StaticURLCollection,
-    CustomLivePreview,
-    ConditionalURL,
-  ],
-  globals: [Header, Footer],
-  onInit: seed,
-  typescript: {
-    outputFile: path.resolve(dirname, 'payload-types.ts'),
-  },
-  blocks: [MediaBlock],
+  seed,
 })

--- a/test/live-preview/e2e.spec.ts
+++ b/test/live-preview/e2e.spec.ts
@@ -103,7 +103,6 @@ describe('Live Preview', () => {
 
     await reInitializeDB({
       serverURL,
-      snapshotKey: 'livePreviewTest',
     })
 
     await ensureCompilationIsDone({ page, serverURL })

--- a/test/live-preview/int.spec.ts
+++ b/test/live-preview/int.spec.ts
@@ -1,5 +1,3 @@
-import type { Payload } from 'payload'
-
 import {
   handleMessage as handleMessageImport,
   type LivePreviewMessageEvent,
@@ -8,9 +6,8 @@ import {
 import path from 'path'
 import { getFileByPath } from 'payload'
 import { fileURLToPath } from 'url'
-import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { expect } from 'vitest'
 
-import type { NextRESTClient } from '../__helpers/shared/NextRESTClient.js'
 import type { Media, Page, Post, Tenant } from './payload-types.js'
 
 import { pagesSlug, postsSlug, tenantsSlug } from './shared.js'
@@ -18,28 +15,12 @@ import { pagesSlug, postsSlug, tenantsSlug } from './shared.js'
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
-let payload: Payload
-let restClient: NextRESTClient
-
 import type { CollectionPopulationRequestHandler } from '../../packages/live-preview/src/types.js'
 
-import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
+import { test } from '../__helpers/int/vitest.js'
+import testConfig from './config.js'
 
-const requestHandler: CollectionPopulationRequestHandler = ({ data, endpoint }) => {
-  const url = `/${endpoint}`
-  const headers: Record<string, string> = {
-    'Content-Type': 'application/json',
-    'X-Payload-HTTP-Method-Override': 'GET',
-  }
-
-  return restClient.POST(url as any, {
-    body: JSON.stringify(data),
-    credentials: 'include',
-    headers,
-  })
-}
-
-describe('Collections - Live Preview', () => {
+test.suite({ config: testConfig })('Collections - Live Preview', () => {
   const serverURL: string = `http://localhost:${process.env.PORT || 3000}`
 
   let testPost: Post
@@ -52,9 +33,22 @@ describe('Collections - Live Preview', () => {
   let mergeData: (
     args: Omit<Parameters<typeof mergeDataImport<any>>[0], 'requestHandler' | 'serverURL'>,
   ) => Promise<Record<string, any>> = mergeDataImport as any
+  let createPageWithInitialData: (initialData: Partial<Page>) => Promise<Page>
 
-  beforeAll(async () => {
-    ;({ payload, restClient } = await initPayloadInt(dirname))
+  test.beforeEach(async ({ payload, restClient }) => {
+    const requestHandler: CollectionPopulationRequestHandler = ({ data, endpoint }) => {
+      const url = `/${endpoint}`
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+        'X-Payload-HTTP-Method-Override': 'GET',
+      }
+
+      return restClient.POST(url as any, {
+        body: JSON.stringify(data),
+        credentials: 'include',
+        headers,
+      })
+    }
 
     mergeData = async (args) => {
       return await mergeDataImport({
@@ -74,6 +68,27 @@ describe('Collections - Live Preview', () => {
       }
 
       return await handleMessageImport(newArgs)
+    }
+
+    createPageWithInitialData = async (initialData) => {
+      await payload.db.deleteOne({
+        collection: pagesSlug,
+        where: {
+          slug: {
+            equals: 'testPage',
+          },
+        },
+        returning: false,
+      })
+
+      return payload.create({
+        collection: pagesSlug,
+        depth: 0,
+        data: {
+          ...initialData,
+          slug: 'testPage',
+        } as Page,
+      })
     }
 
     tenant = await payload.create({
@@ -112,11 +127,7 @@ describe('Collections - Live Preview', () => {
     })
   })
 
-  afterAll(async () => {
-    await payload.destroy()
-  })
-
-  it('handles `postMessage`', async () => {
+  test('handles `postMessage`', async () => {
     const handledMessage = await handleMessage({
       depth: 1,
       event: {
@@ -143,30 +154,7 @@ describe('Collections - Live Preview', () => {
     expect(handledMessage.title).toEqual('Test Page (Changed)')
   })
 
-  async function createPageWithInitialData(initialData: Partial<Page>) {
-    await payload.db.deleteOne({
-      collection: pagesSlug,
-      where: {
-        slug: {
-          equals: 'testPage',
-        },
-      },
-      returning: false,
-    })
-
-    const page = await payload.create({
-      collection: pagesSlug,
-      depth: 0,
-      data: {
-        ...initialData,
-        slug: 'testPage',
-      } as Page,
-    })
-
-    return page
-  }
-
-  it('— strings - merges data', async () => {
+  test('— strings - merges data', async () => {
     const initialData = await createPageWithInitialData({
       title: 'Test Page',
     })
@@ -184,7 +172,7 @@ describe('Collections - Live Preview', () => {
     expect(mergedData.title).toEqual('Test Page (Changed)')
   })
 
-  it('— strings - merges localized data', async () => {
+  test('— strings - merges localized data', async () => {
     const initialData = await createPageWithInitialData({
       title: 'Test Page',
     })
@@ -202,7 +190,7 @@ describe('Collections - Live Preview', () => {
     expect(mergedData.localizedTitle).toEqual('Test Page (Changed)')
   })
 
-  it('— arrays - can clear all rows', async () => {
+  test('— arrays - can clear all rows', async () => {
     const initialData = await createPageWithInitialData({
       title: 'Test Page',
       arrayOfRelationships: [
@@ -240,7 +228,7 @@ describe('Collections - Live Preview', () => {
     expect(mergedData2.arrayOfRelationships).toEqual([])
   })
 
-  it('— uploads - adds and removes media', async () => {
+  test('— uploads - adds and removes media', async () => {
     const initialData = await createPageWithInitialData({
       title: 'Test Page',
     })
@@ -278,7 +266,7 @@ describe('Collections - Live Preview', () => {
     expect(mergedDataWithoutUpload.hero.media).toBeFalsy()
   })
 
-  it('— uploads - populates within Lexical rich text editor', async () => {
+  test('— uploads - populates within Lexical rich text editor', async () => {
     const initialData = await createPageWithInitialData({
       title: 'Test Page',
     })
@@ -376,7 +364,7 @@ describe('Collections - Live Preview', () => {
     expect(merge2.richTextLexical.root.children[0].type).toEqual('paragraph')
   })
 
-  it('— relationships - populates monomorphic has one relationships', async () => {
+  test('— relationships - populates monomorphic has one relationships', async () => {
     const initialData = await createPageWithInitialData({
       title: 'Test Page',
     })
@@ -394,7 +382,7 @@ describe('Collections - Live Preview', () => {
     expect(merge1.relationshipMonoHasOne).toMatchObject(testPost)
   })
 
-  it('— relationships - populates monomorphic has many relationships', async () => {
+  test('— relationships - populates monomorphic has many relationships', async () => {
     const initialData = await createPageWithInitialData({
       title: 'Test Page',
     })
@@ -412,7 +400,7 @@ describe('Collections - Live Preview', () => {
     expect(merge1.relationshipMonoHasMany).toMatchObject([testPost])
   })
 
-  it('— relationships - populates polymorphic has one relationships', async () => {
+  test('— relationships - populates polymorphic has one relationships', async () => {
     const initialData = await createPageWithInitialData({
       title: 'Test Page',
     })
@@ -433,7 +421,7 @@ describe('Collections - Live Preview', () => {
     })
   })
 
-  it('— relationships - populates polymorphic has many relationships', async () => {
+  test('— relationships - populates polymorphic has many relationships', async () => {
     const initialData = await createPageWithInitialData({
       title: 'Test Page',
     })
@@ -453,7 +441,7 @@ describe('Collections - Live Preview', () => {
     ])
   })
 
-  it('— relationships - can clear relationships', async () => {
+  test('— relationships - can clear relationships', async () => {
     const initialData = await createPageWithInitialData({
       title: 'Test Page',
       relationshipMonoHasOne: testPost.id,
@@ -480,7 +468,7 @@ describe('Collections - Live Preview', () => {
     expect(merge2.relationshipPolyHasMany).toEqual([])
   })
 
-  it('— relationships - populates within tabs', async () => {
+  test('— relationships - populates within tabs', async () => {
     const initialData = await createPageWithInitialData({
       title: 'Test Page',
     })
@@ -500,7 +488,7 @@ describe('Collections - Live Preview', () => {
     expect(merge1.tab.relationshipInTab).toMatchObject(testPost)
   })
 
-  it('— relationships - populates within arrays', async () => {
+  test('— relationships - populates within arrays', async () => {
     const initialData = await createPageWithInitialData({
       title: 'Test Page',
     })
@@ -732,15 +720,15 @@ describe('Collections - Live Preview', () => {
     expect(merge2[fieldName].root.children[3].value).toMatchObject(media)
   }
 
-  it('— relationships - populates within Lexical rich text editor', async () => {
+  test('— relationships - populates within Lexical rich text editor', async () => {
     await lexicalTest('richTextLexical')
   })
 
-  it('— relationships - populates within Localized Lexical rich text editor', async () => {
+  test('— relationships - populates within Localized Lexical rich text editor', async () => {
     await lexicalTest('richTextLexicalLocalized')
   })
 
-  it('— relationships - re-populates externally updated relationships', async () => {
+  test('— relationships - re-populates externally updated relationships', async ({ payload }) => {
     const initialData = await createPageWithInitialData({
       title: 'Test Page',
     })
@@ -808,7 +796,7 @@ describe('Collections - Live Preview', () => {
     ])
   })
 
-  it('— relationships - populates localized relationships', async () => {
+  test('— relationships - populates localized relationships', async ({ payload }) => {
     const post = await payload.create({
       collection: postsSlug,
       data: {
@@ -862,7 +850,7 @@ describe('Collections - Live Preview', () => {
     expect(merge1.relationToLocalized).toHaveProperty('localizedTitle', 'Test Post Spanish')
   })
 
-  it('— blocks - adds, reorders, and removes blocks', async () => {
+  test('— blocks - adds, reorders, and removes blocks', async () => {
     const block1ID = '123'
     const block2ID = '456'
 

--- a/test/live-preview/int.spec.ts
+++ b/test/live-preview/int.spec.ts
@@ -18,9 +18,8 @@ const dirname = path.dirname(filename)
 import type { CollectionPopulationRequestHandler } from '../../packages/live-preview/src/types.js'
 
 import { test } from '../__helpers/int/vitest.js'
-import testConfig from './config.js'
 
-test.suite({ config: testConfig })('Collections - Live Preview', () => {
+test.suite({ config: './config.ts' })('Collections - Live Preview', () => {
   const serverURL: string = `http://localhost:${process.env.PORT || 3000}`
 
   let testPost: Post

--- a/test/loader/int.spec.ts
+++ b/test/loader/int.spec.ts
@@ -1,24 +1,25 @@
-import { describe, expect, it } from 'vitest'
+import { expect } from 'vitest'
 
+import { test } from '../__helpers/int/vitest.js'
 import { startChildProcess } from './startChildProcess.js'
 
-describe('Loader', () => {
-  it('should load dependencies without extensions', async () => {
+test.suite({})('Loader', () => {
+  test('should load dependencies without extensions', async () => {
     const code = await startChildProcess('./dependency-test.js')
     expect(code).toStrictEqual(0)
   })
 
-  it('should import complex configs', async () => {
+  test('should import complex configs', async () => {
     const code = await startChildProcess('../fields/config.ts')
     expect(code).toStrictEqual(0)
   })
 
-  it('should import configs that rely on custom components', async () => {
+  test('should import configs that rely on custom components', async () => {
     const code = await startChildProcess('../admin/config.ts')
     expect(code).toStrictEqual(0)
   })
 
-  it('should import unexported, direct .js file from commonjs module', async () => {
+  test('should import unexported, direct .js file from commonjs module', async () => {
     /*
     Background of this test: next/Link.js is a CJS module which directly resolves to the Link.js JavaScript file. This file is not part of the package.json main or exports fields.
     This test ensures that the loader can resolve this file even if the .js extension is omitted.

--- a/test/locked-documents/config.ts
+++ b/test/locked-documents/config.ts
@@ -20,28 +20,27 @@ const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
 export default buildConfigWithDefaults({
-  admin: {
-    importMap: {
-      baseDir: path.resolve(dirname),
+  suite: 'locked-documents',
+  config: {
+    admin: {
+      importMap: {
+        baseDir: path.resolve(dirname),
+      },
+    },
+    collections: [
+      AutosaveCollection,
+      PagesCollection,
+      PostsCollection,
+      ServerComponentsCollection,
+      SimpleCollection,
+      SimpleWithVersionsCollection,
+      TestsCollection,
+      Users,
+    ],
+    globals: [AdminGlobal, AutosaveGlobal, GlobalWithVersions, MenuGlobal],
+    typescript: {
+      outputFile: path.resolve(dirname, 'payload-types.ts'),
     },
   },
-  collections: [
-    AutosaveCollection,
-    PagesCollection,
-    PostsCollection,
-    ServerComponentsCollection,
-    SimpleCollection,
-    SimpleWithVersionsCollection,
-    TestsCollection,
-    Users,
-  ],
-  globals: [AdminGlobal, AutosaveGlobal, GlobalWithVersions, MenuGlobal],
-  onInit: async (payload) => {
-    if (process.env.SEED_IN_CONFIG_ONINIT !== 'false') {
-      await seed(payload)
-    }
-  },
-  typescript: {
-    outputFile: path.resolve(dirname, 'payload-types.ts'),
-  },
+  seed,
 })

--- a/test/locked-documents/e2e.spec.ts
+++ b/test/locked-documents/e2e.spec.ts
@@ -69,7 +69,6 @@ describe('Locked Documents', () => {
   beforeEach(async () => {
     await reInitializeDB({
       serverURL,
-      snapshotKey: 'lockedDocumentsTest',
     })
   })
 

--- a/test/locked-documents/int.spec.ts
+++ b/test/locked-documents/int.spec.ts
@@ -9,13 +9,12 @@ import type { Post, User } from './payload-types.js'
 
 import { test } from '../__helpers/int/vitest.js'
 import { devUser } from '../credentials.js'
-import testConfig from './config.js'
 import { menuSlug } from './globals/Menu/index.js'
 import { pagesSlug, postsSlug } from './slugs.js'
 
 const lockedDocumentCollection = 'payload-locked-documents'
 
-test.suite({ config: testConfig })('Locked documents', () => {
+test.suite({ config: './config.ts' })('Locked documents', () => {
   let post: Post
   let user: any
   let user2: any

--- a/test/locked-documents/int.spec.ts
+++ b/test/locked-documents/int.spec.ts
@@ -1,35 +1,27 @@
-import type { Payload, SanitizedCollectionConfig, SanitizedGlobalConfig } from 'payload'
-import { describe, beforeAll, afterAll, afterEach, it, expect } from 'vitest'
+import type { SanitizedCollectionConfig, SanitizedGlobalConfig } from 'payload'
 
-import path from 'path'
 import { Locked, NotFound } from 'payload'
 import { wait } from 'payload/shared'
 import { fileURLToPath } from 'url'
+import { expect } from 'vitest'
 
 import type { Post, User } from './payload-types.js'
 
+import { test } from '../__helpers/int/vitest.js'
 import { devUser } from '../credentials.js'
-import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
+import testConfig from './config.js'
 import { menuSlug } from './globals/Menu/index.js'
 import { pagesSlug, postsSlug } from './slugs.js'
 
 const lockedDocumentCollection = 'payload-locked-documents'
 
-let payload: Payload
-
-const filename = fileURLToPath(import.meta.url)
-const dirname = path.dirname(filename)
-
-describe('Locked documents', () => {
+test.suite({ config: testConfig })('Locked documents', () => {
   let post: Post
   let user: any
   let user2: any
   let postConfig: SanitizedCollectionConfig
 
-  beforeAll(async () => {
-    // @ts-expect-error: initPayloadInt does not have a proper type definition
-    ;({ payload } = await initPayloadInt(dirname))
-
+  test.beforeEach(async ({ payload }) => {
     postConfig = payload.config.collections.find(
       ({ slug }) => slug === postsSlug,
     ) as SanitizedCollectionConfig
@@ -74,15 +66,11 @@ describe('Locked documents', () => {
     })
   })
 
-  afterAll(async () => {
-    await payload.destroy()
-  })
-
-  afterEach(() => {
+  test.afterEach(() => {
     postConfig.lockDocuments = { duration: 300 }
   })
 
-  it('should update unlocked document - collection', async () => {
+  test('should update unlocked document - collection', async ({ payload }) => {
     const updatedPost = await payload.update({
       collection: postsSlug,
       data: {
@@ -94,7 +82,7 @@ describe('Locked documents', () => {
     expect(updatedPost.text).toEqual('updated post')
   })
 
-  it('should update unlocked document - global', async () => {
+  test('should update unlocked document - global', async ({ payload }) => {
     const updatedGlobalMenu = await payload.updateGlobal({
       slug: menuSlug,
       data: {
@@ -105,7 +93,7 @@ describe('Locked documents', () => {
     expect(updatedGlobalMenu.globalText).toEqual('updated global text')
   })
 
-  it('should delete unlocked document - collection', async () => {
+  test('should delete unlocked document - collection', async ({ payload }) => {
     const { docs } = await payload.find({
       collection: postsSlug,
       depth: 0,
@@ -126,7 +114,7 @@ describe('Locked documents', () => {
     expect(deletedResults).toHaveLength(1)
   })
 
-  it('should allow update of stale locked document - collection', async () => {
+  test('should allow update of stale locked document - collection', async ({ payload }) => {
     const newPost2 = await payload.create({
       collection: postsSlug,
       data: {
@@ -191,7 +179,7 @@ describe('Locked documents', () => {
     expect(docsFromLocksCollection.docs).toHaveLength(0)
   })
 
-  it('should allow update of stale locked document - global', async () => {
+  test('should allow update of stale locked document - global', async ({ payload }) => {
     // Set lock duration to 1 second for testing purposes
     const globalConfig = payload.config.globals.find(
       ({ slug }) => slug === menuSlug,
@@ -247,7 +235,7 @@ describe('Locked documents', () => {
     expect(docsFromLocksCollection.docs).toHaveLength(0)
   })
 
-  it('should not allow update of locked document - collection', async () => {
+  test('should not allow update of locked document - collection', async ({ payload }) => {
     const newPost = await payload.create({
       collection: postsSlug,
       data: {
@@ -294,7 +282,7 @@ describe('Locked documents', () => {
     expect(updatedPost.text).toEqual('some post')
   })
 
-  it('should not allow update of locked document - global', async () => {
+  test('should not allow update of locked document - global', async ({ payload }) => {
     // Give locking ownership to another user
     await payload.create({
       collection: lockedDocumentCollection,
@@ -326,11 +314,11 @@ describe('Locked documents', () => {
     })
 
     // Should not allow update - expect data not to change
-    expect(updatedGlobalMenu.globalText).toEqual('global text 2')
+    expect(updatedGlobalMenu.globalText).toEqual('global text')
   })
 
   // Try to delete locked document (collection)
-  it('should not allow delete of locked document - collection', async () => {
+  test('should not allow delete of locked document - collection', async ({ payload }) => {
     const newPost3 = await payload.create({
       collection: postsSlug,
       data: {
@@ -375,7 +363,7 @@ describe('Locked documents', () => {
     expect(findPostDocs.docs).toHaveLength(1)
   })
 
-  it('should allow delete of stale locked document - collection', async () => {
+  test('should allow delete of stale locked document - collection', async ({ payload }) => {
     const newPost4 = await payload.create({
       collection: postsSlug,
       data: {
@@ -439,7 +427,9 @@ describe('Locked documents', () => {
     expect(docsFromLocksCollection.docs).toHaveLength(0)
   })
 
-  it('should allow update of locked document w/ overrideLock flag - collection', async () => {
+  test('should allow update of locked document w/ overrideLock flag - collection', async ({
+    payload,
+  }) => {
     const newPost5 = await payload.create({
       collection: postsSlug,
       data: {
@@ -497,7 +487,9 @@ describe('Locked documents', () => {
     expect(docsFromLocksCollection.docs).toHaveLength(0)
   })
 
-  it('should allow update of locked document w/ overrideLock flag - global', async () => {
+  test('should allow update of locked document w/ overrideLock flag - global', async ({
+    payload,
+  }) => {
     // Give locking ownership to another user
     const lockedGlobalInstance = await payload.create({
       collection: lockedDocumentCollection,
@@ -544,7 +536,9 @@ describe('Locked documents', () => {
     expect(docsFromLocksCollection.docs).toHaveLength(0)
   })
 
-  it('should allow delete of locked document w/ overrideLock flag - collection', async () => {
+  test('should allow delete of locked document w/ overrideLock flag - collection', async ({
+    payload,
+  }) => {
     const newPost6 = await payload.create({
       collection: postsSlug,
       data: {
@@ -603,7 +597,9 @@ describe('Locked documents', () => {
     expect(docsFromLocksCollection.docs).toHaveLength(0)
   })
 
-  it('should allow take over on locked doc (simulates take over modal from admin ui)', async () => {
+  test('should allow take over on locked doc (simulates take over modal from admin ui)', async ({
+    payload,
+  }) => {
     const newPost7 = await payload.create({
       collection: postsSlug,
       data: {

--- a/test/login-with-username/config.ts
+++ b/test/login-with-username/config.ts
@@ -7,48 +7,51 @@ const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
 export const LoginWithUsernameConfig = buildConfigWithDefaults({
-  typescript: {
-    outputFile: path.resolve(dirname, 'payload-types.ts'),
+  suite: 'login-with-username',
+  config: {
+    typescript: {
+      outputFile: path.resolve(dirname, 'payload-types.ts'),
+    },
+    collections: [
+      {
+        slug: 'users',
+        auth: {
+          loginWithUsername: {
+            requireEmail: false,
+            allowEmailLogin: false,
+          },
+        },
+        fields: [],
+        versions: false,
+      },
+      {
+        slug: 'login-with-either',
+        auth: {
+          loginWithUsername: {
+            requireEmail: false,
+            allowEmailLogin: true,
+            requireUsername: false,
+          },
+        },
+        fields: [],
+        versions: false,
+      },
+      {
+        slug: 'require-email',
+        auth: {
+          loginWithUsername: {
+            requireEmail: true,
+            allowEmailLogin: false,
+          },
+        },
+        fields: [],
+        admin: {
+          useAsTitle: 'email',
+        },
+        versions: false,
+      },
+    ],
   },
-  collections: [
-    {
-      slug: 'users',
-      auth: {
-        loginWithUsername: {
-          requireEmail: false,
-          allowEmailLogin: false,
-        },
-      },
-      fields: [],
-      versions: false,
-    },
-    {
-      slug: 'login-with-either',
-      auth: {
-        loginWithUsername: {
-          requireEmail: false,
-          allowEmailLogin: true,
-          requireUsername: false,
-        },
-      },
-      fields: [],
-      versions: false,
-    },
-    {
-      slug: 'require-email',
-      auth: {
-        loginWithUsername: {
-          requireEmail: true,
-          allowEmailLogin: false,
-        },
-      },
-      fields: [],
-      admin: {
-        useAsTitle: 'email',
-      },
-      versions: false,
-    },
-  ],
 })
 
 export default LoginWithUsernameConfig

--- a/test/login-with-username/int.spec.ts
+++ b/test/login-with-username/int.spec.ts
@@ -1,27 +1,12 @@
-import type { Payload } from 'payload'
-
-import path from 'path'
 import { fileURLToPath } from 'url'
-import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { expect } from 'vitest'
 
+import { test } from '../__helpers/int/vitest.js'
 import { devUser } from '../credentials.js'
-import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
+import testConfig from './config.js'
 
-let payload: Payload
-
-const filename = fileURLToPath(import.meta.url)
-const dirname = path.dirname(filename)
-
-describe('Login With Username Feature', () => {
-  beforeAll(async () => {
-    ;({ payload } = await initPayloadInt(dirname))
-  })
-
-  afterAll(async () => {
-    await payload.destroy()
-  })
-
-  it('should not allow creation with neither email nor username', async () => {
+test.suite({ config: testConfig })('Login With Username Feature', () => {
+  test('should not allow creation with neither email nor username', async ({ payload }) => {
     let errors = []
     try {
       await payload.create({
@@ -37,7 +22,7 @@ describe('Login With Username Feature', () => {
     expect(errors).toHaveLength(2)
   })
 
-  it('should not allow removing both username and email fields', async () => {
+  test('should not allow removing both username and email fields', async ({ payload }) => {
     const emailToUse = 'example@email.com'
     const usernameToUse = 'exampleUser'
 
@@ -89,7 +74,7 @@ describe('Login With Username Feature', () => {
     expect(errors).toHaveLength(2)
   })
 
-  it('should allow login with either username or email', async () => {
+  test('should allow login with either username or email', async ({ payload }) => {
     await payload.create({
       collection: 'login-with-either',
       data: {
@@ -118,7 +103,7 @@ describe('Login With Username Feature', () => {
     expect(loginWithUsername).toHaveProperty('token')
   })
 
-  it('should allow mutliple creates with optional email and username', async () => {
+  test('should allow mutliple creates with optional email and username', async ({ payload }) => {
     // create a user with just email
     await payload.create({
       collection: 'login-with-either',

--- a/test/login-with-username/int.spec.ts
+++ b/test/login-with-username/int.spec.ts
@@ -3,9 +3,8 @@ import { expect } from 'vitest'
 
 import { test } from '../__helpers/int/vitest.js'
 import { devUser } from '../credentials.js'
-import testConfig from './config.js'
 
-test.suite({ config: testConfig })('Login With Username Feature', () => {
+test.suite({ config: './config.ts' })('Login With Username Feature', () => {
   test('should not allow creation with neither email nor username', async ({ payload }) => {
     let errors = []
     try {

--- a/test/nested-fields/config.ts
+++ b/test/nested-fields/config.ts
@@ -16,178 +16,184 @@ import { devUser } from '../credentials.js'
 // - tabs -> named-tab -> fields
 
 export default buildConfigWithDefaults({
-  admin: {
-    importMap: {
-      baseDir: path.resolve(dirname),
+  suite: 'nested-fields',
+  config: {
+    admin: {
+      importMap: {
+        baseDir: path.resolve(dirname),
+      },
+    },
+    collections: [
+      {
+        slug: 'nested-fields',
+        fields: [
+          {
+            name: 'array',
+            type: 'array',
+            fields: [
+              {
+                type: 'row',
+                fields: [
+                  {
+                    type: 'collapsible',
+                    fields: [
+                      {
+                        name: 'group',
+                        type: 'group',
+                        fields: [
+                          {
+                            type: 'tabs',
+                            tabs: [
+                              {
+                                name: 'namedTab',
+                                fields: [
+                                  {
+                                    type: 'tabs',
+                                    tabs: [
+                                      {
+                                        fields: [
+                                          {
+                                            name: 'blocks',
+                                            type: 'blocks',
+                                            blocks: [
+                                              {
+                                                slug: 'blockWithFields',
+                                                fields: [
+                                                  {
+                                                    name: 'text',
+                                                    type: 'text',
+                                                  },
+                                                  {
+                                                    name: 'blockArray',
+                                                    type: 'array',
+                                                    fields: [
+                                                      {
+                                                        name: 'arrayText',
+                                                        type: 'text',
+                                                      },
+                                                    ],
+                                                  },
+                                                ],
+                                              },
+                                            ],
+                                          },
+                                        ],
+                                        label: 'Unnamed Tab',
+                                      },
+                                    ],
+                                  },
+                                ],
+                                label: 'Named Tab',
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                    label: 'Collapsible',
+                  },
+                ],
+              },
+            ],
+          },
+
+          {
+            type: 'tabs',
+            label: 'Tabs',
+            tabs: [
+              {
+                name: 'tab1',
+                fields: [
+                  {
+                    name: 'layout',
+                    type: 'blocks',
+                    blocks: [
+                      {
+                        slug: 'block-1',
+                        fields: [
+                          {
+                            name: 'items',
+                            type: 'array',
+                            fields: [
+                              {
+                                name: 'title',
+                                type: 'text',
+                                required: true,
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                      {
+                        slug: 'block-2',
+                        fields: [
+                          {
+                            name: 'items',
+                            type: 'array',
+                            fields: [
+                              {
+                                name: 'title2',
+                                type: 'text',
+                                required: true,
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+                label: 'Tab 1',
+              },
+            ],
+          },
+          {
+            name: 'blocksWithSimilarConfigs',
+            type: 'blocks',
+            blocks: [
+              {
+                slug: 'block-1',
+                fields: [
+                  {
+                    name: 'items',
+                    type: 'array',
+                    fields: [
+                      {
+                        name: 'title',
+                        type: 'text',
+                        required: true,
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                slug: 'block-2',
+                fields: [
+                  {
+                    name: 'items',
+                    type: 'array',
+                    fields: [
+                      {
+                        name: 'title2',
+                        type: 'text',
+                        required: true,
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+        versions: false,
+      },
+    ],
+    typescript: {
+      outputFile: path.resolve(dirname, 'payload-types.ts'),
     },
   },
-  collections: [
-    {
-      slug: 'nested-fields',
-      fields: [
-        {
-          name: 'array',
-          type: 'array',
-          fields: [
-            {
-              type: 'row',
-              fields: [
-                {
-                  label: 'Collapsible',
-                  type: 'collapsible',
-                  fields: [
-                    {
-                      type: 'group',
-                      name: 'group',
-                      fields: [
-                        {
-                          type: 'tabs',
-                          tabs: [
-                            {
-                              name: 'namedTab',
-                              label: 'Named Tab',
-                              fields: [
-                                {
-                                  type: 'tabs',
-                                  tabs: [
-                                    {
-                                      label: 'Unnamed Tab',
-                                      fields: [
-                                        {
-                                          name: 'blocks',
-                                          type: 'blocks',
-                                          blocks: [
-                                            {
-                                              slug: 'blockWithFields',
-                                              fields: [
-                                                {
-                                                  type: 'text',
-                                                  name: 'text',
-                                                },
-                                                {
-                                                  type: 'array',
-                                                  name: 'blockArray',
-                                                  fields: [
-                                                    {
-                                                      type: 'text',
-                                                      name: 'arrayText',
-                                                    },
-                                                  ],
-                                                },
-                                              ],
-                                            },
-                                          ],
-                                        },
-                                      ],
-                                    },
-                                  ],
-                                },
-                              ],
-                            },
-                          ],
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
-        },
-
-        {
-          type: 'tabs',
-          label: 'Tabs',
-          tabs: [
-            {
-              label: 'Tab 1',
-              name: 'tab1',
-              fields: [
-                {
-                  type: 'blocks',
-                  name: 'layout',
-                  blocks: [
-                    {
-                      slug: 'block-1',
-                      fields: [
-                        {
-                          type: 'array',
-                          name: 'items',
-                          fields: [
-                            {
-                              type: 'text',
-                              name: 'title',
-                              required: true,
-                            },
-                          ],
-                        },
-                      ],
-                    },
-                    {
-                      slug: 'block-2',
-                      fields: [
-                        {
-                          type: 'array',
-                          name: 'items',
-                          fields: [
-                            {
-                              type: 'text',
-                              name: 'title2',
-                              required: true,
-                            },
-                          ],
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
-        },
-        {
-          type: 'blocks',
-          name: 'blocksWithSimilarConfigs',
-          blocks: [
-            {
-              slug: 'block-1',
-              fields: [
-                {
-                  type: 'array',
-                  name: 'items',
-                  fields: [
-                    {
-                      type: 'text',
-                      name: 'title',
-                      required: true,
-                    },
-                  ],
-                },
-              ],
-            },
-            {
-              slug: 'block-2',
-              fields: [
-                {
-                  type: 'array',
-                  name: 'items',
-                  fields: [
-                    {
-                      type: 'text',
-                      name: 'title2',
-                      required: true,
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
-        },
-      ],
-      versions: false,
-    },
-  ],
-  onInit: async (payload) => {
+  seed: async (payload) => {
     await payload.create({
       collection: 'users',
       data: {
@@ -195,8 +201,5 @@ export default buildConfigWithDefaults({
         password: devUser.password,
       },
     })
-  },
-  typescript: {
-    outputFile: path.resolve(dirname, 'payload-types.ts'),
   },
 })

--- a/test/payload-cloud/config.ts
+++ b/test/payload-cloud/config.ts
@@ -17,13 +17,24 @@ dotenv.config({
 })
 
 export default buildConfigWithDefaults({
-  admin: {
-    importMap: {
-      baseDir: path.resolve(dirname),
+  suite: 'payload-cloud',
+  config: {
+    admin: {
+      importMap: {
+        baseDir: path.resolve(dirname),
+      },
+    },
+    collections: [Documents, Media, Users],
+    plugins: [payloadCloudPlugin()],
+    serverURL: process.env.PAYLOAD_PUBLIC_SERVER_URL,
+    typescript: {
+      outputFile: path.resolve(dirname, 'payload-types.ts'),
+    },
+    upload: {
+      useTempFiles: true,
     },
   },
-  collections: [Documents, Media, Users],
-  onInit: async (payload) => {
+  seed: async (payload) => {
     await payload.create({
       collection: 'users',
       data: {
@@ -31,13 +42,5 @@ export default buildConfigWithDefaults({
         password: devUser.password,
       },
     })
-  },
-  plugins: [payloadCloudPlugin()],
-  serverURL: process.env.PAYLOAD_PUBLIC_SERVER_URL,
-  typescript: {
-    outputFile: path.resolve(dirname, 'payload-types.ts'),
-  },
-  upload: {
-    useTempFiles: true,
   },
 })

--- a/test/payload-cloud/int.spec.ts
+++ b/test/payload-cloud/int.spec.ts
@@ -1,36 +1,25 @@
 import fs from 'fs'
 import path from 'path'
-import { type Payload } from 'payload'
 import { fileURLToPath } from 'url'
 import { promisify } from 'util'
-import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { expect } from 'vitest'
 
-import type { NextRESTClient } from '../__helpers/shared/NextRESTClient.js'
-
-import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
+import { test } from '../__helpers/int/vitest.js'
 import { createStreamableFile } from '../uploads/createStreamableFile.js'
+import testConfig from './config.js'
 
 const stat = promisify(fs.stat)
-
-let restClient: NextRESTClient
-let payload: Payload
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
-describe('@payloadcms/payload--cloud', () => {
-  beforeAll(async () => {
-    ;({ payload, restClient } = await initPayloadInt(dirname))
-  })
+test.suite({ config: testConfig })('@payloadcms/payload--cloud', () => {
+  test.describe('tests', () => {
+    test.todo('payload-cloud tests')
 
-  afterAll(async () => {
-    await payload.destroy()
-  })
-
-  describe('tests', () => {
-    it.todo('payload-cloud tests')
-
-    it('should not throw file MIME type error when useTempFiles is true', async () => {
+    test('should not throw file MIME type error when useTempFiles is true', async ({
+      restClient,
+    }) => {
       const formData = new FormData()
       const filePath = path.join(dirname, './image.png')
       const { file, handle } = await createStreamableFile(filePath)
@@ -46,13 +35,13 @@ describe('@payloadcms/payload--cloud', () => {
       expect(response.status).toBe(201)
     })
 
-    it.each([
+    test.for([
       { fileType: 'text', fileName: 'test-document.txt' },
       { fileType: 'PDF', fileName: 'test-pdf.pdf' },
       { fileType: 'audio', fileName: 'audio.mp3' },
     ])(
       'should save $fileType files with correct file size when useTempFiles is true',
-      async ({ fileName }) => {
+      async ({ fileName }, { payload, restClient }) => {
         const formData = new FormData()
         const filePath = path.join(dirname, `./${fileName}`)
         const originalStats = await stat(filePath)

--- a/test/payload-cloud/int.spec.ts
+++ b/test/payload-cloud/int.spec.ts
@@ -6,14 +6,13 @@ import { expect } from 'vitest'
 
 import { test } from '../__helpers/int/vitest.js'
 import { createStreamableFile } from '../uploads/createStreamableFile.js'
-import testConfig from './config.js'
 
 const stat = promisify(fs.stat)
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
-test.suite({ config: testConfig })('@payloadcms/payload--cloud', () => {
+test.suite({ config: './config.ts' })('@payloadcms/payload--cloud', () => {
   test.describe('tests', () => {
     test.todo('payload-cloud tests')
 

--- a/test/plugin-ecommerce/config.ts
+++ b/test/plugin-ecommerce/config.ts
@@ -15,6 +15,7 @@ import { Users } from './collections/Users.js'
 import { seed } from './seed/index.js'
 
 export const currenciesConfig: NonNullable<EcommercePluginConfig['currencies']> = {
+  defaultCurrency: 'USD',
   supportedCurrencies: [
     USD,
     EUR,
@@ -25,18 +26,99 @@ export const currenciesConfig: NonNullable<EcommercePluginConfig['currencies']> 
       symbol: '¥',
     },
   ],
-  defaultCurrency: 'USD',
 }
 
 export default buildConfigWithDefaults({
-  collections: [Users, Media],
-  admin: {
-    importMap: {
-      baseDir: path.resolve(dirname),
+  suite: 'plugin-ecommerce',
+  config: {
+    admin: {
+      importMap: {
+        baseDir: path.resolve(dirname),
+      },
+    },
+    collections: [Users, Media],
+    jobs: {
+      autoRun: undefined,
+    },
+    maxDepth: 10,
+    plugins: [
+      ecommercePlugin({
+        access: {
+          adminOnlyFieldAccess: ({ req }) => Boolean(req.user),
+          adminOrPublishedStatus: ({ req }) => {
+            if (req.user) {
+              return true
+            }
+
+            return {
+              _status: {
+                equals: 'published',
+              },
+            }
+          },
+          customerOnlyFieldAccess: ({ req }) => Boolean(req.user),
+          isAdmin: ({ req }) => Boolean(req.user),
+          isAuthenticated: ({ req }) => Boolean(req.user),
+          isCustomer: ({ req }) => Boolean(req.user),
+          isDocumentOwner: ({ req }) => {
+            if (req.user) {
+              return {
+                customer: {
+                  equals: req.user.id,
+                },
+              }
+            }
+            return false
+          },
+        },
+        carts: {
+          allowGuestCarts: true,
+        },
+        currencies: currenciesConfig,
+        customers: {
+          slug: 'users',
+        },
+        payments: {
+          paymentMethods: [
+            stripeAdapter({
+              publishableKey: process.env.STRIPE_PUBLISHABLE_KEY!,
+              secretKey: process.env.STRIPE_SECRET_KEY!,
+              webhooks: {
+                'payment_intent.succeeded': ({ event, req }) => {
+                  console.log({ data: event.data.object, event })
+                  req.payload.logger.info('Payment succeeded')
+                },
+              },
+              webhookSecret: process.env.STRIPE_WEBHOOKS_SECRET!,
+            }),
+          ],
+        },
+        products: {
+          productsCollectionOverride: ({ defaultCollection }) => ({
+            ...defaultCollection,
+            admin: {
+              ...defaultCollection.admin,
+              defaultColumns: ['name', ...(defaultCollection.admin?.defaultColumns ?? [])],
+              useAsTitle: 'name',
+            },
+            fields: [
+              {
+                name: 'name',
+                type: 'text',
+                required: true,
+              },
+              ...defaultCollection.fields,
+            ],
+          }),
+          variants: true,
+        },
+      }),
+    ],
+    typescript: {
+      outputFile: path.resolve(dirname, 'payload-types.ts'),
     },
   },
-  maxDepth: 10,
-  onInit: async (payload) => {
+  seed: async (payload) => {
     await payload.create({
       collection: 'users',
       data: {
@@ -46,84 +128,5 @@ export default buildConfigWithDefaults({
     })
 
     await seed(payload)
-  },
-  jobs: {
-    autoRun: undefined,
-  },
-  plugins: [
-    ecommercePlugin({
-      access: {
-        adminOnlyFieldAccess: ({ req }) => Boolean(req.user),
-        adminOrPublishedStatus: ({ req }) => {
-          if (req.user) {
-            return true
-          }
-
-          return {
-            _status: {
-              equals: 'published',
-            },
-          }
-        },
-        customerOnlyFieldAccess: ({ req }) => Boolean(req.user),
-        isAdmin: ({ req }) => Boolean(req.user),
-        isAuthenticated: ({ req }) => Boolean(req.user),
-        isCustomer: ({ req }) => Boolean(req.user),
-        isDocumentOwner: ({ req }) => {
-          if (req.user) {
-            return {
-              customer: {
-                equals: req.user.id,
-              },
-            }
-          }
-          return false
-        },
-      },
-      carts: {
-        allowGuestCarts: true,
-      },
-      customers: {
-        slug: 'users',
-      },
-      products: {
-        variants: true,
-        productsCollectionOverride: ({ defaultCollection }) => ({
-          ...defaultCollection,
-          admin: {
-            ...defaultCollection.admin,
-            defaultColumns: ['name', ...(defaultCollection.admin?.defaultColumns ?? [])],
-            useAsTitle: 'name',
-          },
-          fields: [
-            {
-              name: 'name',
-              type: 'text',
-              required: true,
-            },
-            ...defaultCollection.fields,
-          ],
-        }),
-      },
-      payments: {
-        paymentMethods: [
-          stripeAdapter({
-            secretKey: process.env.STRIPE_SECRET_KEY!,
-            publishableKey: process.env.STRIPE_PUBLISHABLE_KEY!,
-            webhookSecret: process.env.STRIPE_WEBHOOKS_SECRET!,
-            webhooks: {
-              'payment_intent.succeeded': ({ event, req }) => {
-                console.log({ event, data: event.data.object })
-                req.payload.logger.info('Payment succeeded')
-              },
-            },
-          }),
-        ],
-      },
-      currencies: currenciesConfig,
-    }),
-  ],
-  typescript: {
-    outputFile: path.resolve(dirname, 'payload-types.ts'),
   },
 })

--- a/test/plugin-ecommerce/int.spec.ts
+++ b/test/plugin-ecommerce/int.spec.ts
@@ -1,17 +1,10 @@
-import path from 'path'
-import { type Payload } from 'payload'
 import { fileURLToPath } from 'url'
-import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { expect } from 'vitest'
 
 import type { NextRESTClient } from '../__helpers/shared/NextRESTClient.js'
 
-import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
-
-let payload: Payload
-let restClient: NextRESTClient
-
-const filename = fileURLToPath(import.meta.url)
-const dirname = path.dirname(filename)
+import { test } from '../__helpers/int/vitest.js'
+import testConfig from './config.js'
 
 // Helper to create a guest cart with items
 async function createGuestCartWithItems(
@@ -50,18 +43,8 @@ async function createGuestCartWithItems(
   return { cartId, cartSecret }
 }
 
-describe('ecommerce', () => {
-  beforeAll(async () => {
-    ;({ payload, restClient } = await initPayloadInt(dirname))
-  })
-
-  afterAll(async () => {
-    if (typeof payload.db.destroy === 'function') {
-      await payload.db.destroy()
-    }
-  })
-
-  it('should add a variants collection', async () => {
+test.suite({ config: testConfig })('ecommerce', () => {
+  test('should add a variants collection', async ({ payload }) => {
     const variants = await payload.find({
       collection: 'variants',
       depth: 0,
@@ -71,7 +54,7 @@ describe('ecommerce', () => {
     expect(variants).toBeTruthy()
   })
 
-  it('should only merge plugin translations for supportedLanguages', () => {
+  test('should only merge plugin translations for supportedLanguages', ({ payload }) => {
     // The shared test buildConfig defaults supportedLanguages to { de, en, es }.
     const supportedLangKeys = Object.keys(payload.config.i18n.supportedLanguages).sort()
     expect(supportedLangKeys).toEqual(['de', 'en', 'es'])
@@ -88,8 +71,8 @@ describe('ecommerce', () => {
     expect(arTranslations?.['plugin-ecommerce']).toBeUndefined()
   })
 
-  describe('guest cart access', () => {
-    it('should allow guest users to create carts', async () => {
+  test.describe('guest cart access', () => {
+    test('should allow guest users to create carts', async ({ restClient }) => {
       // Create a cart without authentication
       const cartResponse = await restClient
         .POST('/carts', {
@@ -105,7 +88,7 @@ describe('ecommerce', () => {
       expect(cartResponse.doc.secret).toBeTruthy() // Secret should be returned on creation
     })
 
-    it('should allow access to cart with valid secret', async () => {
+    test('should allow access to cart with valid secret', async ({ restClient }) => {
       // Create a cart without authentication
       const createResponse = await restClient
         .POST('/carts', {
@@ -129,7 +112,7 @@ describe('ecommerce', () => {
       expect(readResponse.secret).toBeUndefined() // Secret should NOT be returned on subsequent reads
     })
 
-    it('should allow updating cart with valid secret', async () => {
+    test('should allow updating cart with valid secret', async ({ restClient }) => {
       // Create a cart without authentication
       const createResponse = await restClient
         .POST('/carts', {
@@ -158,7 +141,7 @@ describe('ecommerce', () => {
       expect(updateResponse.doc.purchasedAt).toBeTruthy()
     })
 
-    it('should allow deleting cart with valid secret', async () => {
+    test('should allow deleting cart with valid secret', async ({ restClient }) => {
       // Create a cart without authentication
       const createResponse = await restClient
         .POST('/carts', {
@@ -180,7 +163,7 @@ describe('ecommerce', () => {
       expect(deleteResponse).toBeTruthy()
     })
 
-    it('should deny access without valid secret', async () => {
+    test('should deny access without valid secret', async ({ restClient }) => {
       // Create a cart without authentication
       const createResponse = await restClient
         .POST('/carts', {
@@ -200,7 +183,7 @@ describe('ecommerce', () => {
       expect(readResponse.status).toBe(403)
     })
 
-    it('should deny access with incorrect secret', async () => {
+    test('should deny access with incorrect secret', async ({ restClient }) => {
       // Create a cart without authentication
       const createResponse = await restClient
         .POST('/carts', {
@@ -221,7 +204,7 @@ describe('ecommerce', () => {
       expect(readResponse.status).toBe(404)
     })
 
-    it('should not expose secret field directly', async () => {
+    test('should not expose secret field directly', async ({ restClient }) => {
       // Create a cart without authentication
       const createResponse = await restClient
         .POST('/carts', {
@@ -244,7 +227,7 @@ describe('ecommerce', () => {
       expect(readResponse.secret).toBeUndefined()
     })
 
-    it('should deny creating cart with custom secret', async () => {
+    test('should deny creating cart with custom secret', async ({ restClient }) => {
       // Try to create a cart with a custom secret
       const createResponse = await restClient.POST('/carts', {
         auth: false,
@@ -260,7 +243,7 @@ describe('ecommerce', () => {
       expect(result.doc.secret).not.toBe('custom-secret')
     })
 
-    it('should deny updating secret field', async () => {
+    test('should deny updating secret field', async ({ restClient }) => {
       // Create a cart without authentication
       const createResponse = await restClient
         .POST('/carts', {
@@ -296,11 +279,11 @@ describe('ecommerce', () => {
     })
   })
 
-  describe('cart item endpoints', () => {
+  test.describe('cart item endpoints', () => {
     let productId: string
     let variantId: string
 
-    beforeAll(async () => {
+    test.beforeEach(async ({ payload }) => {
       // Get an existing product and variant from seed data
       const products = await payload.find({
         collection: 'products',
@@ -315,8 +298,8 @@ describe('ecommerce', () => {
       variantId = variants.docs[0]?.id as string
     })
 
-    describe('add-item endpoint', () => {
-      it('should add an item to a guest cart', async () => {
+    test.describe('add-item endpoint', () => {
+      test('should add an item to a guest cart', async ({ restClient }) => {
         // Create a cart without authentication
         const createResponse = await restClient
           .POST('/carts', {
@@ -357,7 +340,7 @@ describe('ecommerce', () => {
         expect(cartResponse.items[0].quantity).toBe(2)
       })
 
-      it('should add item with variant to cart', async () => {
+      test('should add item with variant to cart', async ({ restClient }) => {
         const createResponse = await restClient
           .POST('/carts', {
             auth: false,
@@ -395,7 +378,7 @@ describe('ecommerce', () => {
         expect(cartResponse.items[0].variant).toBeTruthy()
       })
 
-      it('should increment quantity when adding same item', async () => {
+      test('should increment quantity when adding same item', async ({ restClient }) => {
         const createResponse = await restClient
           .POST('/carts', {
             auth: false,
@@ -442,7 +425,7 @@ describe('ecommerce', () => {
         expect(cartResponse.items[0].quantity).toBe(5)
       })
 
-      it('should require cart ID to add item', async () => {
+      test('should require cart ID to add item', async ({ restClient }) => {
         const addItemResponse = await restClient.POST(`/carts/nonexistent-cart-id/add-item`, {
           auth: false,
           body: JSON.stringify({
@@ -456,7 +439,7 @@ describe('ecommerce', () => {
         expect(addItemResponse.status).not.toBe(200)
       })
 
-      it('should require product in add item request', async () => {
+      test('should require product in add item request', async ({ restClient }) => {
         const createResponse = await restClient
           .POST('/carts', {
             auth: false,
@@ -484,8 +467,8 @@ describe('ecommerce', () => {
       })
     })
 
-    describe('remove-item endpoint', () => {
-      it('should remove an item from cart', async () => {
+    test.describe('remove-item endpoint', () => {
+      test('should remove an item from cart', async ({ restClient }) => {
         const { cartId, cartSecret } = await createGuestCartWithItems(restClient, productId)
 
         // Get cart to find item ID
@@ -517,7 +500,7 @@ describe('ecommerce', () => {
         expect(cartAfter.items).toHaveLength(0)
       })
 
-      it('should fail to remove nonexistent item', async () => {
+      test('should fail to remove nonexistent item', async ({ restClient }) => {
         const { cartId, cartSecret } = await createGuestCartWithItems(restClient, productId)
 
         const removeResponse = await restClient
@@ -534,8 +517,8 @@ describe('ecommerce', () => {
       })
     })
 
-    describe('update-item endpoint', () => {
-      it('should update item quantity directly', async () => {
+    test.describe('update-item endpoint', () => {
+      test('should update item quantity directly', async ({ restClient }) => {
         const { cartId, cartSecret } = await createGuestCartWithItems(restClient, productId)
 
         const cartBefore = await restClient
@@ -565,7 +548,7 @@ describe('ecommerce', () => {
         expect(cartAfter.items[0].quantity).toBe(5)
       })
 
-      it('should increment item quantity with $inc operator', async () => {
+      test('should increment item quantity with $inc operator', async ({ restClient }) => {
         const { cartId, cartSecret } = await createGuestCartWithItems(restClient, productId)
 
         const cartBefore = await restClient
@@ -596,7 +579,7 @@ describe('ecommerce', () => {
         expect(cartAfter.items[0].quantity).toBe(initialQuantity + 3)
       })
 
-      it('should decrement item quantity with $inc operator', async () => {
+      test('should decrement item quantity with $inc operator', async ({ restClient }) => {
         // First create a cart with quantity > 1
         const createResponse = await restClient
           .POST('/carts', {
@@ -650,7 +633,7 @@ describe('ecommerce', () => {
         expect(cartAfter.items[0].quantity).toBe(3)
       })
 
-      it('should remove item when quantity reaches zero', async () => {
+      test('should remove item when quantity reaches zero', async ({ restClient }) => {
         const { cartId, cartSecret } = await createGuestCartWithItems(restClient, productId)
 
         const cartBefore = await restClient
@@ -679,8 +662,8 @@ describe('ecommerce', () => {
       })
     })
 
-    describe('clear endpoint', () => {
-      it('should clear all items from cart', async () => {
+    test.describe('clear endpoint', () => {
+      test('should clear all items from cart', async ({ restClient }) => {
         // Create cart with multiple items
         const createResponse = await restClient
           .POST('/carts', {
@@ -745,7 +728,7 @@ describe('ecommerce', () => {
         expect(cartAfter.items).toHaveLength(0)
       })
 
-      it('should fail to clear nonexistent cart', async () => {
+      test('should fail to clear nonexistent cart', async ({ restClient }) => {
         const clearResponse = await restClient.POST(`/carts/nonexistent-cart-id/clear`, {
           auth: false,
           body: JSON.stringify({
@@ -758,11 +741,11 @@ describe('ecommerce', () => {
     })
   })
 
-  describe('cart merge endpoint', () => {
+  test.describe('cart merge endpoint', () => {
     let productId: string
     let variantId: string
 
-    beforeAll(async () => {
+    test.beforeEach(async ({ payload }) => {
       const products = await payload.find({
         collection: 'products',
         limit: 1,
@@ -776,7 +759,7 @@ describe('ecommerce', () => {
       variantId = variants.docs[0]?.id as string
     })
 
-    it('should merge guest cart into user cart', async () => {
+    test('should merge guest cart into user cart', async ({ payload, restClient }) => {
       // Create a guest cart with items
       const { cartId: guestCartId, cartSecret } = await createGuestCartWithItems(
         restClient,
@@ -842,7 +825,7 @@ describe('ecommerce', () => {
       expect(mergedCart.items.length).toBeGreaterThanOrEqual(1)
     })
 
-    it('should combine quantities when merging same items', async () => {
+    test('should combine quantities when merging same items', async ({ payload, restClient }) => {
       // Create guest cart with product (quantity 3)
       const createResponse = await restClient
         .POST('/carts', {
@@ -927,7 +910,7 @@ describe('ecommerce', () => {
       expect(mergedItem.quantity).toBe(5) // 3 + 2
     })
 
-    it('should delete source cart after merge', async () => {
+    test('should delete source cart after merge', async ({ payload, restClient }) => {
       const { cartId: guestCartId, cartSecret } = await createGuestCartWithItems(
         restClient,
         productId,
@@ -976,7 +959,7 @@ describe('ecommerce', () => {
       expect(guestCartResponse.status).toBe(404)
     })
 
-    it('should require authentication for merge', async () => {
+    test('should require authentication for merge', async ({ restClient }) => {
       const { cartId: guestCartId, cartSecret } = await createGuestCartWithItems(
         restClient,
         productId,
@@ -1010,7 +993,7 @@ describe('ecommerce', () => {
       expect(mergeResponse.message).toContain('Authentication required')
     })
 
-    it('should fail merge with invalid source secret', async () => {
+    test('should fail merge with invalid source secret', async ({ payload, restClient }) => {
       const { cartId: guestCartId } = await createGuestCartWithItems(restClient, productId)
 
       const testUser = await payload.create({
@@ -1052,10 +1035,10 @@ describe('ecommerce', () => {
     })
   })
 
-  describe('authenticated user cart operations', () => {
+  test.describe('authenticated user cart operations', () => {
     let productId: string
 
-    beforeAll(async () => {
+    test.beforeEach(async ({ payload }) => {
       const products = await payload.find({
         collection: 'products',
         limit: 1,
@@ -1063,7 +1046,10 @@ describe('ecommerce', () => {
       productId = products.docs[0]?.id as string
     })
 
-    it('should allow authenticated users to access their cart without secret', async () => {
+    test('should allow authenticated users to access their cart without secret', async ({
+      payload,
+      restClient,
+    }) => {
       const testUser = await payload.create({
         collection: 'users',
         data: {
@@ -1099,7 +1085,10 @@ describe('ecommerce', () => {
       expect(getResponse.id).toBe(cartId)
     })
 
-    it('should allow authenticated users to add items without secret', async () => {
+    test('should allow authenticated users to add items without secret', async ({
+      payload,
+      restClient,
+    }) => {
       const testUser = await payload.create({
         collection: 'users',
         data: {
@@ -1141,7 +1130,10 @@ describe('ecommerce', () => {
       expect(addItemResponse.success).toBe(true)
     })
 
-    it('should not generate secret for authenticated user carts', async () => {
+    test('should not generate secret for authenticated user carts', async ({
+      payload,
+      restClient,
+    }) => {
       const testUser = await payload.create({
         collection: 'users',
         data: {
@@ -1173,10 +1165,10 @@ describe('ecommerce', () => {
     })
   })
 
-  describe('cart transfer to user', () => {
+  test.describe('cart transfer to user', () => {
     let productId: string
 
-    beforeAll(async () => {
+    test.beforeEach(async ({ payload }) => {
       const products = await payload.find({
         collection: 'products',
         limit: 1,
@@ -1184,7 +1176,10 @@ describe('ecommerce', () => {
       productId = products.docs[0]?.id as string
     })
 
-    it('should allow transferring guest cart to user by updating customer field', async () => {
+    test('should allow transferring guest cart to user by updating customer field', async ({
+      payload,
+      restClient,
+    }) => {
       // Create guest cart with items
       const { cartId: guestCartId, cartSecret } = await createGuestCartWithItems(
         restClient,

--- a/test/plugin-ecommerce/int.spec.ts
+++ b/test/plugin-ecommerce/int.spec.ts
@@ -4,7 +4,6 @@ import { expect } from 'vitest'
 import type { NextRESTClient } from '../__helpers/shared/NextRESTClient.js'
 
 import { test } from '../__helpers/int/vitest.js'
-import testConfig from './config.js'
 
 // Helper to create a guest cart with items
 async function createGuestCartWithItems(
@@ -43,7 +42,7 @@ async function createGuestCartWithItems(
   return { cartId, cartSecret }
 }
 
-test.suite({ config: testConfig })('ecommerce', () => {
+test.suite({ config: './config.ts' })('ecommerce', () => {
   test('should add a variants collection', async ({ payload }) => {
     const variants = await payload.find({
       collection: 'variants',

--- a/test/plugin-form-builder/config.ts
+++ b/test/plugin-form-builder/config.ts
@@ -34,33 +34,138 @@ const colorField: Block = {
   },
 }
 
-const beforeEmail: BeforeEmail<FormSubmission> = (emails, { req: { payload }, originalDoc }) => {
+const beforeEmail: BeforeEmail<FormSubmission> = (emails, { originalDoc, req: { payload } }) => {
   return emails
 }
 
 export default buildConfigWithDefaults({
-  admin: {
-    importMap: {
-      baseDir: path.resolve(dirname),
-    },
-    components: {
-      afterNavLinks: ['/components/AfterNavLinks/index.js#AfterNavLinks'],
-      views: {
-        uploadFormTest: {
-          Component: '/components/views/UploadFormTest/index.js#UploadFormTestView',
-          path: '/upload-form-test',
+  suite: 'plugin-form-builder',
+  config: {
+    admin: {
+      components: {
+        afterNavLinks: ['/components/AfterNavLinks/index.js#AfterNavLinks'],
+        views: {
+          uploadFormTest: {
+            Component: '/components/views/UploadFormTest/index.js#UploadFormTestView',
+            path: '/upload-form-test',
+          },
         },
       },
+      importMap: {
+        baseDir: path.resolve(dirname),
+      },
+    },
+    collections: [Pages, Users, Media, Documents],
+    editor: lexicalEditor({}),
+    localization: {
+      defaultLocale: 'en',
+      fallback: true,
+      locales: ['en', 'es', 'de'],
+    },
+    // email: nodemailerAdapter(),
+    plugins: [
+      formBuilderPlugin({
+        // handlePayment: handleFormPayments,
+        // defaultToEmail: 'devs@payloadcms.com',
+        beforeEmail,
+        fields: {
+          colorField,
+          date: {
+            ...formFields.date,
+            fields: [
+              ...(formFields.date && 'fields' in formFields.date
+                ? formFields.date.fields.map((field) => {
+                    if ('name' in field && field.name === 'defaultValue') {
+                      return {
+                        ...field,
+                        admin: {
+                          ...field.admin,
+                          description: 'This is a date field',
+                        },
+                        timezone: true,
+                      } as Field
+                    }
+                    return field
+                  })
+                : []),
+            ],
+          },
+          payment: true,
+          text: {
+            ...formFields.text,
+            labels: {
+              plural: 'Custom Text Fields',
+              singular: 'Custom Text Field',
+            },
+          },
+          upload: true,
+          // payment: {
+          //     paymentProcessor: {
+          //       options: [
+          //         {
+          //           label: 'Stripe',
+          //           value: 'stripe'
+          //         },
+          //       ],
+          //       defaultValue: 'stripe',
+          //     },
+          // },
+        },
+        formOverrides: {
+          // labels: {
+          //   singular: 'Contact Form',
+          //   plural: 'Contact Forms'
+          // },
+          fields: ({ defaultFields }) => {
+            return [
+              ...defaultFields,
+              {
+                name: 'custom',
+                type: 'text',
+              },
+            ]
+          },
+        },
+        formSubmissionOverrides: {
+          access: {
+            update: ({ req }) => Boolean(req.user?.roles?.includes('admin')),
+          },
+          fields: ({ defaultFields }) => {
+            const modifiedFields: Field[] = defaultFields.map((field) => {
+              if ('name' in field && field.type === 'group' && field.name === 'payment') {
+                return {
+                  ...field,
+                  fields: [
+                    ...field.fields, // comment this out to override payments group entirely
+                    {
+                      name: 'stripeCheckoutSession',
+                      type: 'text',
+                    },
+                  ],
+                }
+              }
+
+              return field
+            })
+
+            return [
+              ...modifiedFields,
+              {
+                name: 'custom',
+                type: 'text',
+              },
+            ]
+          },
+        },
+        redirectRelationships: ['pages'],
+        uploadCollections: [mediaSlug, documentsSlug],
+      }),
+    ],
+    typescript: {
+      outputFile: path.resolve(dirname, 'payload-types.ts'),
     },
   },
-  collections: [Pages, Users, Media, Documents],
-  editor: lexicalEditor({}),
-  localization: {
-    defaultLocale: 'en',
-    fallback: true,
-    locales: ['en', 'es', 'de'],
-  },
-  onInit: async (payload) => {
+  seed: async (payload) => {
     await payload.create({
       collection: 'users',
       data: {
@@ -71,107 +176,5 @@ export default buildConfigWithDefaults({
     })
 
     await seed(payload)
-  },
-  // email: nodemailerAdapter(),
-  plugins: [
-    formBuilderPlugin({
-      // handlePayment: handleFormPayments,
-      // defaultToEmail: 'devs@payloadcms.com',
-      fields: {
-        colorField,
-        payment: true,
-        text: {
-          ...formFields.text,
-          labels: {
-            plural: 'Custom Text Fields',
-            singular: 'Custom Text Field',
-          },
-        },
-        date: {
-          ...formFields.date,
-          fields: [
-            ...(formFields.date && 'fields' in formFields.date
-              ? formFields.date.fields.map((field) => {
-                  if ('name' in field && field.name === 'defaultValue') {
-                    return {
-                      ...field,
-                      timezone: true,
-                      admin: {
-                        ...field.admin,
-                        description: 'This is a date field',
-                      },
-                    } as Field
-                  }
-                  return field
-                })
-              : []),
-          ],
-        },
-        upload: true,
-        // payment: {
-        //     paymentProcessor: {
-        //       options: [
-        //         {
-        //           label: 'Stripe',
-        //           value: 'stripe'
-        //         },
-        //       ],
-        //       defaultValue: 'stripe',
-        //     },
-        // },
-      },
-      uploadCollections: [mediaSlug, documentsSlug],
-      beforeEmail,
-      formOverrides: {
-        // labels: {
-        //   singular: 'Contact Form',
-        //   plural: 'Contact Forms'
-        // },
-        fields: ({ defaultFields }) => {
-          return [
-            ...defaultFields,
-            {
-              name: 'custom',
-              type: 'text',
-            },
-          ]
-        },
-      },
-      formSubmissionOverrides: {
-        access: {
-          update: ({ req }) => Boolean(req.user?.roles?.includes('admin')),
-        },
-        fields: ({ defaultFields }) => {
-          const modifiedFields: Field[] = defaultFields.map((field) => {
-            if ('name' in field && field.type === 'group' && field.name === 'payment') {
-              return {
-                ...field,
-                fields: [
-                  ...field.fields, // comment this out to override payments group entirely
-                  {
-                    name: 'stripeCheckoutSession',
-                    type: 'text',
-                  },
-                ],
-              }
-            }
-
-            return field
-          })
-
-          return [
-            ...modifiedFields,
-            {
-              name: 'custom',
-              type: 'text',
-            },
-          ]
-        },
-      },
-      redirectRelationships: ['pages'],
-    }),
-  ],
-  typescript: {
-    outputFile: path.resolve(dirname, 'payload-types.ts'),
   },
 })

--- a/test/plugin-form-builder/int.spec.ts
+++ b/test/plugin-form-builder/int.spec.ts
@@ -11,7 +11,6 @@ import { serializeLexical } from '../../packages/plugin-form-builder/src/utiliti
 import { replaceDoubleCurlys } from '../../packages/plugin-form-builder/src/utilities/replaceDoubleCurlys.js'
 import { test } from '../__helpers/int/vitest.js'
 import { createStreamableFile } from '../uploads/createStreamableFile.js'
-import testConfig from './config.js'
 import { documentsSlug, formsSlug, formSubmissionsSlug, mediaSlug } from './shared.js'
 
 const filename = fileURLToPath(import.meta.url)
@@ -22,7 +21,7 @@ const testImagePath = path.resolve(dirname, '../uploads/image.png')
 const testPdfPath = path.resolve(dirname, '../uploads/test-pdf.pdf')
 let form: Form
 
-test.suite({ config: testConfig })('@payloadcms/plugin-form-builder', () => {
+test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
   test.beforeEach(async ({ payload }) => {
     const formConfig: Omit<Form, 'createdAt' | 'id' | 'updatedAt'> = {
       confirmationType: 'message',

--- a/test/plugin-form-builder/int.spec.ts
+++ b/test/plugin-form-builder/int.spec.ts
@@ -1,19 +1,17 @@
-import type { Payload } from 'payload'
-
 import path from 'path'
 import { ValidationError } from 'payload'
 import { fileURLToPath } from 'url'
-import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { expect } from 'vitest'
 
-import type { NextRESTClient } from '../__helpers/shared/NextRESTClient.js'
 import type { Form } from './payload-types.js'
 
 import { handleUploads } from '../../packages/plugin-form-builder/src/collections/FormSubmissions/hooks/handleUploads.js'
 import { keyValuePairToHtmlTable } from '../../packages/plugin-form-builder/src/utilities/keyValuePairToHtmlTable.js'
 import { serializeLexical } from '../../packages/plugin-form-builder/src/utilities/lexical/serializeLexical.js'
 import { replaceDoubleCurlys } from '../../packages/plugin-form-builder/src/utilities/replaceDoubleCurlys.js'
-import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
+import { test } from '../__helpers/int/vitest.js'
 import { createStreamableFile } from '../uploads/createStreamableFile.js'
+import testConfig from './config.js'
 import { documentsSlug, formsSlug, formSubmissionsSlug, mediaSlug } from './shared.js'
 
 const filename = fileURLToPath(import.meta.url)
@@ -22,15 +20,10 @@ const dirname = path.dirname(filename)
 // Path to test image file
 const testImagePath = path.resolve(dirname, '../uploads/image.png')
 const testPdfPath = path.resolve(dirname, '../uploads/test-pdf.pdf')
-
-let payload: Payload
-let restClient: NextRESTClient
 let form: Form
 
-describe('@payloadcms/plugin-form-builder', () => {
-  beforeAll(async () => {
-    ;({ payload, restClient } = await initPayloadInt(dirname))
-
+test.suite({ config: testConfig })('@payloadcms/plugin-form-builder', () => {
+  test.beforeEach(async ({ payload }) => {
     const formConfig: Omit<Form, 'createdAt' | 'id' | 'updatedAt'> = {
       confirmationType: 'message',
       confirmationMessage: {
@@ -79,24 +72,20 @@ describe('@payloadcms/plugin-form-builder', () => {
     })) as unknown as Form
   })
 
-  afterAll(async () => {
-    await payload.destroy()
-  })
-
-  describe('plugin collections', () => {
-    it('adds forms collection', async () => {
+  test.describe('plugin collections', () => {
+    test('adds forms collection', async ({ payload }) => {
       const { docs: forms } = await payload.find({ collection: formsSlug })
       expect(forms.length).toBeGreaterThan(0)
     })
 
-    it('adds form submissions collection', async () => {
+    test('adds form submissions collection', async ({ payload }) => {
       const { docs: formSubmissions } = await payload.find({ collection: formSubmissionsSlug })
       expect(formSubmissions).toHaveLength(1)
     })
   })
 
-  describe('form building', () => {
-    it('can create a simple form', async () => {
+  test.describe('form building', () => {
+    test('can create a simple form', async ({ payload }) => {
       const formConfig: Omit<Form, 'createdAt' | 'id' | 'updatedAt'> = {
         confirmationType: 'message',
         confirmationMessage: {
@@ -149,7 +138,7 @@ describe('@payloadcms/plugin-form-builder', () => {
       expect(testForm.fields[0]).toHaveProperty('name', 'name')
     })
 
-    it('can use form overrides', async () => {
+    test('can use form overrides', async ({ payload }) => {
       const formConfig: Omit<Form, 'createdAt' | 'id' | 'updatedAt'> = {
         confirmationType: 'message',
         confirmationMessage: {
@@ -196,8 +185,8 @@ describe('@payloadcms/plugin-form-builder', () => {
     })
   })
 
-  describe('form submissions and validations', () => {
-    it('can create a form submission', async () => {
+  test.describe('form submissions and validations', () => {
+    test('can create a form submission', async ({ payload }) => {
       const formSubmission = await payload.create({
         collection: formSubmissionsSlug,
         data: {
@@ -219,7 +208,7 @@ describe('@payloadcms/plugin-form-builder', () => {
       expect(formSubmission.submissionData[0]).toHaveProperty('value', 'Test Submission')
     })
 
-    it('does not create a form submission for a non-existing form', async () => {
+    test('does not create a form submission for a non-existing form', async ({ payload }) => {
       const req = async () =>
         payload.create({
           collection: formSubmissionsSlug,
@@ -238,9 +227,9 @@ describe('@payloadcms/plugin-form-builder', () => {
       await expect(req).rejects.toThrow(ValidationError)
     })
 
-    describe('replaces curly braces', () => {
-      describe('lexical serializer', () => {
-        it('specific field names', async () => {
+    test.describe('replaces curly braces', () => {
+      test.describe('lexical serializer', () => {
+        test('specific field names', async () => {
           const mockName = 'Test Submission'
           const mockEmail = 'dev@payloadcms.com'
 
@@ -297,7 +286,7 @@ describe('@payloadcms/plugin-form-builder', () => {
           expect(serializedEmail).toContain(`Email: ${mockEmail}`)
         })
 
-        it('wildcard "{{*}}"', async () => {
+        test('wildcard "{{*}}"', async () => {
           const mockName = 'Test Submission'
           const mockEmail = 'dev@payloadcms.com'
 
@@ -341,7 +330,7 @@ describe('@payloadcms/plugin-form-builder', () => {
           expect(serializedEmail).toContain(`email : ${mockEmail}`)
         })
 
-        it('wildcard with table formatting "{{*:table}}"', async () => {
+        test('wildcard with table formatting "{{*:table}}"', async () => {
           const mockName = 'Test Submission'
           const mockEmail = 'dev@payloadcms.com'
 
@@ -386,7 +375,7 @@ describe('@payloadcms/plugin-form-builder', () => {
           expect(serializedEmail).toContain(`<tr><td>email</td><td>${mockEmail}</td></tr>`)
         })
 
-        it('serializes automatically detected links', async () => {
+        test('serializes automatically detected links', async () => {
           const url = 'https://example.com'
           const serializedEmail = await serializeLexical({
             root: {
@@ -459,19 +448,19 @@ describe('@payloadcms/plugin-form-builder', () => {
     })
   })
 
-  describe('replaceDoubleCurlys', () => {
+  test.describe('replaceDoubleCurlys', () => {
     const testVariables = [
       { field: 'name', value: '<script>alert("xss")</script>' },
       { field: '<img onerror=alert(1)>', value: 'normal' },
     ]
 
-    it('escapes HTML in named variable replacement', () => {
+    test('escapes HTML in named variable replacement', () => {
       const result = replaceDoubleCurlys('Hello {{name}}', testVariables)
       expect(result).not.toContain('<script>')
       expect(result).toContain('&lt;script&gt;')
     })
 
-    it('escapes HTML in wildcard (*) field names and values', () => {
+    test('escapes HTML in wildcard (*) field names and values', () => {
       const result = replaceDoubleCurlys('{{*}}', testVariables)
       expect(result).not.toContain('<script>')
       expect(result).not.toContain('<img')
@@ -479,7 +468,7 @@ describe('@payloadcms/plugin-form-builder', () => {
       expect(result).toContain('&lt;img onerror=alert(1)&gt;')
     })
 
-    it('escapes HTML in table (*:table) output', () => {
+    test('escapes HTML in table (*:table) output', () => {
       const result = replaceDoubleCurlys('{{*:table}}', testVariables)
       expect(result).not.toContain('<script>')
       expect(result).not.toContain('<img onerror')
@@ -487,18 +476,18 @@ describe('@payloadcms/plugin-form-builder', () => {
       expect(result).toContain('&lt;script&gt;')
     })
 
-    it('does not double-escape safe text', () => {
+    test('does not double-escape safe text', () => {
       const variables = [{ field: 'greeting', value: 'Hello World' }]
       const result = replaceDoubleCurlys('{{greeting}}', variables)
       expect(result).toBe('Hello World')
     })
 
-    it('returns original string when no variables provided', () => {
+    test('returns original string when no variables provided', () => {
       const result = replaceDoubleCurlys('{{name}}')
       expect(result).toBe('{{name}}')
     })
 
-    it('properly encodes quotes and special characters', () => {
+    test('properly encodes quotes and special characters', () => {
       const variables = [{ field: 'name', value: '"><img src=x onerror=alert(1)>' }]
       const result = replaceDoubleCurlys('Value: {{name}}', variables)
       expect(result).not.toContain('">')
@@ -507,8 +496,8 @@ describe('@payloadcms/plugin-form-builder', () => {
     })
   })
 
-  describe('keyValuePairToHtmlTable', () => {
-    it('escapes HTML in keys and values', () => {
+  test.describe('keyValuePairToHtmlTable', () => {
+    test('escapes HTML in keys and values', () => {
       const result = keyValuePairToHtmlTable({
         '<script>alert(1)</script>': '<img src=x onerror=alert(1)>',
         name: 'safe value',
@@ -522,7 +511,7 @@ describe('@payloadcms/plugin-form-builder', () => {
       expect(result).toContain('safe value')
     })
 
-    it('produces valid table structure', () => {
+    test('produces valid table structure', () => {
       const result = keyValuePairToHtmlTable({ email: 'test@test.com', name: 'John' })
       expect(result).toMatch(/^<table>.*<\/table>$/)
       expect(result).toContain('<tr><td>')
@@ -531,16 +520,16 @@ describe('@payloadcms/plugin-form-builder', () => {
     })
   })
 
-  describe('Lexical TextHTMLConverter', () => {
+  test.describe('Lexical TextHTMLConverter', () => {
     // Dynamic import to avoid circular dependency with serializeLexical
     let FormBuilderTextConverter: any
-    beforeAll(async () => {
+    test.beforeAll(async () => {
       FormBuilderTextConverter = (
         await import('../../packages/plugin-form-builder/src/utilities/lexical/converters/text.js')
       ).TextHTMLConverter
     })
 
-    it('escapes script tags in text', () => {
+    test('escapes script tags in text', () => {
       const result = FormBuilderTextConverter.converter({
         node: { format: 0, text: '<script>alert("xss")</script>' },
         submissionData: undefined,
@@ -549,7 +538,7 @@ describe('@payloadcms/plugin-form-builder', () => {
       expect(result).toContain('&lt;script&gt;')
     })
 
-    it('escapes HTML while preserving formatting', () => {
+    test('escapes HTML while preserving formatting', () => {
       const result = FormBuilderTextConverter.converter({
         node: { format: 1, text: '<img src=x onerror=alert(1)>' },
         submissionData: undefined,
@@ -559,7 +548,7 @@ describe('@payloadcms/plugin-form-builder', () => {
       expect(result).toContain('&lt;img')
     })
 
-    it('applies submission data replacement after escaping', () => {
+    test('applies submission data replacement after escaping', () => {
       const result = FormBuilderTextConverter.converter({
         node: { format: 0, text: 'Hello {{name}}' },
         submissionData: [{ field: 'name', value: '<b>World</b>' }],
@@ -570,7 +559,7 @@ describe('@payloadcms/plugin-form-builder', () => {
       expect(result).toContain('&lt;b&gt;')
     })
 
-    it('does not over-escape normal text', () => {
+    test('does not over-escape normal text', () => {
       const result = FormBuilderTextConverter.converter({
         node: { format: 0, text: 'Hello World' },
         submissionData: undefined,
@@ -579,16 +568,16 @@ describe('@payloadcms/plugin-form-builder', () => {
     })
   })
 
-  describe('Lexical LinkHTMLConverter', () => {
+  test.describe('Lexical LinkHTMLConverter', () => {
     // Dynamic import to avoid circular dependency with serializeLexical
     let FormBuilderLinkConverter: any
-    beforeAll(async () => {
+    test.beforeAll(async () => {
       FormBuilderLinkConverter = (
         await import('../../packages/plugin-form-builder/src/utilities/lexical/converters/link.js')
       ).LinkHTMLConverter
     })
 
-    it('blocks javascript: in link href', async () => {
+    test('blocks javascript: in link href', async () => {
       const result = await FormBuilderLinkConverter.converter({
         converters: [],
         node: {
@@ -602,7 +591,7 @@ describe('@payloadcms/plugin-form-builder', () => {
       expect(result).toContain('href="#"')
     })
 
-    it('blocks data: in link href', async () => {
+    test('blocks data: in link href', async () => {
       const result = await FormBuilderLinkConverter.converter({
         converters: [],
         node: {
@@ -620,7 +609,7 @@ describe('@payloadcms/plugin-form-builder', () => {
       expect(result).toContain('href="#"')
     })
 
-    it('properly encodes special characters in href', async () => {
+    test('properly encodes special characters in href', async () => {
       const result = await FormBuilderLinkConverter.converter({
         converters: [],
         node: {
@@ -635,7 +624,7 @@ describe('@payloadcms/plugin-form-builder', () => {
       expect(result).toContain('&lt;img')
     })
 
-    it('allows safe https URLs', async () => {
+    test('allows safe https URLs', async () => {
       const result = await FormBuilderLinkConverter.converter({
         converters: [],
         node: {
@@ -648,7 +637,7 @@ describe('@payloadcms/plugin-form-builder', () => {
       expect(result).toContain('href="https://example.com/page"')
     })
 
-    it('allows mailto: URLs', async () => {
+    test('allows mailto: URLs', async () => {
       const result = await FormBuilderLinkConverter.converter({
         converters: [],
         node: {
@@ -661,7 +650,7 @@ describe('@payloadcms/plugin-form-builder', () => {
       expect(result).toContain('href="mailto:test@example.com"')
     })
 
-    it('allows relative URLs', async () => {
+    test('allows relative URLs', async () => {
       const result = await FormBuilderLinkConverter.converter({
         converters: [],
         node: {
@@ -675,13 +664,13 @@ describe('@payloadcms/plugin-form-builder', () => {
     })
   })
 
-  describe('upload fields', () => {
+  test.describe('upload fields', () => {
     const createdFormIds: string[] = []
     const createdSubmissionIds: string[] = []
     const createdMediaIds: string[] = []
     const createdDocumentIds: string[] = []
 
-    afterEach(async () => {
+    test.afterEach(async ({ payload }) => {
       for (const id of createdSubmissionIds) {
         try {
           await payload.delete({ collection: formSubmissionsSlug, id })
@@ -751,8 +740,8 @@ describe('@payloadcms/plugin-form-builder', () => {
       },
     }
 
-    describe('form creation with upload fields', () => {
-      it('should create a form with a single upload field', async () => {
+    test.describe('form creation with upload fields', () => {
+      test('should create a form with a single upload field', async ({ payload }) => {
         const testForm = await payload.create({
           collection: formsSlug,
           data: {
@@ -779,7 +768,7 @@ describe('@payloadcms/plugin-form-builder', () => {
         expect(testForm.fields[0]).toHaveProperty('uploadCollection', mediaSlug)
       })
 
-      it('should create a form with multiple upload fields', async () => {
+      test('should create a form with multiple upload fields', async ({ payload }) => {
         const testForm = await payload.create({
           collection: formsSlug,
           data: {
@@ -806,7 +795,7 @@ describe('@payloadcms/plugin-form-builder', () => {
         expect(testForm.fields).toHaveLength(2)
       })
 
-      it('should create a form with mixed field types including upload', async () => {
+      test('should create a form with mixed field types including upload', async ({ payload }) => {
         const testForm = await payload.create({
           collection: formsSlug,
           data: {
@@ -828,8 +817,10 @@ describe('@payloadcms/plugin-form-builder', () => {
       })
     })
 
-    describe('required field validation', () => {
-      it('should reject submission when required upload field is missing', async () => {
+    test.describe('required field validation', () => {
+      test('should reject submission when required upload field is missing', async ({
+        payload,
+      }) => {
         const testForm = await payload.create({
           collection: formsSlug,
           data: {
@@ -861,7 +852,9 @@ describe('@payloadcms/plugin-form-builder', () => {
         ).rejects.toThrow(ValidationError)
       })
 
-      it('should reject submission when required upload field has empty string', async () => {
+      test('should reject submission when required upload field has empty string', async ({
+        payload,
+      }) => {
         const testForm = await payload.create({
           collection: formsSlug,
           data: {
@@ -893,7 +886,9 @@ describe('@payloadcms/plugin-form-builder', () => {
         ).rejects.toThrow(ValidationError)
       })
 
-      it('should accept submission when required upload field has valid file ID', async () => {
+      test('should accept submission when required upload field has valid file ID', async ({
+        payload,
+      }) => {
         // Create a test media document
         const mediaDoc = await payload.create({
           collection: mediaSlug,
@@ -940,8 +935,10 @@ describe('@payloadcms/plugin-form-builder', () => {
       })
     })
 
-    describe('optional field handling', () => {
-      it('should accept submission when optional upload field is omitted', async () => {
+    test.describe('optional field handling', () => {
+      test('should accept submission when optional upload field is omitted', async ({
+        payload,
+      }) => {
         const testForm = await payload.create({
           collection: formsSlug,
           data: {
@@ -975,7 +972,7 @@ describe('@payloadcms/plugin-form-builder', () => {
         expect(submission).toHaveProperty('id')
       })
 
-      it('should accept submission with only some upload fields filled', async () => {
+      test('should accept submission with only some upload fields filled', async ({ payload }) => {
         const mediaDoc = await payload.create({
           collection: mediaSlug,
           data: { alt: 'test' },
@@ -1029,8 +1026,8 @@ describe('@payloadcms/plugin-form-builder', () => {
       })
     })
 
-    describe('mimeType validation', () => {
-      it('should reject file with disallowed mime type', async () => {
+    test.describe('mimeType validation', () => {
+      test('should reject file with disallowed mime type', async ({ payload }) => {
         // Create a PDF document in documents collection
         const pdfDoc = await payload.create({
           collection: documentsSlug,
@@ -1073,7 +1070,7 @@ describe('@payloadcms/plugin-form-builder', () => {
         ).rejects.toThrow(ValidationError)
       })
 
-      it('should accept file with allowed mime type', async () => {
+      test('should accept file with allowed mime type', async ({ payload }) => {
         const mediaDoc = await payload.create({
           collection: mediaSlug,
           data: { alt: 'test' },
@@ -1116,8 +1113,8 @@ describe('@payloadcms/plugin-form-builder', () => {
       })
     })
 
-    describe('file reference validation', () => {
-      it('should reject non-existent file ID', async () => {
+    test.describe('file reference validation', () => {
+      test('should reject non-existent file ID', async ({ payload }) => {
         const testForm = await payload.create({
           collection: formsSlug,
           data: {
@@ -1149,8 +1146,8 @@ describe('@payloadcms/plugin-form-builder', () => {
       })
     })
 
-    describe('other form data integrity', () => {
-      it('should save all non-upload fields when upload succeeds', async () => {
+    test.describe('other form data integrity', () => {
+      test('should save all non-upload fields when upload succeeds', async ({ payload }) => {
         const mediaDoc = await payload.create({
           collection: mediaSlug,
           data: { alt: 'test' },
@@ -1203,7 +1200,7 @@ describe('@payloadcms/plugin-form-builder', () => {
         expect(submission.submissionUploads?.[0].value).toBeTruthy()
       })
 
-      it('should handle form with no upload fields same as before', async () => {
+      test('should handle form with no upload fields same as before', async ({ payload }) => {
         const testForm = await payload.create({
           collection: formsSlug,
           data: {
@@ -1231,8 +1228,8 @@ describe('@payloadcms/plugin-form-builder', () => {
       })
     })
 
-    describe('direct file upload via REST', () => {
-      it('should upload file directly with form submission', async () => {
+    test.describe('direct file upload via REST', () => {
+      test('should upload file directly with form submission', async ({ payload, restClient }) => {
         const testForm = await payload.create({
           collection: formsSlug,
           data: {
@@ -1298,7 +1295,10 @@ describe('@payloadcms/plugin-form-builder', () => {
         expect(mediaDoc).toHaveProperty('filename')
       })
 
-      it('should reject direct upload when MIME type is not allowed', async () => {
+      test('should reject direct upload when MIME type is not allowed', async ({
+        payload,
+        restClient,
+      }) => {
         const testForm = await payload.create({
           collection: formsSlug,
           data: {
@@ -1342,7 +1342,10 @@ describe('@payloadcms/plugin-form-builder', () => {
         expect(response.status).toBe(400)
       })
 
-      it('should create submission with mixed direct upload and other fields', async () => {
+      test('should create submission with mixed direct upload and other fields', async ({
+        payload,
+        restClient,
+      }) => {
         const testForm = await payload.create({
           collection: formsSlug,
           data: {
@@ -1412,7 +1415,10 @@ describe('@payloadcms/plugin-form-builder', () => {
         createdMediaIds.push(String(photoMediaId))
       })
 
-      it('should still accept pre-uploaded file IDs for backwards compatibility', async () => {
+      test('should still accept pre-uploaded file IDs for backwards compatibility', async ({
+        payload,
+        restClient,
+      }) => {
         // Pre-upload a file
         const mediaDoc = await payload.create({
           collection: mediaSlug,
@@ -1470,8 +1476,11 @@ describe('@payloadcms/plugin-form-builder', () => {
       })
     })
 
-    describe('submissionUploads population', () => {
-      it('should populate submissionUploads when direct file upload succeeds', async () => {
+    test.describe('submissionUploads population', () => {
+      test('should populate submissionUploads when direct file upload succeeds', async ({
+        payload,
+        restClient,
+      }) => {
         const testForm = await payload.create({
           collection: formsSlug,
           data: {
@@ -1531,7 +1540,10 @@ describe('@payloadcms/plugin-form-builder', () => {
         expect(result.doc.submissionUploads[0].value).toHaveLength(1)
       })
 
-      it('should populate submissionUploads when pre-uploaded file ID is provided', async () => {
+      test('should populate submissionUploads when pre-uploaded file ID is provided', async ({
+        payload,
+        restClient,
+      }) => {
         const mediaDoc = await payload.create({
           collection: mediaSlug,
           data: { alt: 'pre-upload' },
@@ -1580,7 +1592,10 @@ describe('@payloadcms/plugin-form-builder', () => {
         expect(result.doc.submissionUploads[0].value).toHaveLength(1)
       })
 
-      it('should not populate submissionUploads when form has no upload fields', async () => {
+      test('should not populate submissionUploads when form has no upload fields', async ({
+        payload,
+        restClient,
+      }) => {
         const testForm = await payload.create({
           collection: formsSlug,
           data: {
@@ -1618,7 +1633,10 @@ describe('@payloadcms/plugin-form-builder', () => {
         ).toBe(true)
       })
 
-      it('should populate one submissionUploads entry per file for multiple direct uploads', async () => {
+      test('should populate one submissionUploads entry per file for multiple direct uploads', async ({
+        payload,
+        restClient,
+      }) => {
         const testForm = await payload.create({
           collection: formsSlug,
           data: {
@@ -1680,7 +1698,10 @@ describe('@payloadcms/plugin-form-builder', () => {
         expect(result.doc.submissionUploads[0].value).toHaveLength(2)
       })
 
-      it('should populate submissionUploads for hasMany + polymorphic (multi-file media + single document)', async () => {
+      test('should populate submissionUploads for hasMany + polymorphic (multi-file media + single document)', async ({
+        payload,
+        restClient,
+      }) => {
         // Pre-upload two media files and one document
         const media1 = await payload.create({
           collection: mediaSlug,
@@ -1781,8 +1802,11 @@ describe('@payloadcms/plugin-form-builder', () => {
       })
     })
 
-    describe('multiple guard', () => {
-      it('should reject direct upload of multiple files when multiple is false', async () => {
+    test.describe('multiple guard', () => {
+      test('should reject direct upload of multiple files when multiple is false', async ({
+        payload,
+        restClient,
+      }) => {
         const testForm = await payload.create({
           collection: formsSlug,
           data: {
@@ -1837,7 +1861,9 @@ describe('@payloadcms/plugin-form-builder', () => {
         expect(errorMessages).toContain('does not allow multiple files')
       })
 
-      it('should reject comma-separated pre-uploaded IDs when multiple is false', async () => {
+      test('should reject comma-separated pre-uploaded IDs when multiple is false', async ({
+        payload,
+      }) => {
         const mediaDoc1 = await payload.create({
           collection: mediaSlug,
           data: { alt: 'first' },
@@ -1882,8 +1908,10 @@ describe('@payloadcms/plugin-form-builder', () => {
       })
     })
 
-    describe('uploadCollection allowlist guard', () => {
-      it('should reject uploads when uploadCollection is not in plugin config', async () => {
+    test.describe('uploadCollection allowlist guard', () => {
+      test('should reject uploads when uploadCollection is not in plugin config', async ({
+        payload,
+      }) => {
         // The form's select field enforces valid uploadCollection values at the schema level.
         // To test the defence-in-depth guard in handleUploads, create a valid form and call
         // the hook directly with a formConfig that excludes the form's uploadCollection.
@@ -1934,8 +1962,11 @@ describe('@payloadcms/plugin-form-builder', () => {
       })
     })
 
-    describe('dangling doc cleanup', () => {
-      it('should delete successfully created docs when a later file fails validation', async () => {
+    test.describe('dangling doc cleanup', () => {
+      test('should delete successfully created docs when a later file fails validation', async ({
+        payload,
+        restClient,
+      }) => {
         const testForm = await payload.create({
           collection: formsSlug,
           data: {

--- a/test/plugin-mcp/config.ts
+++ b/test/plugin-mcp/config.ts
@@ -23,352 +23,355 @@ const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
 export default buildConfigWithDefaults({
-  endpoints: [
-    {
-      handler: () => Response.json({ status: 'ok' }),
-      method: 'get',
-      path: '/health',
-    },
-  ],
-  admin: {
-    importMap: {
-      baseDir: path.resolve(dirname),
-    },
-  },
-  collections: [
-    Users,
-    Media,
-    DispatchMedia,
-    Posts,
-    Products,
-    Rolls,
-    ModifiedPrompts,
-    ReturnedResources,
-    Pages,
-    FieldTypes,
-  ],
-  localization: {
-    defaultLocale: 'en',
-    fallback: true,
-    locales: [
-      { code: 'en', label: 'English' },
-      { code: 'es', label: 'Spanish' },
-      { code: 'fr', label: 'French' },
-    ],
-  },
-  globals: [SiteSettings],
-  onInit: seed,
-  plugins: [
-    testRBACPlugin(),
-
-    // Plugin listed BEFORE mcp in the array — injects a tool via slug + options
-    definePlugin({
-      order: 1,
-      slug: 'before-mcp',
-      plugin: ({ config, plugins }) => {
-        const mcp = plugins['@payloadcms/plugin-mcp']
-        if (mcp?.options) {
-          const opts = mcp.options
-          opts.tools ??= {}
-          opts.tools.injectedBefore = {
-            description: 'Tool injected by a plugin listed before mcp',
-            handler: () => ({
-              content: [{ type: 'text' as const, text: 'injected-before' }],
-            }),
-            input: { type: 'object', properties: {} },
-          }
-        }
-        return config
+  suite: 'plugin-mcp',
+  config: {
+    endpoints: [
+      {
+        handler: () => Response.json({ status: 'ok' }),
+        method: 'get',
+        path: '/health',
       },
-    })(),
+    ],
+    admin: {
+      importMap: {
+        baseDir: path.resolve(dirname),
+      },
+    },
+    collections: [
+      Users,
+      Media,
+      DispatchMedia,
+      Posts,
+      Products,
+      Rolls,
+      ModifiedPrompts,
+      ReturnedResources,
+      Pages,
+      FieldTypes,
+    ],
+    localization: {
+      defaultLocale: 'en',
+      fallback: true,
+      locales: [
+        { code: 'en', label: 'English' },
+        { code: 'es', label: 'Spanish' },
+        { code: 'fr', label: 'French' },
+      ],
+    },
+    globals: [SiteSettings],
+    plugins: [
+      testRBACPlugin(),
 
-    mcpPlugin({
-      collections: {
-        users: {
-          description: 'User accounts.',
-          // Opt-in auth ops: enabling these exposes login/verify/etc. via MCP.
-          tools: {
-            auth: true,
-            forgotPassword: true,
-            login: true,
-            resetPassword: true,
-            unlock: true,
-            verify: true,
-          },
-        },
-        'field-types': {
-          description: 'A collection covering all Payload field types for MCP schema testing.',
-        },
-        pages: {
-          description: 'Pages with block-based layouts.',
-        },
-        posts: {
-          description: 'This is a Payload collection with Post documents.',
-          overrideResponse: (response, doc, req) => {
-            req.payload.logger.info('[Override MCP response for Posts]:')
-            response.content.push({
-              type: 'text',
-              text: `Override MCP response for Posts!`,
-            })
-            return response
-          },
-          tools: {
-            // Built-in override — keep `findDocuments` enabled, just tighten its
-            // client-facing description. (Built-in keys autocomplete here.)
-            find: {
-              annotations: { title: 'Find Posts' },
-              description:
-                'Find blog posts. Pass an `id` to fetch one; omit it to list with pagination.',
-            },
-
-            // Custom collection-scoped tool — exposed once as `publish`, with
-            // slug deciding which collection it acts on.
-            publish: defineCollectionTool({
-              annotations: {
-                title: 'Publish Post',
-                destructiveHint: false,
-                idempotentHint: false,
-                openWorldHint: false,
-                readOnlyHint: false,
-              },
-              description: 'Publish a draft post by ID.',
-              input: z.object({
-                id: z.string().describe('The post ID to publish.'),
+      // Plugin listed BEFORE mcp in the array — injects a tool via slug + options
+      definePlugin({
+        order: 1,
+        slug: 'before-mcp',
+        plugin: ({ config, plugins }) => {
+          const mcp = plugins['@payloadcms/plugin-mcp']
+          if (mcp?.options) {
+            const opts = mcp.options
+            opts.tools ??= {}
+            opts.tools.injectedBefore = {
+              description: 'Tool injected by a plugin listed before mcp',
+              handler: () => ({
+                content: [{ type: 'text' as const, text: 'injected-before' }],
               }),
-            }).handler(async ({ slug, input, authorizedMCP, req }) => {
-              const result = await req.payload.update({
-                id: input.id,
-                collection: slug,
-                data: { _status: 'published' },
-                req,
-                overrideAccess: authorizedMCP.overrideAccess,
+              input: { type: 'object', properties: {} },
+            }
+          }
+          return config
+        },
+      })(),
+
+      mcpPlugin({
+        collections: {
+          users: {
+            description: 'User accounts.',
+            // Opt-in auth ops: enabling these exposes login/verify/etc. via MCP.
+            tools: {
+              auth: true,
+              forgotPassword: true,
+              login: true,
+              resetPassword: true,
+              unlock: true,
+              verify: true,
+            },
+          },
+          'field-types': {
+            description: 'A collection covering all Payload field types for MCP schema testing.',
+          },
+          pages: {
+            description: 'Pages with block-based layouts.',
+          },
+          posts: {
+            description: 'This is a Payload collection with Post documents.',
+            overrideResponse: (response, doc, req) => {
+              req.payload.logger.info('[Override MCP response for Posts]:')
+              response.content.push({
+                type: 'text',
+                text: `Override MCP response for Posts!`,
               })
-              return {
-                content: [
-                  {
-                    type: 'text' as const,
-                    text: `Published ${slug} ${input.id}.\n\`\`\`json\n${JSON.stringify(result)}\n\`\`\``,
+              return response
+            },
+            tools: {
+              // Built-in override — keep `findDocuments` enabled, just tighten its
+              // client-facing description. (Built-in keys autocomplete here.)
+              find: {
+                annotations: { title: 'Find Posts' },
+                description:
+                  'Find blog posts. Pass an `id` to fetch one; omit it to list with pagination.',
+              },
+
+              // Custom collection-scoped tool — exposed once as `publish`, with
+              // slug deciding which collection it acts on.
+              publish: defineCollectionTool({
+                annotations: {
+                  title: 'Publish Post',
+                  destructiveHint: false,
+                  idempotentHint: false,
+                  openWorldHint: false,
+                  readOnlyHint: false,
+                },
+                description: 'Publish a draft post by ID.',
+                input: z.object({
+                  id: z.string().describe('The post ID to publish.'),
+                }),
+              }).handler(async ({ slug, input, authorizedMCP, req }) => {
+                const result = await req.payload.update({
+                  id: input.id,
+                  collection: slug,
+                  data: { _status: 'published' },
+                  req,
+                  overrideAccess: authorizedMCP.overrideAccess,
+                })
+                return {
+                  content: [
+                    {
+                      type: 'text' as const,
+                      text: `Published ${slug} ${input.id}.\n\`\`\`json\n${JSON.stringify(result)}\n\`\`\``,
+                    },
+                  ],
+                }
+              }),
+            },
+          },
+          media: {
+            description: 'This is a Payload collection with Media documents.',
+            // Partial-disable — all default tools except delete remain enabled.
+            tools: {
+              delete: false,
+            },
+          },
+          rolls: {
+            tools: {
+              create: false,
+            },
+          },
+        },
+        globals: {
+          'site-settings': {
+            description: 'Site-wide configuration settings.',
+            tools: {
+              find: {
+                annotations: { title: 'Find Site Settings' },
+              },
+            },
+          },
+        },
+        mcp: {
+          serverOptions: {
+            serverInfo: {
+              name: 'My Custom MCP Server',
+              version: '1.0.0',
+            },
+          },
+        },
+        tools: {
+          hiddenTool: defineTool({
+            access: () => false,
+            description: 'This tool should be hidden by its access callback',
+          }).handler(() => ({
+            content: [{ type: 'text' as const, text: 'hidden' }],
+          })),
+          diceRoll: defineTool({
+            annotations: {
+              title: 'Dice Roll',
+              destructiveHint: false,
+              idempotentHint: false,
+              openWorldHint: false,
+              readOnlyHint: false,
+            },
+            description: 'Rolls a virtual dice with a specified number of sides',
+            input: z.object({
+              sides: z
+                .number()
+                .int()
+                .min(2)
+                .max(1000)
+                .optional()
+                .default(6)
+                .describe('Number of sides on the dice (default: 6)'),
+            }),
+          }).handler(async ({ input, authorizedMCP, req }) => {
+            const sides = input.sides
+            const result = Math.floor(Math.random() * sides) + 1
+
+            req.payload.logger.info(
+              `Dice Roll MCP Tool rolled a ${sides} sided die and got a ${result}`,
+            )
+
+            await req.payload.create({
+              collection: 'rolls',
+              data: {
+                sides,
+                result,
+                user: req.user?.id,
+              },
+              req,
+              draft: true,
+              overrideAccess: authorizedMCP.overrideAccess,
+            })
+
+            return {
+              content: [
+                {
+                  type: 'text' as const,
+                  text: `# Dice Roll Result\n\n**Sides:** ${sides}\n**Result:** ${result}\n\n🎲 You rolled a **${result}** on a ${sides}-sided die!`,
+                },
+              ],
+            }
+          }),
+        },
+        prompts: {
+          echo: definePrompt({
+            argsSchema: z.object({ message: z.string() }),
+            description: 'Creates a prompt to process a message',
+            title: 'Echo Prompt',
+          }).handler(async ({ input: { message }, req }) => {
+            const { payload } = req
+
+            payload.logger.info(`Echo Prompt was sent: ${message}`)
+
+            const modifiedPrompt = `This prompt was sent: ${message}`
+
+            await payload.create({
+              collection: 'modified-prompts',
+              data: {
+                original: message,
+                modified: modifiedPrompt,
+                user: req.user?.id,
+              },
+              req,
+              draft: true,
+              overrideAccess: false,
+            })
+
+            return {
+              messages: [
+                {
+                  content: { type: 'text', text: modifiedPrompt },
+                  role: 'user',
+                },
+                {
+                  content: {
+                    type: 'text',
+                    text: `This prompt was sent by userId: ${req.user?.id}`,
                   },
+                  role: 'assistant',
+                },
+              ],
+            }
+          }),
+        },
+        resources: {
+          data: {
+            description: 'Data is a resource that contains special data.',
+            handler: async ({ req, uri }) => {
+              const payload = req.payload
+
+              payload.logger.info(`Data resource was requested`)
+
+              const text = 'My special data.'
+              await payload.create({
+                collection: 'returned-resources',
+                data: {
+                  uri: uri.href,
+                  content: text,
+                  user: req.user?.id,
+                },
+                req,
+                draft: true,
+                overrideAccess: false,
+              })
+
+              return {
+                contents: [
+                  { uri: uri.href, text },
+                  { uri: uri.href, text: `This was requested by user: ${req.user?.id}` },
                 ],
               }
-            }),
-          },
-        },
-        media: {
-          description: 'This is a Payload collection with Media documents.',
-          // Partial-disable — all default tools except delete remain enabled.
-          tools: {
-            delete: false,
-          },
-        },
-        rolls: {
-          tools: {
-            create: false,
-          },
-        },
-      },
-      globals: {
-        'site-settings': {
-          description: 'Site-wide configuration settings.',
-          tools: {
-            find: {
-              annotations: { title: 'Find Site Settings' },
             },
+            mimeType: 'text/plain',
+            title: 'Data',
+            uri: 'data://app',
           },
-        },
-      },
-      mcp: {
-        serverOptions: {
-          serverInfo: {
-            name: 'My Custom MCP Server',
-            version: '1.0.0',
-          },
-        },
-      },
-      tools: {
-        hiddenTool: defineTool({
-          access: () => false,
-          description: 'This tool should be hidden by its access callback',
-        }).handler(() => ({
-          content: [{ type: 'text' as const, text: 'hidden' }],
-        })),
-        diceRoll: defineTool({
-          annotations: {
-            title: 'Dice Roll',
-            destructiveHint: false,
-            idempotentHint: false,
-            openWorldHint: false,
-            readOnlyHint: false,
-          },
-          description: 'Rolls a virtual dice with a specified number of sides',
-          input: z.object({
-            sides: z
-              .number()
-              .int()
-              .min(2)
-              .max(1000)
-              .optional()
-              .default(6)
-              .describe('Number of sides on the dice (default: 6)'),
-          }),
-        }).handler(async ({ input, authorizedMCP, req }) => {
-          const sides = input.sides
-          const result = Math.floor(Math.random() * sides) + 1
+          dataByID: {
+            description: 'Data is a resource that contains special data.',
+            handler: async ({ params: { id }, req, uri }) => {
+              const payload = req.payload
 
-          req.payload.logger.info(
-            `Dice Roll MCP Tool rolled a ${sides} sided die and got a ${result}`,
-          )
+              payload.logger.info(`Data by ID resource was requested`)
 
-          await req.payload.create({
-            collection: 'rolls',
-            data: {
-              sides,
-              result,
-              user: req.user?.id,
-            },
-            req,
-            draft: true,
-            overrideAccess: authorizedMCP.overrideAccess,
-          })
-
-          return {
-            content: [
-              {
-                type: 'text' as const,
-                text: `# Dice Roll Result\n\n**Sides:** ${sides}\n**Result:** ${result}\n\n🎲 You rolled a **${result}** on a ${sides}-sided die!`,
-              },
-            ],
-          }
-        }),
-      },
-      prompts: {
-        echo: definePrompt({
-          argsSchema: z.object({ message: z.string() }),
-          description: 'Creates a prompt to process a message',
-          title: 'Echo Prompt',
-        }).handler(async ({ input: { message }, req }) => {
-          const { payload } = req
-
-          payload.logger.info(`Echo Prompt was sent: ${message}`)
-
-          const modifiedPrompt = `This prompt was sent: ${message}`
-
-          await payload.create({
-            collection: 'modified-prompts',
-            data: {
-              original: message,
-              modified: modifiedPrompt,
-              user: req.user?.id,
-            },
-            req,
-            draft: true,
-            overrideAccess: false,
-          })
-
-          return {
-            messages: [
-              {
-                content: { type: 'text', text: modifiedPrompt },
-                role: 'user',
-              },
-              {
-                content: {
-                  type: 'text',
-                  text: `This prompt was sent by userId: ${req.user?.id}`,
+              const text = `My special data for ID: ${id}`
+              await payload.create({
+                collection: 'returned-resources',
+                data: {
+                  uri: uri.href,
+                  content: text,
+                  user: req.user?.id,
                 },
-                role: 'assistant',
-              },
-            ],
-          }
-        }),
-      },
-      resources: {
-        data: {
-          description: 'Data is a resource that contains special data.',
-          handler: async ({ req, uri }) => {
-            const payload = req.payload
+                req,
+                draft: true,
+                overrideAccess: false,
+              })
 
-            payload.logger.info(`Data resource was requested`)
-
-            const text = 'My special data.'
-            await payload.create({
-              collection: 'returned-resources',
-              data: {
-                uri: uri.href,
-                content: text,
-                user: req.user?.id,
-              },
-              req,
-              draft: true,
-              overrideAccess: false,
-            })
-
-            return {
-              contents: [
-                { uri: uri.href, text },
-                { uri: uri.href, text: `This was requested by user: ${req.user?.id}` },
-              ],
-            }
+              return {
+                contents: [
+                  { uri: uri.href, text },
+                  { uri: uri.href, text: `This was requested by user: ${req.user?.id}` },
+                ],
+              }
+            },
+            mimeType: 'text/plain',
+            title: 'Data By ID',
+            uri: new ResourceTemplate('data://app/{id}', { list: undefined }),
           },
-          mimeType: 'text/plain',
-          title: 'Data',
-          uri: 'data://app',
         },
-        dataByID: {
-          description: 'Data is a resource that contains special data.',
-          handler: async ({ params: { id }, req, uri }) => {
-            const payload = req.payload
-
-            payload.logger.info(`Data by ID resource was requested`)
-
-            const text = `My special data for ID: ${id}`
-            await payload.create({
-              collection: 'returned-resources',
-              data: {
-                uri: uri.href,
-                content: text,
-                user: req.user?.id,
-              },
-              req,
-              draft: true,
-              overrideAccess: false,
-            })
-
-            return {
-              contents: [
-                { uri: uri.href, text },
-                { uri: uri.href, text: `This was requested by user: ${req.user?.id}` },
-              ],
+      }),
+      // Plugin listed AFTER mcp in the array — also injects a tool via slug + options
+      definePlugin({
+        order: 1,
+        slug: 'after-mcp',
+        plugin: ({ config, plugins }) => {
+          const mcp = plugins['@payloadcms/plugin-mcp']
+          if (mcp?.options) {
+            const opts = mcp.options
+            opts.tools ??= {}
+            opts.tools.injectedAfter = {
+              description: 'Tool injected by a plugin listed after mcp',
+              handler: () => ({
+                content: [{ type: 'text' as const, text: 'injected-after' }],
+              }),
+              input: { type: 'object', properties: {} },
             }
-          },
-          mimeType: 'text/plain',
-          title: 'Data By ID',
-          uri: new ResourceTemplate('data://app/{id}', { list: undefined }),
-        },
-      },
-    }),
-    // Plugin listed AFTER mcp in the array — also injects a tool via slug + options
-    definePlugin({
-      order: 1,
-      slug: 'after-mcp',
-      plugin: ({ config, plugins }) => {
-        const mcp = plugins['@payloadcms/plugin-mcp']
-        if (mcp?.options) {
-          const opts = mcp.options
-          opts.tools ??= {}
-          opts.tools.injectedAfter = {
-            description: 'Tool injected by a plugin listed after mcp',
-            handler: () => ({
-              content: [{ type: 'text' as const, text: 'injected-after' }],
-            }),
-            input: { type: 'object', properties: {} },
           }
-        }
-        return config
-      },
-    })(),
-  ],
-  typescript: {
-    outputFile: path.resolve(dirname, 'payload-types.ts'),
+          return config
+        },
+      })(),
+    ],
+    typescript: {
+      outputFile: path.resolve(dirname, 'payload-types.ts'),
+    },
   },
+  seed,
 })

--- a/test/plugin-mcp/helpers/mcpFixtures.ts
+++ b/test/plugin-mcp/helpers/mcpFixtures.ts
@@ -1,5 +1,5 @@
 import type { ProtocolEra } from '@modelcontextprotocol/client'
-import type { Payload, SanitizedConfig } from 'payload'
+import type { Payload } from 'payload'
 
 import { randomUUID } from 'crypto'
 import { onTestFinished } from 'vitest'
@@ -99,12 +99,7 @@ const protocolEras: Array<{ label: string; protocolEra: ProtocolEra }> = [
 ]
 
 export const test = Object.assign(payloadTest, {
-  suite: ({ config }: { config: Promise<SanitizedConfig> | SanitizedConfig }) => {
-    payloadTest.override('testConfig', config)
-    payloadTest.override('testSuiteConfigured', true)
-
-    return payloadTest.describe
-  },
+  suite: base.suite,
 })
 
 /** Registers every MCP integration test independently against both protocol eras. */

--- a/test/plugin-mcp/helpers/mcpFixtures.ts
+++ b/test/plugin-mcp/helpers/mcpFixtures.ts
@@ -1,155 +1,151 @@
 import type { ProtocolEra } from '@modelcontextprotocol/client'
-import type { Payload } from 'payload'
+import type { Payload, SanitizedConfig } from 'payload'
 
 import { randomUUID } from 'crypto'
-import path from 'path'
-import { fileURLToPath } from 'url'
-import { test as base, onTestFinished } from 'vitest'
+import { onTestFinished } from 'vitest'
 
 import type { TestRBAC } from '../../__helpers/plugins/rbac/index.js'
 import type { NextRESTClient } from '../../__helpers/shared/NextRESTClient.js'
 import type { McpClient } from './mcpClient.js'
 
-import { initPayloadInt } from '../../__helpers/shared/initPayloadInt.js'
+import { test as base } from '../../__helpers/int/vitest.js'
 import { devUser } from '../../credentials.js'
 import { createMcpClient } from './mcpClient.js'
 
-export let payload: Payload
-export let restClient: NextRESTClient
-export let limitedUserId: string
-export let userId: string
-
-export async function getApiKey(rbac: TestRBAC = {}): Promise<string> {
-  const apiKey = randomUUID()
-
-  await payload.update({
-    id: userId,
-    collection: 'users',
-    data: {
-      apiKey,
-      enableAPIKey: true,
-      rbac,
-    },
-    overrideAccess: true,
-  })
-
-  return apiKey
+type McpSetup = {
+  getApiKey: (rbac?: TestRBAC) => Promise<string>
+  getLimitedApiKey: () => Promise<string>
+  limitedUserId: string
+  userId: string
 }
 
-export async function getLimitedApiKey(): Promise<string> {
-  const apiKey = randomUUID()
-
-  await payload.update({
-    id: limitedUserId,
-    collection: 'users',
-    data: {
-      apiKey,
-      enableAPIKey: true,
-    },
-    overrideAccess: true,
-  })
-
-  return apiKey
-}
-
-const fixtureDir = path.dirname(fileURLToPath(import.meta.url))
-const suiteDir = path.resolve(fixtureDir, '..')
-
-type McpTestContext = {
+type McpTestContext = McpSetup & {
   mcp: McpClient
+  payload: Payload
   protocolEra: ProtocolEra
+  restClient: NextRESTClient
 }
 
 type McpTestFunction = (context: McpTestContext) => Promise<void> | void
 
-type ScopedFixtures = {
-  $worker: { _setup: void }
-}
+const payloadTest = base.extend<'mcpSetup', McpSetup>(
+  'mcpSetup',
+  { auto: true },
+  async ({ payload, restClient }) => {
+    const loginResponse: { user: { id: string } } = await restClient
+      .POST('/users/login', {
+        body: JSON.stringify({ email: devUser.email, password: devUser.password }),
+      })
+      .then((res) => res.json())
+    const userId = loginResponse.user.id
 
-const payloadTest = base.extend<ScopedFixtures>({
-  _setup: [
-    // eslint-disable-next-line no-empty-pattern
-    async ({}, use) => {
-      const initialized = await initPayloadInt(suiteDir)
-      payload = initialized.payload
-      restClient = initialized.restClient
+    const limitedUser = await payload.create({
+      collection: 'users',
+      data: {
+        email: 'limited-mcp-user@payloadcms.com',
+        password: randomUUID(),
+        rbac: {
+          globals: {
+            'site-settings': {
+              update: false,
+            },
+          },
+        } satisfies TestRBAC,
+      },
+      overrideAccess: true,
+    })
+    const limitedUserId = limitedUser.id
 
-      const loginResponse: { user: { id: string } } = await restClient
-        .POST('/users/login', {
-          body: JSON.stringify({ email: devUser.email, password: devUser.password }),
-        })
-        .then((res) => res.json())
-      userId = loginResponse.user.id
+    const getApiKey = async (rbac: TestRBAC = {}): Promise<string> => {
+      const apiKey = randomUUID()
 
-      const limitedUser = await payload.create({
+      await payload.update({
+        id: userId,
         collection: 'users',
         data: {
-          email: 'limited-mcp-user@payloadcms.com',
-          password: randomUUID(),
-          rbac: {
-            globals: {
-              'site-settings': {
-                update: false,
-              },
-            },
-          } satisfies TestRBAC,
+          apiKey,
+          enableAPIKey: true,
+          rbac,
         },
         overrideAccess: true,
       })
-      limitedUserId = limitedUser.id
 
-      await use()
+      return apiKey
+    }
 
-      await payload.delete({
+    const getLimitedApiKey = async (): Promise<string> => {
+      const apiKey = randomUUID()
+
+      await payload.update({
         id: limitedUserId,
         collection: 'users',
+        data: {
+          apiKey,
+          enableAPIKey: true,
+        },
         overrideAccess: true,
       })
-      await payload.destroy()
-    },
-    { auto: true, scope: 'worker' },
-  ],
-})
+
+      return apiKey
+    }
+
+    return { getApiKey, getLimitedApiKey, limitedUserId, userId }
+  },
+)
 
 const protocolEras: Array<{ label: string; protocolEra: ProtocolEra }> = [
   { label: '2025 legacy', protocolEra: 'legacy' },
   { label: '2026 modern', protocolEra: 'modern' },
 ]
 
+export const test = Object.assign(payloadTest, {
+  suite: ({ config }: { config: Promise<SanitizedConfig> | SanitizedConfig }) => {
+    payloadTest.override('testConfig', config)
+    payloadTest.override('testSuiteConfigured', true)
+
+    return payloadTest.describe
+  },
+})
+
 /** Registers every MCP integration test independently against both protocol eras. */
-export function it(name: string, test: McpTestFunction, timeout?: number): void {
+export function it(name: string, testFunction: McpTestFunction, timeout?: number): void {
   for (const { label, protocolEra } of protocolEras) {
-    registerMcpTest({ name, label, protocolEra, test, timeout })
+    registerMcpTest({ label, name, protocolEra, testFunction, timeout })
   }
 }
 
 /** Registers an integration test for behavior that exists only in the modern era. */
-export function itModern(name: string, test: McpTestFunction, timeout?: number): void {
-  registerMcpTest({ name, label: '2026 modern', protocolEra: 'modern', test, timeout })
+export function itModern(name: string, testFunction: McpTestFunction, timeout?: number): void {
+  registerMcpTest({
+    label: '2026 modern',
+    name,
+    protocolEra: 'modern',
+    testFunction,
+    timeout,
+  })
 }
 
 const registerMcpTest = ({
-  name,
   label,
+  name,
   protocolEra,
-  test,
+  testFunction,
   timeout,
 }: {
   label: string
   name: string
   protocolEra: ProtocolEra
-  test: McpTestFunction
+  testFunction: McpTestFunction
   timeout?: number
 }): void => {
   payloadTest(
     `${name} [${label}]`,
-    // eslint-disable-next-line no-empty-pattern
-    async ({}) => {
+    async ({ mcpSetup, payload, restClient }) => {
       const mcp = createMcpClient({ protocolEra, restClient })
 
       onTestFinished(() => mcp.close())
 
-      await test({ mcp, protocolEra })
+      await testFunction({ mcp, payload, protocolEra, restClient, ...mcpSetup })
     },
     timeout,
   )

--- a/test/plugin-mcp/int.spec.ts
+++ b/test/plugin-mcp/int.spec.ts
@@ -9,7 +9,6 @@ import { expect, vi } from 'vitest'
 import type { TestFileServer } from '../__helpers/shared/startTestFileServer.js'
 
 import { startTestFileServer } from '../__helpers/shared/startTestFileServer.js'
-import testConfig from './config.js'
 import { getToolDoc, getToolText } from './helpers/mcpClient.js'
 import { it, itModern, test } from './helpers/mcpFixtures.js'
 const dirname = path.dirname(fileURLToPath(import.meta.url))
@@ -101,7 +100,7 @@ function draft2020Violations(schema: unknown, rootPath: string): string[] {
   walk(schema, rootPath)
   return errors
 }
-test.suite({ config: testConfig })('@payloadcms/plugin-mcp', () => {
+test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
   test.afterEach(() => {
     vi.unstubAllEnvs()
   })

--- a/test/plugin-mcp/int.spec.ts
+++ b/test/plugin-mcp/int.spec.ts
@@ -4,24 +4,15 @@ import type { UploadInstructions } from 'payload'
 import { readFile } from 'fs/promises'
 import path from 'path'
 import { fileURLToPath } from 'url'
-import { afterEach, describe, expect, vi } from 'vitest'
+import { expect, vi } from 'vitest'
 
 import type { TestFileServer } from '../__helpers/shared/startTestFileServer.js'
 
 import { startTestFileServer } from '../__helpers/shared/startTestFileServer.js'
+import testConfig from './config.js'
 import { getToolDoc, getToolText } from './helpers/mcpClient.js'
-import {
-  getApiKey,
-  getLimitedApiKey,
-  it,
-  itModern,
-  payload,
-  restClient,
-  userId,
-} from './helpers/mcpFixtures.js'
-
+import { it, itModern, test } from './helpers/mcpFixtures.js'
 const dirname = path.dirname(fileURLToPath(import.meta.url))
-
 type CreateOneDocumentInput = {
   slug: string
   data: Record<string, unknown>
@@ -33,10 +24,13 @@ type CreateOneDocumentInput = {
   returning?: boolean
   select?: Record<string, unknown>
 }
-
 const callCreateDocumentsWithOne = async (
   client: Client,
-  { arguments: { data, file, ...options } }: { arguments: CreateOneDocumentInput },
+  {
+    arguments: { data, file, ...options },
+  }: {
+    arguments: CreateOneDocumentInput
+  },
 ) =>
   client.callTool({
     arguments: {
@@ -46,22 +40,24 @@ const callCreateDocumentsWithOne = async (
     },
     name: 'createDocuments',
   })
-
 const getCreatedDocument = <T = Record<string, unknown>>(
   result: Parameters<typeof getToolDoc>[0],
 ): T => {
   const batch = getToolDoc<{
-    docs: Array<{ doc: T; index: number }>
-    errors: Array<{ index: number; message: string }>
+    docs: Array<{
+      doc: T
+      index: number
+    }>
+    errors: Array<{
+      index: number
+      message: string
+    }>
   }>(result)
-
   if (batch.docs.length !== 1 || batch.errors.length > 0) {
     throw new Error(`Expected exactly one created document: ${JSON.stringify(batch)}`)
   }
-
   return batch.docs[0]!.doc
 }
-
 /**
  * Reports JSON Schema draft 2020-12 violations in a tool's `input_schema
  */
@@ -105,61 +101,50 @@ function draft2020Violations(schema: unknown, rootPath: string): string[] {
   walk(schema, rootPath)
   return errors
 }
-
-describe('@payloadcms/plugin-mcp', () => {
-  afterEach(() => {
+test.suite({ config: testConfig })('@payloadcms/plugin-mcp', () => {
+  test.afterEach(() => {
     vi.unstubAllEnvs()
   })
-
-  it('should handle an era-supported basic request', async ({ mcp, protocolEra }) => {
+  it('should handle an era-supported basic request', async ({ mcp, protocolEra, getApiKey }) => {
     const apiKey = await getApiKey()
     const client = await mcp.connect(apiKey)
-
     // ping was removed from the modern wire vocabulary, but remains part of
     // the 2025 era and should retain its previous integration coverage.
     const response = protocolEra === 'legacy' ? await client.ping() : await client.listTools()
-
     expect(response).toBeDefined()
   })
-
-  it('should negotiate the requested protocol era', async ({ mcp, protocolEra }) => {
+  it('should negotiate the requested protocol era', async ({ mcp, protocolEra, getApiKey }) => {
     const apiKey = await getApiKey()
     const client = await mcp.connect(apiKey)
-
     expect(client.getProtocolEra()).toBe(protocolEra)
   })
-
   it('should reject invalid API keys before MCP handling', async ({ mcp }) => {
     await expect(mcp.connect('invalid-api-key')).rejects.toThrow()
-
     expect(
       mcp.getHTTPResponses().some(({ method, status }) => method === 'POST' && status === 401),
     ).toBe(true)
   })
-
-  it('should keep simultaneous requests separate', async ({ mcp }) => {
+  it('should keep simultaneous requests separate', async ({ mcp, getApiKey, getLimitedApiKey }) => {
     const [apiKey, limitedApiKey] = await Promise.all([getApiKey(), getLimitedApiKey()])
     const [client, limitedClient] = await Promise.all([
       mcp.connect(apiKey),
       mcp.connect(limitedApiKey),
     ])
     const [tools, limitedTools] = await Promise.all([client.listTools(), limitedClient.listTools()])
-
     expect(tools.tools.some((tool) => tool.name === 'updateGlobal')).toBe(true)
     expect(limitedTools.tools.some((tool) => tool.name === 'updateGlobal')).toBe(false)
   })
-
-  it('should return JSON responses without SSE in either protocol era', async ({ mcp }) => {
+  it('should return JSON responses without SSE in either protocol era', async ({
+    mcp,
+    getApiKey,
+  }) => {
     const apiKey = await getApiKey()
     const client = await mcp.connect(apiKey)
-
     await client.listTools()
-
     const responses = mcp.getHTTPResponses()
     const successfulPostResponses = responses.filter(
       ({ method, status }) => method === 'POST' && status === 200,
     )
-
     expect(successfulPostResponses.length).toBeGreaterThan(0)
     expect(
       successfulPostResponses.every(({ contentType }) => contentType === 'application/json'),
@@ -168,27 +153,27 @@ describe('@payloadcms/plugin-mcp', () => {
       false,
     )
   })
-
-  it('should reject misleading non-JSON content types', async ({ mcp }) => {
+  it('should reject misleading non-JSON content types', async ({ mcp, getApiKey }) => {
     const apiKey = await getApiKey()
     const response = await mcp.rawPost({
       apiKey,
       body: {},
       contentType: 'text/plain; profile=application/json',
     })
-
     expect(response.status).toBe(415)
     await expect(response.json()).resolves.toEqual({
       error: {
-        code: -32_000,
+        code: -32000,
         message: 'Unsupported Media Type: Content-Type must be application/json',
       },
       id: null,
       jsonrpc: '2.0',
     })
   })
-
-  it('should accept JSON content types case-insensitively and with parameters', async ({ mcp }) => {
+  it('should accept JSON content types case-insensitively and with parameters', async ({
+    mcp,
+    getApiKey,
+  }) => {
     const apiKey = await getApiKey()
     const response = await mcp.rawPost({
       apiKey,
@@ -204,21 +189,16 @@ describe('@payloadcms/plugin-mcp', () => {
       },
       contentType: 'Application/JSON; charset=utf-8',
     })
-
     expect(response.status).toBe(200)
   })
-
   /* eslint-disable vitest/no-standalone-expect -- itModern is a custom Vitest test registrar. */
-  itModern('should reject subscription streams without opening SSE', async ({ mcp }) => {
+  itModern('should reject subscription streams without opening SSE', async ({ mcp, getApiKey }) => {
     const apiKey = await getApiKey()
     const client = await mcp.connect(apiKey)
-
     await expect(client.listen({ toolsListChanged: true })).rejects.toThrow(
       'Subscription limit reached',
     )
-
     const responses = mcp.getHTTPResponses()
-
     expect(responses.at(-1)).toMatchObject({
       contentType: 'application/json',
       method: 'POST',
@@ -229,22 +209,22 @@ describe('@payloadcms/plugin-mcp', () => {
     )
   })
   /* eslint-enable vitest/no-standalone-expect */
-
-  describe('API Keyed Access', () => {
-    it('should not allow GET /api/mcp', async () => {
+  test.describe('API Keyed Access', () => {
+    it('should not allow GET /api/mcp', async ({ getApiKey, restClient }) => {
       const apiKey = await getApiKey()
       const response = await restClient.GET(`/mcp`, {
         headers: {
           Authorization: `users API-Key ${apiKey}`,
         },
       })
-
       // MCP is POST-only; the optional GET stream answers 405 (Method Not Allowed)
       // per the Streamable HTTP spec, so clients skip the server-push stream.
       expect(response.status).toBe(405)
     })
-
-    it('should not allow POST /api/mcp with unauthorized API key', async () => {
+    it('should not allow POST /api/mcp with unauthorized API key', async ({
+      getApiKey,
+      restClient,
+    }) => {
       const apiKey = await getApiKey()
       const response = await restClient.POST('/mcp', {
         body: JSON.stringify({}),
@@ -254,17 +234,17 @@ describe('@payloadcms/plugin-mcp', () => {
           'Content-Type': 'application/json',
         },
       })
-
       const json: any = await response.json()
-
       expect(response.status).toBe(401)
       expect(json?.errors).toBeDefined()
       expect(json.errors[0].message).toBe(
         'Unauthorized, you must be logged in to make this request.',
       )
     })
-
-    it('should not accept Bearer API keys for default API-key auth', async () => {
+    it('should not accept Bearer API keys for default API-key auth', async ({
+      getApiKey,
+      restClient,
+    }) => {
       const apiKey = await getApiKey()
       const response = await restClient.POST('/mcp', {
         body: JSON.stringify({}),
@@ -274,9 +254,7 @@ describe('@payloadcms/plugin-mcp', () => {
           'Content-Type': 'application/json',
         },
       })
-
       const json: any = await response.json()
-
       expect(response.status).toBe(401)
       expect(json?.errors).toBeDefined()
       expect(json.errors[0].message).toBe(
@@ -284,9 +262,8 @@ describe('@payloadcms/plugin-mcp', () => {
       )
     })
   })
-
-  describe('List', () => {
-    it('should list tools', async ({ mcp }) => {
+  test.describe('List', () => {
+    it('should list tools', async ({ mcp, getApiKey, payload }) => {
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
       const toolsResponse = await client.listTools()
@@ -294,7 +271,6 @@ describe('@payloadcms/plugin-mcp', () => {
       expect(toolsResponse.tools).toBeDefined()
       expect(Array.isArray(toolsResponse.tools)).toBe(true)
       expect(toolsResponse.tools.length).toBeGreaterThan(0)
-
       const toolsByName: Record<string, any> = Object.fromEntries(
         toolsResponse.tools.map((t: { name: string }) => [t.name, t]),
       )
@@ -305,9 +281,7 @@ describe('@payloadcms/plugin-mcp', () => {
       const rollToolKeys = pluginItems
         .filter((item: any) => item.type === 'collectionTool' && item.collectionSlug === 'rolls')
         .map((item: any) => item.configKey)
-
       expect(rollToolKeys).not.toContain('create')
-
       const getConfigInfo = toolsByName['getConfigInfo']
       expect(getConfigInfo).toBeDefined()
       expect(getConfigInfo.description).toContain('List the Payload collection and global slugs')
@@ -322,7 +296,6 @@ describe('@payloadcms/plugin-mcp', () => {
         pluginItems.find((item: any) => item.type === 'tool' && item.configKey === 'getConfigInfo')
           ?.label,
       ).toBe('Config Info')
-
       const createDocuments = toolsByName['createDocuments']
       expect(createDocuments).toBeDefined()
       expect(createDocuments.description).toContain('Create one or more documents')
@@ -334,7 +307,6 @@ describe('@payloadcms/plugin-mcp', () => {
         readOnlyHint: false,
       })
       expect(toolsByName.createDocument).toBeUndefined()
-
       const findDocuments = toolsByName['findDocuments']
       expect(findDocuments).toBeDefined()
       expect(findDocuments.description).toContain('Find documents in any collection')
@@ -353,7 +325,6 @@ describe('@payloadcms/plugin-mcp', () => {
             item.configKey === 'find',
         )?.label,
       ).toBe('Find Posts')
-
       const countDocuments = toolsByName['countDocuments']
       expect(countDocuments).toBeDefined()
       expect(countDocuments.annotations).toMatchObject({
@@ -363,7 +334,6 @@ describe('@payloadcms/plugin-mcp', () => {
         openWorldHint: false,
         readOnlyHint: true,
       })
-
       const duplicateDocument = toolsByName['duplicateDocument']
       expect(duplicateDocument).toBeDefined()
       expect(duplicateDocument.annotations).toMatchObject({
@@ -373,7 +343,6 @@ describe('@payloadcms/plugin-mcp', () => {
         openWorldHint: false,
         readOnlyHint: false,
       })
-
       const findDistinct = toolsByName['findDistinct']
       expect(findDistinct).toBeDefined()
       expect(findDistinct.annotations).toMatchObject({
@@ -383,7 +352,6 @@ describe('@payloadcms/plugin-mcp', () => {
         openWorldHint: false,
         readOnlyHint: true,
       })
-
       const findVersions = toolsByName['findVersions']
       expect(findVersions).toBeDefined()
       expect(findVersions.annotations).toMatchObject({
@@ -393,7 +361,6 @@ describe('@payloadcms/plugin-mcp', () => {
         openWorldHint: false,
         readOnlyHint: true,
       })
-
       const restoreVersion = toolsByName['restoreVersion']
       expect(restoreVersion).toBeDefined()
       expect(restoreVersion.annotations).toMatchObject({
@@ -403,7 +370,6 @@ describe('@payloadcms/plugin-mcp', () => {
         openWorldHint: false,
         readOnlyHint: false,
       })
-
       // diceRoll: custom top-level tool
       const diceRoll = toolsByName['diceRoll']
       expect(diceRoll).toBeDefined()
@@ -421,7 +387,6 @@ describe('@payloadcms/plugin-mcp', () => {
         pluginItems.find((item: any) => item.type === 'tool' && item.configKey === 'diceRoll')
           ?.label,
       ).toBe('Dice Roll')
-
       const publish = toolsByName['publish']
       expect(publish).toBeDefined()
       expect(publish.annotations).toMatchObject({
@@ -439,7 +404,6 @@ describe('@payloadcms/plugin-mcp', () => {
             item.configKey === 'publish',
         )?.label,
       ).toBe('Publish Post')
-
       const auth = toolsByName['auth']
       expect(auth).toBeDefined()
       expect(auth.annotations).toMatchObject({
@@ -450,7 +414,6 @@ describe('@payloadcms/plugin-mcp', () => {
         readOnlyHint: true,
       })
       expect(toolsByName.hiddenTool).toBeUndefined()
-
       const createDocumentsTools = toolsResponse.tools.filter(
         (tool: { name: string }) => tool.name === 'createDocuments',
       )
@@ -535,7 +498,6 @@ describe('@payloadcms/plugin-mcp', () => {
       expect(whereDef.properties.and.type).toBe('array')
       expect(whereDef.properties.or.type).toBe('array')
       expect(whereDef.additionalProperties.propertyNames.enum).toContain('equals')
-
       // Each document keeps its data and file together; shared options stay at the top level.
       expect(createDocuments.inputSchema).toBeDefined()
       expect(createDocuments.inputSchema.type).toBe('object')
@@ -558,7 +520,6 @@ describe('@payloadcms/plugin-mcp', () => {
         description: 'Return complete documents instead of only their IDs.',
       })
       expect(createDocuments.inputSchema.properties.select).toBeDefined()
-
       // Find tool: no `data` wrapper, just metadata fields
       expect(findDocuments.inputSchema).toBeDefined()
       expect(findDocuments.inputSchema.type).toBe('object')
@@ -569,7 +530,6 @@ describe('@payloadcms/plugin-mcp', () => {
       expect(findDocuments.inputSchema.properties.select).toBeDefined()
       expect(findDocuments.inputSchema.properties.select.type).toBe('object')
       expect(findDocuments.inputSchema.properties.where).toBeDefined()
-
       expect(countDocuments.inputSchema.properties.slug).toBeDefined()
       expect(countDocuments.inputSchema.properties.locale).toBeDefined()
       expect(countDocuments.inputSchema.properties.locale.type).toBe('string')
@@ -580,13 +540,11 @@ describe('@payloadcms/plugin-mcp', () => {
       expect(findVersions.inputSchema.properties.slug).toBeDefined()
       expect(findVersions.inputSchema.properties.where).toBeDefined()
       expect(restoreVersion.inputSchema.properties.id).toBeDefined()
-
       const getUploadInstructions = toolsByName.getUploadInstructions
       expect(getUploadInstructions.inputSchema.properties.slug.type).toBe('string')
       expect(getUploadInstructions.inputSchema.properties.filename.type).toBe('string')
       expect(getUploadInstructions.inputSchema.properties.filesize.type).toBe('integer')
       expect(getUploadInstructions.inputSchema.properties.mimeType.type).toBe('string')
-
       // Custom top-level tool schema
       expect(diceRoll.inputSchema).toBeDefined()
       expect(diceRoll.inputSchema.type).toBe('object')
@@ -595,53 +553,51 @@ describe('@payloadcms/plugin-mcp', () => {
       expect(diceRoll.inputSchema.properties.sides.minimum).toBe(2)
       expect(diceRoll.inputSchema.properties.sides.maximum).toBe(1000)
     })
-
-    it('should return config info', async ({ mcp }) => {
+    it('should return config info', async ({ mcp, getApiKey }) => {
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
       const response = await client.callTool({ arguments: {}, name: 'getConfigInfo' })
       const text = getToolText(response)
-
       expect(text).toContain('Collections:')
       expect(text).toContain('posts')
       expect(text).toContain('Globals:')
       expect(text).toContain('site-settings')
     })
-
     it('should expose only tool input schemas that are valid JSON Schema draft 2020-12', async ({
       mcp,
+      getApiKey,
     }) => {
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
       const toolsResponse = await client.listTools()
-      const tools = toolsResponse.tools as Array<{ inputSchema?: object; name: string }>
-
+      const tools = toolsResponse.tools as Array<{
+        inputSchema?: object
+        name: string
+      }>
       // MCP clients validate each input_schema against the strict 2020-12 meta-schema. The SDK's own validator is
       // lenient (it only compiles), so lint for what the meta-schema enforces.
       const invalid = tools.flatMap((tool) =>
         tool.inputSchema ? draft2020Violations(tool.inputSchema, tool.name) : [],
       )
-
       expect(invalid).toEqual([])
     })
-
-    it('should list tools injected by other plugins via slug and options', async ({ mcp }) => {
+    it('should list tools injected by other plugins via slug and options', async ({
+      mcp,
+      getApiKey,
+    }) => {
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
       const toolsResponse = await client.listTools()
       const toolNames = toolsResponse.tools.map((t: { name: string }) => t.name)
-
       // Both plugins inject tools into mcp's options via slug discovery,
       // regardless of whether they are listed before or after mcp in the plugins array
       expect(toolNames).toContain('injectedBefore')
       expect(toolNames).toContain('injectedAfter')
     })
-
-    it('should list resources', async ({ mcp }) => {
+    it('should list resources', async ({ mcp, getApiKey }) => {
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
       const resourcesResponse = await client.listResources()
-
       expect(resourcesResponse).toBeDefined()
       expect(resourcesResponse.resources).toBeDefined()
       expect(resourcesResponse.resources).toHaveLength(1)
@@ -653,12 +609,10 @@ describe('@payloadcms/plugin-mcp', () => {
       )
       expect(resourcesResponse.resources[0].mimeType).toBe('text/plain')
     })
-
-    it('should list prompts', async ({ mcp }) => {
+    it('should list prompts', async ({ mcp, getApiKey }) => {
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
       const promptsResponse = await client.listPrompts()
-
       expect(promptsResponse).toBeDefined()
       expect(promptsResponse.prompts).toBeDefined()
       expect(promptsResponse.prompts).toHaveLength(1)
@@ -670,15 +624,12 @@ describe('@payloadcms/plugin-mcp', () => {
       expect(promptsResponse.prompts[0].arguments[0].name).toBe('message')
       expect(promptsResponse.prompts[0].arguments[0].required).toBe(true)
     })
-
-    it('should list globals', async ({ mcp }) => {
+    it('should list globals', async ({ mcp, getApiKey }) => {
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
       const toolsResponse = await client.listTools()
-
       expect(toolsResponse).toBeDefined()
       expect(toolsResponse.tools).toBeDefined()
-
       const findGlobalTool = toolsResponse.tools.find((t: any) => t.name === 'findGlobal')
       expect(findGlobalTool).toBeDefined()
       expect(findGlobalTool.description).toContain('Find any Payload global')
@@ -735,7 +686,6 @@ describe('@payloadcms/plugin-mcp', () => {
         openWorldHint: false,
         readOnlyHint: true,
       })
-
       const restoreGlobalVersionTool = toolsResponse.tools.find(
         (t: any) => t.name === 'restoreGlobalVersion',
       )
@@ -748,14 +698,13 @@ describe('@payloadcms/plugin-mcp', () => {
         readOnlyHint: false,
       })
     })
-
     it('should list updateDocument when API key permits update and include select schema', async ({
       mcp,
+      getApiKey,
     }) => {
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
       const toolsResponse = await client.listTools()
-
       const updateToolSchema = toolsResponse.tools.find((t: any) => t.name === 'updateDocument')
       expect(updateToolSchema).toBeDefined()
       expect(updateToolSchema.inputSchema.properties.select).toBeDefined()
@@ -771,9 +720,8 @@ describe('@payloadcms/plugin-mcp', () => {
       expect(updateToolSchema.inputSchema.properties.showHiddenFields).toBeUndefined()
     })
   })
-
-  describe('Prompts', () => {
-    it('should get echo prompt', async ({ mcp }) => {
+  test.describe('Prompts', () => {
+    it('should get echo prompt', async ({ mcp, getApiKey, payload, userId }) => {
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
       const promptResponse = await client.getPrompt({
@@ -782,7 +730,6 @@ describe('@payloadcms/plugin-mcp', () => {
           message: 'Hello, world!',
         },
       })
-
       expect(promptResponse).toBeDefined()
       expect(promptResponse.messages).toHaveLength(2)
       expect(promptResponse.messages[0].content.type).toBe('text')
@@ -793,7 +740,6 @@ describe('@payloadcms/plugin-mcp', () => {
       expect(promptResponse.messages[1].content.text).toContain(
         `This prompt was sent by userId: ${userId}`,
       )
-
       const { docs } = await payload.find({
         collection: 'modified-prompts',
         where: {
@@ -802,7 +748,6 @@ describe('@payloadcms/plugin-mcp', () => {
           },
         },
       })
-
       const modifiedPrompt = docs?.[0]
       expect(modifiedPrompt?.original).toBe('Hello, world!')
       expect(modifiedPrompt?.modified).toBe('This prompt was sent: Hello, world!')
@@ -810,21 +755,18 @@ describe('@payloadcms/plugin-mcp', () => {
       expect(modifiedPrompt?.user?.id).toBe(userId)
     })
   })
-
-  describe('Resources', () => {
-    it('should read the data resource', async ({ mcp }) => {
+  test.describe('Resources', () => {
+    it('should read the data resource', async ({ mcp, getApiKey, payload, userId }) => {
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
       const resourceResponse = await client.readResource({
         uri: 'data://app',
       })
-
       expect(resourceResponse).toBeDefined()
       expect(resourceResponse.contents).toHaveLength(2)
       expect(resourceResponse.contents[0].uri).toBe('data://app')
       expect(resourceResponse.contents[0].text).toContain('My special data.')
       expect(resourceResponse.contents[1].text).toContain(`This was requested by user: ${userId}`)
-
       const { docs } = await payload.find({
         collection: 'returned-resources',
         where: {
@@ -833,27 +775,23 @@ describe('@payloadcms/plugin-mcp', () => {
           },
         },
       })
-
       const returnedResource = docs?.[0]
       expect(returnedResource?.uri).toBe('data://app')
       expect(returnedResource?.content).toBe('My special data.')
       // @ts-expect-error - doc.user is a string | User
       expect(returnedResource?.user?.id).toBe(userId)
     })
-
-    it('should read the dataByID resource', async ({ mcp }) => {
+    it('should read the dataByID resource', async ({ mcp, getApiKey, payload, userId }) => {
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
       const resourceResponse = await client.readResource({
         uri: 'data://app/1',
       })
-
       expect(resourceResponse).toBeDefined()
       expect(resourceResponse.contents).toHaveLength(2)
       expect(resourceResponse.contents[0].uri).toBe('data://app/1')
       expect(resourceResponse.contents[0].text).toContain('My special data for ID: 1')
       expect(resourceResponse.contents[1].text).toContain(`This was requested by user: ${userId}`)
-
       const { docs } = await payload.find({
         collection: 'returned-resources',
         where: {
@@ -862,7 +800,6 @@ describe('@payloadcms/plugin-mcp', () => {
           },
         },
       })
-
       const returnedResource = docs?.[0]
       expect(returnedResource?.uri).toBe('data://app/1')
       expect(returnedResource?.content).toBe('My special data for ID: 1')
@@ -870,9 +807,8 @@ describe('@payloadcms/plugin-mcp', () => {
       expect(returnedResource?.user?.id).toBe(userId)
     })
   })
-
-  describe('Custom MCP Tools', () => {
-    it('should call diceRoll', async ({ mcp }) => {
+  test.describe('Custom MCP Tools', () => {
+    it('should call diceRoll', async ({ mcp, getApiKey, payload, userId }) => {
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
       const callResponse = await client.callTool({
@@ -881,7 +817,6 @@ describe('@payloadcms/plugin-mcp', () => {
         },
         name: 'diceRoll',
       })
-
       expect(callResponse).toBeDefined()
       expect(callResponse.content).toHaveLength(1)
       expect(callResponse.content[0].type).toBe('text')
@@ -889,7 +824,6 @@ describe('@payloadcms/plugin-mcp', () => {
       expect(callResponse.content[0].text).toContain('**Result:**')
       expect(callResponse.content[0].text).toContain('🎲 You rolled a **')
       expect(callResponse.content[0].text).toContain('** on a 6-sided die!')
-
       const { docs } = await payload.find({
         collection: 'rolls',
         where: {
@@ -898,7 +832,6 @@ describe('@payloadcms/plugin-mcp', () => {
           },
         },
       })
-
       const roll = docs?.[0]
       expect(roll?.sides).toBe(6)
       expect(roll?.result).toBeDefined()
@@ -906,28 +839,16 @@ describe('@payloadcms/plugin-mcp', () => {
       expect(roll?.user?.id).toBe(userId)
     })
   })
-
-  describe('Collections', () => {
-    const createdMediaIDs: Array<number | string> = []
-    const createdPostIDs: Array<number | string> = []
+  test.describe('Collections', () => {
     const uploadServers: TestFileServer[] = []
-
-    afterEach(async () => {
+    test.afterEach(async () => {
       await Promise.all(uploadServers.map(({ close }) => close()))
       uploadServers.length = 0
-
-      for (const id of createdMediaIDs) {
-        await payload.delete({ collection: 'media', id })
-      }
-      createdMediaIDs.length = 0
-
-      for (const id of createdPostIDs) {
-        await payload.delete({ collection: 'posts', id })
-      }
-      createdPostIDs.length = 0
     })
-
-    it('getCollectionSchema returns collection fields for createDocuments', async ({ mcp }) => {
+    it('getCollectionSchema returns collection fields for createDocuments', async ({
+      mcp,
+      getApiKey,
+    }) => {
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
       const schemaResponse = await client.callTool({
@@ -937,15 +858,14 @@ describe('@payloadcms/plugin-mcp', () => {
         name: 'getCollectionSchema',
       })
       const schema = getToolDoc<JsonSchemaType>(schemaResponse)
-
       expect(schema.properties?.title).toBeDefined()
       expect(schema.properties?.content).toBeDefined()
       expect(schema.properties?._status?.enum).toEqual(['draft', 'published'])
       expect(schema.properties?.badProperty).toBeUndefined()
     })
-
     it('getCollectionSchema: should hide inaccessible collection fields unless access is overridden', async ({
       mcp,
+      getApiKey,
     }) => {
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
@@ -956,13 +876,10 @@ describe('@payloadcms/plugin-mcp', () => {
         name: 'getCollectionSchema',
       })
       const schema = getToolDoc<JsonSchemaType>(schemaResponse)
-
       expect(schema.properties?.email).toBeDefined()
       expect(schema.properties?.hash).toBeUndefined()
       expect(schema.required).not.toContain('hash')
-
       vi.stubEnv('NODE_ENV', 'development')
-
       const overrideClient = await mcp.connect(apiKey, { overrideAccess: true })
       const overrideResponse = await overrideClient.callTool({
         arguments: {
@@ -971,11 +888,9 @@ describe('@payloadcms/plugin-mcp', () => {
         name: 'getCollectionSchema',
       })
       const overrideSchema = getToolDoc<JsonSchemaType>(overrideResponse)
-
       expect(overrideSchema.properties?.hash).toBeDefined()
     })
-
-    it('should create one document with createDocuments', async ({ mcp }) => {
+    it('should create one document with createDocuments', async ({ mcp, getApiKey }) => {
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
       const callResponse = await client.callTool({
@@ -992,7 +907,6 @@ describe('@payloadcms/plugin-mcp', () => {
         },
         name: 'createDocuments',
       })
-
       expect(callResponse).toBeDefined()
       expect(callResponse.content).toHaveLength(2)
       const responseText = getToolText(callResponse)
@@ -1008,8 +922,10 @@ describe('@payloadcms/plugin-mcp', () => {
       })
       expect(overrideText).toContain('Override MCP response for Posts!')
     })
-
-    it('should create a draft without required fields using createDocuments', async ({ mcp }) => {
+    it('should create a draft without required fields using createDocuments', async ({
+      getApiKey,
+      mcp,
+    }) => {
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
       const callResponse = await client.callTool({
@@ -1030,7 +946,6 @@ describe('@payloadcms/plugin-mcp', () => {
         id: number | string
       }>(callResponse)
 
-      createdPostIDs.push(createdPost.id)
       expect(createdPost).toMatchObject({
         _status: 'draft',
         content: 'Incomplete draft',
@@ -1039,6 +954,7 @@ describe('@payloadcms/plugin-mcp', () => {
 
     it('should create multiple documents and keep stable indexes for partial failures', async ({
       mcp,
+      getApiKey,
     }) => {
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
@@ -1058,8 +974,6 @@ describe('@payloadcms/plugin-mcp', () => {
         errors: Array<{ index: number; message: string }>
       }>(callResponse)
 
-      createdPostIDs.push(...result.docs.map(({ id }) => id))
-
       expect(callResponse.isError).not.toBe(true)
       expect(result.docs).toEqual([
         { id: expect.anything(), index: 0 },
@@ -1067,8 +981,11 @@ describe('@payloadcms/plugin-mcp', () => {
       ])
       expect(result.errors).toEqual([expect.objectContaining({ index: 1 })])
     })
-
-    it('should create multiple upload documents with different files', async ({ mcp }) => {
+    it('should create multiple upload documents with different files', async ({
+      mcp,
+      getApiKey,
+      payload,
+    }) => {
       const [png, jpeg] = await Promise.all([
         readFile(path.resolve(dirname, '../uploads/image.png')),
         readFile(path.resolve(dirname, '../uploads/image.jpg')),
@@ -1106,12 +1023,9 @@ describe('@payloadcms/plugin-mcp', () => {
         errors: Array<{ index: number; message: string }>
       }>(callResponse)
 
-      createdMediaIDs.push(...result.docs.map(({ id }) => id))
-
       const [storedPNG, storedJPEG] = await Promise.all(
         result.docs.map(({ id }) => payload.findByID({ collection: 'media', id })),
       )
-
       expect(result.errors).toEqual([])
       expect(storedPNG).toMatchObject({
         alt: 'First bulk upload',
@@ -1126,15 +1040,13 @@ describe('@payloadcms/plugin-mcp', () => {
         mimeType: 'image/jpeg',
       })
     })
-
-    it('should create an upload document from a URL', async ({ mcp }) => {
+    it('should create an upload document from a URL', async ({ mcp, getApiKey, payload }) => {
       const image = await readFile(path.resolve(dirname, '../uploads/image.png'))
       const server = await startTestFileServer({
         contentType: 'image/png',
         data: image,
       })
       uploadServers.push(server)
-
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
       const callResponse = await callCreateDocumentsWithOne(client, {
@@ -1150,21 +1062,19 @@ describe('@payloadcms/plugin-mcp', () => {
           },
         },
       })
-      const createdMedia = getCreatedDocument<{ id: number | string }>(callResponse)
-      createdMediaIDs.push(createdMedia.id)
-
+      const createdMedia = getCreatedDocument<{
+        id: number | string
+      }>(callResponse)
       const storedMedia = await payload.findByID({
         id: createdMedia.id,
         collection: 'media',
       })
-
       expect(storedMedia.alt).toBe('Uploaded from a URL through MCP')
       expect(storedMedia.filename).toBe('mcp-url.png')
       expect(storedMedia.mimeType).toBe('image/png')
       expect(storedMedia.filesize).toBe(image.length)
     })
-
-    it('should replace an upload document from base64', async ({ mcp }) => {
+    it('should replace an upload document from base64', async ({ mcp, getApiKey, payload }) => {
       const media = await payload.create({
         collection: 'media',
         data: {
@@ -1172,9 +1082,7 @@ describe('@payloadcms/plugin-mcp', () => {
         },
         filePath: path.resolve(dirname, '../uploads/image.jpg'),
       })
-      createdMediaIDs.push(media.id)
       const image = await readFile(path.resolve(dirname, '../uploads/image.png'))
-
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
       await client.callTool({
@@ -1193,25 +1101,24 @@ describe('@payloadcms/plugin-mcp', () => {
         },
         name: 'updateDocument',
       })
-
       const storedMedia = await payload.findByID({
         id: media.id,
         collection: 'media',
       })
-
       expect(storedMedia.alt).toBe('Replaced from base64 through MCP')
       expect(storedMedia.filename).toBe('mcp-replacement.png')
       expect(storedMedia.mimeType).toBe('image/png')
       expect(storedMedia.filesize).toBe(image.length)
     })
-
     it('should create and update uploads without sending file bytes through MCP', async ({
       mcp,
+      getApiKey,
+      payload,
+      restClient,
     }) => {
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
       const file = await readFile(new URL('../uploads/image.png', import.meta.url))
-
       const upload = async (filename: string) => {
         const response = await client.callTool({
           arguments: {
@@ -1223,13 +1130,10 @@ describe('@payloadcms/plugin-mcp', () => {
           name: 'getUploadInstructions',
         })
         const instructions = getToolDoc<UploadInstructions>(response)
-
         expect(instructions.file.uploadReference.uploadId).toBeTruthy()
-
         if (instructions.type !== 'http') {
           throw new Error('Expected HTTP upload instructions')
         }
-
         const uploadPath = new URL(instructions.request.url, restClient.serverURL).pathname.replace(
           payload.config.routes.api,
           '',
@@ -1238,14 +1142,10 @@ describe('@payloadcms/plugin-mcp', () => {
           body: file,
           headers: instructions.request.headers,
         })
-
         expect(uploadResponse.status).toBe(204)
-
         return { file: instructions.file, source: 'uploadReference' as const }
       }
-
       let id: number | string | undefined
-
       try {
         const createResponse = await callCreateDocumentsWithOne(client, {
           arguments: {
@@ -1261,11 +1161,9 @@ describe('@payloadcms/plugin-mcp', () => {
           width: number
         }>(createResponse)
         id = created.id
-
         expect(created.alt).toBe('Created through MCP')
         expect(created.filename).toBe('mcp-created.png')
         expect(created.width).toBeGreaterThan(0)
-
         const updateResponse = await client.callTool({
           arguments: {
             slug: 'media',
@@ -1276,8 +1174,10 @@ describe('@payloadcms/plugin-mcp', () => {
           },
           name: 'updateDocument',
         })
-        const updated = getToolDoc<{ alt: string; filename: string }>(updateResponse)
-
+        const updated = getToolDoc<{
+          alt: string
+          filename: string
+        }>(updateResponse)
         expect(updated.alt).toBe('Updated through MCP')
         expect(updated.filename).toBe('mcp-updated.png')
       } finally {
@@ -1286,9 +1186,9 @@ describe('@payloadcms/plugin-mcp', () => {
         }
       }
     })
-
     it('should return named upload instructions for provider-specific uploaders', async ({
       mcp,
+      getApiKey,
     }) => {
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
@@ -1302,7 +1202,6 @@ describe('@payloadcms/plugin-mcp', () => {
         name: 'getUploadInstructions',
       })
       const instructions = getToolDoc<UploadInstructions>(response)
-
       expect(instructions).toMatchObject({
         data: { token: 'test-token' },
         name: 'uploadToTestProvider',
@@ -1316,8 +1215,11 @@ describe('@payloadcms/plugin-mcp', () => {
         client.callTool({ arguments: {}, name: 'uploadToTestProvider' }),
       ).rejects.toThrow()
     })
-
-    it('should create a published document from data._status', async ({ mcp }) => {
+    it('should create a published document from data._status', async ({
+      mcp,
+      getApiKey,
+      payload,
+    }) => {
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
       const callResponse = await callCreateDocumentsWithOne(client, {
@@ -1331,20 +1233,21 @@ describe('@payloadcms/plugin-mcp', () => {
           locale: 'en',
         },
       })
-      const createdPost = getCreatedDocument<{ id: number | string }>(callResponse)
-      createdPostIDs.push(createdPost.id)
-
+      const createdPost = getCreatedDocument<{
+        id: number | string
+      }>(callResponse)
       const storedPost = await payload.findByID({
         id: createdPost.id,
         collection: 'posts',
         draft: false,
         locale: 'all',
       })
-
       expect(storedPost._status).toMatchObject({ en: 'published' })
     })
-
-    it('should call createDocuments with select to limit returned fields', async ({ mcp }) => {
+    it('should call createDocuments with select to limit returned fields', async ({
+      mcp,
+      getApiKey,
+    }) => {
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
 
@@ -1371,13 +1274,11 @@ describe('@payloadcms/plugin-mcp', () => {
           returning: true,
         },
       })
-
       expect(callResponse).toBeDefined()
       expect(callResponse.content[0].text).toContain('"title":"Select Create Post"')
       expect(callResponse.content[0].text).not.toContain('Content should be omitted')
     })
-
-    it('should return upload requirements from getCollectionSchema', async ({ mcp }) => {
+    it('should return upload requirements from getCollectionSchema', async ({ mcp, getApiKey }) => {
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
       const callResponse = await client.callTool({
@@ -1386,7 +1287,6 @@ describe('@payloadcms/plugin-mcp', () => {
         },
         name: 'getCollectionSchema',
       })
-
       expect(callResponse.structuredContent?.upload).toMatchObject({
         enabled: true,
         filesRequiredOnCreate: true,
@@ -1394,8 +1294,7 @@ describe('@payloadcms/plugin-mcp', () => {
         sources: ['externalURL', 'base64', 'uploadReference'],
       })
     })
-
-    it('should create an upload document from base64', async ({ mcp }) => {
+    it('should create an upload document from base64', async ({ mcp, getApiKey, payload }) => {
       const image = await readFile(path.resolve(dirname, '../uploads/image.png'))
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
@@ -1413,21 +1312,19 @@ describe('@payloadcms/plugin-mcp', () => {
           },
         },
       })
-      const createdMedia = getCreatedDocument<{ id: number | string }>(callResponse)
-      createdMediaIDs.push(createdMedia.id)
-
+      const createdMedia = getCreatedDocument<{
+        id: number | string
+      }>(callResponse)
       const storedMedia = await payload.findByID({
         id: createdMedia.id,
         collection: 'media',
       })
-
       expect(storedMedia.alt).toBe('Uploaded from base64 through MCP')
       expect(storedMedia.filename).toBe('mcp-base64.png')
       expect(storedMedia.mimeType).toBe('image/png')
       expect(storedMedia.filesize).toBe(image.length)
     })
-
-    it('should call findDocuments', async ({ mcp }) => {
+    it('should call findDocuments', async ({ mcp, getApiKey, payload }) => {
       const post = await payload.create({
         collection: 'posts',
         data: {
@@ -1435,8 +1332,6 @@ describe('@payloadcms/plugin-mcp', () => {
           title: 'Test Post for Finding',
         },
       })
-      createdPostIDs.push(post.id)
-
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
       const callResponse = await client.callTool({
@@ -1448,7 +1343,6 @@ describe('@payloadcms/plugin-mcp', () => {
         },
         name: 'findDocuments',
       })
-
       expect(callResponse).toBeDefined()
       expect(callResponse.content).toHaveLength(2)
       expect(callResponse.content[0].type).toBe('text')
@@ -1460,9 +1354,10 @@ describe('@payloadcms/plugin-mcp', () => {
       expect(callResponse.content[1].type).toBe('text')
       expect(callResponse.content[1].text).toContain('Override MCP response for Posts!')
     })
-
     it('should call findDocuments with select and return only requested fields', async ({
       mcp,
+      getApiKey,
+      payload,
     }) => {
       await payload.create({
         collection: 'posts',
@@ -1471,7 +1366,6 @@ describe('@payloadcms/plugin-mcp', () => {
           title: 'Select Test Post',
         },
       })
-
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
       const callResponse = await client.callTool({
@@ -1484,7 +1378,6 @@ describe('@payloadcms/plugin-mcp', () => {
         },
         name: 'findDocuments',
       })
-
       expect(callResponse).toBeDefined()
       expect(callResponse.content).toHaveLength(2)
       const responseText: string = callResponse.content[0].text
@@ -1492,8 +1385,7 @@ describe('@payloadcms/plugin-mcp', () => {
       expect(responseText).toContain('"title":"Select Test Post (MCP Hook Override)"')
       expect(responseText).not.toContain('"content": "Content that should be omitted"')
     })
-
-    it('should call countDocuments', async ({ mcp }) => {
+    it('should call countDocuments', async ({ mcp, getApiKey, payload }) => {
       const product = await payload.create({
         collection: 'products',
         data: {
@@ -1501,7 +1393,6 @@ describe('@payloadcms/plugin-mcp', () => {
           title: 'Countable Product',
         },
       })
-
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
       const callResponse = await client.callTool({
@@ -1516,14 +1407,13 @@ describe('@payloadcms/plugin-mcp', () => {
         },
         name: 'countDocuments',
       })
-      const result = getToolDoc<{ totalDocs: number }>(callResponse)
-
+      const result = getToolDoc<{
+        totalDocs: number
+      }>(callResponse)
       expect(result.totalDocs).toBeGreaterThanOrEqual(1)
-
       await payload.delete({ id: product.id, collection: 'products' })
     })
-
-    it('should call duplicateDocument', async ({ mcp }) => {
+    it('should call duplicateDocument', async ({ mcp, getApiKey, payload }) => {
       const product = await payload.create({
         collection: 'products',
         data: {
@@ -1531,7 +1421,6 @@ describe('@payloadcms/plugin-mcp', () => {
           title: 'Original Product',
         },
       })
-
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
       const callResponse = await client.callTool({
@@ -1544,17 +1433,22 @@ describe('@payloadcms/plugin-mcp', () => {
         },
         name: 'duplicateDocument',
       })
-      const duplicated = getToolDoc<{ id: number | string; title: string }>(callResponse)
-
+      const duplicated = getToolDoc<{
+        id: number | string
+        title: string
+      }>(callResponse)
       expect(duplicated.id).toBeDefined()
       expect(duplicated.id).not.toBe(product.id)
       expect(duplicated.title).toBe('Duplicated Product')
-
       await payload.delete({ id: duplicated.id, collection: 'products' })
       await payload.delete({ id: product.id, collection: 'products' })
     })
-
-    it('should not enable duplicateDocument for auth collections by default', async ({ mcp }) => {
+    it('should not enable duplicateDocument for auth collections by default', async ({
+      mcp,
+      getApiKey,
+      payload,
+      userId,
+    }) => {
       const plugin = payload.config.plugins.find(
         (plugin) => plugin.slug === '@payloadcms/plugin-mcp',
       ) as any
@@ -1564,9 +1458,7 @@ describe('@payloadcms/plugin-mcp', () => {
           item.collectionSlug === 'users' &&
           item.configKey === 'duplicate',
       )
-
       expect(userDuplicateItem).toBeUndefined()
-
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
       const callResponse = await client.callTool({
@@ -1579,14 +1471,12 @@ describe('@payloadcms/plugin-mcp', () => {
         },
         name: 'duplicateDocument',
       })
-
       expect(callResponse.isError).toBe(true)
       expect(getToolText(callResponse)).toContain(
         'MCP access to "duplicateDocument" is not enabled for collection "users"',
       )
     })
-
-    it('should call findDistinct', async ({ mcp }) => {
+    it('should call findDistinct', async ({ mcp, getApiKey, payload }) => {
       const product = await payload.create({
         collection: 'products',
         data: {
@@ -1594,7 +1484,6 @@ describe('@payloadcms/plugin-mcp', () => {
           title: 'Distinct Product',
         },
       })
-
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
       const callResponse = await client.callTool({
@@ -1604,14 +1493,15 @@ describe('@payloadcms/plugin-mcp', () => {
         },
         name: 'findDistinct',
       })
-      const result = getToolDoc<{ values: Array<{ title: string }> }>(callResponse)
-
+      const result = getToolDoc<{
+        values: Array<{
+          title: string
+        }>
+      }>(callResponse)
       expect(result.values.some((value) => value.title === 'Distinct Product')).toBe(true)
-
       await payload.delete({ id: product.id, collection: 'products' })
     })
-
-    it('should call collection version tools', async ({ mcp }) => {
+    it('should call collection version tools', async ({ mcp, getApiKey, payload }) => {
       const post = await payload.create({
         collection: 'posts',
         data: {
@@ -1619,7 +1509,6 @@ describe('@payloadcms/plugin-mcp', () => {
           title: 'Versioned Post',
         },
       })
-
       await payload.update({
         id: post.id,
         collection: 'posts',
@@ -1627,7 +1516,6 @@ describe('@payloadcms/plugin-mcp', () => {
           title: 'Versioned Post Updated',
         },
       })
-
       const versions = await payload.findVersions({
         collection: 'posts',
         limit: 1,
@@ -1639,10 +1527,8 @@ describe('@payloadcms/plugin-mcp', () => {
         },
       })
       const versionID = String(versions.docs[0]!.id)
-
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
-
       const countResponse = await client.callTool({
         arguments: {
           slug: 'posts',
@@ -1654,9 +1540,10 @@ describe('@payloadcms/plugin-mcp', () => {
         },
         name: 'countVersions',
       })
-      const countResult = getToolDoc<{ totalDocs: number }>(countResponse)
+      const countResult = getToolDoc<{
+        totalDocs: number
+      }>(countResponse)
       expect(countResult.totalDocs).toBeGreaterThanOrEqual(1)
-
       const findResponse = await client.callTool({
         arguments: {
           slug: 'posts',
@@ -1669,9 +1556,12 @@ describe('@payloadcms/plugin-mcp', () => {
         },
         name: 'findVersions',
       })
-      const findResult = getToolDoc<{ docs: Array<{ id: number | string }> }>(findResponse)
+      const findResult = getToolDoc<{
+        docs: Array<{
+          id: number | string
+        }>
+      }>(findResponse)
       expect(findResult.docs).toHaveLength(1)
-
       const findByIDResponse = await client.callTool({
         arguments: {
           slug: 'posts',
@@ -1679,12 +1569,14 @@ describe('@payloadcms/plugin-mcp', () => {
         },
         name: 'findVersionByID',
       })
-      const version = getToolDoc<{ id: number | string; version: { title: string } }>(
-        findByIDResponse,
-      )
+      const version = getToolDoc<{
+        id: number | string
+        version: {
+          title: string
+        }
+      }>(findByIDResponse)
       expect(String(version.id)).toBe(versionID)
       expect(version.version.title).toContain('Versioned Post')
-
       const restoreResponse = await client.callTool({
         arguments: {
           slug: 'posts',
@@ -1692,14 +1584,17 @@ describe('@payloadcms/plugin-mcp', () => {
         },
         name: 'restoreVersion',
       })
-      const restored = getToolDoc<{ id: number | string }>(restoreResponse)
+      const restored = getToolDoc<{
+        id: number | string
+      }>(restoreResponse)
       expect(restored.id).toBe(post.id)
-
       await payload.delete({ id: post.id, collection: 'posts' })
     })
-
     it('should pass populate, joins, trash, and pagination to findDocuments list queries', async ({
       mcp,
+      getApiKey,
+      payload,
+      userId,
     }) => {
       const post = await payload.create({
         collection: 'posts',
@@ -1711,9 +1606,7 @@ describe('@payloadcms/plugin-mcp', () => {
       })
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
-
       const findSpy = vi.spyOn(payload, 'find')
-
       try {
         const callResponse = await client.callTool({
           arguments: {
@@ -1728,7 +1621,6 @@ describe('@payloadcms/plugin-mcp', () => {
           },
           name: 'findDocuments',
         })
-
         expect(callResponse).toBeDefined()
         expect(findSpy).toHaveBeenCalledWith(
           expect.objectContaining({
@@ -1744,8 +1636,12 @@ describe('@payloadcms/plugin-mcp', () => {
         await payload.delete({ id: post.id, collection: 'posts' })
       }
     })
-
-    it('should pass populate, joins, and trash to findDocuments ID queries', async ({ mcp }) => {
+    it('should pass populate, joins, and trash to findDocuments ID queries', async ({
+      mcp,
+      getApiKey,
+      payload,
+      userId,
+    }) => {
       const post = await payload.create({
         collection: 'posts',
         data: {
@@ -1756,9 +1652,7 @@ describe('@payloadcms/plugin-mcp', () => {
       })
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
-
       const findByIDSpy = vi.spyOn(payload, 'findByID')
-
       try {
         const callResponse = await client.callTool({
           arguments: {
@@ -1770,7 +1664,6 @@ describe('@payloadcms/plugin-mcp', () => {
           },
           name: 'findDocuments',
         })
-
         expect(callResponse).toBeDefined()
         expect(findByIDSpy).toHaveBeenCalledWith(
           expect.objectContaining({
@@ -1786,8 +1679,7 @@ describe('@payloadcms/plugin-mcp', () => {
         await payload.delete({ id: post.id, collection: 'posts' })
       }
     })
-
-    it('should call updateDocument', async ({ mcp }) => {
+    it('should call updateDocument', async ({ mcp, getApiKey, payload }) => {
       const post = await payload.create({
         collection: 'posts',
         data: {
@@ -1795,7 +1687,6 @@ describe('@payloadcms/plugin-mcp', () => {
           title: 'Test Post for Updating',
         },
       })
-
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
       const callResponse = await client.callTool({
@@ -1808,7 +1699,6 @@ describe('@payloadcms/plugin-mcp', () => {
         },
         name: 'updateDocument',
       })
-
       expect(callResponse).toBeDefined()
       expect(callResponse.content).toHaveLength(2)
       expect(callResponse.content[0].type).toBe('text')
@@ -1823,7 +1713,11 @@ describe('@payloadcms/plugin-mcp', () => {
       expect(getToolDoc(callResponse)).toEqual({ id: post.id })
     })
 
-    it('should normalize string document IDs to the configured ID type', async ({ mcp }) => {
+    it('should normalize string document IDs to the configured ID type', async ({
+      getApiKey,
+      mcp,
+      payload,
+    }) => {
       const page = await payload.create({
         collection: 'pages',
         data: { title: 'Numeric ID' },
@@ -1848,8 +1742,11 @@ describe('@payloadcms/plugin-mcp', () => {
         await payload.delete({ id: page.id, collection: 'pages' })
       }
     })
-
-    it('should forward publishAllLocales when updating a document', async ({ mcp }) => {
+    it('should forward publishAllLocales when updating a document', async ({
+      mcp,
+      getApiKey,
+      payload,
+    }) => {
       const post = await payload.create({
         collection: 'posts',
         data: {
@@ -1858,7 +1755,6 @@ describe('@payloadcms/plugin-mcp', () => {
         draft: true,
         locale: 'en',
       })
-
       try {
         await payload.update({
           id: post.id,
@@ -1867,7 +1763,6 @@ describe('@payloadcms/plugin-mcp', () => {
           draft: true,
           locale: 'es',
         })
-
         const apiKey = await getApiKey()
         const client = await mcp.connect(apiKey)
         const callResponse = await client.callTool({
@@ -1896,7 +1791,6 @@ describe('@payloadcms/plugin-mcp', () => {
           draft: true,
           locale: 'es',
         })
-
         expect(callResponse).toBeDefined()
         expect(publishedPost._status).toMatchObject({ en: 'published' })
         expect(publishedPost._status).not.toMatchObject({ es: 'published' })
@@ -1907,8 +1801,11 @@ describe('@payloadcms/plugin-mcp', () => {
         await payload.delete({ collection: 'posts', id: post.id })
       }
     })
-
-    it('should call updateDocument with nullable union type field set to null', async ({ mcp }) => {
+    it('should call updateDocument with nullable union type field set to null', async ({
+      mcp,
+      getApiKey,
+      payload,
+    }) => {
       const post = await payload.create({
         collection: 'posts',
         data: {
@@ -1916,7 +1813,6 @@ describe('@payloadcms/plugin-mcp', () => {
           title: 'Union Type Null Test',
         },
       })
-
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
       const callResponse = await client.callTool({
@@ -1930,25 +1826,26 @@ describe('@payloadcms/plugin-mcp', () => {
         },
         name: 'updateDocument',
       })
-
       expect(callResponse).toBeDefined()
       expect(callResponse.content[0].type).toBe('text')
       expect(callResponse.content[0].text).toContain(
         'Document updated successfully in collection "posts"!',
       )
       expect(callResponse.content[0].text).toContain('"content":null')
-
       await payload.delete({ id: post.id, collection: 'posts' })
     })
-
-    it('should call updateDocument with relationship union type field', async ({ mcp }) => {
+    it('should call updateDocument with relationship union type field', async ({
+      mcp,
+      getApiKey,
+      payload,
+      userId,
+    }) => {
       const post = await payload.create({
         collection: 'posts',
         data: {
           title: 'Union Type Relationship Test',
         },
       })
-
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
       const callResponse = await client.callTool({
@@ -1962,20 +1859,20 @@ describe('@payloadcms/plugin-mcp', () => {
         },
         name: 'updateDocument',
       })
-
       expect(callResponse).toBeDefined()
       expect(callResponse.content[0].type).toBe('text')
       expect(callResponse.content[0].text).toContain(
         'Document updated successfully in collection "posts"!',
       )
-
       const updatedDoc = getToolDoc(callResponse)
       expect(updatedDoc.author).toBe(userId)
-
       await payload.delete({ id: post.id, collection: 'posts' })
     })
-
-    it('should call updateDocument with select to limit returned fields', async ({ mcp }) => {
+    it('should call updateDocument with select to limit returned fields', async ({
+      mcp,
+      getApiKey,
+      payload,
+    }) => {
       const post = await payload.create({
         collection: 'posts',
         data: {
@@ -1983,7 +1880,6 @@ describe('@payloadcms/plugin-mcp', () => {
           title: 'Select Update Post',
         },
       })
-
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
 
@@ -2013,15 +1909,13 @@ describe('@payloadcms/plugin-mcp', () => {
         },
         name: 'updateDocument',
       })
-
       expect(callResponse).toBeDefined()
       const responseText: string = callResponse.content[0].text
       expect(responseText).toContain('"title":"Select Update Post Edited"')
       expect(responseText).not.toContain('Updated but should be omitted')
       expect(responseText).not.toContain('"content":')
     })
-
-    it('should call deleteDocuments', async ({ mcp }) => {
+    it('should call deleteDocuments', async ({ mcp, getApiKey, payload }) => {
       const post = await payload.create({
         collection: 'posts',
         data: {
@@ -2029,7 +1923,6 @@ describe('@payloadcms/plugin-mcp', () => {
           title: 'Test Post for Deleting',
         },
       })
-
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
       const callResponse = await client.callTool({
@@ -2039,7 +1932,6 @@ describe('@payloadcms/plugin-mcp', () => {
         },
         name: 'deleteDocuments',
       })
-
       expect(callResponse).toBeDefined()
       expect(callResponse.content).toHaveLength(2)
       expect(callResponse.content[0].type).toBe('text')
@@ -2050,8 +1942,11 @@ describe('@payloadcms/plugin-mcp', () => {
       expect(callResponse.content[0].text).toContain('```json')
       expect(callResponse.content[0].text).toContain('"content":"Content for test post to delete."')
     })
-
-    it('should call updateDocument with object where clause', async ({ mcp }) => {
+    it('should call updateDocument with object where clause', async ({
+      mcp,
+      getApiKey,
+      payload,
+    }) => {
       const matching = await payload.create({
         collection: 'posts',
         data: {
@@ -2066,7 +1961,6 @@ describe('@payloadcms/plugin-mcp', () => {
           title: 'Where Object Update Excluded',
         },
       })
-
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
       const callResponse = await client.callTool({
@@ -2084,7 +1978,6 @@ describe('@payloadcms/plugin-mcp', () => {
         },
         name: 'updateDocument',
       })
-
       expect(callResponse).toBeDefined()
       expect(callResponse.content[0].type).toBe('text')
       expect(callResponse.content[0].text).toContain('Updated: 1 documents')
@@ -2093,14 +1986,15 @@ describe('@payloadcms/plugin-mcp', () => {
       ])
 
       const untouched = await payload.findByID({ id: excluded.id, collection: 'posts' })
-
       expect(untouched.content).toBe('Original content')
-
       await payload.delete({ id: matching.id, collection: 'posts' })
       await payload.delete({ id: excluded.id, collection: 'posts' })
     })
-
-    it('should call deleteDocuments with object where clause', async ({ mcp }) => {
+    it('should call deleteDocuments with object where clause', async ({
+      mcp,
+      getApiKey,
+      payload,
+    }) => {
       await payload.create({
         collection: 'posts',
         data: {
@@ -2115,7 +2009,6 @@ describe('@payloadcms/plugin-mcp', () => {
           title: 'Where Object Delete Two',
         },
       })
-
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
       const callResponse = await client.callTool({
@@ -2130,14 +2023,12 @@ describe('@payloadcms/plugin-mcp', () => {
         },
         name: 'deleteDocuments',
       })
-
       expect(callResponse).toBeDefined()
       expect(callResponse.content[0].type).toBe('text')
       expect(callResponse.content[0].text).toContain('Deleted: 2 documents')
       expect(callResponse.content[0].text).toContain('Errors: 0')
     })
-
-    it('should reject a where clause with an invalid operator', async ({ mcp }) => {
+    it('should reject a where clause with an invalid operator', async ({ mcp, getApiKey }) => {
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
       const callResponse = await client.callTool({
@@ -2147,14 +2038,16 @@ describe('@payloadcms/plugin-mcp', () => {
         },
         name: 'findDocuments',
       })
-
       // The SDK surfaces schema validation failures as tool error results
       expect(callResponse.isError).toBe(true)
       expect(callResponse.content[0].text).toContain('Input validation error')
       expect(callResponse.content[0].text).toContain('equalz')
     })
-
-    it('should handle point fields with object format in createDocuments', async ({ mcp }) => {
+    it('should handle point fields with object format in createDocuments', async ({
+      mcp,
+      getApiKey,
+      payload,
+    }) => {
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
       const callResponse = await callCreateDocumentsWithOne(client, {
@@ -2170,26 +2063,23 @@ describe('@payloadcms/plugin-mcp', () => {
           },
         },
       })
-
       expect(callResponse).toBeDefined()
       expect(callResponse.content).toHaveLength(2)
       expect(callResponse.content[0].type).toBe('text')
       expect(callResponse.content[0].text).toContain('Created 1 of 1 documents')
-
       const createdDoc = getCreatedDocument(callResponse)
-
       expect(createdDoc.location).toEqual([-74.006, 40.7128])
-
       expect(callResponse.content[1].type).toBe('text')
       expect(callResponse.content[1].text).toContain('Override MCP response for Posts!')
-
       await payload.delete({ id: createdDoc.id, collection: 'posts' })
     })
-
-    it('should handle point fields with object format in updateDocument', async ({ mcp }) => {
+    it('should handle point fields with object format in updateDocument', async ({
+      mcp,
+      getApiKey,
+      payload,
+    }) => {
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
-
       const createdPost = await payload.create({
         collection: 'posts',
         data: {
@@ -2197,7 +2087,6 @@ describe('@payloadcms/plugin-mcp', () => {
           title: 'Post to Update Location',
         },
       })
-
       const callResponse = await client.callTool({
         arguments: {
           slug: 'posts',
@@ -2212,30 +2101,22 @@ describe('@payloadcms/plugin-mcp', () => {
         },
         name: 'updateDocument',
       })
-
       expect(callResponse).toBeDefined()
       expect(callResponse.content).toHaveLength(2)
       expect(callResponse.content[0].type).toBe('text')
       expect(callResponse.content[0].text).toContain('Document updated successfully')
-
       const updatedDoc = getToolDoc(callResponse)
-
       expect(updatedDoc.location).toEqual([-0.1278, 51.5074])
-
       expect(callResponse.content[1].type).toBe('text')
       expect(callResponse.content[1].text).toContain('Override MCP response for Posts!')
-
       await payload.delete({ id: createdPost.id, collection: 'posts' })
     })
   })
-
-  describe('Blocks fields', () => {
+  test.describe('Blocks fields', () => {
     const createdPageIds: (number | string)[] = []
-
-    it('should create a page with a block', async ({ mcp }) => {
+    it('should create a page with a block', async ({ mcp, getApiKey }) => {
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
-
       const callResponse = await callCreateDocumentsWithOne(client, {
         arguments: {
           slug: 'pages',
@@ -2251,21 +2132,17 @@ describe('@payloadcms/plugin-mcp', () => {
           },
         },
       })
-
       expect(callResponse).toBeDefined()
       expect(callResponse.isError).toBeFalsy()
       expect(callResponse.content[0].type).toBe('text')
       expect(callResponse.content[0].text).toContain('"title":"Hero Page"')
       expect(callResponse.content[0].text).toContain('"blockType":"hero"')
       expect(callResponse.content[0].text).toContain('"heading":"Welcome to our site"')
-
       createdPageIds.push(getCreatedDocument(callResponse).id)
     })
-
-    it('should create a page with multiple block types', async ({ mcp }) => {
+    it('should create a page with multiple block types', async ({ mcp, getApiKey }) => {
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
-
       const callResponse = await callCreateDocumentsWithOne(client, {
         arguments: {
           slug: 'pages',
@@ -2285,18 +2162,15 @@ describe('@payloadcms/plugin-mcp', () => {
           },
         },
       })
-
       expect(callResponse).toBeDefined()
       expect(callResponse.isError).toBeFalsy()
       expect(callResponse.content[0].text).toContain('"blockType":"hero"')
       expect(callResponse.content[0].text).toContain('"blockType":"textContent"')
       expect(callResponse.content[0].text).toContain('"heading":"Page Hero"')
       expect(callResponse.content[0].text).toContain('"body":"This is the body text."')
-
       createdPageIds.push(getCreatedDocument(callResponse).id)
     })
-
-    it('should update a page layout that contains blocks', async ({ mcp }) => {
+    it('should update a page layout that contains blocks', async ({ mcp, getApiKey, payload }) => {
       const page = await payload.create({
         collection: 'pages',
         data: {
@@ -2304,12 +2178,9 @@ describe('@payloadcms/plugin-mcp', () => {
           layout: [],
         },
       })
-
       createdPageIds.push(page.id)
-
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
-
       const callResponse = await client.callTool({
         arguments: {
           slug: 'pages',
@@ -2330,25 +2201,26 @@ describe('@payloadcms/plugin-mcp', () => {
         },
         name: 'updateDocument',
       })
-
       expect(callResponse).toBeDefined()
       expect(callResponse.isError).toBeFalsy()
       expect(callResponse.content[0].text).toContain('"blockType":"hero"')
       expect(callResponse.content[0].text).toContain('"heading":"Updated Hero Heading"')
       expect(callResponse.content[0].text).toContain('"blockType":"textContent"')
       expect(callResponse.content[0].text).toContain('"body":"Updated body text."')
-
       const updatedPage = await payload.findByID({
         collection: 'pages',
         id: page.id,
       })
-
       expect((updatedPage as any).layout).toHaveLength(2)
       expect((updatedPage as any).layout[0].blockType).toBe('hero')
       expect((updatedPage as any).layout[0].heading).toBe('Updated Hero Heading')
     })
 
-    it('should return a concise validation error for invalid block data', async ({ mcp }) => {
+    it('should return a concise validation error for invalid block data', async ({
+      getApiKey,
+      mcp,
+      payload,
+    }) => {
       const page = await payload.create({
         collection: 'pages',
         data: {
@@ -2392,9 +2264,8 @@ describe('@payloadcms/plugin-mcp', () => {
       expect(callResponse.content[0].text).not.toContain('invalid_union')
     })
   })
-
-  describe('Virtual Fields', () => {
-    it('should not include virtual fields in collection schema', async ({ mcp }) => {
+  test.describe('Virtual Fields', () => {
+    it('should not include virtual fields in collection schema', async ({ mcp, getApiKey }) => {
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
       const schemaResponse = await client.callTool({
@@ -2404,11 +2275,13 @@ describe('@payloadcms/plugin-mcp', () => {
         name: 'getCollectionSchema',
       })
       const schema = getToolDoc<JsonSchemaType>(schemaResponse)
-
       expect(schema.properties?.computedTitle).toBeUndefined()
     })
-
-    it('should ignore virtual fields when creating a post via MCP', async ({ mcp }) => {
+    it('should ignore virtual fields when creating a post via MCP', async ({
+      mcp,
+      getApiKey,
+      payload,
+    }) => {
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
       const callResponse = await callCreateDocumentsWithOne(client, {
@@ -2420,24 +2293,26 @@ describe('@payloadcms/plugin-mcp', () => {
           },
         },
       })
-
       const text = getToolText(callResponse)
       expect(text).toContain('Created 1 of 1 documents in collection "posts".')
       expect(text).toContain('"title":"Virtual Field Create Test"')
       expect(text).not.toContain('"computedTitle"')
-
-      const { id: createdId } = getCreatedDocument<{ id: string }>(callResponse)
+      const { id: createdId } = getCreatedDocument<{
+        id: string
+      }>(callResponse)
       if (createdId) {
         await payload.delete({ id: createdId, collection: 'posts' })
       }
     })
-
-    it('should ignore virtual fields when updating a post via MCP', async ({ mcp }) => {
+    it('should ignore virtual fields when updating a post via MCP', async ({
+      mcp,
+      getApiKey,
+      payload,
+    }) => {
       const post = await payload.create({
         collection: 'posts',
         data: { title: 'Virtual Field Update Test' },
       })
-
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
       const callResponse = await client.callTool({
@@ -2449,18 +2324,19 @@ describe('@payloadcms/plugin-mcp', () => {
         },
         name: 'updateDocument',
       })
-
       const text = getToolText(callResponse)
       expect(text).toContain('Document updated successfully')
       expect(text).toContain('"title":"Virtual Field Updated Title"')
       expect(text).not.toContain('"computedTitle"')
-
       await payload.delete({ id: post.id, collection: 'posts' })
     })
   })
-
-  describe('payloadAPI context', () => {
-    it('should call operations with the payloadAPI context as MCP', async ({ mcp }) => {
+  test.describe('payloadAPI context', () => {
+    it('should call operations with the payloadAPI context as MCP', async ({
+      mcp,
+      getApiKey,
+      payload,
+    }) => {
       await payload.create({
         collection: 'posts',
         data: {
@@ -2468,7 +2344,6 @@ describe('@payloadcms/plugin-mcp', () => {
           title: 'Test Post for Finding',
         },
       })
-
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
       const callResponse = await client.callTool({
@@ -2480,7 +2355,6 @@ describe('@payloadcms/plugin-mcp', () => {
         },
         name: 'findDocuments',
       })
-
       expect(callResponse).toBeDefined()
       expect(callResponse.content).toHaveLength(2)
       expect(callResponse.content[0].type).toBe('text')
@@ -2488,24 +2362,22 @@ describe('@payloadcms/plugin-mcp', () => {
         '"title":"Test Post for Finding (MCP Hook Override)"',
       )
     })
-
-    it('should find site-settings global', async ({ mcp }) => {
+    it('should find site-settings global', async ({ mcp, getApiKey }) => {
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
       const callResponse = await client.callTool({
         arguments: { depth: 9, slug: 'site-settings' },
         name: 'findGlobal',
       })
-
       expect(callResponse).toBeDefined()
       expect(callResponse.content).toBeDefined()
       expect(callResponse.content[0].type).toBe('text')
       expect(callResponse.content[0].text).toContain('Global "site-settings"')
       expect(callResponse.content[0].text).toContain('```json')
     })
-
     it('getGlobalSchema: should hide inaccessible global fields unless access is overridden', async ({
       mcp,
+      getApiKey,
     }) => {
       const apiKey = await getApiKey({
         fields: {
@@ -2520,23 +2392,18 @@ describe('@payloadcms/plugin-mcp', () => {
         name: 'getGlobalSchema',
       })
       const schema = getToolDoc<JsonSchemaType>(schemaResponse)
-
       expect(schema.properties?.siteName).toBeDefined()
       expect(schema.properties?.contactEmail).toBeUndefined()
-
       vi.stubEnv('NODE_ENV', 'development')
-
       const overrideClient = await mcp.connect(apiKey, { overrideAccess: true })
       const overrideResponse = await overrideClient.callTool({
         arguments: { slug: 'site-settings' },
         name: 'getGlobalSchema',
       })
       const overrideSchema = getToolDoc<JsonSchemaType>(overrideResponse)
-
       expect(overrideSchema.properties?.contactEmail).toBeDefined()
     })
-
-    it('should find site-settings global with select', async ({ mcp }) => {
+    it('should find site-settings global with select', async ({ mcp, getApiKey, payload }) => {
       await payload.updateGlobal({
         slug: 'site-settings',
         data: {
@@ -2546,7 +2413,6 @@ describe('@payloadcms/plugin-mcp', () => {
           siteName: 'MCP Site',
         },
       })
-
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
       const callResponse = await client.callTool({
@@ -2556,7 +2422,6 @@ describe('@payloadcms/plugin-mcp', () => {
         },
         name: 'findGlobal',
       })
-
       expect(callResponse).toBeDefined()
       expect(callResponse.content).toBeDefined()
       expect(callResponse.content[0].type).toBe('text')
@@ -2566,12 +2431,10 @@ describe('@payloadcms/plugin-mcp', () => {
       expect(responseText).not.toContain('contactEmail')
       expect(responseText).not.toContain('maintenanceMode')
     })
-
-    it('should pass populate to findGlobal', async ({ mcp }) => {
+    it('should pass populate to findGlobal', async ({ mcp, getApiKey, payload }) => {
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
       const findGlobalSpy = vi.spyOn(payload, 'findGlobal')
-
       try {
         const callResponse = await client.callTool({
           arguments: {
@@ -2580,7 +2443,6 @@ describe('@payloadcms/plugin-mcp', () => {
           },
           name: 'findGlobal',
         })
-
         expect(callResponse).toBeDefined()
         expect(findGlobalSpy).toHaveBeenCalledWith(
           expect.objectContaining({
@@ -2592,8 +2454,7 @@ describe('@payloadcms/plugin-mcp', () => {
         findGlobalSpy.mockRestore()
       }
     })
-
-    it('should update site-settings global', async ({ mcp }) => {
+    it('should update site-settings global', async ({ mcp, getApiKey }) => {
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
       const callResponse = await client.callTool({
@@ -2607,14 +2468,12 @@ describe('@payloadcms/plugin-mcp', () => {
         },
         name: 'updateGlobal',
       })
-
       expect(callResponse).toBeDefined()
       expect(callResponse.content).toBeDefined()
       expect(callResponse.content[0].type).toBe('text')
       expect(callResponse.content[0].text).toContain('Global "site-settings" updated successfully')
     })
-
-    it('should update site-settings global with select', async ({ mcp }) => {
+    it('should update site-settings global with select', async ({ mcp, getApiKey }) => {
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
       const callResponse = await client.callTool({
@@ -2629,7 +2488,6 @@ describe('@payloadcms/plugin-mcp', () => {
         },
         name: 'updateGlobal',
       })
-
       expect(callResponse).toBeDefined()
       expect(callResponse.content).toBeDefined()
       expect(callResponse.content[0].type).toBe('text')
@@ -2639,8 +2497,7 @@ describe('@payloadcms/plugin-mcp', () => {
       expect(responseText).not.toContain('maintenanceMode')
       expect(responseText).not.toContain('contactEmail')
     })
-
-    it('should call global version tools', async ({ mcp }) => {
+    it('should call global version tools', async ({ mcp, getApiKey, payload }) => {
       await payload.updateGlobal({
         slug: 'site-settings',
         data: {
@@ -2649,7 +2506,6 @@ describe('@payloadcms/plugin-mcp', () => {
           siteName: 'Versioned Global',
         },
       })
-
       await payload.updateGlobal({
         slug: 'site-settings',
         data: {
@@ -2658,26 +2514,24 @@ describe('@payloadcms/plugin-mcp', () => {
           siteName: 'Versioned Global Updated',
         },
       })
-
       const versions = await payload.findGlobalVersions({
         slug: 'site-settings',
         limit: 1,
         sort: '-updatedAt',
       })
       const versionID = String(versions.docs[0]!.id)
-
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
-
       const countResponse = await client.callTool({
         arguments: {
           slug: 'site-settings',
         },
         name: 'countGlobalVersions',
       })
-      const countResult = getToolDoc<{ totalDocs: number }>(countResponse)
+      const countResult = getToolDoc<{
+        totalDocs: number
+      }>(countResponse)
       expect(countResult.totalDocs).toBeGreaterThanOrEqual(1)
-
       const findResponse = await client.callTool({
         arguments: {
           slug: 'site-settings',
@@ -2685,9 +2539,12 @@ describe('@payloadcms/plugin-mcp', () => {
         },
         name: 'findGlobalVersions',
       })
-      const findResult = getToolDoc<{ docs: Array<{ id: number | string }> }>(findResponse)
+      const findResult = getToolDoc<{
+        docs: Array<{
+          id: number | string
+        }>
+      }>(findResponse)
       expect(findResult.docs).toHaveLength(1)
-
       const findByIDResponse = await client.callTool({
         arguments: {
           slug: 'site-settings',
@@ -2695,12 +2552,14 @@ describe('@payloadcms/plugin-mcp', () => {
         },
         name: 'findGlobalVersionByID',
       })
-      const version = getToolDoc<{ id: number | string; version: { siteName: string } }>(
-        findByIDResponse,
-      )
+      const version = getToolDoc<{
+        id: number | string
+        version: {
+          siteName: string
+        }
+      }>(findByIDResponse)
       expect(String(version.id)).toBe(versionID)
       expect(version.version.siteName).toContain('Versioned Global')
-
       const restoreResponse = await client.callTool({
         arguments: {
           slug: 'site-settings',
@@ -2708,13 +2567,17 @@ describe('@payloadcms/plugin-mcp', () => {
         },
         name: 'restoreGlobalVersion',
       })
-      const restored = getToolDoc<{ siteName: string }>(restoreResponse)
+      const restored = getToolDoc<{
+        siteName: string
+      }>(restoreResponse)
       expect(restored.siteName).toContain('Versioned Global')
     })
   })
-
-  describe('Payload access control', () => {
-    it('getConfigInfo: should omit entities when Payload access denies read', async ({ mcp }) => {
+  test.describe('Payload access control', () => {
+    it('getConfigInfo: should omit entities when Payload access denies read', async ({
+      mcp,
+      getApiKey,
+    }) => {
       const apiKey = await getApiKey({
         collections: {
           pages: {
@@ -2730,14 +2593,15 @@ describe('@payloadcms/plugin-mcp', () => {
       const client = await mcp.connect(apiKey)
       const response = await client.callTool({ arguments: {}, name: 'getConfigInfo' })
       const text = getToolText(response)
-
       expect(text).toContain('posts')
       expect(text).not.toContain('pages')
       expect(text).toContain('Globals: none')
       expect(text).not.toContain('site-settings')
     })
-
-    it('getConfigInfo: should include entities when access is overridden', async ({ mcp }) => {
+    it('getConfigInfo: should include entities when access is overridden', async ({
+      mcp,
+      getApiKey,
+    }) => {
       const apiKey = await getApiKey({
         collections: {
           pages: {
@@ -2750,19 +2614,16 @@ describe('@payloadcms/plugin-mcp', () => {
           },
         },
       })
-
       vi.stubEnv('NODE_ENV', 'development')
-
       const client = await mcp.connect(apiKey, { overrideAccess: true })
       const response = await client.callTool({ arguments: {}, name: 'getConfigInfo' })
       const text = getToolText(response)
-
       expect(text).toContain('pages')
       expect(text).toContain('Globals: site-settings')
     })
-
     it('getGlobalSchema: should not advertise global write tools when Payload access denies update', async ({
       mcp,
+      getApiKey,
     }) => {
       const apiKey = await getApiKey({
         globals: {
@@ -2774,15 +2635,14 @@ describe('@payloadcms/plugin-mcp', () => {
       const client = await mcp.connect(apiKey)
       const toolsResponse = await client.listTools()
       const toolNames = toolsResponse.tools.map((tool: { name: string }) => tool.name)
-
       expect(toolNames).toContain('findGlobal')
       expect(toolNames).not.toContain('updateGlobal')
       // site-settings is the only global => not having access should hide the entire getGlobalSchema tool
       expect(toolNames).not.toContain('getGlobalSchema')
     })
-
     it('getCollectionSchema: should hide inaccessible fields inside nested field layouts', async ({
       mcp,
+      getApiKey,
     }) => {
       const apiKey = await getApiKey({
         fields: {
@@ -2816,7 +2676,6 @@ describe('@payloadcms/plugin-mcp', () => {
         name: 'getCollectionSchema',
       })
       const schema = getToolDoc<JsonSchemaType>(response)
-
       expect(schema).not.toHaveProperty('properties.groupField.properties.groupText')
       expect(schema).toHaveProperty('properties.groupField.properties.groupNumber')
       expect(schema).not.toHaveProperty('properties.arrayField.items.properties.item')
@@ -2825,8 +2684,10 @@ describe('@payloadcms/plugin-mcp', () => {
       expect(schema).not.toHaveProperty('properties.namedTab.properties.namedTabText')
       expect(schema).not.toHaveProperty('properties.unnamedTabText')
     })
-
-    it('getCollectionSchema: should hide inaccessible fields inside blocks', async ({ mcp }) => {
+    it('getCollectionSchema: should hide inaccessible fields inside blocks', async ({
+      mcp,
+      getApiKey,
+    }) => {
       const apiKey = await getApiKey({
         fields: {
           'pages.layout.hero.heading': {
@@ -2843,7 +2704,6 @@ describe('@payloadcms/plugin-mcp', () => {
         name: 'getCollectionSchema',
       })
       const schema = getToolDoc<JsonSchemaType>(response)
-
       expect(schema).not.toHaveProperty('properties.layout.items.oneOf.0.properties.heading')
       expect(schema).toHaveProperty('properties.layout.items.oneOf.0.properties.subheading')
       expect(schema).not.toHaveProperty(
@@ -2851,9 +2711,9 @@ describe('@payloadcms/plugin-mcp', () => {
         expect.arrayContaining(['heading']),
       )
     })
-
     it('getCollectionSchema: should intersect collection and field write access', async ({
       mcp,
+      getApiKey,
     }) => {
       const deniedCreateApiKey = await getApiKey({
         collections: {
@@ -2875,10 +2735,8 @@ describe('@payloadcms/plugin-mcp', () => {
         name: 'getCollectionSchema',
       })
       const deniedCreateSchema = getToolDoc<JsonSchemaType>(deniedCreateResponse)
-
       expect(deniedCreateSchema.properties?.title).toBeUndefined()
       expect(deniedCreateSchema.required).not.toContain('title')
-
       const deniedUpdateApiKey = await getApiKey({
         collections: {
           pages: {
@@ -2899,13 +2757,12 @@ describe('@payloadcms/plugin-mcp', () => {
         name: 'getCollectionSchema',
       })
       const deniedUpdateSchema = getToolDoc<JsonSchemaType>(deniedUpdateResponse)
-
       expect(deniedUpdateSchema.properties?.title).toBeDefined()
       expect(deniedUpdateSchema.required).toContain('title')
     })
-
     it('getCollectionSchema: should reject when Payload access denies all write operations', async ({
       mcp,
+      getApiKey,
     }) => {
       // Only deny getCollectionSchema call if ALL write operations are false
       const apiKey = await getApiKey({
@@ -2923,14 +2780,11 @@ describe('@payloadcms/plugin-mcp', () => {
         },
         name: 'getCollectionSchema',
       })
-
       expect(responseWriteFalse.isError).toBe(true)
       expect(getToolText(responseWriteFalse)).toContain(
         'MCP access to "getCollectionSchema" is not enabled for collection "pages"',
       )
-
       vi.stubEnv('NODE_ENV', 'development')
-
       const overrideClient = await mcp.connect(apiKey, { overrideAccess: true })
       const overrideResponse = await overrideClient.callTool({
         arguments: {
@@ -2938,15 +2792,10 @@ describe('@payloadcms/plugin-mcp', () => {
         },
         name: 'getCollectionSchema',
       })
-
       expect(overrideResponse.isError).not.toBe(true)
-
       const overrideSchema = getToolDoc<JsonSchemaType>(overrideResponse)
-
       expect(overrideSchema.properties?.title).toBeDefined()
-
       vi.unstubAllEnvs()
-
       const responseUpdateFalse = await (
         await mcp.connect(
           await getApiKey({
@@ -2964,7 +2813,6 @@ describe('@payloadcms/plugin-mcp', () => {
         name: 'getCollectionSchema',
       })
       expect(responseUpdateFalse.isError).not.toBe(true)
-
       const responseCreateFalse = await (
         await mcp.connect(
           await getApiKey({
@@ -2983,9 +2831,9 @@ describe('@payloadcms/plugin-mcp', () => {
       })
       expect(responseCreateFalse.isError).not.toBe(true)
     })
-
     it('updateDocument: should reject when Payload access denies that operation', async ({
       mcp,
+      getApiKey,
     }) => {
       const apiKey = await getApiKey({
         collections: {
@@ -2999,7 +2847,6 @@ describe('@payloadcms/plugin-mcp', () => {
       const updateTool = toolsResponse.tools.find(
         (tool: { name: string }) => tool.name === 'updateDocument',
       )
-
       expect(updateTool).toBeDefined()
       expect(updateTool?.inputSchema).not.toHaveProperty('properties.slug.enum')
 
@@ -3013,26 +2860,17 @@ describe('@payloadcms/plugin-mcp', () => {
         },
         name: 'updateDocument',
       })
-
       expect(callResponse.isError).toBe(true)
       expect(getToolText(callResponse)).toContain(
         'MCP access to "updateDocument" is not enabled for collection "pages"',
       )
     })
   })
-
-  describe('Minified JSON responses', () => {
-    const createdIDs: string[] = []
-
-    afterEach(async () => {
-      for (const id of createdIDs) {
-        await payload.delete({ collection: 'posts', id })
-      }
-      createdIDs.length = 0
-    })
-
+  test.describe('Minified JSON responses', () => {
     it('should return minified JSON without newlines or indentation in resource responses', async ({
       mcp,
+      getApiKey,
+      payload,
     }) => {
       const doc = await payload.create({
         collection: 'posts',
@@ -3041,9 +2879,6 @@ describe('@payloadcms/plugin-mcp', () => {
           content: 'Content for minified test.',
         },
       })
-
-      createdIDs.push(doc.id)
-
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
       const callResponse = await client.callTool({
@@ -3055,10 +2890,8 @@ describe('@payloadcms/plugin-mcp', () => {
         },
         name: 'findDocuments',
       })
-
       const responseText: string = callResponse.content[0].text
       const jsonBlocks = responseText.match(/```json\n[\s\S]*?```/g)
-
       expect(jsonBlocks).toBeTruthy()
       for (const block of jsonBlocks!) {
         const jsonContent = block.replace(/```json\n/, '').replace(/\n```/, '')
@@ -3068,18 +2901,15 @@ describe('@payloadcms/plugin-mcp', () => {
         expect(() => JSON.parse(jsonContent)).not.toThrow()
       }
     })
-
-    it('should return minified JSON in global responses', async ({ mcp }) => {
+    it('should return minified JSON in global responses', async ({ mcp, getApiKey }) => {
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
       const callResponse = await client.callTool({
         arguments: { slug: 'site-settings' },
         name: 'findGlobal',
       })
-
       const responseText: string = callResponse.content[0].text
       const jsonBlocks = responseText.match(/```json\n[\s\S]*?```/g)
-
       expect(jsonBlocks).toBeTruthy()
       for (const block of jsonBlocks!) {
         const jsonContent = block.replace(/```json\n/, '').replace(/\n```/, '')
@@ -3087,8 +2917,11 @@ describe('@payloadcms/plugin-mcp', () => {
         expect(() => JSON.parse(jsonContent)).not.toThrow()
       }
     })
-
-    it('should return minified JSON in findByID resource responses', async ({ mcp }) => {
+    it('should return minified JSON in findByID resource responses', async ({
+      mcp,
+      getApiKey,
+      payload,
+    }) => {
       const doc = await payload.create({
         collection: 'posts',
         data: {
@@ -3096,9 +2929,6 @@ describe('@payloadcms/plugin-mcp', () => {
           content: 'Content for findByID minified test.',
         },
       })
-
-      createdIDs.push(doc.id)
-
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
       const callResponse = await client.callTool({
@@ -3108,27 +2938,22 @@ describe('@payloadcms/plugin-mcp', () => {
         },
         name: 'findDocuments',
       })
-
       const responseText: string = callResponse.content[0].text
       // findByID response format: `Resource from collection "posts":\n${JSON.stringify(doc)}`
       // (no fenced code block — extract the JSON from the second line)
       const jsonPart = responseText.split('\n').slice(1).join('\n')
-
       expect(jsonPart).toBeTruthy()
       expect(() => JSON.parse(jsonPart)).not.toThrow()
       // Minified JSON should be a single line with no newlines
       expect(jsonPart).not.toContain('\n')
     })
   })
-
-  describe('Localization', () => {
-    it('should include locale parameters in tool schemas', async ({ mcp }) => {
+  test.describe('Localization', () => {
+    it('should include locale parameters in tool schemas', async ({ mcp, getApiKey }) => {
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
       const toolsResponse = await client.listTools()
-
       expect(toolsResponse.tools).toBeDefined()
-
       // Check createDocuments has locale parameters
       const createTool = toolsResponse.tools.find((t: any) => t.name === 'createDocuments')
       expect(createTool).toBeDefined()
@@ -3136,27 +2961,23 @@ describe('@payloadcms/plugin-mcp', () => {
       expect(createTool.inputSchema.properties.locale.type).toBe('string')
       expect(createTool.inputSchema.properties.locale.description).toContain('locale code')
       expect(createTool.inputSchema.properties.fallbackLocale).toBeDefined()
-
       // Check updateDocument has locale parameters
       const updateTool = toolsResponse.tools.find((t: any) => t.name === 'updateDocument')
       expect(updateTool).toBeDefined()
       expect(updateTool.inputSchema.properties.locale).toBeDefined()
       expect(updateTool.inputSchema.properties.fallbackLocale).toBeDefined()
-
       // Check findDocuments has locale parameters
       const findTool = toolsResponse.tools.find((t: any) => t.name === 'findDocuments')
       expect(findTool).toBeDefined()
       expect(findTool.inputSchema.properties.locale).toBeDefined()
       expect(findTool.inputSchema.properties.fallbackLocale).toBeDefined()
-
       // Check deleteDocuments has locale parameters
       const deleteTool = toolsResponse.tools.find((t: any) => t.name === 'deleteDocuments')
       expect(deleteTool).toBeDefined()
       expect(deleteTool.inputSchema.properties.locale).toBeDefined()
       expect(deleteTool.inputSchema.properties.fallbackLocale).toBeDefined()
     })
-
-    it('should create post with specific locale', async ({ mcp }) => {
+    it('should create post with specific locale', async ({ mcp, getApiKey }) => {
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
       const callResponse = await callCreateDocumentsWithOne(client, {
@@ -3169,14 +2990,12 @@ describe('@payloadcms/plugin-mcp', () => {
           locale: 'en',
         },
       })
-
       expect(callResponse).toBeDefined()
       expect(callResponse.content[0].text).toContain('Created 1 of 1 documents')
       expect(callResponse.content[0].text).toContain('"title":"Hello World"')
       expect(callResponse.content[0].text).toContain('"content":"This is my first post in English"')
     })
-
-    it('should update post to add translation', async ({ mcp }) => {
+    it('should update post to add translation', async ({ mcp, getApiKey, payload }) => {
       // First create a post in English
       const englishPost = await payload.create({
         collection: 'posts',
@@ -3185,7 +3004,6 @@ describe('@payloadcms/plugin-mcp', () => {
           title: 'English Title',
         },
       })
-
       // Update with Spanish translation via MCP
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
@@ -3202,14 +3020,12 @@ describe('@payloadcms/plugin-mcp', () => {
         },
         name: 'updateDocument',
       })
-
       expect(callResponse).toBeDefined()
       expect(callResponse.content[0].text).toContain('Document updated successfully')
       expect(callResponse.content[0].text).toContain('"title":"Título Español"')
       expect(callResponse.content[0].text).toContain('"content":"Contenido Español"')
     })
-
-    it('should find post in specific locale', async ({ mcp }) => {
+    it('should find post in specific locale', async ({ mcp, getApiKey, payload }) => {
       // Create a post with English and Spanish translations
       const post = await payload.create({
         collection: 'posts',
@@ -3218,7 +3034,6 @@ describe('@payloadcms/plugin-mcp', () => {
           title: 'English Post',
         },
       })
-
       await payload.update({
         id: post.id,
         collection: 'posts',
@@ -3228,7 +3043,6 @@ describe('@payloadcms/plugin-mcp', () => {
         },
         locale: 'es',
       })
-
       // Find in Spanish via MCP
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
@@ -3240,15 +3054,13 @@ describe('@payloadcms/plugin-mcp', () => {
         },
         name: 'findDocuments',
       })
-
       expect(callResponse).toBeDefined()
       expect(callResponse.content[0].text).toContain(
         '"title":"Publicación Española (MCP Hook Override)"',
       )
       expect(callResponse.content[0].text).toContain('"content":"Contenido Español"')
     })
-
-    it('should find post with locale "all"', async ({ mcp }) => {
+    it('should find post with locale "all"', async ({ mcp, getApiKey, payload }) => {
       // Create a post with multiple translations
       const post = await payload.create({
         collection: 'posts',
@@ -3257,7 +3069,6 @@ describe('@payloadcms/plugin-mcp', () => {
           title: 'English Title',
         },
       })
-
       await payload.update({
         id: post.id,
         collection: 'posts',
@@ -3267,7 +3078,6 @@ describe('@payloadcms/plugin-mcp', () => {
         },
         locale: 'es',
       })
-
       await payload.update({
         id: post.id,
         collection: 'posts',
@@ -3277,7 +3087,6 @@ describe('@payloadcms/plugin-mcp', () => {
         },
         locale: 'fr',
       })
-
       // Find with locale: all via MCP
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
@@ -3289,10 +3098,8 @@ describe('@payloadcms/plugin-mcp', () => {
         },
         name: 'findDocuments',
       })
-
       expect(callResponse).toBeDefined()
       const responseText = callResponse.content[0].text
-
       // Should contain locale objects with all translations
       expect(responseText).toContain('"en":')
       expect(responseText).toContain('"es":')
@@ -3301,8 +3108,11 @@ describe('@payloadcms/plugin-mcp', () => {
       expect(responseText).toContain('Título Español (MCP Hook Override)')
       expect(responseText).toContain('Titre Français (MCP Hook Override)')
     })
-
-    it('should use fallback locale when translation does not exist', async ({ mcp }) => {
+    it('should use fallback locale when translation does not exist', async ({
+      mcp,
+      getApiKey,
+      payload,
+    }) => {
       // Create a post only in English with explicit content
       const post = await payload.create({
         collection: 'posts',
@@ -3311,7 +3121,6 @@ describe('@payloadcms/plugin-mcp', () => {
         },
         locale: 'en',
       })
-
       // Try to find in French (which doesn't exist)
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
@@ -3323,7 +3132,6 @@ describe('@payloadcms/plugin-mcp', () => {
         },
         name: 'findDocuments',
       })
-
       expect(json).toBeDefined()
       expect(json.content).toBeDefined()
       expect(json.content[0].type).toBe('text')
@@ -3332,108 +3140,102 @@ describe('@payloadcms/plugin-mcp', () => {
       expect(json.content[0].text).toContain('"content":"Hello World."')
     })
   })
-
-  describe('Field Types', () => {
-    const createdFieldTypeIds: (number | string)[] = []
-
-    describe('Schema validation', () => {
+  test.describe('Field Types', () => {
+    test.describe('Schema validation', () => {
       const getFieldTypeInputProps = async (mcp: any, apiKey: string) => {
         const client = await mcp.connect(apiKey)
         const schemaResponse = await client.callTool({
           arguments: { slug: 'field-types' },
           name: 'getCollectionSchema',
         })
-
         return getToolDoc<any>(schemaResponse).properties
       }
-
-      it('should not include ui field in create tool schema', async ({ mcp }) => {
+      it('should not include ui field in create tool schema', async ({ mcp, getApiKey }) => {
         const apiKey = await getApiKey()
         const inputProps = await getFieldTypeInputProps(mcp, apiKey)
-
         expect(inputProps).not.toHaveProperty('uiField')
       })
-
-      it('should include group field as nested object in create tool schema', async ({ mcp }) => {
+      it('should include group field as nested object in create tool schema', async ({
+        mcp,
+        getApiKey,
+      }) => {
         const apiKey = await getApiKey()
         const inputProps = await getFieldTypeInputProps(mcp, apiKey)
-
         expect(inputProps.groupField).toBeDefined()
         expect(inputProps.groupField.type).toBe('object')
         expect(inputProps.groupField.properties).toBeDefined()
         expect(inputProps.groupField.properties.groupText).toBeDefined()
         expect(inputProps.groupField.properties.groupNumber).toBeDefined()
       })
-
       it('should include collapsible children as top-level fields in create tool schema', async ({
         mcp,
+        getApiKey,
       }) => {
         const apiKey = await getApiKey()
         const inputProps = await getFieldTypeInputProps(mcp, apiKey)
-
         // Children of collapsible appear at the top level, not under a `collapsible` key
         expect(inputProps.collapsibleText).toBeDefined()
         // Nullable text fields render as a type array: ['string', 'null']
         expect(inputProps.collapsibleText.type).toContain('string')
         expect(inputProps.collapsibleText.type).toContain('null')
       })
-
       it('should include row children as top-level fields in create tool schema', async ({
         mcp,
+        getApiKey,
       }) => {
         const apiKey = await getApiKey()
         const inputProps = await getFieldTypeInputProps(mcp, apiKey)
-
         // Children of row appear at the top level, not under a `row` key
         expect(inputProps.rowText).toBeDefined()
         expect(inputProps.rowText.type).toContain('string')
         expect(inputProps.rowText.type).toContain('null')
       })
-
       it('should include named tab as nested object and unnamed tab children at top level in create tool schema', async ({
         mcp,
+        getApiKey,
       }) => {
         const apiKey = await getApiKey()
         const inputProps = await getFieldTypeInputProps(mcp, apiKey)
-
         // Named tab appears as a nested object
         expect(inputProps.namedTab).toBeDefined()
         expect(inputProps.namedTab.type).toBe('object')
         expect(inputProps.namedTab.properties).toBeDefined()
         expect(inputProps.namedTab.properties.namedTabText).toBeDefined()
-
         // Unnamed tab children appear at the top level
         expect(inputProps.unnamedTabText).toBeDefined()
         expect(inputProps.unnamedTabText.type).toContain('string')
         expect(inputProps.unnamedTabText.type).toContain('null')
       })
-
-      it('should include select field with enum values in create tool schema', async ({ mcp }) => {
+      it('should include select field with enum values in create tool schema', async ({
+        mcp,
+        getApiKey,
+      }) => {
         const apiKey = await getApiKey()
         const inputProps = await getFieldTypeInputProps(mcp, apiKey)
-
         expect(inputProps.selectField).toBeDefined()
         expect(inputProps.selectField.enum).toBeDefined()
         expect(inputProps.selectField.enum).toContain('option1')
         expect(inputProps.selectField.enum).toContain('option2')
         expect(inputProps.selectField.enum).toContain('option3')
       })
-
-      it('should include radio field with enum values in create tool schema', async ({ mcp }) => {
+      it('should include radio field with enum values in create tool schema', async ({
+        mcp,
+        getApiKey,
+      }) => {
         const apiKey = await getApiKey()
         const inputProps = await getFieldTypeInputProps(mcp, apiKey)
-
         expect(inputProps.radioField).toBeDefined()
         expect(inputProps.radioField.enum).toBeDefined()
         expect(inputProps.radioField.enum).toContain('radio1')
         expect(inputProps.radioField.enum).toContain('radio2')
         expect(inputProps.radioField.enum).toContain('radio3')
       })
-
-      it('should include array field with item schema in create tool schema', async ({ mcp }) => {
+      it('should include array field with item schema in create tool schema', async ({
+        mcp,
+        getApiKey,
+      }) => {
         const apiKey = await getApiKey()
         const inputProps = await getFieldTypeInputProps(mcp, apiKey)
-
         expect(inputProps.arrayField).toBeDefined()
         expect(inputProps.arrayField.type).toContain('array')
         expect(inputProps.arrayField.items).toBeDefined()
@@ -3442,10 +3244,10 @@ describe('@payloadcms/plugin-mcp', () => {
         expect(inputProps.arrayField.items.properties.itemNumber).toBeDefined()
       })
     })
-
-    describe('Create + round-trip', () => {
+    test.describe('Create + round-trip', () => {
       it('should create and find document with atomic data fields (text, textarea, number, email, checkbox)', async ({
         mcp,
+        getApiKey,
       }) => {
         const apiKey = await getApiKey()
         const client = await mcp.connect(apiKey)
@@ -3461,27 +3263,22 @@ describe('@payloadcms/plugin-mcp', () => {
             },
           },
         })
-
         expect(callResponse).toBeDefined()
         expect(callResponse.isError).toBeFalsy()
         expect(callResponse.content[0].type).toBe('text')
         expect(callResponse.content[0].text).toContain(
           'Created 1 of 1 documents in collection "field-types".',
         )
-
         const doc = getCreatedDocument(callResponse)
-
         expect(doc.textField).toBe('Hello MCP')
         expect(doc.textareaField).toBe('Multi-line\ntext content')
         expect(doc.numberField).toBe(42)
         expect(doc.emailField).toBe('test@example.com')
         expect(doc.checkboxField).toBe(true)
-
-        createdFieldTypeIds.push(doc.id)
       })
-
       it('should return the collection schema when createDocuments fails validation', async ({
         mcp,
+        getApiKey,
       }) => {
         const apiKey = await getApiKey()
         const client = await mcp.connect(apiKey)
@@ -3493,7 +3290,6 @@ describe('@payloadcms/plugin-mcp', () => {
             },
           },
         })
-
         expect(callResponse.isError).toBe(true)
         expect(callResponse.content[0].text).toContain('Use this schema for data')
         expect(callResponse.content[0].text).toContain('"numberField"')
@@ -3513,8 +3309,7 @@ describe('@payloadcms/plugin-mcp', () => {
           },
         })
       })
-
-      it('should create document with date, code, and json fields', async ({ mcp }) => {
+      it('should create document with date, code, and json fields', async ({ mcp, getApiKey }) => {
         const apiKey = await getApiKey()
         const client = await mcp.connect(apiKey)
         const testDate = '2024-01-15T10:30:00.000Z'
@@ -3529,20 +3324,14 @@ describe('@payloadcms/plugin-mcp', () => {
             },
           },
         })
-
         expect(callResponse).toBeDefined()
         expect(callResponse.isError).toBeFalsy()
-
         const doc = getCreatedDocument(callResponse)
-
         expect(doc.codeField).toBe('const x = 42;')
         expect(doc.jsonField).toMatchObject({ key: 'value', nested: { count: 1 } })
         expect(doc.dateField).toBeDefined()
-
-        createdFieldTypeIds.push(doc.id)
       })
-
-      it('should create document with select field', async ({ mcp }) => {
+      it('should create document with select field', async ({ mcp, getApiKey }) => {
         const apiKey = await getApiKey()
         const client = await mcp.connect(apiKey)
         const callResponse = await callCreateDocumentsWithOne(client, {
@@ -3554,18 +3343,12 @@ describe('@payloadcms/plugin-mcp', () => {
             },
           },
         })
-
         expect(callResponse).toBeDefined()
         expect(callResponse.isError).toBeFalsy()
-
         const doc = getCreatedDocument(callResponse)
-
         expect(doc.selectField).toBe('option2')
-
-        createdFieldTypeIds.push(doc.id)
       })
-
-      it('should create document with radio field', async ({ mcp }) => {
+      it('should create document with radio field', async ({ mcp, getApiKey }) => {
         const apiKey = await getApiKey()
         const client = await mcp.connect(apiKey)
         const callResponse = await callCreateDocumentsWithOne(client, {
@@ -3577,18 +3360,12 @@ describe('@payloadcms/plugin-mcp', () => {
             },
           },
         })
-
         expect(callResponse).toBeDefined()
         expect(callResponse.isError).toBeFalsy()
-
         const doc = getCreatedDocument(callResponse)
-
         expect(doc.radioField).toBe('radio3')
-
-        createdFieldTypeIds.push(doc.id)
       })
-
-      it('should create document with group field (nested object)', async ({ mcp }) => {
+      it('should create document with group field (nested object)', async ({ mcp, getApiKey }) => {
         const apiKey = await getApiKey()
         const client = await mcp.connect(apiKey)
         const callResponse = await callCreateDocumentsWithOne(client, {
@@ -3603,20 +3380,17 @@ describe('@payloadcms/plugin-mcp', () => {
             },
           },
         })
-
         expect(callResponse).toBeDefined()
         expect(callResponse.isError).toBeFalsy()
-
         const doc = getCreatedDocument(callResponse)
-
         expect(doc.groupField).toBeDefined()
         expect(doc.groupField.groupText).toBe('Inside the group')
         expect(doc.groupField.groupNumber).toBe(99)
-
-        createdFieldTypeIds.push(doc.id)
       })
-
-      it('should create document with collapsible children at top level', async ({ mcp }) => {
+      it('should create document with collapsible children at top level', async ({
+        mcp,
+        getApiKey,
+      }) => {
         const apiKey = await getApiKey()
         const client = await mcp.connect(apiKey)
         const callResponse = await callCreateDocumentsWithOne(client, {
@@ -3628,19 +3402,13 @@ describe('@payloadcms/plugin-mcp', () => {
             },
           },
         })
-
         expect(callResponse).toBeDefined()
         expect(callResponse.isError).toBeFalsy()
-
         const doc = getCreatedDocument(callResponse)
-
         // collapsibleText is stored at the top level of the document
         expect(doc.collapsibleText).toBe('Text inside collapsible')
-
-        createdFieldTypeIds.push(doc.id)
       })
-
-      it('should create document with row children at top level', async ({ mcp }) => {
+      it('should create document with row children at top level', async ({ mcp, getApiKey }) => {
         const apiKey = await getApiKey()
         const client = await mcp.connect(apiKey)
         const callResponse = await callCreateDocumentsWithOne(client, {
@@ -3652,20 +3420,15 @@ describe('@payloadcms/plugin-mcp', () => {
             },
           },
         })
-
         expect(callResponse).toBeDefined()
         expect(callResponse.isError).toBeFalsy()
-
         const doc = getCreatedDocument(callResponse)
-
         // rowText is stored at the top level of the document
         expect(doc.rowText).toBe('Text inside row')
-
-        createdFieldTypeIds.push(doc.id)
       })
-
       it('should create document with tabs fields (named tab as object, unnamed tab children at top level)', async ({
         mcp,
+        getApiKey,
       }) => {
         const apiKey = await getApiKey()
         const client = await mcp.connect(apiKey)
@@ -3681,23 +3444,16 @@ describe('@payloadcms/plugin-mcp', () => {
             },
           },
         })
-
         expect(callResponse).toBeDefined()
         expect(callResponse.isError).toBeFalsy()
-
         const doc = getCreatedDocument(callResponse)
-
         // Named tab stored as nested object
         expect(doc.namedTab).toBeDefined()
         expect(doc.namedTab.namedTabText).toBe('Inside named tab')
-
         // Unnamed tab child stored at document top level
         expect(doc.unnamedTabText).toBe('Inside unnamed tab')
-
-        createdFieldTypeIds.push(doc.id)
       })
-
-      it('should create document with array field', async ({ mcp }) => {
+      it('should create document with array field', async ({ mcp, getApiKey }) => {
         const apiKey = await getApiKey()
         const client = await mcp.connect(apiKey)
         const callResponse = await callCreateDocumentsWithOne(client, {
@@ -3712,28 +3468,20 @@ describe('@payloadcms/plugin-mcp', () => {
             },
           },
         })
-
         expect(callResponse).toBeDefined()
         expect(callResponse.isError).toBeFalsy()
-
         const doc = getCreatedDocument(callResponse)
-
         expect(doc.arrayField).toHaveLength(2)
         expect(doc.arrayField[0].item).toBe('First item')
         expect(doc.arrayField[0].itemNumber).toBe(1)
         expect(doc.arrayField[1].item).toBe('Second item')
         expect(doc.arrayField[1].itemNumber).toBe(2)
-
-        createdFieldTypeIds.push(doc.id)
       })
-
-      it('should find documents in field-types collection', async ({ mcp }) => {
+      it('should find documents in field-types collection', async ({ mcp, getApiKey, payload }) => {
         const created = await (payload as any).create({
           collection: 'field-types',
           data: { textField: 'Findable doc', numberField: 7 },
         })
-        createdFieldTypeIds.push(created.id)
-
         const apiKey = await getApiKey()
         const client = await mcp.connect(apiKey)
         const callResponse = await client.callTool({
@@ -3743,7 +3491,6 @@ describe('@payloadcms/plugin-mcp', () => {
           },
           name: 'findDocuments',
         })
-
         expect(callResponse).toBeDefined()
         expect(callResponse.isError).toBeFalsy()
         expect(callResponse.content[0].text).toContain('Collection: "field-types"')
@@ -3751,9 +3498,8 @@ describe('@payloadcms/plugin-mcp', () => {
         expect(callResponse.content[0].text).toContain('"numberField":7')
       })
     })
-
-    describe('Update', () => {
-      it('should update document with group field', async ({ mcp }) => {
+    test.describe('Update', () => {
+      it('should update document with group field', async ({ mcp, getApiKey, payload }) => {
         const created = await (payload as any).create({
           collection: 'field-types',
           data: {
@@ -3761,8 +3507,6 @@ describe('@payloadcms/plugin-mcp', () => {
             groupField: { groupText: 'Original', groupNumber: 1 },
           },
         })
-        createdFieldTypeIds.push(created.id)
-
         const apiKey = await getApiKey()
         const client = await mcp.connect(apiKey)
         const callResponse = await client.callTool({
@@ -3779,21 +3523,19 @@ describe('@payloadcms/plugin-mcp', () => {
           },
           name: 'updateDocument',
         })
-
         expect(callResponse).toBeDefined()
         expect(callResponse.isError).toBeFalsy()
         expect(callResponse.content[0].text).toContain(
           'Document updated successfully in collection "field-types"!',
         )
-
         const doc = getToolDoc(callResponse)
-
         expect(doc.groupField.groupText).toBe('Updated group text')
         expect(doc.groupField.groupNumber).toBe(100)
       })
-
       it('should update one required field in a group without requiring its siblings', async ({
+        getApiKey,
         mcp,
+        payload,
       }) => {
         const created = await (payload as any).create({
           collection: 'field-types',
@@ -3803,8 +3545,6 @@ describe('@payloadcms/plugin-mcp', () => {
             textField: 'Partial group update test',
           },
         })
-        createdFieldTypeIds.push(created.id)
-
         const apiKey = await getApiKey()
         const client = await mcp.connect(apiKey)
         const callResponse = await client.callTool({
@@ -3833,6 +3573,8 @@ describe('@payloadcms/plugin-mcp', () => {
 
       it('should return the collection schema when updateDocument fails validation', async ({
         mcp,
+        getApiKey,
+        payload,
       }) => {
         const created = await (payload as any).create({
           collection: 'field-types',
@@ -3841,8 +3583,6 @@ describe('@payloadcms/plugin-mcp', () => {
             textField: 'Validation update test',
           },
         })
-        createdFieldTypeIds.push(created.id)
-
         const apiKey = await getApiKey()
         const client = await mcp.connect(apiKey)
         const callResponse = await client.callTool({
@@ -3855,7 +3595,6 @@ describe('@payloadcms/plugin-mcp', () => {
           },
           name: 'updateDocument',
         })
-
         expect(callResponse.isError).toBe(true)
         expect(callResponse.content[0].text).toContain('Use this schema for data')
         expect(callResponse.content[0].text).toContain('"numberField"')
@@ -3873,9 +3612,10 @@ describe('@payloadcms/plugin-mcp', () => {
           },
         })
       })
-
       it('should update document with collapsible field (children at top level)', async ({
         mcp,
+        getApiKey,
+        payload,
       }) => {
         const created = await (payload as any).create({
           collection: 'field-types',
@@ -3884,8 +3624,6 @@ describe('@payloadcms/plugin-mcp', () => {
             collapsibleText: 'Original collapsible text',
           },
         })
-        createdFieldTypeIds.push(created.id)
-
         const apiKey = await getApiKey()
         const client = await mcp.connect(apiKey)
         const callResponse = await client.callTool({
@@ -3899,16 +3637,12 @@ describe('@payloadcms/plugin-mcp', () => {
           },
           name: 'updateDocument',
         })
-
         expect(callResponse).toBeDefined()
         expect(callResponse.isError).toBeFalsy()
-
         const doc = getToolDoc(callResponse)
-
         expect(doc.collapsibleText).toBe('Updated collapsible text')
       })
-
-      it('should update document with array field', async ({ mcp }) => {
+      it('should update document with array field', async ({ mcp, getApiKey, payload }) => {
         const created = await (payload as any).create({
           collection: 'field-types',
           data: {
@@ -3916,8 +3650,6 @@ describe('@payloadcms/plugin-mcp', () => {
             arrayField: [{ item: 'Original item', itemNumber: 0 }],
           },
         })
-        createdFieldTypeIds.push(created.id)
-
         const apiKey = await getApiKey()
         const client = await mcp.connect(apiKey)
         const callResponse = await client.callTool({
@@ -3935,25 +3667,21 @@ describe('@payloadcms/plugin-mcp', () => {
           },
           name: 'updateDocument',
         })
-
         expect(callResponse).toBeDefined()
         expect(callResponse.isError).toBeFalsy()
-
         const doc = getToolDoc(callResponse)
-
         expect(doc.arrayField).toHaveLength(3)
         expect(doc.arrayField[0].item).toBe('Updated item A')
         expect(doc.arrayField[2].itemNumber).toBe(30)
       })
     })
-
-    describe('Display field safety', () => {
+    test.describe('Display field safety', () => {
       it('should create document with ui field present without errors and ui field absent from response', async ({
         mcp,
+        getApiKey,
       }) => {
         const apiKey = await getApiKey()
         const client = await mcp.connect(apiKey)
-
         // Create a doc without passing any `uiField` value (it has no stored data)
         const callResponse = await callCreateDocumentsWithOne(client, {
           arguments: {
@@ -3963,21 +3691,16 @@ describe('@payloadcms/plugin-mcp', () => {
             },
           },
         })
-
         expect(callResponse).toBeDefined()
         expect(callResponse.isError).toBeFalsy()
         expect(callResponse.content[0].text).toContain('Created 1 of 1 documents')
-
         const doc = getCreatedDocument(callResponse)
-
         // uiField has no stored data and should not appear in the document
         expect(doc).not.toHaveProperty('uiField')
-
-        createdFieldTypeIds.push(doc.id)
       })
-
       it('should create and find document with all structural layout fields populated', async ({
         mcp,
+        getApiKey,
       }) => {
         const apiKey = await getApiKey()
         const client = await mcp.connect(apiKey)
@@ -3994,12 +3717,9 @@ describe('@payloadcms/plugin-mcp', () => {
             },
           },
         })
-
         expect(callResponse).toBeDefined()
         expect(callResponse.isError).toBeFalsy()
-
         const doc = getCreatedDocument(callResponse)
-
         // All data fields are stored correctly regardless of their container type
         expect(doc.groupField.groupText).toBe('Group value')
         expect(doc.groupField.groupNumber).toBe(5)
@@ -4007,11 +3727,8 @@ describe('@payloadcms/plugin-mcp', () => {
         expect(doc.rowText).toBe('Row value')
         expect(doc.namedTab.namedTabText).toBe('Named tab value')
         expect(doc.unnamedTabText).toBe('Unnamed tab value')
-
         // UI field is never present in stored documents
         expect(doc).not.toHaveProperty('uiField')
-
-        createdFieldTypeIds.push(doc.id)
       })
     })
   })

--- a/test/plugin-multi-tenant/config.base.ts
+++ b/test/plugin-multi-tenant/config.base.ts
@@ -81,12 +81,6 @@ export const baseConfig: Partial<Config> = {
       },
     },
   },
-  onInit: async (payload) => {
-    // IMPORTANT: This should only seed, not clear the database.
-    if (process.env.SEED_IN_CONFIG_ONINIT !== 'false') {
-      await seed(payload)
-    }
-  },
   plugins: [
     multiTenantPlugin<ConfigType>({
       userHasAccessToAllTenants: (user) => Boolean(user.roles?.includes('admin')),
@@ -174,3 +168,5 @@ export const baseConfig: Partial<Config> = {
     outputFile: path.resolve(dirname, 'payload-types.ts'),
   },
 }
+
+export { seed }

--- a/test/plugin-multi-tenant/config.conditionalProvider.ts
+++ b/test/plugin-multi-tenant/config.conditionalProvider.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-restricted-exports */
 
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
-import { baseConfig } from './config.base.js'
+import { baseConfig, seed } from './config.base.js'
 
 /**
  * Extends the base multi-tenant config with a ConditionalWrapperProvider
@@ -10,12 +10,16 @@ import { baseConfig } from './config.base.js'
  * exercising the RSC prop sync fix.
  */
 export default buildConfigWithDefaults({
-  ...baseConfig,
-  admin: {
-    ...baseConfig.admin,
-    components: {
-      ...baseConfig.admin?.components,
-      providers: ['/components/ConditionalWrapperProvider/index.js#ConditionalWrapperProvider'],
+  suite: 'plugin-multi-tenant-conditional-provider',
+  config: {
+    ...baseConfig,
+    admin: {
+      ...baseConfig.admin,
+      components: {
+        ...baseConfig.admin?.components,
+        providers: ['/components/ConditionalWrapperProvider/index.js#ConditionalWrapperProvider'],
+      },
     },
   },
+  seed,
 })

--- a/test/plugin-multi-tenant/config.ts
+++ b/test/plugin-multi-tenant/config.ts
@@ -1,4 +1,4 @@
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
-import { baseConfig } from './config.base.js'
+import { baseConfig, seed } from './config.base.js'
 
-export default buildConfigWithDefaults(baseConfig)
+export default buildConfigWithDefaults({ suite: 'plugin-multi-tenant', config: baseConfig, seed })

--- a/test/plugin-multi-tenant/e2e.spec.ts
+++ b/test/plugin-multi-tenant/e2e.spec.ts
@@ -53,7 +53,6 @@ test.describe('Multi Tenant', () => {
 
   test.beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
-    process.env.SEED_IN_CONFIG_ONINIT = 'false' // Makes it so the payload config onInit seed is not run. Otherwise, the seed would be run unnecessarily twice for the initial test run - once for beforeEach and once for onInit
 
     const { payload: payloadFromInit, serverURL: serverFromInit } =
       await initPayloadE2ENoConfig<Config>({ dirname })
@@ -74,7 +73,6 @@ test.describe('Multi Tenant', () => {
   test.beforeEach(async () => {
     await reInitializeDB({
       serverURL,
-      snapshotKey: 'multiTenant',
     })
     await page.goto(usersURL.admin)
   })

--- a/test/plugin-multi-tenant/int.spec.ts
+++ b/test/plugin-multi-tenant/int.spec.ts
@@ -7,7 +7,6 @@ import type { Relationship } from './payload-types.js'
 
 import { test } from '../__helpers/int/vitest.js'
 import { devUser } from '../credentials.js'
-import testConfig from './config.js'
 import {
   menuSlug,
   multiTenantPostsSlug,
@@ -18,7 +17,7 @@ import {
 
 let token: string
 
-test.suite({ config: testConfig })('@payloadcms/plugin-multi-tenant', () => {
+test.suite({ config: './config.ts' })('@payloadcms/plugin-multi-tenant', () => {
   test.beforeEach(async ({ restClient }) => {
     const data = await restClient
       .POST('/users/login', {

--- a/test/plugin-multi-tenant/int.spec.ts
+++ b/test/plugin-multi-tenant/int.spec.ts
@@ -1,14 +1,13 @@
-import type { DefaultDocumentIDType, PaginatedDocs, Payload } from 'payload'
+import type { DefaultDocumentIDType, PaginatedDocs } from 'payload'
 
-import path from 'path'
 import { fileURLToPath } from 'url'
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { expect } from 'vitest'
 
-import type { NextRESTClient } from '../__helpers/shared/NextRESTClient.js'
 import type { Relationship } from './payload-types.js'
 
-import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
+import { test } from '../__helpers/int/vitest.js'
 import { devUser } from '../credentials.js'
+import testConfig from './config.js'
 import {
   menuSlug,
   multiTenantPostsSlug,
@@ -17,17 +16,10 @@ import {
   usersSlug,
 } from './shared.js'
 
-let payload: Payload
-let restClient: NextRESTClient
 let token: string
 
-const filename = fileURLToPath(import.meta.url)
-const dirname = path.dirname(filename)
-
-describe('@payloadcms/plugin-multi-tenant', () => {
-  beforeAll(async () => {
-    ;({ payload, restClient } = await initPayloadInt(dirname))
-
+test.suite({ config: testConfig })('@payloadcms/plugin-multi-tenant', () => {
+  test.beforeEach(async ({ restClient }) => {
     const data = await restClient
       .POST('/users/login', {
         body: JSON.stringify({
@@ -40,12 +32,8 @@ describe('@payloadcms/plugin-multi-tenant', () => {
     token = data.token
   })
 
-  afterAll(async () => {
-    await payload.destroy()
-  })
-
-  describe('tenants', () => {
-    it('should create a tenant', async () => {
+  test.describe('tenants', () => {
+    test('should create a tenant', async ({ payload }) => {
       const tenant1 = await payload.create({
         collection: tenantsSlug,
         data: {
@@ -57,13 +45,13 @@ describe('@payloadcms/plugin-multi-tenant', () => {
       expect(tenant1).toHaveProperty('id')
     })
 
-    describe('relationships', () => {
+    test.describe('relationships', () => {
       let anchorBarRelationships: PaginatedDocs<Relationship>
       let blueDogRelationships: PaginatedDocs<Relationship>
       let anchorBarTenantID: DefaultDocumentIDType
       let blueDogTenantID: DefaultDocumentIDType
 
-      beforeEach(async () => {
+      test.beforeEach(async ({ payload }) => {
         anchorBarRelationships = await payload.find({
           collection: 'relationships',
           where: {
@@ -89,7 +77,9 @@ describe('@payloadcms/plugin-multi-tenant', () => {
         blueDogTenantID = blueDogRelationships.docs[0].tenant.id
       })
 
-      it('ensure relationship document with relationship within same tenant can be created', async () => {
+      test('ensure relationship document with relationship within same tenant can be created', async ({
+        payload,
+      }) => {
         const newRelationship = await payload.create({
           collection: 'relationships',
           data: {
@@ -107,7 +97,9 @@ describe('@payloadcms/plugin-multi-tenant', () => {
         expect(newRelationship.relationship?.title).toBe('Owned by bar with no ac')
       })
 
-      it('ensure relationship document with relationship to different tenant cannot be created if tenant header passed', async () => {
+      test('ensure relationship document with relationship to different tenant cannot be created if tenant header passed', async ({
+        payload,
+      }) => {
         await expect(
           payload.create({
             collection: 'relationships',
@@ -124,7 +116,9 @@ describe('@payloadcms/plugin-multi-tenant', () => {
         ).rejects.toThrow('The following field is invalid: Relationship')
       })
 
-      it('ensure relationship document with relationship to different tenant cannot be created even if no tenant header passed', async () => {
+      test('ensure relationship document with relationship to different tenant cannot be created even if no tenant header passed', async ({
+        payload,
+      }) => {
         // Should filter based on data.tenant instead of tenant cookie
         await expect(
           payload.create({
@@ -142,8 +136,10 @@ describe('@payloadcms/plugin-multi-tenant', () => {
     })
   })
 
-  describe('access control for users with no tenant memberships', () => {
-    it('should return Forbidden error (not 500) for user with no tenants', async () => {
+  test.describe('access control for users with no tenant memberships', () => {
+    test('should return Forbidden error (not 500) for user with no tenants', async ({
+      payload,
+    }) => {
       // Create a user with no tenant memberships
       const noTenantUser = await payload.create({
         collection: usersSlug,
@@ -181,7 +177,9 @@ describe('@payloadcms/plugin-multi-tenant', () => {
       await payload.delete({ id: noTenantUser.id, collection: usersSlug })
     })
 
-    it('should allow user with no tenants to access their own user document', async () => {
+    test('should allow user with no tenants to access their own user document', async ({
+      payload,
+    }) => {
       // Create a user with no tenant memberships
       const noTenantUser = await payload.create({
         collection: usersSlug,
@@ -207,7 +205,9 @@ describe('@payloadcms/plugin-multi-tenant', () => {
       await payload.delete({ id: noTenantUser.id, collection: usersSlug })
     })
 
-    it('should allow admin with empty tenants array to access all documents', async () => {
+    test('should allow admin with empty tenants array to access all documents', async ({
+      payload,
+    }) => {
       // Create an admin user with empty tenants array
       const adminUser = await payload.create({
         collection: usersSlug,
@@ -246,8 +246,10 @@ describe('@payloadcms/plugin-multi-tenant', () => {
     })
   })
 
-  describe('access control with user object passed directly', () => {
-    it('should enforce tenant access when user object is fetched from database', async () => {
+  test.describe('access control with user object passed directly', () => {
+    test('should enforce tenant access when user object is fetched from database', async ({
+      payload,
+    }) => {
       // Create two tenants
       const tenantA = await payload.create({
         collection: tenantsSlug,
@@ -299,8 +301,10 @@ describe('@payloadcms/plugin-multi-tenant', () => {
     })
   })
 
-  describe('tenant cleanup on delete', () => {
-    it('should delete a tenant that has a global collection document without hanging', async () => {
+  test.describe('tenant cleanup on delete', () => {
+    test('should delete a tenant that has a global collection document without hanging', async ({
+      payload,
+    }) => {
       const tenant = await payload.create({
         collection: tenantsSlug,
         data: { name: 'Cleanup Tenant', domain: 'cleanup-tenant.test' },
@@ -324,8 +328,8 @@ describe('@payloadcms/plugin-multi-tenant', () => {
     }, 20000)
   })
 
-  describe('hasMany tenant field filtering', () => {
-    it('should not double-wrap tenant arrays in filterOptions', async () => {
+  test.describe('hasMany tenant field filtering', () => {
+    test('should not double-wrap tenant arrays in filterOptions', async ({ payload }) => {
       const tenant1 = await payload.create({
         collection: tenantsSlug,
         data: { name: 'Tenant 1', domain: 'tenant1.test' },

--- a/test/plugin-nested-docs/config.ts
+++ b/test/plugin-nested-docs/config.ts
@@ -12,18 +12,38 @@ import { Users } from './collections/Users.js'
 import { seed } from './seed/index.js'
 
 export default buildConfigWithDefaults({
-  admin: {
-    importMap: {
-      baseDir: path.resolve(dirname),
+  suite: 'plugin-nested-docs',
+  config: {
+    admin: {
+      importMap: {
+        baseDir: path.resolve(dirname),
+      },
+    },
+    collections: [Pages, Categories, Users],
+    localization: {
+      defaultLocale: 'en',
+      fallback: true,
+      locales: ['en', 'es', 'de'],
+    },
+    plugins: [
+      nestedDocsPlugin({
+        collections: ['pages'],
+        generateLabel: (_, doc) => doc.title as string,
+        generateURL: (docs) => docs.reduce((url, doc) => `${url}/${doc.slug}`, ''),
+      }),
+      nestedDocsPlugin({
+        breadcrumbsFieldSlug: 'categorization',
+        collections: ['categories'],
+        generateLabel: (_, doc) => doc.name as string,
+        generateURL: (docs) => docs.reduce((url, doc) => `${url}/${doc.name}`, ''),
+        parentFieldSlug: 'owner',
+      }),
+    ],
+    typescript: {
+      outputFile: path.resolve(dirname, 'payload-types.ts'),
     },
   },
-  collections: [Pages, Categories, Users],
-  localization: {
-    defaultLocale: 'en',
-    fallback: true,
-    locales: ['en', 'es', 'de'],
-  },
-  onInit: async (payload) => {
+  seed: async (payload) => {
     await payload.create({
       collection: 'users',
       data: {
@@ -33,22 +53,5 @@ export default buildConfigWithDefaults({
     })
 
     await seed(payload)
-  },
-  plugins: [
-    nestedDocsPlugin({
-      collections: ['pages'],
-      generateLabel: (_, doc) => doc.title as string,
-      generateURL: (docs) => docs.reduce((url, doc) => `${url}/${doc.slug}`, ''),
-    }),
-    nestedDocsPlugin({
-      breadcrumbsFieldSlug: 'categorization',
-      collections: ['categories'],
-      generateLabel: (_, doc) => doc.name as string,
-      generateURL: (docs) => docs.reduce((url, doc) => `${url}/${doc.name}`, ''),
-      parentFieldSlug: 'owner',
-    }),
-  ],
-  typescript: {
-    outputFile: path.resolve(dirname, 'payload-types.ts'),
   },
 })

--- a/test/plugin-nested-docs/int.spec.ts
+++ b/test/plugin-nested-docs/int.spec.ts
@@ -1,30 +1,15 @@
-import type { ArrayField, Payload, RelationshipField } from 'payload'
+import type { ArrayField, RelationshipField } from 'payload'
 
-import path from 'path'
 import { wait } from 'payload/shared'
 import { fileURLToPath } from 'url'
-import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { expect } from 'vitest'
 
-import type { Page } from './payload-types.js'
+import { test } from '../__helpers/int/vitest.js'
+import testConfig from './config.js'
 
-import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
-
-let payload: Payload
-
-const filename = fileURLToPath(import.meta.url)
-const dirname = path.dirname(filename)
-
-describe('@payloadcms/plugin-nested-docs', () => {
-  beforeAll(async () => {
-    ;({ payload } = await initPayloadInt(dirname))
-  })
-
-  afterAll(async () => {
-    await payload.destroy()
-  })
-
-  describe('seed', () => {
-    it('should populate two levels of breadcrumbs', async () => {
+test.suite({ config: testConfig })('@payloadcms/plugin-nested-docs', () => {
+  test.describe('seed', () => {
+    test('should populate two levels of breadcrumbs', async ({ payload }) => {
       const query = await payload.find({
         collection: 'pages',
         where: {
@@ -37,7 +22,7 @@ describe('@payloadcms/plugin-nested-docs', () => {
       expect(query.docs[0].breadcrumbs).toHaveLength(2)
     })
 
-    it('should populate three levels of breadcrumbs', async () => {
+    test('should populate three levels of breadcrumbs', async ({ payload }) => {
       const query = await payload.find({
         collection: 'pages',
         where: {
@@ -55,7 +40,7 @@ describe('@payloadcms/plugin-nested-docs', () => {
       )
     })
 
-    it('should update more than 10 (default limit) breadcrumbs', async () => {
+    test('should update more than 10 (default limit) breadcrumbs', async ({ payload }) => {
       // create a parent doc
       const parentDoc = await payload.create({
         collection: 'pages',
@@ -111,7 +96,7 @@ describe('@payloadcms/plugin-nested-docs', () => {
       expect(lastUpdatedChildBreadcrumbs[0].url).toStrictEqual('/11-children-updated')
     })
 
-    it('should return breadcrumbs as an array of objects', async () => {
+    test('should return breadcrumbs as an array of objects', async ({ payload }) => {
       const parentDoc = await payload.create({
         collection: 'pages',
         data: {
@@ -141,7 +126,9 @@ describe('@payloadcms/plugin-nested-docs', () => {
       })
     })
 
-    it('should update child doc breadcrumb without affecting any other data', async () => {
+    test('should update child doc breadcrumb without affecting any other data', async ({
+      payload,
+    }) => {
       const parentDoc = await payload.create({
         collection: 'pages',
         data: {
@@ -193,10 +180,10 @@ describe('@payloadcms/plugin-nested-docs', () => {
     })
   })
 
-  describe('versions', () => {
+  test.describe('versions', () => {
     const createdPageIDs: (number | string)[] = []
 
-    afterEach(async () => {
+    test.afterEach(async ({ payload }) => {
       // Clean up in reverse order (children before parents)
       for (const id of [...createdPageIDs].reverse()) {
         await payload.delete({ collection: 'pages', id })
@@ -204,7 +191,9 @@ describe('@payloadcms/plugin-nested-docs', () => {
       createdPageIDs.length = 0
     })
 
-    it('should preserve published version of child when parent is saved and child has unpublished draft', async () => {
+    test('should preserve published version of child when parent is saved and child has unpublished draft', async ({
+      payload,
+    }) => {
       // Step 1: Create parent page and publish it
       const parentDoc = await payload.create({
         collection: 'pages',
@@ -281,7 +270,9 @@ describe('@payloadcms/plugin-nested-docs', () => {
       expect(draftChild.title).toBe('Version Child Draft Edit')
     })
 
-    it('should update breadcrumbs for draft-only children when parent is saved', async () => {
+    test('should update breadcrumbs for draft-only children when parent is saved', async ({
+      payload,
+    }) => {
       const parentDoc = await payload.create({
         collection: 'pages',
         data: {
@@ -328,7 +319,9 @@ describe('@payloadcms/plugin-nested-docs', () => {
       expect(updatedDraftChild.breadcrumbs?.[0]?.url).toBe('/draft-parent-updated')
     })
 
-    it('should update breadcrumbs for both published and draft versions when parent changes', async () => {
+    test('should update breadcrumbs for both published and draft versions when parent changes', async ({
+      payload,
+    }) => {
       const parent = await payload.create({
         collection: 'pages',
         data: {
@@ -393,8 +386,10 @@ describe('@payloadcms/plugin-nested-docs', () => {
     })
   })
 
-  describe('scheduled publish', () => {
-    it('should allow scheduled publish on a collection with a nested-docs breadcrumbs field', async () => {
+  test.describe('scheduled publish', () => {
+    test('should allow scheduled publish on a collection with a nested-docs breadcrumbs field', async ({
+      payload,
+    }) => {
       const draft = await payload.create({
         collection: 'pages',
         data: {
@@ -440,13 +435,13 @@ describe('@payloadcms/plugin-nested-docs', () => {
     })
   })
 
-  describe('overrides', () => {
+  test.describe('overrides', () => {
     let collection
-    beforeAll(() => {
+    test.beforeEach(({ payload }) => {
       collection = payload.config.collections.find(({ slug }) => slug === 'categories')
     })
 
-    it('should allow overriding breadcrumbs field', () => {
+    test('should allow overriding breadcrumbs field', () => {
       const breadcrumbField = collection.fields.find(
         (field) => field.type === 'array' && field.name === 'categorization',
       ) as ArrayField
@@ -460,7 +455,7 @@ describe('@payloadcms/plugin-nested-docs', () => {
       expect(breadcrumbField.admin.readOnly).toStrictEqual(true)
     })
 
-    it('should allow overriding parent field', () => {
+    test('should allow overriding parent field', () => {
       const parentField = collection.fields.find(
         (field) => field.type === 'relationship' && field.name === 'owner',
       ) as RelationshipField
@@ -468,7 +463,7 @@ describe('@payloadcms/plugin-nested-docs', () => {
       expect(parentField.admin.description).toStrictEqual('custom')
     })
 
-    it('should allow custom breadcrumb and parent slugs', async () => {
+    test('should allow custom breadcrumb and parent slugs', async ({ payload }) => {
       const parent = await payload.create({
         collection: 'categories',
         data: {

--- a/test/plugin-nested-docs/int.spec.ts
+++ b/test/plugin-nested-docs/int.spec.ts
@@ -5,9 +5,8 @@ import { fileURLToPath } from 'url'
 import { expect } from 'vitest'
 
 import { test } from '../__helpers/int/vitest.js'
-import testConfig from './config.js'
 
-test.suite({ config: testConfig })('@payloadcms/plugin-nested-docs', () => {
+test.suite({ config: './config.ts' })('@payloadcms/plugin-nested-docs', () => {
   test.describe('seed', () => {
     test('should populate two levels of breadcrumbs', async ({ payload }) => {
       const query = await payload.find({

--- a/test/plugin-redirects/config.ts
+++ b/test/plugin-redirects/config.ts
@@ -11,43 +11,69 @@ import { Users } from './collections/Users.js'
 import { seed } from './seed/index.js'
 
 export default buildConfigWithDefaults({
-  admin: {
-    importMap: {
-      baseDir: path.resolve(dirname),
-    },
-  },
-  collections: [Users, Pages],
-  i18n: {
-    translations: {
-      // Test that custom translations can override ONLY specific keys
-      // All other keys will use the plugin's defaults
-      en: {
-        $schema: './translation-schema.json',
-        'plugin-redirects': {
-          fromUrl: 'Source URL (Custom)', // Override just this one key
-          // All other keys (customUrl, internalLink, etc.) will use plugin defaults
-        },
-      },
-      de: {
-        $schema: './translation-schema.json',
-        'plugin-redirects': {
-          // Full German translations (not included in plugin by default)
-          customUrl: 'Benutzerdefinierte URL',
-          documentToRedirect: 'Dokument zum Weiterleiten',
-          fromUrl: 'Quell-URL',
-          internalLink: 'Interner Link',
-          redirectType: 'Weiterleitungstyp',
-          toUrlType: 'Ziel-URL-Typ',
-        },
+  suite: 'plugin-redirects',
+  config: {
+    admin: {
+      importMap: {
+        baseDir: path.resolve(dirname),
       },
     },
+    collections: [Users, Pages],
+    i18n: {
+      translations: {
+        // Test that custom translations can override ONLY specific keys
+        // All other keys will use the plugin's defaults
+        de: {
+          $schema: './translation-schema.json',
+          'plugin-redirects': {
+            // Full German translations (not included in plugin by default)
+            customUrl: 'Benutzerdefinierte URL',
+            documentToRedirect: 'Dokument zum Weiterleiten',
+            fromUrl: 'Quell-URL',
+            internalLink: 'Interner Link',
+            redirectType: 'Weiterleitungstyp',
+            toUrlType: 'Ziel-URL-Typ',
+          },
+        },
+        en: {
+          $schema: './translation-schema.json',
+          'plugin-redirects': {
+            fromUrl: 'Source URL (Custom)', // Override just this one key
+            // All other keys (customUrl, internalLink, etc.) will use plugin defaults
+          },
+        },
+      },
+    },
+    localization: {
+      defaultLocale: 'en',
+      fallback: true,
+      locales: ['en', 'es', 'de'],
+    },
+    plugins: [
+      redirectsPlugin({
+        collections: ['pages'],
+        overrides: {
+          fields: ({ defaultFields }) => {
+            return [
+              ...defaultFields,
+              {
+                name: 'customField',
+                type: 'text',
+              },
+            ]
+          },
+        },
+        redirectTypeFieldOverride: {
+          label: 'Redirect Type (Overridden)',
+        },
+        redirectTypes: ['301', '302'],
+      }),
+    ],
+    typescript: {
+      outputFile: path.resolve(dirname, 'payload-types.ts'),
+    },
   },
-  localization: {
-    defaultLocale: 'en',
-    fallback: true,
-    locales: ['en', 'es', 'de'],
-  },
-  onInit: async (payload) => {
+  seed: async (payload) => {
     await payload.create({
       collection: 'users',
       data: {
@@ -57,28 +83,5 @@ export default buildConfigWithDefaults({
     })
 
     await seed(payload)
-  },
-  plugins: [
-    redirectsPlugin({
-      collections: ['pages'],
-      overrides: {
-        fields: ({ defaultFields }) => {
-          return [
-            ...defaultFields,
-            {
-              type: 'text',
-              name: 'customField',
-            },
-          ]
-        },
-      },
-      redirectTypes: ['301', '302'],
-      redirectTypeFieldOverride: {
-        label: 'Redirect Type (Overridden)',
-      },
-    }),
-  ],
-  typescript: {
-    outputFile: path.resolve(dirname, 'payload-types.ts'),
   },
 })

--- a/test/plugin-redirects/int.spec.ts
+++ b/test/plugin-redirects/int.spec.ts
@@ -1,24 +1,16 @@
-import type { Payload } from 'payload'
-import { describe, beforeAll, afterAll, it, expect } from 'vitest'
-
-import path from 'path'
 import { fileURLToPath } from 'url'
+import { expect } from 'vitest'
 
 import type { Page } from './payload-types.js'
 
-import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
+import { test } from '../__helpers/int/vitest.js'
+import testConfig from './config.js'
 import { pagesSlug } from './shared.js'
 
-let payload: Payload
 let page: Page
 
-const filename = fileURLToPath(import.meta.url)
-const dirname = path.dirname(filename)
-
-describe('@payloadcms/plugin-redirects', () => {
-  beforeAll(async () => {
-    ;({ payload } = await initPayloadInt(dirname))
-
+test.suite({ config: testConfig })('@payloadcms/plugin-redirects', () => {
+  test.beforeEach(async ({ payload }) => {
     page = await payload.create({
       collection: 'pages',
       data: {
@@ -27,11 +19,7 @@ describe('@payloadcms/plugin-redirects', () => {
     })
   })
 
-  afterAll(async () => {
-    await payload.destroy()
-  })
-
-  it('should add a redirects collection', async () => {
+  test('should add a redirects collection', async ({ payload }) => {
     const redirect = await payload.find({
       collection: 'redirects',
       depth: 0,
@@ -41,7 +29,7 @@ describe('@payloadcms/plugin-redirects', () => {
     expect(redirect).toBeTruthy()
   })
 
-  it('should add a redirect with to internal page', async () => {
+  test('should add a redirect with to internal page', async ({ payload }) => {
     const redirect = await payload.create({
       collection: 'redirects',
       data: {
@@ -62,7 +50,7 @@ describe('@payloadcms/plugin-redirects', () => {
     expect(redirect.to.reference.value).toMatchObject(page)
   })
 
-  it('should add a redirect with to custom url', async () => {
+  test('should add a redirect with to custom url', async ({ payload }) => {
     const redirect = await payload.create({
       collection: 'redirects',
       data: {

--- a/test/plugin-redirects/int.spec.ts
+++ b/test/plugin-redirects/int.spec.ts
@@ -4,12 +4,11 @@ import { expect } from 'vitest'
 import type { Page } from './payload-types.js'
 
 import { test } from '../__helpers/int/vitest.js'
-import testConfig from './config.js'
 import { pagesSlug } from './shared.js'
 
 let page: Page
 
-test.suite({ config: testConfig })('@payloadcms/plugin-redirects', () => {
+test.suite({ config: './config.ts' })('@payloadcms/plugin-redirects', () => {
   test.beforeEach(async ({ payload }) => {
     page = await payload.create({
       collection: 'pages',

--- a/test/plugin-search/config.ts
+++ b/test/plugin-search/config.ts
@@ -15,47 +15,113 @@ import { Users } from './collections/Users.js'
 import { seed } from './seed/index.js'
 
 export default buildConfigWithDefaults({
-  collections: [
-    Users,
-    Pages,
-    Posts,
-    {
-      slug: 'custom-ids-1',
-      fields: [{ type: 'text', name: 'id' }],
-      versions: false,
+  suite: 'plugin-search',
+  config: {
+    admin: {
+      importMap: {
+        baseDir: path.resolve(dirname),
+      },
     },
-    {
-      slug: 'custom-ids-2',
-      fields: [{ type: 'text', name: 'id' }],
-      versions: false,
+    collections: [
+      Users,
+      Pages,
+      Posts,
+      {
+        slug: 'custom-ids-1',
+        fields: [{ name: 'id', type: 'text' }],
+        versions: false,
+      },
+      {
+        slug: 'custom-ids-2',
+        fields: [{ name: 'id', type: 'text' }],
+        versions: false,
+      },
+      {
+        slug: 'filtered-locales',
+        fields: [
+          {
+            name: 'title',
+            type: 'text',
+            localized: true,
+          },
+          {
+            name: 'syncEnglishOnly',
+            type: 'checkbox',
+          },
+        ],
+        versions: false,
+      },
+    ],
+    localization: {
+      defaultLocale: 'en',
+      fallback: true,
+      locales: ['en', 'es', 'de'],
     },
-    {
-      slug: 'filtered-locales',
-      fields: [
-        {
-          type: 'text',
-          name: 'title',
-          localized: true,
+    plugins: [
+      searchPlugin<Config>({
+        beforeSync: ({ originalDoc, searchDoc }) => {
+          return {
+            ...searchDoc,
+            slug: originalDoc.slug,
+            excerpt: originalDoc?.excerpt || 'This is a fallback excerpt',
+          }
         },
-        {
-          type: 'checkbox',
-          name: 'syncEnglishOnly',
+        collections: ['pages', 'posts', 'custom-ids-1', 'custom-ids-2', 'filtered-locales'],
+        defaultPriorities: {
+          pages: 10,
+          posts: ({ title }) => (title === 'Hello, world!' ? 30 : 20),
         },
-      ],
-      versions: false,
+        searchOverrides: {
+          access: {
+            // Used for int test
+            delete: ({ req: { user } }) => user?.email === devUser.email,
+          },
+          fields: ({ defaultFields }) => [
+            ...defaultFields,
+            // This is necessary to test whether search docs were deleted or not with SQLite
+            // Because IDs in SQLite, apparently, aren't unique if we count deleted rows without AUTOINCREMENT option
+            // Thus we have a custom UUID field.
+            {
+              name: 'id',
+              type: 'text',
+              hooks: {
+                beforeChange: [
+                  ({ operation }) => {
+                    if (operation === 'create') {
+                      return randomUUID()
+                    }
+                  },
+                ],
+              },
+            },
+            {
+              name: 'excerpt',
+              type: 'textarea',
+              admin: {
+                position: 'sidebar',
+              },
+            },
+            {
+              name: 'slug',
+              type: 'text',
+              localized: true,
+              required: false,
+            },
+          ],
+        },
+        skipSync: ({ collectionSlug, doc, locale }) => {
+          if (collectionSlug === 'filtered-locales' && doc.syncEnglishOnly) {
+            return locale !== 'en'
+          }
+          return false
+        },
+      }),
+    ],
+    typescript: {
+      outputFile: path.resolve(dirname, 'payload-types.ts'),
     },
-  ],
-  localization: {
-    defaultLocale: 'en',
-    fallback: true,
-    locales: ['en', 'es', 'de'],
   },
-  admin: {
-    importMap: {
-      baseDir: path.resolve(dirname),
-    },
-  },
-  onInit: async (payload) => {
+  seed: async (payload) => {
     await payload.create({
       collection: 'users',
       data: {
@@ -65,68 +131,5 @@ export default buildConfigWithDefaults({
     })
 
     await seed(payload)
-  },
-  plugins: [
-    searchPlugin<Config>({
-      beforeSync: ({ originalDoc, searchDoc }) => {
-        return {
-          ...searchDoc,
-          excerpt: originalDoc?.excerpt || 'This is a fallback excerpt',
-          slug: originalDoc.slug,
-        }
-      },
-      collections: ['pages', 'posts', 'custom-ids-1', 'custom-ids-2', 'filtered-locales'],
-      skipSync: ({ locale, doc, collectionSlug }) => {
-        if (collectionSlug === 'filtered-locales' && doc.syncEnglishOnly) {
-          return locale !== 'en'
-        }
-        return false
-      },
-      defaultPriorities: {
-        pages: 10,
-        posts: ({ title }) => (title === 'Hello, world!' ? 30 : 20),
-      },
-      searchOverrides: {
-        access: {
-          // Used for int test
-          delete: ({ req: { user } }) => user?.email === devUser.email,
-        },
-        fields: ({ defaultFields }) => [
-          ...defaultFields,
-          // This is necessary to test whether search docs were deleted or not with SQLite
-          // Because IDs in SQLite, apparently, aren't unique if we count deleted rows without AUTOINCREMENT option
-          // Thus we have a custom UUID field.
-          {
-            name: 'id',
-            type: 'text',
-            hooks: {
-              beforeChange: [
-                ({ operation }) => {
-                  if (operation === 'create') {
-                    return randomUUID()
-                  }
-                },
-              ],
-            },
-          },
-          {
-            name: 'excerpt',
-            type: 'textarea',
-            admin: {
-              position: 'sidebar',
-            },
-          },
-          {
-            name: 'slug',
-            required: false,
-            type: 'text',
-            localized: true,
-          },
-        ],
-      },
-    }),
-  ],
-  typescript: {
-    outputFile: path.resolve(dirname, 'payload-types.ts'),
   },
 })

--- a/test/plugin-search/int.spec.ts
+++ b/test/plugin-search/int.spec.ts
@@ -4,12 +4,11 @@ import { expect } from 'vitest'
 
 import { test } from '../__helpers/int/vitest.js'
 import { devUser } from '../credentials.js'
-import testConfig from './config.js'
 import { pagesSlug, postsSlug } from './shared.js'
 
 let token: string
 
-test.suite({ config: testConfig })('@payloadcms/plugin-search', () => {
+test.suite({ config: './config.ts' })('@payloadcms/plugin-search', () => {
   test.beforeEach(async ({ restClient }) => {
     const data = await restClient
       .POST('/users/login', {

--- a/test/plugin-search/int.spec.ts
+++ b/test/plugin-search/int.spec.ts
@@ -1,27 +1,16 @@
-import type { Payload } from 'payload'
-
-import path from 'path'
 import { wait } from 'payload/shared'
 import { fileURLToPath } from 'url'
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { expect } from 'vitest'
 
-import type { NextRESTClient } from '../__helpers/shared/NextRESTClient.js'
-
-import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
+import { test } from '../__helpers/int/vitest.js'
 import { devUser } from '../credentials.js'
+import testConfig from './config.js'
 import { pagesSlug, postsSlug } from './shared.js'
 
-let payload: Payload
-let restClient: NextRESTClient
 let token: string
 
-const filename = fileURLToPath(import.meta.url)
-const dirname = path.dirname(filename)
-
-describe('@payloadcms/plugin-search', () => {
-  beforeAll(async () => {
-    ;({ payload, restClient } = await initPayloadInt(dirname))
-
+test.suite({ config: testConfig })('@payloadcms/plugin-search', () => {
+  test.beforeEach(async ({ restClient }) => {
     const data = await restClient
       .POST('/users/login', {
         body: JSON.stringify({
@@ -34,7 +23,7 @@ describe('@payloadcms/plugin-search', () => {
     token = data.token
   })
 
-  beforeEach(async () => {
+  test.beforeEach(async ({ payload }) => {
     await payload.delete({
       collection: 'search',
       depth: 0,
@@ -66,11 +55,7 @@ describe('@payloadcms/plugin-search', () => {
     ])
   })
 
-  afterAll(async () => {
-    await payload.destroy()
-  })
-
-  it('should add a search collection', async () => {
+  test('should add a search collection', async ({ payload }) => {
     const search = await payload.find({
       collection: 'search',
       depth: 0,
@@ -80,7 +65,7 @@ describe('@payloadcms/plugin-search', () => {
     expect(search).toBeTruthy()
   })
 
-  it('should sync published pages to the search collection', async () => {
+  test('should sync published pages to the search collection', async ({ payload }) => {
     const pageToSync = await payload.create({
       collection: 'pages',
       data: {
@@ -106,7 +91,7 @@ describe('@payloadcms/plugin-search', () => {
     expect(results[0].excerpt).toBe('This is a test page')
   })
 
-  it('should not sync drafts pages to the search collection', async () => {
+  test('should not sync drafts pages to the search collection', async ({ payload }) => {
     const draftPage = await payload.create({
       collection: 'pages',
       data: {
@@ -133,7 +118,9 @@ describe('@payloadcms/plugin-search', () => {
     expect(results).toHaveLength(0)
   })
 
-  it('should not delete a search doc if a published item has a new draft but remains published', async () => {
+  test('should not delete a search doc if a published item has a new draft but remains published', async ({
+    payload,
+  }) => {
     const publishedPage = await payload.create({
       collection: 'pages',
       data: {
@@ -205,7 +192,7 @@ describe('@payloadcms/plugin-search', () => {
     expect(deletedResults).toHaveLength(0)
   })
 
-  it('should sync changes made to an existing search document', async () => {
+  test('should sync changes made to an existing search document', async ({ payload }) => {
     const pageToReceiveUpdates = await payload.create({
       collection: 'pages',
       data: {
@@ -260,7 +247,9 @@ describe('@payloadcms/plugin-search', () => {
     expect(updatedResults[0].excerpt).toBe('This is a test page (updated)')
   })
 
-  it('should clear the search document when the original document is deleted', async () => {
+  test('should clear the search document when the original document is deleted', async ({
+    payload,
+  }) => {
     const page = await payload.create({
       collection: 'pages',
       data: {
@@ -309,7 +298,9 @@ describe('@payloadcms/plugin-search', () => {
     expect(deletedResults).toHaveLength(0)
   })
 
-  it('should clear the proper search document when having the same doc.value but different doc.relationTo', async () => {
+  test('should clear the proper search document when having the same doc.value but different doc.relationTo', async ({
+    payload,
+  }) => {
     const custom_id_1 = await payload.create({
       collection: 'custom-ids-1',
       data: { id: 'custom_id' },
@@ -349,7 +340,7 @@ describe('@payloadcms/plugin-search', () => {
     expect(docAfter.doc.relationTo).toBe('custom-ids-2')
   })
 
-  it('should sync localized data', async () => {
+  test('should sync localized data', async ({ payload }) => {
     const createdDoc = await payload.create({
       collection: 'posts',
       data: {
@@ -388,7 +379,10 @@ describe('@payloadcms/plugin-search', () => {
     expect(syncedSearchData.docs[0].slug).toEqual('es')
   })
 
-  it('should respond with 401 when invalid permissions on user before reindex', async () => {
+  test('should respond with 401 when invalid permissions on user before reindex', async ({
+    payload,
+    restClient,
+  }) => {
     const testCreds = {
       email: 'test@payloadcms.com',
       password: 'test',
@@ -417,7 +411,9 @@ describe('@payloadcms/plugin-search', () => {
     expect(endpointRes.status).toEqual(401)
   })
 
-  it('should respond with 400 when invalid collection args passed to reindex', async () => {
+  test('should respond with 400 when invalid collection args passed to reindex', async ({
+    restClient,
+  }) => {
     const endpointNoArgsRes = await restClient.POST(`/search/reindex`, {
       body: JSON.stringify({}),
       headers: {
@@ -448,7 +444,10 @@ describe('@payloadcms/plugin-search', () => {
     expect(endpointInvalidArrRes.status).toBe(400)
   })
 
-  it('should delete existing search indexes before reindexing', async () => {
+  test('should delete existing search indexes before reindexing', async ({
+    payload,
+    restClient,
+  }) => {
     await payload.create({
       collection: postsSlug,
       data: {
@@ -496,7 +495,7 @@ describe('@payloadcms/plugin-search', () => {
     expect(results).toHaveLength(0)
   })
 
-  it('should reindex whole collections', async () => {
+  test('should reindex whole collections', async ({ payload, restClient }) => {
     await Promise.all([
       payload.create({
         collection: pagesSlug,
@@ -538,7 +537,10 @@ describe('@payloadcms/plugin-search', () => {
     expect(totalAfterReindex).toBe(totalBeforeReindex)
   })
 
-  it('should report correct aggregate counts when reindexing multiple collections', async () => {
+  test('should report correct aggregate counts when reindexing multiple collections', async ({
+    payload,
+    restClient,
+  }) => {
     await Promise.all([
       payload.create({
         collection: postsSlug,
@@ -569,7 +571,10 @@ describe('@payloadcms/plugin-search', () => {
     )
   })
 
-  it('should index locale-specific data for all locales when reindexing multiple collections', async () => {
+  test('should index locale-specific data for all locales when reindexing multiple collections', async ({
+    payload,
+    restClient,
+  }) => {
     // Create a post with distinct slugs per locale — these are mapped into the search doc via beforeSync
     const { id: postId } = await payload.create({
       collection: postsSlug,
@@ -628,7 +633,7 @@ describe('@payloadcms/plugin-search', () => {
     expect(deDoc.slug).toBe('post-slug-de')
   })
 
-  it('should exclude drafts from reindexing by default', async () => {
+  test('should exclude drafts from reindexing by default', async ({ payload, restClient }) => {
     await Promise.all([
       payload.create({
         collection: pagesSlug,
@@ -680,7 +685,7 @@ describe('@payloadcms/plugin-search', () => {
     )
   })
 
-  it('should reindex all configured locales', async () => {
+  test('should reindex all configured locales', async ({ payload, restClient }) => {
     const post = await payload.create({
       collection: postsSlug,
       locale: 'en',
@@ -762,7 +767,7 @@ describe('@payloadcms/plugin-search', () => {
     expect(postAfterReindex?.slug).toStrictEqual(postBeforeReindex?.slug)
   })
 
-  it('should sync trashed documents correctly with search plugin', async () => {
+  test('should sync trashed documents correctly with search plugin', async ({ payload }) => {
     // Create a published post
     const publishedPost = await payload.create({
       collection: postsSlug,
@@ -825,8 +830,8 @@ describe('@payloadcms/plugin-search', () => {
     })
   })
 
-  describe('locale filtering', () => {
-    it('should filter locales when skipSync excludes them', async () => {
+  test.describe('locale filtering', () => {
+    test('should filter locales when skipSync excludes them', async ({ payload }) => {
       // Test config has 3 locales: ['en', 'es', 'de']
       // For 'filtered-locales' collection with syncEnglishOnly: true, only 'en' should be indexed
 
@@ -882,7 +887,7 @@ describe('@payloadcms/plugin-search', () => {
       })
     })
 
-    it('should index all locales when skipSync allows all locales', async () => {
+    test('should index all locales when skipSync allows all locales', async ({ payload }) => {
       // Test config has 3 locales: ['en', 'es', 'de']
       // For 'posts' collection, skipSync returns false for all locales
 
@@ -944,7 +949,7 @@ describe('@payloadcms/plugin-search', () => {
       })
     })
 
-    it('should index all locales when syncEnglishOnly is false', async () => {
+    test('should index all locales when syncEnglishOnly is false', async ({ payload }) => {
       // For 'filtered-locales' collection with syncEnglishOnly: false, all locales should be indexed
 
       // Create a doc with syncEnglishOnly disabled

--- a/test/plugin-sentry/config.ts
+++ b/test/plugin-sentry/config.ts
@@ -12,17 +12,41 @@ import { Posts } from './collections/Posts.js'
 import { Users } from './collections/Users.js'
 
 export default buildConfigWithDefaults({
-  admin: {
-    components: {
-      beforeDashboard: ['/TestErrors.js#TestErrors'],
+  suite: 'plugin-sentry',
+  config: {
+    admin: {
+      components: {
+        beforeDashboard: ['/TestErrors.js#TestErrors'],
+      },
+      importMap: {
+        baseDir: path.resolve(dirname),
+      },
+      user: Users.slug,
     },
-    importMap: {
-      baseDir: path.resolve(dirname),
+    collections: [Posts, Users],
+    endpoints: [
+      {
+        handler: () => {
+          throw new APIError('Test Plugin-Sentry Exception', 500)
+        },
+        method: 'get',
+        path: '/exception',
+      },
+    ],
+    plugins: [
+      sentryPlugin({
+        options: {
+          captureErrors: [400, 403, 404],
+          debug: true,
+        },
+        Sentry,
+      }),
+    ],
+    typescript: {
+      outputFile: path.resolve(dirname, 'payload-types.ts'),
     },
-    user: Users.slug,
   },
-  collections: [Posts, Users],
-  onInit: async (payload) => {
+  seed: async (payload) => {
     await payload.create({
       collection: 'users',
       data: {
@@ -30,26 +54,5 @@ export default buildConfigWithDefaults({
         password: devUser.password,
       },
     })
-  },
-  endpoints: [
-    {
-      path: '/exception',
-      handler: () => {
-        throw new APIError('Test Plugin-Sentry Exception', 500)
-      },
-      method: 'get',
-    },
-  ],
-  plugins: [
-    sentryPlugin({
-      Sentry,
-      options: {
-        debug: true,
-        captureErrors: [400, 403, 404],
-      },
-    }),
-  ],
-  typescript: {
-    outputFile: path.resolve(dirname, 'payload-types.ts'),
   },
 })

--- a/test/plugin-sentry/int.spec.ts
+++ b/test/plugin-sentry/int.spec.ts
@@ -1,9 +1,8 @@
 import { fileURLToPath } from 'url'
 
 import { test } from '../__helpers/int/vitest.js'
-import testConfig from './config.js'
 
-test.suite({ config: testConfig })('@payloadcms/plugin-sentry', () => {
+test.suite({ config: './config.ts' })('@payloadcms/plugin-sentry', () => {
   test.describe('tests', () => {
     test.todo('plugin-sentry tests')
   })

--- a/test/plugin-sentry/int.spec.ts
+++ b/test/plugin-sentry/int.spec.ts
@@ -1,26 +1,10 @@
-import type { Payload } from 'payload'
-import { describe, beforeAll, afterAll, it } from 'vitest'
-
-import path from 'path'
 import { fileURLToPath } from 'url'
 
-import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
+import { test } from '../__helpers/int/vitest.js'
+import testConfig from './config.js'
 
-let payload: Payload
-
-const filename = fileURLToPath(import.meta.url)
-const dirname = path.dirname(filename)
-
-describe('@payloadcms/plugin-sentry', () => {
-  beforeAll(async () => {
-    ;({ payload } = await initPayloadInt(dirname))
-  })
-
-  afterAll(async () => {
-    await payload.destroy()
-  })
-
-  describe('tests', () => {
-    it.todo('plugin-sentry tests')
+test.suite({ config: testConfig })('@payloadcms/plugin-sentry', () => {
+  test.describe('tests', () => {
+    test.todo('plugin-sentry tests')
   })
 })

--- a/test/plugin-seo/config.ts
+++ b/test/plugin-seo/config.ts
@@ -4,11 +4,12 @@ const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 import type { GenerateDescription, GenerateTitle, GenerateURL } from '@payloadcms/plugin-seo/types'
 import type { Field } from 'payload'
-import type { Page } from './payload-types.js'
 
 import { seoPlugin } from '@payloadcms/plugin-seo'
 import { en } from '@payloadcms/translations/languages/en'
 import { es } from '@payloadcms/translations/languages/es'
+
+import type { Page } from './payload-types.js'
 
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
 import { devUser } from '../credentials.js'
@@ -31,31 +32,75 @@ const generateURL: GenerateURL<Page> = ({ doc, locale }) => {
 }
 
 export default buildConfigWithDefaults({
-  collections: [Users, Pages, Media, PagesWithImportedFields],
-  i18n: {
-    supportedLanguages: {
-      en,
-      es,
+  suite: 'plugin-seo',
+  config: {
+    admin: {
+      importMap: {
+        baseDir: path.resolve(dirname),
+      },
     },
-    translations: {
-      es: {
-        'plugin-seo': {
-          autoGenerate: 'Auto-génerar',
+    collections: [Users, Pages, Media, PagesWithImportedFields],
+    i18n: {
+      supportedLanguages: {
+        en,
+        es,
+      },
+      translations: {
+        es: {
+          'plugin-seo': {
+            autoGenerate: 'Auto-génerar',
+          },
         },
       },
     },
-  },
-  admin: {
-    importMap: {
-      baseDir: path.resolve(dirname),
+    localization: {
+      defaultLocale: 'en',
+      fallback: true,
+      locales: ['en', 'es', 'de'],
+    },
+    plugins: [
+      seoPlugin({
+        collections: ['pages'],
+        fields: ({ defaultFields }) => {
+          const modifiedFields = defaultFields.map((field) => {
+            if ('name' in field && field.name === 'title') {
+              return {
+                ...field,
+                admin: {
+                  ...field.admin,
+                  components: {
+                    ...field.admin.components,
+                    afterInput: '/components/AfterInput.js#AfterInput',
+                    beforeInput: '/components/BeforeInput.js#BeforeInput',
+                  },
+                },
+                required: true,
+              } as Field
+            }
+            return field
+          })
+
+          return [
+            ...modifiedFields,
+            {
+              name: 'ogTitle',
+              type: 'text',
+              label: 'og:title',
+            },
+          ]
+        },
+        generateDescription,
+        generateTitle,
+        generateURL,
+        tabbedUI: true,
+        uploadsCollection: 'media',
+      }),
+    ],
+    typescript: {
+      outputFile: path.resolve(dirname, 'payload-types.ts'),
     },
   },
-  localization: {
-    defaultLocale: 'en',
-    fallback: true,
-    locales: ['en', 'es', 'de'],
-  },
-  onInit: async (payload) => {
+  seed: async (payload) => {
     await payload.create({
       collection: 'users',
       data: {
@@ -65,46 +110,5 @@ export default buildConfigWithDefaults({
     })
 
     await seed(payload)
-  },
-  plugins: [
-    seoPlugin({
-      collections: ['pages'],
-      fields: ({ defaultFields }) => {
-        const modifiedFields = defaultFields.map((field) => {
-          if ('name' in field && field.name === 'title') {
-            return {
-              ...field,
-              required: true,
-              admin: {
-                ...field.admin,
-                components: {
-                  ...field.admin.components,
-                  afterInput: '/components/AfterInput.js#AfterInput',
-                  beforeInput: '/components/BeforeInput.js#BeforeInput',
-                },
-              },
-            } as Field
-          }
-          return field
-        })
-
-        return [
-          ...modifiedFields,
-          {
-            name: 'ogTitle',
-            type: 'text',
-            label: 'og:title',
-          },
-        ]
-      },
-      generateDescription,
-      generateTitle,
-      generateURL,
-      tabbedUI: true,
-      uploadsCollection: 'media',
-    }),
-  ],
-  typescript: {
-    outputFile: path.resolve(dirname, 'payload-types.ts'),
   },
 })

--- a/test/plugin-seo/int.spec.ts
+++ b/test/plugin-seo/int.spec.ts
@@ -1,28 +1,24 @@
-import type { Payload } from 'payload'
-
 import path from 'path'
 import { getFileByPath } from 'payload'
 import { fileURLToPath } from 'url'
-import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import { expect } from 'vitest'
 
-import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
+import { test } from '../__helpers/int/vitest.js'
 import { removeFiles } from '../__helpers/shared/removeFiles.js'
+import testConfig from './config.js'
 import { mediaSlug } from './shared.js'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
-let payload: Payload
-
-describe('@payloadcms/plugin-seo', () => {
+test.suite({ config: testConfig })('@payloadcms/plugin-seo', () => {
   let page = null
   let mediaDoc = null
   let mediaDoc2 = null
 
-  beforeAll(async () => {
+  test.beforeEach(async ({ payload }) => {
     const uploadsDir = path.resolve(dirname, './media')
     removeFiles(path.normalize(uploadsDir))
-    ;({ payload } = await initPayloadInt(dirname))
 
     // Create image
     const filePath = path.resolve(dirname, './image-1.jpg')
@@ -54,11 +50,9 @@ describe('@payloadcms/plugin-seo', () => {
     })
   })
 
-  afterAll(async () => {
-    await payload.destroy()
-  })
-
-  it('should return different previousValue and value in afterChange hooks when relationship changes', async () => {
+  test('should return different previousValue and value in afterChange hooks when relationship changes', async ({
+    payload,
+  }) => {
     // The existing page has mediaDoc as featuredMedia
     // Update it to mediaDoc2 and we expect to see different previousValue and value in the hook
     const context: { identicalCount?: number } = {}
@@ -79,7 +73,7 @@ describe('@payloadcms/plugin-seo', () => {
     expect(context.identicalCount).toBeUndefined()
   })
 
-  it('should add meta title', async () => {
+  test('should add meta title', async ({ payload }) => {
     const pageWithTitle = await payload.update({
       collection: 'pages',
       id: page.id,
@@ -96,7 +90,7 @@ describe('@payloadcms/plugin-seo', () => {
     expect(pageWithTitle.meta.title).toBe('Hello, world!')
   })
 
-  it('should add meta description', async () => {
+  test('should add meta description', async ({ payload }) => {
     const pageWithDescription = await payload.update({
       collection: 'pages',
       id: page.id,
@@ -113,7 +107,7 @@ describe('@payloadcms/plugin-seo', () => {
     expect(pageWithDescription.meta.description).toBe('This is a test page')
   })
 
-  it('should add meta image', async () => {
+  test('should add meta image', async ({ payload }) => {
     const pageWithImage = await payload.update({
       collection: 'pages',
       id: page.id,
@@ -130,7 +124,7 @@ describe('@payloadcms/plugin-seo', () => {
     expect(pageWithImage.meta.image).toBe(mediaDoc.id)
   })
 
-  it('should add custom meta field', async () => {
+  test('should add custom meta field', async ({ payload }) => {
     const pageWithCustomField = await payload.update({
       collection: 'pages',
       id: page.id,
@@ -147,7 +141,20 @@ describe('@payloadcms/plugin-seo', () => {
     expect(pageWithCustomField.meta.ogTitle).toBe('Hello, world!')
   })
 
-  it('should localize meta fields', async () => {
+  test('should localize meta fields', async ({ payload }) => {
+    await payload.update({
+      collection: 'pages',
+      id: page.id,
+      data: {
+        meta: {
+          title: 'Hello, world!',
+          description: 'This is a test page',
+        },
+      },
+      locale: 'en',
+      depth: 0,
+    })
+
     const pageWithLocalizedMeta = await payload.update({
       collection: 'pages',
       id: page.id,

--- a/test/plugin-seo/int.spec.ts
+++ b/test/plugin-seo/int.spec.ts
@@ -5,13 +5,12 @@ import { expect } from 'vitest'
 
 import { test } from '../__helpers/int/vitest.js'
 import { removeFiles } from '../__helpers/shared/removeFiles.js'
-import testConfig from './config.js'
 import { mediaSlug } from './shared.js'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
-test.suite({ config: testConfig })('@payloadcms/plugin-seo', () => {
+test.suite({ config: './config.ts' })('@payloadcms/plugin-seo', () => {
   let page = null
   let mediaDoc = null
   let mediaDoc2 = null

--- a/test/plugin-stripe/config.ts
+++ b/test/plugin-stripe/config.ts
@@ -18,18 +18,79 @@ process.env.STRIPE_WEBHOOKS_ENDPOINT_SECRET = 'whsec_123'
 process.env.STRIPE_SECRET_KEY = 'sk_test_123'
 
 export default buildConfigWithDefaults({
-  admin: {
-    importMap: {
-      baseDir: path.resolve(dirname),
+  suite: 'plugin-stripe',
+  config: {
+    admin: {
+      importMap: {
+        baseDir: path.resolve(dirname),
+      },
+    },
+    collections: [Users, Products, Customers],
+    localization: {
+      defaultLocale: 'en',
+      fallback: true,
+      locales: ['en', 'es', 'de'],
+    },
+    plugins: [
+      stripePlugin({
+        isTestKey: true,
+        logs: true,
+        rest: false,
+        stripeSecretKey: process.env.STRIPE_SECRET_KEY,
+        stripeWebhooksEndpointSecret: process.env.STRIPE_WEBHOOKS_ENDPOINT_SECRET,
+        sync: [
+          {
+            collection: 'customers',
+            fields: [
+              {
+                fieldPath: 'name',
+                stripeProperty: 'name',
+              },
+              {
+                fieldPath: 'email',
+                stripeProperty: 'email',
+              },
+              // NOTE: nested fields are not supported yet, because the Stripe API keeps everything separate at the top-level
+              // because of this, we need to wire our own custom webhooks to handle these changes
+              // In the future, support for nested fields may look something like this:
+              // {
+              //   field: 'subscriptions.name',
+              //   property: 'plan.name',
+              // }
+            ],
+            stripeResourceType: 'customers',
+            stripeResourceTypeSingular: 'customer',
+          },
+          {
+            collection: 'products',
+            fields: [
+              {
+                fieldPath: 'name',
+                stripeProperty: 'name',
+              },
+              {
+                fieldPath: 'price.stripePriceID',
+                stripeProperty: 'default_price',
+              },
+            ],
+            stripeResourceType: 'products',
+            stripeResourceTypeSingular: 'product',
+          },
+        ],
+        webhooks: {
+          'customer.subscription.created': subscriptionCreatedOrUpdated,
+          'customer.subscription.deleted': subscriptionDeleted,
+          'customer.subscription.updated': subscriptionCreatedOrUpdated,
+          'product.created': syncPriceJSON,
+          'product.updated': syncPriceJSON,
+        },
+      }),
+    ],
+    typescript: {
+      outputFile: path.resolve(dirname, 'payload-types.ts'),
     },
   },
-  collections: [Users, Products, Customers],
-  localization: {
-    defaultLocale: 'en',
-    fallback: true,
-    locales: ['en', 'es', 'de'],
-  },
-  onInit: async (payload) => {
+  seed: async (payload) => {
     await payload.create({
       collection: 'users',
       data: {
@@ -39,63 +100,5 @@ export default buildConfigWithDefaults({
     })
 
     await seed(payload)
-  },
-  plugins: [
-    stripePlugin({
-      isTestKey: true,
-      logs: true,
-      rest: false,
-      stripeSecretKey: process.env.STRIPE_SECRET_KEY,
-      stripeWebhooksEndpointSecret: process.env.STRIPE_WEBHOOKS_ENDPOINT_SECRET,
-      sync: [
-        {
-          collection: 'customers',
-          fields: [
-            {
-              fieldPath: 'name',
-              stripeProperty: 'name',
-            },
-            {
-              fieldPath: 'email',
-              stripeProperty: 'email',
-            },
-            // NOTE: nested fields are not supported yet, because the Stripe API keeps everything separate at the top-level
-            // because of this, we need to wire our own custom webhooks to handle these changes
-            // In the future, support for nested fields may look something like this:
-            // {
-            //   field: 'subscriptions.name',
-            //   property: 'plan.name',
-            // }
-          ],
-          stripeResourceType: 'customers',
-          stripeResourceTypeSingular: 'customer',
-        },
-        {
-          collection: 'products',
-          fields: [
-            {
-              fieldPath: 'name',
-              stripeProperty: 'name',
-            },
-            {
-              fieldPath: 'price.stripePriceID',
-              stripeProperty: 'default_price',
-            },
-          ],
-          stripeResourceType: 'products',
-          stripeResourceTypeSingular: 'product',
-        },
-      ],
-      webhooks: {
-        'customer.subscription.created': subscriptionCreatedOrUpdated,
-        'customer.subscription.deleted': subscriptionDeleted,
-        'customer.subscription.updated': subscriptionCreatedOrUpdated,
-        'product.created': syncPriceJSON,
-        'product.updated': syncPriceJSON,
-      },
-    }),
-  ],
-  typescript: {
-    outputFile: path.resolve(dirname, 'payload-types.ts'),
   },
 })

--- a/test/plugin-stripe/int.spec.ts
+++ b/test/plugin-stripe/int.spec.ts
@@ -2,9 +2,8 @@ import { fileURLToPath } from 'url'
 import { expect } from 'vitest'
 
 import { test } from '../__helpers/int/vitest.js'
-import testConfig from './config.js'
 
-test.suite({ config: testConfig })('Stripe Plugin', () => {
+test.suite({ config: './config.ts' })('Stripe Plugin', () => {
   test('should create products', async ({ payload }) => {
     const product = await payload.create({
       collection: 'products',

--- a/test/plugin-stripe/int.spec.ts
+++ b/test/plugin-stripe/int.spec.ts
@@ -1,26 +1,11 @@
-import type { Payload } from 'payload'
-import { describe, beforeAll, afterAll, it, expect } from 'vitest'
-
-import path from 'path'
 import { fileURLToPath } from 'url'
+import { expect } from 'vitest'
 
-import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
+import { test } from '../__helpers/int/vitest.js'
+import testConfig from './config.js'
 
-let payload: Payload
-
-const filename = fileURLToPath(import.meta.url)
-const dirname = path.dirname(filename)
-
-describe('Stripe Plugin', () => {
-  beforeAll(async () => {
-    ;({ payload } = await initPayloadInt(dirname))
-  })
-
-  afterAll(async () => {
-    await payload.destroy()
-  })
-
-  it('should create products', async () => {
+test.suite({ config: testConfig })('Stripe Plugin', () => {
+  test('should create products', async ({ payload }) => {
     const product = await payload.create({
       collection: 'products',
       data: {
@@ -34,13 +19,13 @@ describe('Stripe Plugin', () => {
   // Test various common API calls like `products.create`, etc.
   // Send the requests through the Payload->Stripe proxy
   // Query Stripe directly to ensure the data is as expected
-  it.todo('should open REST API proxy')
+  test.todo('should open REST API proxy')
 
   // Test various common webhook events like `product.created`, etc.
   // These could potentially be mocked
-  it.todo('should handle incoming Stripe webhook events')
+  test.todo('should handle incoming Stripe webhook events')
 
   // Test that the data is synced to Stripe automatically without the use of custom hooks/proxy
   // I.e. the `sync` config option
-  it.todo('should auto-sync data based on config')
+  test.todo('should auto-sync data based on config')
 })

--- a/test/plugins/config.ts
+++ b/test/plugins/config.ts
@@ -30,8 +30,8 @@ const readerPlugin = definePlugin<ReaderPluginOptions>({
     ...config,
     custom: {
       ...(config.custom || {}),
-      readerSawValue: (config.custom?.writerValue as string) ?? null,
       readerItems: options.items.map((i) => i.name),
+      readerSawValue: (config.custom?.writerValue as string) ?? null,
     },
   }),
 })
@@ -60,41 +60,47 @@ const writerPlugin = definePlugin({
 })
 
 export default buildConfigWithDefaults({
-  admin: {
-    importMap: {
-      baseDir: path.resolve(dirname),
+  suite: 'plugins',
+  config: {
+    admin: {
+      importMap: {
+        baseDir: path.resolve(dirname),
+      },
+    },
+    collections: [
+      {
+        slug: 'users',
+        auth: true,
+        fields: [],
+        versions: false,
+      },
+    ],
+    plugins: [
+      (config) => ({
+        ...config,
+        collections: [
+          ...(config.collections || []),
+          {
+            slug: pagesSlug,
+            fields: [
+              {
+                name: 'title',
+                type: 'text',
+              },
+            ],
+            versions: false,
+          },
+        ],
+      }),
+      // Intentionally listed BEFORE the writer to verify order sorting works
+      readerPlugin({ items: [{ name: 'user-provided' }] }),
+      writerPlugin(),
+    ],
+    typescript: {
+      outputFile: path.resolve(dirname, 'payload-types.ts'),
     },
   },
-  collections: [
-    {
-      slug: 'users',
-      auth: true,
-      fields: [],
-      versions: false,
-    },
-  ],
-  plugins: [
-    (config) => ({
-      ...config,
-      collections: [
-        ...(config.collections || []),
-        {
-          slug: pagesSlug,
-          fields: [
-            {
-              name: 'title',
-              type: 'text',
-            },
-          ],
-          versions: false,
-        },
-      ],
-    }),
-    // Intentionally listed BEFORE the writer to verify order sorting works
-    readerPlugin({ items: [{ name: 'user-provided' }] }),
-    writerPlugin(),
-  ],
-  onInit: async (payload) => {
+  seed: async (payload) => {
     await payload.create({
       collection: 'users',
       data: {
@@ -102,8 +108,5 @@ export default buildConfigWithDefaults({
         password: devUser.password,
       },
     })
-  },
-  typescript: {
-    outputFile: path.resolve(dirname, 'payload-types.ts'),
   },
 })

--- a/test/plugins/int.spec.ts
+++ b/test/plugins/int.spec.ts
@@ -4,9 +4,9 @@ import { expect } from 'vitest'
 import type { ReaderPluginOptions } from './config.js'
 
 import { test } from '../__helpers/int/vitest.js'
-import testConfig, { pagesSlug } from './config.js'
+import { pagesSlug } from './config.js'
 
-test.suite({ config: testConfig })('Collections - Plugins', () => {
+test.suite({ config: './config.ts' })('Collections - Plugins', () => {
   test('created pages collection', async ({ payload }) => {
     const { id } = await payload.create({
       collection: pagesSlug,

--- a/test/plugins/int.spec.ts
+++ b/test/plugins/int.spec.ts
@@ -1,29 +1,13 @@
-import type { Payload } from 'payload'
-
-import path from 'path'
 import { fileURLToPath } from 'url'
-import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { expect } from 'vitest'
 
 import type { ReaderPluginOptions } from './config.js'
 
-import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
-import { pagesSlug } from './config.js'
+import { test } from '../__helpers/int/vitest.js'
+import testConfig, { pagesSlug } from './config.js'
 
-let payload: Payload
-
-const filename = fileURLToPath(import.meta.url)
-const dirname = path.dirname(filename)
-
-describe('Collections - Plugins', () => {
-  beforeAll(async () => {
-    ;({ payload } = await initPayloadInt(dirname))
-  })
-
-  afterAll(async () => {
-    await payload.destroy()
-  })
-
-  it('created pages collection', async () => {
+test.suite({ config: testConfig })('Collections - Plugins', () => {
+  test('created pages collection', async ({ payload }) => {
     const { id } = await payload.create({
       collection: pagesSlug,
       data: {
@@ -34,14 +18,14 @@ describe('Collections - Plugins', () => {
     expect(id).toBeDefined()
   })
 
-  describe('plugin order, slug, and options', () => {
-    it('should execute plugins sorted by order regardless of array position', () => {
+  test.describe('plugin order, slug, and options', () => {
+    test('should execute plugins sorted by order regardless of array position', ({ payload }) => {
       // The reader (order 10) is listed BEFORE the writer (order 1) in the array,
       // but order sorting ensures the writer runs first.
       expect(payload.config.custom?.readerSawValue).toBe('written-by-low-priority')
     })
 
-    it('should allow plugins to find each other by slug', () => {
+    test('should allow plugins to find each other by slug', ({ payload }) => {
       const reader = payload.config.plugins?.find((p) => p.slug === 'priority-reader')
       const writer = payload.config.plugins?.find((p) => p.slug === 'priority-writer')
 
@@ -49,7 +33,7 @@ describe('Collections - Plugins', () => {
       expect(writer).toBeDefined()
     })
 
-    it('should allow a plugin to mutate another plugin options via slug', () => {
+    test('should allow a plugin to mutate another plugin options via slug', ({ payload }) => {
       // The writer (runs first) finds the reader by slug and pushes into its options.items.
       // The reader (runs second) sees both the user-provided and injected items.
       const items = payload.config.custom?.readerItems as string[]
@@ -58,7 +42,7 @@ describe('Collections - Plugins', () => {
       expect(items).toContain('injected-by-writer')
     })
 
-    it('should expose typed options on plugins found by slug', () => {
+    test('should expose typed options on plugins found by slug', ({ payload }) => {
       const reader = payload.config.plugins?.find((p) => p.slug === 'priority-reader')
 
       expect(reader).toBeDefined()

--- a/test/v4/baseConfig.ts
+++ b/test/v4/baseConfig.ts
@@ -190,681 +190,682 @@ export const baseConfig: Partial<Config> = {
     fallback: true,
     locales: ['en', 'es', 'de'],
   },
-  onInit: async (payload) => {
-    // Clear existing data before seeding
-    await resetDB(payload, collectionSlugs)
+  typescript: {
+    outputFile: path.resolve(dirname, 'payload-types.ts'),
+  },
+}
 
-    // Seed users
-    const devUserDoc = await payload.create({
-      collection: 'users',
-      data: {
-        email: devUser.email,
-        password: devUser.password,
-        roles: ['admin'],
-      },
-    })
+export const seed: NonNullable<Config['onInit']> = async (payload) => {
+  // Clear existing data before seeding
+  await resetDB(payload, collectionSlugs)
 
+  // Seed users
+  const devUserDoc = await payload.create({
+    collection: 'users',
+    data: {
+      email: devUser.email,
+      password: devUser.password,
+      roles: ['admin'],
+    },
+  })
+
+  await payload.create({
+    collection: 'users',
+    data: {
+      email: 'user@payloadcms.com',
+      password: 'test',
+      roles: ['user'],
+    },
+  })
+
+  await payload.create({
+    collection: 'users',
+    data: {
+      email: 'dev2@payloadcms.com',
+      password: devUser.password,
+      roles: ['admin'],
+    },
+  })
+
+  const authors = [
+    { email: 'alice@example.com', password: 'password123' },
+    { email: 'bob@example.com', password: 'password123' },
+    { email: 'charlie@example.com', password: 'password123' },
+  ]
+
+  for (const author of authors) {
     await payload.create({
       collection: 'users',
-      data: {
-        email: 'user@payloadcms.com',
-        password: 'test',
-        roles: ['user'],
-      },
+      data: author,
+    })
+  }
+
+  // Seed text-fields collection for relationship testing
+  const posts = [
+    { title: 'Getting Started with Payload' },
+    { title: 'Advanced Relationship Fields' },
+    { title: 'Building a Blog with Payload' },
+    { title: 'Understanding Collections' },
+    { title: 'Working with Uploads' },
+    { title: 'Custom Components Guide' },
+    { title: 'Authentication Deep Dive' },
+    { title: 'GraphQL vs REST API' },
+  ]
+
+  const createdPosts: { id: number | string }[] = []
+  for (const post of posts) {
+    const created = await payload.create({
+      collection: textFieldsSlug,
+      data: post,
+    })
+    createdPosts.push(created)
+  }
+
+  const richTextCount = await payload.count({ collection: richTextFieldsSlug })
+  if (richTextCount.totalDocs === 0) {
+    const uploadDoc = await payload.create({
+      collection: uploadsSlug,
+      data: { alt: 'Farming image' },
+      file: imageFile,
     })
 
-    await payload.create({
+    const formattedUploadID =
+      payload.db.defaultIDType === 'number' ? uploadDoc.id : `"${uploadDoc.id}"`
+
+    const devUserDoc = await payload.find({
       collection: 'users',
+      limit: 1,
+      where: { email: { equals: devUser.email } },
+    })
+    const userId = devUserDoc.docs[0]?.id
+    const formattedUserID =
+      userId !== undefined
+        ? payload.db.defaultIDType === 'number'
+          ? userId
+          : `"${userId}"`
+        : undefined
+
+    const richTextContent = getRichTextContent(formattedUploadID, formattedUserID)
+
+    await payload.create({
+      collection: richTextFieldsSlug,
       data: {
-        email: 'dev2@payloadcms.com',
-        password: devUser.password,
-        roles: ['admin'],
+        code: codeContent,
+        content: richTextContent,
+        lists: listsContent,
+        table: tableContent,
+        title: 'Data harvest \u2013 how AI and sensors are revolutionizing farming',
+        typography: getTypographyContent(formattedUserID),
       },
     })
+  }
 
-    const authors = [
-      { email: 'alice@example.com', password: 'password123' },
-      { email: 'bob@example.com', password: 'password123' },
-      { email: 'charlie@example.com', password: 'password123' },
-    ]
+  // Seed relationship-fields to test join field
+  const createdRelationship = await payload.create({
+    collection: relationshipFieldsSlug,
+    data: {
+      authorRequired: devUserDoc.id,
+      relatedPosts: createdPosts.slice(0, 3).map((p) => p.id) as string[],
+    },
+  })
+  await payload.create({
+    collection: relationshipFieldsSlug,
+    data: {
+      authorRequired: devUserDoc.id,
+      relatedPosts: createdPosts.slice(3, 6).map((p) => p.id) as string[],
+    },
+  })
 
-    for (const author of authors) {
-      await payload.create({
-        collection: 'users',
-        data: author,
-      })
-    }
+  // Seed blocks collection
+  await payload.create({
+    collection: blocksFieldsSlug,
+    data: blocksSeedData,
+  })
 
-    // Seed text-fields collection for relationship testing
-    const posts = [
-      { title: 'Getting Started with Payload' },
-      { title: 'Advanced Relationship Fields' },
-      { title: 'Building a Blog with Payload' },
-      { title: 'Understanding Collections' },
-      { title: 'Working with Uploads' },
-      { title: 'Custom Components Guide' },
-      { title: 'Authentication Deep Dive' },
-      { title: 'GraphQL vs REST API' },
-    ]
+  // Seed join fields collection
+  const joinCategory = await payload.create({
+    collection: joinFieldsSlug,
+    data: {
+      name: 'Example Category',
+    },
+  })
 
-    const createdPosts: { id: number | string }[] = []
-    for (const post of posts) {
-      const created = await payload.create({
-        collection: textFieldsSlug,
-        data: post,
-      })
-      createdPosts.push(created)
-    }
-
-    const richTextCount = await payload.count({ collection: richTextFieldsSlug })
-    if (richTextCount.totalDocs === 0) {
-      const uploadDoc = await payload.create({
-        collection: uploadsSlug,
-        data: { alt: 'Farming image' },
-        file: imageFile,
-      })
-
-      const formattedUploadID =
-        payload.db.defaultIDType === 'number' ? uploadDoc.id : `"${uploadDoc.id}"`
-
-      const devUserDoc = await payload.find({
-        collection: 'users',
-        limit: 1,
-        where: { email: { equals: devUser.email } },
-      })
-      const userId = devUserDoc.docs[0]?.id
-      const formattedUserID =
-        userId !== undefined
-          ? payload.db.defaultIDType === 'number'
-            ? userId
-            : `"${userId}"`
-          : undefined
-
-      const richTextContent = getRichTextContent(formattedUploadID, formattedUserID)
-
-      await payload.create({
-        collection: richTextFieldsSlug,
-        data: {
-          code: codeContent,
-          content: richTextContent,
-          lists: listsContent,
-          table: tableContent,
-          title: 'Data harvest \u2013 how AI and sensors are revolutionizing farming',
-          typography: getTypographyContent(formattedUserID),
-        },
-      })
-    }
-
-    // Seed relationship-fields to test join field
-    const createdRelationship = await payload.create({
-      collection: relationshipFieldsSlug,
+  // Create 15 posts to test join field pagination (defaultLimit: 3)
+  for (let i = 1; i <= 15; i++) {
+    await payload.create({
+      collection: joinPostsSlug,
       data: {
-        authorRequired: devUserDoc.id,
-        relatedPosts: createdPosts.slice(0, 3).map((p) => p.id) as string[],
+        _status: i % 2 === 0 ? 'published' : 'draft',
+        category: joinCategory.id,
+        title: `Post ${i}`,
       },
     })
+  }
+
+  // Seed tags hierarchy for testing hierarchy field
+  const techTag = await payload.create({
+    collection: tagsSlug,
+    data: { name: 'Technology' },
+  })
+
+  const frontendTag = await payload.create({
+    collection: tagsSlug,
+    data: { name: 'Frontend', parent: techTag.id },
+  })
+
+  await payload.create({
+    collection: tagsSlug,
+    data: { name: 'React', parent: frontendTag.id },
+  })
+
+  await payload.create({
+    collection: tagsSlug,
+    data: { name: 'Vue', parent: frontendTag.id },
+  })
+
+  const backendTag = await payload.create({
+    collection: tagsSlug,
+    data: { name: 'Backend', parent: techTag.id },
+  })
+
+  await payload.create({
+    collection: tagsSlug,
+    data: { name: 'Node.js', parent: backendTag.id },
+  })
+
+  await payload.create({
+    collection: tagsSlug,
+    data: { name: 'Python', parent: backendTag.id },
+  })
+
+  await payload.create({
+    collection: tagsSlug,
+    data: { name: 'Design' },
+  })
+
+  // Add more root-level tags to test pagination (20+ total root tags)
+  const additionalTags = [
+    'Marketing',
+    'Sales',
+    'Finance',
+    'HR',
+    'Operations',
+    'Legal',
+    'Engineering',
+    'Product',
+    'Research',
+    'Analytics',
+    'Support',
+    'Quality',
+    'Security',
+    'Infrastructure',
+    'Data Science',
+    'DevOps',
+    'Mobile',
+    'Cloud',
+  ]
+
+  for (const tagName of additionalTags) {
     await payload.create({
-      collection: relationshipFieldsSlug,
+      collection: tagsSlug,
+      data: { name: tagName },
+    })
+  }
+
+  // Seed tag-items collection with 30 untagged items for hierarchy pagination testing
+  for (let i = 1; i <= 30; i++) {
+    await payload.create({
+      collection: tagItemsSlug,
       data: {
-        authorRequired: devUserDoc.id,
-        relatedPosts: createdPosts.slice(3, 6).map((p) => p.id) as string[],
+        description: `Description for tag item ${i}`,
+        title: `Tag Item ${i}`,
       },
     })
+  }
 
-    // Seed blocks collection
-    await payload.create({
-      collection: blocksFieldsSlug,
-      data: blocksSeedData,
-    })
+  // Seed folders for hierarchy testing
+  const rootFolder = await payload.create({
+    collection: foldersSlug,
+    data: { name: 'Root Folder' },
+  })
 
-    // Seed join fields collection
-    const joinCategory = await payload.create({
-      collection: joinFieldsSlug,
-      data: {
-        name: 'Example Category',
-      },
-    })
+  await payload.create({
+    collection: foldersSlug,
+    data: { name: 'Subfolder A', parent: rootFolder.id },
+  })
 
-    // Create 15 posts to test join field pagination (defaultLimit: 3)
-    for (let i = 1; i <= 15; i++) {
-      await payload.create({
-        collection: joinPostsSlug,
-        data: {
-          _status: i % 2 === 0 ? 'published' : 'draft',
-          category: joinCategory.id,
-          title: `Post ${i}`,
-        },
-      })
-    }
+  await payload.create({
+    collection: foldersSlug,
+    data: { name: 'Subfolder B', parent: rootFolder.id },
+  })
 
-    // Seed tags hierarchy for testing hierarchy field
-    const techTag = await payload.create({
-      collection: tagsSlug,
-      data: { name: 'Technology' },
-    })
+  // Seed nested child folders under a single parent to test nested LoadMoreRow pagination
+  const nestedParentFolder = await payload.create({
+    collection: foldersSlug,
+    data: { name: 'Nested Parent Folder', parent: rootFolder.id },
+  })
 
-    const frontendTag = await payload.create({
-      collection: tagsSlug,
-      data: { name: 'Frontend', parent: techTag.id },
-    })
-
-    await payload.create({
-      collection: tagsSlug,
-      data: { name: 'React', parent: frontendTag.id },
-    })
-
-    await payload.create({
-      collection: tagsSlug,
-      data: { name: 'Vue', parent: frontendTag.id },
-    })
-
-    const backendTag = await payload.create({
-      collection: tagsSlug,
-      data: { name: 'Backend', parent: techTag.id },
-    })
-
-    await payload.create({
-      collection: tagsSlug,
-      data: { name: 'Node.js', parent: backendTag.id },
-    })
-
-    await payload.create({
-      collection: tagsSlug,
-      data: { name: 'Python', parent: backendTag.id },
-    })
-
-    await payload.create({
-      collection: tagsSlug,
-      data: { name: 'Design' },
-    })
-
-    // Add more root-level tags to test pagination (20+ total root tags)
-    const additionalTags = [
-      'Marketing',
-      'Sales',
-      'Finance',
-      'HR',
-      'Operations',
-      'Legal',
-      'Engineering',
-      'Product',
-      'Research',
-      'Analytics',
-      'Support',
-      'Quality',
-      'Security',
-      'Infrastructure',
-      'Data Science',
-      'DevOps',
-      'Mobile',
-      'Cloud',
-    ]
-
-    for (const tagName of additionalTags) {
-      await payload.create({
-        collection: tagsSlug,
-        data: { name: tagName },
-      })
-    }
-
-    // Seed tag-items collection with 30 untagged items for hierarchy pagination testing
-    for (let i = 1; i <= 30; i++) {
-      await payload.create({
-        collection: tagItemsSlug,
-        data: {
-          description: `Description for tag item ${i}`,
-          title: `Tag Item ${i}`,
-        },
-      })
-    }
-
-    // Seed folders for hierarchy testing
-    const rootFolder = await payload.create({
-      collection: foldersSlug,
-      data: { name: 'Root Folder' },
-    })
-
+  for (let i = 1; i <= 10; i++) {
     await payload.create({
       collection: foldersSlug,
-      data: { name: 'Subfolder A', parent: rootFolder.id },
+      data: { name: `Nested Child ${i}`, parent: nestedParentFolder.id },
     })
+  }
 
+  // Seed a third level: Nested Parent Folder > Branch Folder > Leaf Child N
+  const branchFolder = await payload.create({
+    collection: foldersSlug,
+    data: { name: 'Branch Folder', parent: nestedParentFolder.id },
+  })
+
+  for (let i = 1; i <= 10; i++) {
     await payload.create({
       collection: foldersSlug,
-      data: { name: 'Subfolder B', parent: rootFolder.id },
+      data: { name: `Leaf Child ${i}`, parent: branchFolder.id },
     })
+  }
 
-    // Seed nested child folders under a single parent to test nested LoadMoreRow pagination
-    const nestedParentFolder = await payload.create({
-      collection: foldersSlug,
-      data: { name: 'Nested Parent Folder', parent: rootFolder.id },
-    })
-
-    for (let i = 1; i <= 10; i++) {
-      await payload.create({
-        collection: foldersSlug,
-        data: { name: `Nested Child ${i}`, parent: nestedParentFolder.id },
-      })
-    }
-
-    // Seed a third level: Nested Parent Folder > Branch Folder > Leaf Child N
-    const branchFolder = await payload.create({
-      collection: foldersSlug,
-      data: { name: 'Branch Folder', parent: nestedParentFolder.id },
-    })
-
-    for (let i = 1; i <= 10; i++) {
-      await payload.create({
-        collection: foldersSlug,
-        data: { name: `Leaf Child ${i}`, parent: branchFolder.id },
-      })
-    }
-
-    // Seed folder-items collection with 30 items (no folder assigned) for hierarchy pagination testing
-    for (let i = 1; i <= 30; i++) {
-      await payload.create({
-        collection: folderItemsSlug,
-        data: {
-          title: `Folder Item ${i}`,
-        },
-      })
-    }
-
-    // Seed search-bar-test collection with 300 items for pagination testing
-    const categories = ['news', 'blog', 'tutorial', 'docs']
-    const statuses = ['draft', 'published', 'archived']
-
-    for (let i = 1; i <= 300; i++) {
-      const index = i.toString().padStart(3, '0')
-      await payload.create({
-        collection: 'search-bar-test',
-        data: {
-          category: categories[i % categories.length],
-          description: `Description for document ${index}`,
-          priority: i,
-          status: statuses[i % statuses.length],
-          title: `Document ${index}`,
-        },
-      })
-    }
-
-    // Seed orderable collection for testing drag-and-drop ordering
-    const orderableItems = [
-      { priority: 'high', title: 'First Task' },
-      { priority: 'medium', title: 'Second Task' },
-      { priority: 'low', title: 'Third Task' },
-      { priority: 'high', title: 'Fourth Task' },
-      { priority: 'medium', title: 'Fifth Task' },
-    ]
-
-    for (const item of orderableItems) {
-      await payload.create({
-        collection: orderableSlug,
-        data: item,
-      })
-    }
-
-    // Seed query presets for search-bar-test collection
-    const presetAccessEveryone = {
-      delete: { constraint: 'everyone' },
-      read: { constraint: 'everyone' },
-      update: { constraint: 'everyone' },
-    }
-
+  // Seed folder-items collection with 30 items (no folder assigned) for hierarchy pagination testing
+  for (let i = 1; i <= 30; i++) {
     await payload.create({
-      collection: 'payload-query-presets',
+      collection: folderItemsSlug,
       data: {
-        access: presetAccessEveryone,
-        isShared: true,
-        relatedCollection: 'search-bar-test',
-        title: 'Published Only',
-        where: {
-          status: { equals: 'published' },
-        },
+        title: `Folder Item ${i}`,
       },
     })
+  }
 
+  // Seed search-bar-test collection with 300 items for pagination testing
+  const categories = ['news', 'blog', 'tutorial', 'docs']
+  const statuses = ['draft', 'published', 'archived']
+
+  for (let i = 1; i <= 300; i++) {
+    const index = i.toString().padStart(3, '0')
     await payload.create({
-      collection: 'payload-query-presets',
+      collection: 'search-bar-test',
       data: {
-        access: presetAccessEveryone,
-        isShared: true,
-        relatedCollection: 'search-bar-test',
-        title: 'News Articles',
-        where: {
-          category: { equals: 'news' },
-        },
+        category: categories[i % categories.length],
+        description: `Description for document ${index}`,
+        priority: i,
+        status: statuses[i % statuses.length],
+        title: `Document ${index}`,
       },
     })
+  }
 
+  // Seed orderable collection for testing drag-and-drop ordering
+  const orderableItems = [
+    { priority: 'high', title: 'First Task' },
+    { priority: 'medium', title: 'Second Task' },
+    { priority: 'low', title: 'Third Task' },
+    { priority: 'high', title: 'Fourth Task' },
+    { priority: 'medium', title: 'Fifth Task' },
+  ]
+
+  for (const item of orderableItems) {
     await payload.create({
-      collection: 'payload-query-presets',
-      data: {
-        access: presetAccessEveryone,
-        isShared: true,
-        relatedCollection: 'search-bar-test',
-        title: 'Drafts',
-        where: {
-          status: { equals: 'draft' },
-        },
-      },
+      collection: orderableSlug,
+      data: item,
     })
+  }
 
-    // Seed draft-versions collection with many versions for pagination testing
-    const { id: draftVersionsDocID } = await payload.create({
+  // Seed query presets for search-bar-test collection
+  const presetAccessEveryone = {
+    delete: { constraint: 'everyone' },
+    read: { constraint: 'everyone' },
+    update: { constraint: 'everyone' },
+  }
+
+  await payload.create({
+    collection: 'payload-query-presets',
+    data: {
+      access: presetAccessEveryone,
+      isShared: true,
+      relatedCollection: 'search-bar-test',
+      title: 'Published Only',
+      where: {
+        status: { equals: 'published' },
+      },
+    },
+  })
+
+  await payload.create({
+    collection: 'payload-query-presets',
+    data: {
+      access: presetAccessEveryone,
+      isShared: true,
+      relatedCollection: 'search-bar-test',
+      title: 'News Articles',
+      where: {
+        category: { equals: 'news' },
+      },
+    },
+  })
+
+  await payload.create({
+    collection: 'payload-query-presets',
+    data: {
+      access: presetAccessEveryone,
+      isShared: true,
+      relatedCollection: 'search-bar-test',
+      title: 'Drafts',
+      where: {
+        status: { equals: 'draft' },
+      },
+    },
+  })
+
+  // Seed draft-versions collection with many versions for pagination testing
+  const { id: draftVersionsDocID } = await payload.create({
+    collection: draftVersionsSlug,
+    data: {
+      content: 'Initial content',
+      title: 'Document With Many Versions',
+    },
+    draft: true,
+  })
+
+  for (let i = 0; i < 20; i++) {
+    await payload.update({
+      id: draftVersionsDocID,
       collection: draftVersionsSlug,
       data: {
-        content: 'Initial content',
-        title: 'Document With Many Versions',
+        content: `Updated content version ${i + 2}`,
+        title: `Document With Many Versions - v${i + 2}`,
       },
-      draft: true,
     })
+  }
 
-    for (let i = 0; i < 20; i++) {
-      await payload.update({
-        id: draftVersionsDocID,
-        collection: draftVersionsSlug,
-        data: {
-          content: `Updated content version ${i + 2}`,
-          title: `Document With Many Versions - v${i + 2}`,
+  // Seed talks showcase collection
+  const existingUpload = await payload.find({
+    collection: uploadsSlug,
+    limit: 1,
+  })
+  const heroUploadID = existingUpload.docs[0]?.id
+
+  const buildAbstract = (text: string) => ({
+    root: {
+      type: 'root',
+      children: [
+        {
+          type: 'paragraph',
+          children: [
+            {
+              type: 'text',
+              detail: 0,
+              format: 0,
+              mode: 'normal',
+              style: '',
+              text,
+              version: 1,
+            },
+          ],
+          direction: 'ltr' as const,
+          format: '' as const,
+          indent: 0,
+          textFormat: 0,
+          version: 1,
         },
-      })
-    }
+      ],
+      direction: 'ltr' as const,
+      format: '' as const,
+      indent: 0,
+      version: 1,
+    },
+  })
 
-    // Seed talks showcase collection
-    const existingUpload = await payload.find({
-      collection: uploadsSlug,
-      limit: 1,
-    })
-    const heroUploadID = existingUpload.docs[0]?.id
+  const reactTalk = await payload.create({
+    collection: talksSlug,
+    data: {
+      slug: 'server-components-in-production',
+      _status: 'published',
+      abstract: buildAbstract(
+        'React Server Components reshape how we think about data fetching, bundling, and the boundary between server and client. This talk walks through a real-world migration of a 400-route admin panel.',
+      ),
+      attendeeCount: 412,
+      capacity: 800,
+      contactEmail: 'organizers@example.com',
+      customCss: '.talk-hero { background: linear-gradient(135deg, #6366f1, #ec4899); }',
+      customSchema: {
+        name: 'Server Components in Production',
+        '@context': 'https://schema.org',
+        '@type': 'Event',
+      },
+      difficultyLevel: 'intermediate',
+      durationMinutes: 45,
+      endTime: '2026-09-15T15:45:00.000Z',
+      gallery: heroUploadID
+        ? [
+            { caption: 'Speaker on the main stage', image: heroUploadID },
+            { caption: 'Audience Q&A', image: heroUploadID },
+          ]
+        : [],
+      heroImage: heroUploadID,
+      internalNotes: {
+        flagged: false,
+        reviewerNotes: 'Strong technical talk, confirmed slot.',
+      },
+      isFeatured: true,
+      isVirtual: false,
+      keywords: ['react', 'rsc', 'next.js', 'performance'],
+      languages: ['en'],
+      metaDescription:
+        'How we migrated a 400-route admin panel to React Server Components, with real benchmarks and trade-offs.',
+      metaTitle: 'Server Components in Production — A Migration Retrospective',
+      ogImage: heroUploadID,
+      organizer: devUserDoc.id,
+      priority: 9,
+      recordingUrl: 'https://example.com/watch/rsc-prod',
+      registrationDeadline: '2026-09-10T00:00:00.000Z',
+      registrationUrl: 'https://example.com/register',
+      resources: [
+        { type: 'slides', label: 'Slide deck (PDF)', url: 'https://example.com/slides.pdf' },
+        { type: 'code', label: 'Source code', url: 'https://github.com/example/rsc-demo' },
+        { type: 'docs', label: 'Migration guide', url: 'https://example.com/guide' },
+      ],
+      room: 'Main Stage',
+      sections: [
+        {
+          blockType: 'talk-hero',
+          eyebrow: 'Keynote',
+          heading: 'Server Components in Production',
+          subheading: 'A 12-month migration retrospective.',
+        },
+        {
+          attribution: 'Jordan Smith',
+          blockType: 'talk-quote',
+          quote:
+            'We cut our largest route bundle by 67% — but the architectural shift mattered more than the bytes.',
+          role: 'Staff Engineer',
+        },
+        {
+          blockType: 'talk-cta',
+          label: 'Read the full case study',
+          style: 'primary',
+          url: 'https://example.com/case-study',
+        },
+      ],
+      shortDescription:
+        'Lessons learned migrating a large admin app to React Server Components — what worked, what hurt, and what we would do again.',
+      slidesUrl: 'https://example.com/slides/rsc-prod',
+      startTime: '2026-09-15T15:00:00.000Z',
+      status: 'confirmed',
+      title: 'Server Components in Production',
+      track: 'frontend',
+      venueLocation: [-122.4194, 37.7749],
+    },
+  })
 
-    const buildAbstract = (text: string) => ({
-      root: {
-        type: 'root',
-        children: [
+  const aiTalk = await payload.create({
+    collection: talksSlug,
+    data: {
+      slug: 'llm-agents-without-the-hype',
+      _status: 'published',
+      abstract: buildAbstract(
+        'Most "agent" demos collapse outside the happy path. This session shares the evaluation framework we use to ship agent features into a regulated product.',
+      ),
+      attendeeCount: 78,
+      capacity: 120,
+      contactEmail: 'ai-track@example.com',
+      difficultyLevel: 'advanced',
+      durationMinutes: 30,
+      endTime: '2026-09-16T19:00:00.000Z',
+      isFeatured: false,
+      isVirtual: true,
+      keywords: ['llm', 'agents', 'evals'],
+      languages: ['en', 'es'],
+      organizer: devUserDoc.id,
+      priority: 6,
+      registrationUrl: 'https://example.com/register/ai',
+      relatedTalks: [reactTalk.id],
+      resources: [
+        { type: 'code', label: 'Eval harness repo', url: 'https://github.com/example/evals' },
+      ],
+      room: 'Workshop Room B',
+      sections: [
+        {
+          blockType: 'talk-hero',
+          heading: 'LLM Agents Without the Hype',
+          subheading: 'Building evals before features.',
+        },
+      ],
+      shortDescription:
+        'A pragmatic look at when LLM agents help, when they make things worse, and the eval harness we built to tell the difference.',
+      startTime: '2026-09-16T18:30:00.000Z',
+      status: 'accepted',
+      title: 'LLM Agents Without the Hype',
+      track: 'ai-ml',
+    },
+  })
+
+  await payload.create({
+    collection: talksSlug,
+    data: {
+      slug: 'designing-indexes-for-search',
+      _status: 'draft',
+      attendeeCount: 0,
+      difficultyLevel: 'intermediate',
+      durationMinutes: 25,
+      isFeatured: false,
+      isVirtual: false,
+      keywords: ['postgres', 'indexes', 'search'],
+      languages: ['en'],
+      organizer: devUserDoc.id,
+      priority: 4,
+      relatedTalks: [reactTalk.id, aiTalk.id],
+      shortDescription:
+        'A proposal walkthrough — we have not been accepted yet, but here is the outline.',
+      status: 'proposed',
+      title: 'Designing Database Indexes for Search',
+      track: 'backend',
+    },
+    draft: true,
+  })
+
+  // Seed drawers collection: a couple of docs linked via the
+  // self-referencing `child` field so drawers can be drilled into.
+  const drawerSeeds = [
+    { status: 'published' as const, title: 'Landing Page' },
+    { status: 'draft' as const, title: 'About Page' },
+  ]
+
+  let previousNestedChild: number | string | undefined
+  for (let i = drawerSeeds.length - 1; i >= 0; i--) {
+    const seed = drawerSeeds[i]!
+    const created = await payload.create({
+      collection: drawersSlug,
+      data: {
+        blocks: [
+          { blockType: 'hero-block', heading: `${seed.title} Hero` },
           {
-            type: 'paragraph',
+            blockType: 'content-block',
+            body: 'Some content for this page.',
+            heading: 'Overview',
+          },
+          { blockType: 'cta-block', label: 'Get Started', url: '/get-started' },
+        ],
+        child: previousNestedChild as string,
+        content: {
+          root: {
+            type: 'root',
             children: [
               {
-                type: 'text',
-                detail: 0,
-                format: 0,
-                mode: 'normal',
-                style: '',
-                text,
+                type: 'paragraph',
+                children: [
+                  {
+                    type: 'text',
+                    detail: 0,
+                    format: 0,
+                    mode: 'normal',
+                    style: '',
+                    text: 'Visit the ',
+                    version: 1,
+                  },
+                  {
+                    type: 'link',
+                    children: [
+                      {
+                        type: 'text',
+                        detail: 0,
+                        format: 0,
+                        mode: 'normal',
+                        style: '',
+                        text: 'Payload website',
+                        version: 1,
+                      },
+                    ],
+                    direction: 'ltr' as const,
+                    fields: {
+                      linkType: 'custom' as const,
+                      newTab: true,
+                      rel: ['noopener'],
+                      url: 'https://payloadcms.com',
+                    },
+                    format: '' as const,
+                    indent: 0,
+                    version: 3,
+                  },
+                  {
+                    type: 'text',
+                    detail: 0,
+                    format: 0,
+                    mode: 'normal',
+                    style: '',
+                    text: ' or ',
+                    version: 1,
+                  },
+                  {
+                    type: 'inlineBlock',
+                    fields: {
+                      id: '67b489ce0000000000000001',
+                      blockType: 'inline-cta',
+                      label: 'Get Started',
+                      url: '/get-started',
+                    },
+                    version: 1,
+                  },
+                ],
+                direction: 'ltr' as const,
+                format: '' as const,
+                indent: 0,
+                textFormat: 0,
+                textStyle: '',
                 version: 1,
               },
             ],
             direction: 'ltr' as const,
             format: '' as const,
             indent: 0,
-            textFormat: 0,
             version: 1,
           },
-        ],
-        direction: 'ltr' as const,
-        format: '' as const,
-        indent: 0,
-        version: 1,
-      },
-    })
-
-    const reactTalk = await payload.create({
-      collection: talksSlug,
-      data: {
-        slug: 'server-components-in-production',
-        _status: 'published',
-        abstract: buildAbstract(
-          'React Server Components reshape how we think about data fetching, bundling, and the boundary between server and client. This talk walks through a real-world migration of a 400-route admin panel.',
-        ),
-        attendeeCount: 412,
-        capacity: 800,
-        contactEmail: 'organizers@example.com',
-        customCss: '.talk-hero { background: linear-gradient(135deg, #6366f1, #ec4899); }',
-        customSchema: {
-          name: 'Server Components in Production',
-          '@context': 'https://schema.org',
-          '@type': 'Event',
         },
-        difficultyLevel: 'intermediate',
-        durationMinutes: 45,
-        endTime: '2026-09-15T15:45:00.000Z',
-        gallery: heroUploadID
-          ? [
-              { caption: 'Speaker on the main stage', image: heroUploadID },
-              { caption: 'Audience Q&A', image: heroUploadID },
-            ]
-          : [],
-        heroImage: heroUploadID,
-        internalNotes: {
-          flagged: false,
-          reviewerNotes: 'Strong technical talk, confirmed slot.',
-        },
-        isFeatured: true,
-        isVirtual: false,
-        keywords: ['react', 'rsc', 'next.js', 'performance'],
-        languages: ['en'],
-        metaDescription:
-          'How we migrated a 400-route admin panel to React Server Components, with real benchmarks and trade-offs.',
-        metaTitle: 'Server Components in Production — A Migration Retrospective',
-        ogImage: heroUploadID,
-        organizer: devUserDoc.id,
-        priority: 9,
-        recordingUrl: 'https://example.com/watch/rsc-prod',
-        registrationDeadline: '2026-09-10T00:00:00.000Z',
-        registrationUrl: 'https://example.com/register',
-        resources: [
-          { type: 'slides', label: 'Slide deck (PDF)', url: 'https://example.com/slides.pdf' },
-          { type: 'code', label: 'Source code', url: 'https://github.com/example/rsc-demo' },
-          { type: 'docs', label: 'Migration guide', url: 'https://example.com/guide' },
-        ],
-        room: 'Main Stage',
-        sections: [
-          {
-            blockType: 'talk-hero',
-            eyebrow: 'Keynote',
-            heading: 'Server Components in Production',
-            subheading: 'A 12-month migration retrospective.',
-          },
-          {
-            attribution: 'Jordan Smith',
-            blockType: 'talk-quote',
-            quote:
-              'We cut our largest route bundle by 67% — but the architectural shift mattered more than the bytes.',
-            role: 'Staff Engineer',
-          },
-          {
-            blockType: 'talk-cta',
-            label: 'Read the full case study',
-            style: 'primary',
-            url: 'https://example.com/case-study',
-          },
-        ],
-        shortDescription:
-          'Lessons learned migrating a large admin app to React Server Components — what worked, what hurt, and what we would do again.',
-        slidesUrl: 'https://example.com/slides/rsc-prod',
-        startTime: '2026-09-15T15:00:00.000Z',
-        status: 'confirmed',
-        title: 'Server Components in Production',
-        track: 'frontend',
-        venueLocation: [-122.4194, 37.7749],
+        publishedAt: new Date().toISOString(),
+        relatedRelationship: createdRelationship.id,
+        relatedText: createdPosts[i]?.id as string,
+        status: seed.status,
+        title: seed.title,
       },
     })
-
-    const aiTalk = await payload.create({
-      collection: talksSlug,
-      data: {
-        slug: 'llm-agents-without-the-hype',
-        _status: 'published',
-        abstract: buildAbstract(
-          'Most "agent" demos collapse outside the happy path. This session shares the evaluation framework we use to ship agent features into a regulated product.',
-        ),
-        attendeeCount: 78,
-        capacity: 120,
-        contactEmail: 'ai-track@example.com',
-        difficultyLevel: 'advanced',
-        durationMinutes: 30,
-        endTime: '2026-09-16T19:00:00.000Z',
-        isFeatured: false,
-        isVirtual: true,
-        keywords: ['llm', 'agents', 'evals'],
-        languages: ['en', 'es'],
-        organizer: devUserDoc.id,
-        priority: 6,
-        registrationUrl: 'https://example.com/register/ai',
-        relatedTalks: [reactTalk.id],
-        resources: [
-          { type: 'code', label: 'Eval harness repo', url: 'https://github.com/example/evals' },
-        ],
-        room: 'Workshop Room B',
-        sections: [
-          {
-            blockType: 'talk-hero',
-            heading: 'LLM Agents Without the Hype',
-            subheading: 'Building evals before features.',
-          },
-        ],
-        shortDescription:
-          'A pragmatic look at when LLM agents help, when they make things worse, and the eval harness we built to tell the difference.',
-        startTime: '2026-09-16T18:30:00.000Z',
-        status: 'accepted',
-        title: 'LLM Agents Without the Hype',
-        track: 'ai-ml',
-      },
-    })
-
-    await payload.create({
-      collection: talksSlug,
-      data: {
-        slug: 'designing-indexes-for-search',
-        _status: 'draft',
-        attendeeCount: 0,
-        difficultyLevel: 'intermediate',
-        durationMinutes: 25,
-        isFeatured: false,
-        isVirtual: false,
-        keywords: ['postgres', 'indexes', 'search'],
-        languages: ['en'],
-        organizer: devUserDoc.id,
-        priority: 4,
-        relatedTalks: [reactTalk.id, aiTalk.id],
-        shortDescription:
-          'A proposal walkthrough — we have not been accepted yet, but here is the outline.',
-        status: 'proposed',
-        title: 'Designing Database Indexes for Search',
-        track: 'backend',
-      },
-      draft: true,
-    })
-
-    // Seed drawers collection: a couple of docs linked via the
-    // self-referencing `child` field so drawers can be drilled into.
-    const drawerSeeds = [
-      { status: 'published' as const, title: 'Landing Page' },
-      { status: 'draft' as const, title: 'About Page' },
-    ]
-
-    let previousNestedChild: number | string | undefined
-    for (let i = drawerSeeds.length - 1; i >= 0; i--) {
-      const seed = drawerSeeds[i]!
-      const created = await payload.create({
-        collection: drawersSlug,
-        data: {
-          blocks: [
-            { blockType: 'hero-block', heading: `${seed.title} Hero` },
-            {
-              blockType: 'content-block',
-              body: 'Some content for this page.',
-              heading: 'Overview',
-            },
-            { blockType: 'cta-block', label: 'Get Started', url: '/get-started' },
-          ],
-          child: previousNestedChild as string,
-          content: {
-            root: {
-              type: 'root',
-              children: [
-                {
-                  type: 'paragraph',
-                  children: [
-                    {
-                      type: 'text',
-                      detail: 0,
-                      format: 0,
-                      mode: 'normal',
-                      style: '',
-                      text: 'Visit the ',
-                      version: 1,
-                    },
-                    {
-                      type: 'link',
-                      children: [
-                        {
-                          type: 'text',
-                          detail: 0,
-                          format: 0,
-                          mode: 'normal',
-                          style: '',
-                          text: 'Payload website',
-                          version: 1,
-                        },
-                      ],
-                      direction: 'ltr' as const,
-                      fields: {
-                        linkType: 'custom' as const,
-                        newTab: true,
-                        rel: ['noopener'],
-                        url: 'https://payloadcms.com',
-                      },
-                      format: '' as const,
-                      indent: 0,
-                      version: 3,
-                    },
-                    {
-                      type: 'text',
-                      detail: 0,
-                      format: 0,
-                      mode: 'normal',
-                      style: '',
-                      text: ' or ',
-                      version: 1,
-                    },
-                    {
-                      type: 'inlineBlock',
-                      fields: {
-                        id: '67b489ce0000000000000001',
-                        blockType: 'inline-cta',
-                        label: 'Get Started',
-                        url: '/get-started',
-                      },
-                      version: 1,
-                    },
-                  ],
-                  direction: 'ltr' as const,
-                  format: '' as const,
-                  indent: 0,
-                  textFormat: 0,
-                  textStyle: '',
-                  version: 1,
-                },
-              ],
-              direction: 'ltr' as const,
-              format: '' as const,
-              indent: 0,
-              version: 1,
-            },
-          },
-          publishedAt: new Date().toISOString(),
-          relatedRelationship: createdRelationship.id,
-          relatedText: createdPosts[i]?.id as string,
-          status: seed.status,
-          title: seed.title,
-        },
-      })
-      previousNestedChild = created.id
-    }
-  },
-  typescript: {
-    outputFile: path.resolve(dirname, 'payload-types.ts'),
-  },
+    previousNestedChild = created.id
+  }
 }

--- a/test/v4/config.ts
+++ b/test/v4/config.ts
@@ -1,6 +1,6 @@
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
-import { baseConfig } from './baseConfig.js'
+import { baseConfig, seed } from './baseConfig.js'
 
-export default buildConfigWithDefaults(baseConfig)
+export default buildConfigWithDefaults({ suite: 'v4', config: baseConfig, seed })
 
 export { collections } from './baseConfig.js'


### PR DESCRIPTION
## What?

Migrates 19 integration suites from a mix of module-scoped `initPayloadInt`, config `onInit` seeding, and manual lifecycle hooks to explicit Vitest fixtures:

- configs move test seeding out of `onInit` and register `{ suite, config, seed }` with `buildConfigWithDefaults`
- root `describe` blocks become `test.suite({ config })`
- lifecycle-only `beforeAll`, `beforeEach`, and `afterAll` hooks are removed where the fixture now owns initialization, reset/seed, and teardown

For these suites, Payload is created once per file, reset and optionally seeded once before each test that requests `payload`, `restClient`, or `sdk`, and destroyed after the file.

## Why?

This makes test isolation consistent and removes reliance on config `onInit` hooks for seeding.

Migration batch 4/5 in stack #17993. Depends on #17990.
