### PR TITLE
refactor: reuse storage utilities and log unlinking temp files errors

### DIFF
--- a/packages/payload/src/collections/operations/create.ts
+++ b/packages/payload/src/collections/operations/create.ts
@@ -459,7 +459,9 @@ export const createOperation = async <
       result,
     })
 
-    await unlinkTempFiles({ collectionConfig, config, req })
+    await unlinkTempFiles({ collectionConfig, config, req }).catch((unlinkError) => {
+      req.payload.logger.error({ err: unlinkError, msg: 'Failed to remove temp file' })
+    })
 
     // /////////////////////////////////////
     // Return results

--- a/packages/payload/src/collections/operations/update.ts
+++ b/packages/payload/src/collections/operations/update.ts
@@ -325,6 +325,8 @@ export const updateOperation = async <
       collectionConfig,
       config,
       req,
+    }).catch((unlinkError) => {
+      req.payload.logger.error({ err: unlinkError, msg: 'Failed to remove temp file' })
     })
 
     // Process sequentially when using single transaction mode to avoid shared state issues

--- a/packages/payload/src/collections/operations/updateByID.ts
+++ b/packages/payload/src/collections/operations/updateByID.ts
@@ -240,6 +240,8 @@ export const updateByIDOperation = async <
       collectionConfig,
       config,
       req,
+    }).catch((unlinkError) => {
+      req.payload.logger.error({ err: unlinkError, msg: 'Failed to remove temp file' })
     })
 
     // /////////////////////////////////////

--- a/packages/payload/src/uploads/generateFileData.resolveTempFileHandling.spec.ts
+++ b/packages/payload/src/uploads/generateFileData.resolveTempFileHandling.spec.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveTempFileHandling } from './generateFileData.js'
+
+describe('resolveTempFileHandling', () => {
+  it.each([
+    {
+      disableLocalStorage: true,
+      expected: { type: 'useBuffer' },
+      hasProcessedBuffer: true,
+      tempFilePath: '/tmp/file',
+    },
+    {
+      disableLocalStorage: false,
+      expected: { type: 'useBuffer' },
+      hasProcessedBuffer: true,
+      tempFilePath: '/tmp/file',
+    },
+    {
+      disableLocalStorage: true,
+      expected: { type: 'useBuffer' },
+      hasProcessedBuffer: true,
+      tempFilePath: undefined,
+    },
+    {
+      disableLocalStorage: false,
+      expected: { type: 'useBuffer' },
+      hasProcessedBuffer: true,
+      tempFilePath: undefined,
+    },
+    {
+      disableLocalStorage: true,
+      expected: { type: 'skip' },
+      hasProcessedBuffer: false,
+      tempFilePath: '/tmp/file',
+    },
+    {
+      disableLocalStorage: false,
+      expected: { sourcePath: '/tmp/file', type: 'copyFromTempFile' },
+      hasProcessedBuffer: false,
+      tempFilePath: '/tmp/file',
+    },
+    {
+      disableLocalStorage: true,
+      expected: { type: 'useBuffer' },
+      hasProcessedBuffer: false,
+      tempFilePath: undefined,
+    },
+    {
+      disableLocalStorage: false,
+      expected: { type: 'useBuffer' },
+      hasProcessedBuffer: false,
+      tempFilePath: undefined,
+    },
+  ])(
+    'hasProcessedBuffer=$hasProcessedBuffer, tempFilePath=$tempFilePath, disableLocalStorage=$disableLocalStorage -> $expected.type',
+    ({ disableLocalStorage, expected, hasProcessedBuffer, tempFilePath }) => {
+      expect(
+        resolveTempFileHandling({ disableLocalStorage, hasProcessedBuffer, tempFilePath }),
+      ).toEqual(expected)
+    },
+  )
+})

--- a/packages/payload/src/uploads/generateFileData.ts
+++ b/packages/payload/src/uploads/generateFileData.ts
@@ -18,6 +18,7 @@ import { getExternalFile } from './getExternalFile.js'
 import { getFileByPath } from './getFileByPath.js'
 import { getImageSize } from './getImageSize.js'
 import { getSafeFileName } from './getSafeFilename.js'
+import { hasCropOrResizeEdit } from './hasCropOrResizeEdit.js'
 import { createImageSizes } from './image-resizing/createImageSizes.js'
 import { isAnimatedImage } from './isAnimatedImage.js'
 import { isImage } from './isImage.js'
@@ -48,7 +49,7 @@ const shouldReupload = (
     return false
   }
 
