### PR TITLE
docs: fix invalid TypeScript examples

### DIFF
--- a/docs/custom-components/edit-view.mdx
+++ b/docs/custom-components/edit-view.mdx
@@ -21,10 +21,11 @@ The Edit View can be swapped out in its entirety for a Custom View, or it can be
 To swap out the entire Edit View with a [Custom View](./custom-views), use the `views.edit.default` property in your [Collection Config](../configuration/collections) or [Global Config](../configuration/globals):
 
 ```tsx
-import { buildConfig } from 'payload'
+import type { CollectionConfig } from 'payload'
 
-const config = buildConfig({
-  // ...
+export const MyCollection: CollectionConfig = {
+  slug: 'my-collection',
+  fields: [],
   admin: {
     components: {
       views: {
@@ -38,7 +39,7 @@ const config = buildConfig({
       },
     },
   },
-})
+}
 ```
 
 Here is an example of a custom Edit View:

--- a/docs/fields/overview.mdx
+++ b/docs/fields/overview.mdx
@@ -519,7 +519,6 @@ import {
   relationship,
   richText,
   select,
-  tabs,
   text,
   textarea,
   upload,

--- a/docs/fields/text.mdx
+++ b/docs/fields/text.mdx
@@ -239,7 +239,12 @@ export const ExampleCollection: CollectionConfig = {
     // highlight-line
     slugField({
       overrides: (defaultField) => {
-        defaultField.fields[1].label = 'Custom Slug Label'
+        const slugTextField = defaultField.fields[1]
+
+        if (slugTextField?.type === 'text') {
+          slugTextField.label = 'Custom Slug Label'
+        }
+
         return defaultField
       },
     }),


### PR DESCRIPTION
## Summary

- remove the nonexistent tabs validator from the shared validation example
- narrow the generated slug text field before overriding its label
- move the custom Edit View example into a typed CollectionConfig

Closes #17994

## Testing

- type-checked all three corrected snippets against Payload 3.x declarations
- pnpm exec prettier --check docs/fields/overview.mdx docs/fields/text.mdx docs/custom-components/edit-view.mdx
- git diff --check origin/3.x...HEAD