-  if (uploadEdits.crop || uploadEdits.heightInPixels || uploadEdits.widthInPixels) {
+  if (hasCropOrResizeEdit(uploadEdits)) {
     return true
   }
 
@@ -65,6 +66,35 @@ const shouldReupload = (
   }
 
   return false
+}
+
+type TempFileHandling =
+  | { sourcePath: string; type: 'copyFromTempFile' }
+  | { type: 'skip' }
+  | { type: 'useBuffer' }
+
+/**
+ * Decides how to get a file's bytes onto disk when sharp did not need to process it (a processed
+ * file is already an in-memory buffer, so it always takes the `useBuffer` path). Copies straight
+ * from the temp file when possible, rather than reading a potentially large temp file into memory
+ * just to write it back out - see the `generateFileData` function doc for why.
+ */
+const resolveTempFileHandling = ({
+  disableLocalStorage,
+  hasProcessedBuffer,
+  tempFilePath,
+}: {
+  disableLocalStorage: boolean
+  hasProcessedBuffer: boolean
+  tempFilePath: string | undefined
+}): TempFileHandling => {
+  if (hasProcessedBuffer || !tempFilePath) {
+    return { type: 'useBuffer' }
+  }
+
+  return disableLocalStorage
+    ? { type: 'skip' }
+    : { type: 'copyFromTempFile', sourcePath: tempFilePath }
 }
 
 /**
@@ -358,23 +388,23 @@ export const generateFileData = async <T>({
     } else {
       // file.data is empty when useTempFiles is on, so the real content lives at
       // file.tempFilePath instead (see the function doc for why we avoid buffering it).
-      const skipTempFileBuffer =
-        disableLocalStorage && Boolean(file.tempFilePath) && !fileBuffer?.data
+      const tempFileHandling = resolveTempFileHandling({
+        disableLocalStorage: Boolean(disableLocalStorage),
+        hasProcessedBuffer: Boolean(fileBuffer?.data),
+        tempFilePath: file.tempFilePath,
+      })
 
-      const shouldCopyFromTempFile =
-        !fileBuffer?.data && Boolean(file.tempFilePath) && !disableLocalStorage
-
-      if (shouldCopyFromTempFile) {
+      if (tempFileHandling.type === 'copyFromTempFile') {
         filesToSave.push({
           path: `${staticPath}/${fsSafeName}`,
-          sourcePath: file.tempFilePath!,
+          sourcePath: tempFileHandling.sourcePath,
         })
-      } else {
+      } else if (tempFileHandling.type === 'useBuffer') {
         let bufferToSave: Buffer
         if (fileBuffer?.data) {
           bufferToSave = fileBuffer.data
         } else if (file.tempFilePath) {
-          bufferToSave = skipTempFileBuffer ? Buffer.alloc(0) : await fs.readFile(file.tempFilePath)
+          bufferToSave = await fs.readFile(file.tempFilePath)
         } else {
           bufferToSave = file.data
         }
@@ -384,7 +414,7 @@ export const generateFileData = async <T>({
         const fileDataIsPartialView =
           !fileBuffer?.data && !file.tempFilePath && bufferToSave.length !== file.size
 
-        if (!skipTempFileBuffer && !fileDataIsPartialView) {
+        if (!fileDataIsPartialView) {
           filesToSave.push({
             buffer: bufferToSave,
             path: `${staticPath}/${fsSafeName}`,

--- a/packages/payload/src/uploads/generateFileData.ts
+++ b/packages/payload/src/uploads/generateFileData.ts
@@ -68,7 +68,7 @@ const shouldReupload = (
   return false
 }
 
-type TempFileHandling =
+export type TempFileHandling =
   | { sourcePath: string; type: 'copyFromTempFile' }
   | { type: 'skip' }
   | { type: 'useBuffer' }
@@ -79,7 +79,7 @@ type TempFileHandling =
  * from the temp file when possible, rather than reading a potentially large temp file into memory
  * just to write it back out - see the `generateFileData` function doc for why.
  */
-const resolveTempFileHandling = ({
+export const resolveTempFileHandling = ({
   disableLocalStorage,
   hasProcessedBuffer,
   tempFilePath,

--- a/packages/payload/src/uploads/getFileFromUploadInstructions.ts
+++ b/packages/payload/src/uploads/getFileFromUploadInstructions.ts
@@ -14,6 +14,7 @@ import type { SanitizedUploadConfig, UploadEdits, UploadInstructions } from './t
 import { APIError } from '../errors/APIError.js'
 import { getFileContentRequirement, HEADER_PROBE_BYTE_LENGTH } from './getFileContentRequirement.js'
 import { getImageSize } from './getImageSize.js'
+import { hasCropOrResizeEdit } from './hasCropOrResizeEdit.js'
 import { getStagedFile } from './stagedUpload.js'
 
 export const getFileFromUploadInstructions = async ({
@@ -90,10 +91,10 @@ export const getFileFromUploadInstructions = async ({
 }
 
 /**
- * Whether the request's `uploadEdits` query param carries a crop or resize edit - mirrors the
- * raw `req.query.uploadEdits` read in generateFileData.ts's `shouldReupload`/`cropData` checks,
- * since a full parse (with its `data`/`originalDoc` focal-point fallback) isn't available yet
- * at this point in the request lifecycle.
+ * Whether the request's `uploadEdits` query param carries a crop or resize edit - reads the raw
+ * `req.query.uploadEdits`, since a full parse (with its `data`/`originalDoc` focal-point
+ * fallback, done in generateFileData.ts) isn't available yet at this point in the request
+ * lifecycle.
  */
 const requestHasSizeEdits = (req: PayloadRequest): boolean => {
   const uploadEdits = req.query?.uploadEdits
@@ -101,8 +102,7 @@ const requestHasSizeEdits = (req: PayloadRequest): boolean => {
     return false
   }
 
-  const { crop, heightInPixels, widthInPixels } = uploadEdits as UploadEdits
-  return Boolean(crop || heightInPixels || widthInPixels)
+  return hasCropOrResizeEdit(uploadEdits as UploadEdits)
 }
 
 /**

--- a/packages/payload/src/uploads/hasCropOrResizeEdit.spec.ts
+++ b/packages/payload/src/uploads/hasCropOrResizeEdit.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+
+import { hasCropOrResizeEdit } from './hasCropOrResizeEdit.js'
+
+describe('hasCropOrResizeEdit', () => {
+  it('returns true when a crop is present', () => {
+    expect(hasCropOrResizeEdit({ crop: { height: 10, unit: 'px', width: 10, x: 0, y: 0 } })).toBe(
+      true,
+    )
+  })
+
+  it('returns true when heightInPixels is present', () => {
+    expect(hasCropOrResizeEdit({ heightInPixels: 100 })).toBe(true)
+  })
+
+  it('returns true when widthInPixels is present', () => {
+    expect(hasCropOrResizeEdit({ widthInPixels: 100 })).toBe(true)
+  })
+
+  it('returns false when only focalPoint is present', () => {
+    expect(hasCropOrResizeEdit({ focalPoint: { x: 50, y: 50 } })).toBe(false)
+  })
+
+  it('returns false for an empty uploadEdits object', () => {
+    expect(hasCropOrResizeEdit({})).toBe(false)
+  })
+
+  it('returns false when uploadEdits is undefined', () => {
+    expect(hasCropOrResizeEdit(undefined)).toBe(false)
+  })
+})

--- a/packages/payload/src/uploads/hasCropOrResizeEdit.ts
+++ b/packages/payload/src/uploads/hasCropOrResizeEdit.ts
@@ -1,0 +1,8 @@
+import type { UploadEdits } from './types.js'
+
+/**
+ * Whether upload edits change the image's pixel dimensions (crop or an explicit resize), as
+ * opposed to `focalPoint`, which does not.
+ */
+export const hasCropOrResizeEdit = (uploadEdits: undefined | UploadEdits): boolean =>
+  Boolean(uploadEdits?.crop || uploadEdits?.heightInPixels || uploadEdits?.widthInPixels)

--- a/packages/payload/src/uploads/unlinkTempFiles.ts
+++ b/packages/payload/src/uploads/unlinkTempFiles.ts
@@ -24,9 +24,9 @@ export const unlinkTempFiles: (args: Args) => Promise<void> = async ({
   // A file fetched from a client-upload reference always gets its own temp file for
   // post-processing (see getFileFromUploadInstructions.ts), regardless of the global
   // useTempFiles setting, so it must always be cleaned up here too.
-  const isClientUploadTempFile = Boolean(file?.uploadReference)
+  const isClientUploadReference = Boolean(file?.uploadReference)
 
-  if (collectionConfig.upload && (config.upload?.useTempFiles || isClientUploadTempFile)) {
+  if (collectionConfig.upload && (config.upload?.useTempFiles || isClientUploadReference)) {
     const fileArray = [{ file }]
     await mapAsync(fileArray, async ({ file }) => {
       // Still need this check because this will not be populated if using local API


### PR DESCRIPTION
## Summary

This PR applies review follow-ups from #17856. It removes duplicate logic, simplifies a temp file save decision, and adds error logging for temp file cleanup.

## How

- Add a shared `hasCropOrResizeEdit` helper. `generateFileData` and `getFileFromUploadInstructions` now use it, instead of each keeping its own copy of the same crop-or-resize check.
- Replace two boolean flags with one `resolveTempFileHandling` function. It returns one outcome for an unprocessed temp file: copy it, read it into a buffer, or skip the save.
- Rename `isClientUploadTempFile` to `isClientUploadReference` in `unlinkTempFiles`. The new name states that the file has an upload reference, not that it is a temp file.


## Related work

- Follow-up to #17856
