### PR TITLE
fix: apply draft access in findByID

### DIFF
--- a/packages/payload/src/collections/operations/findByID.ts
+++ b/packages/payload/src/collections/operations/findByID.ts
@@ -28,6 +28,9 @@ import { getSelectMode } from '../../utilities/getSelectMode.js'
 import { hasDraftsEnabled } from '../../utilities/getVersionsConfig.js'
 import { killTransaction } from '../../utilities/killTransaction.js'
 import { sanitizeSelect } from '../../utilities/sanitizeSelect.js'
+import { buildVersionCollectionFields } from '../../versions/buildCollectionFields.js'
+import { appendVersionToQueryKey } from '../../versions/drafts/appendVersionToQueryKey.js'
+import { getQueryDraftsSelect } from '../../versions/drafts/getQueryDraftsSelect.js'
 import { replaceWithDraftIfAvailable } from '../../versions/drafts/replaceWithDraftIfAvailable.js'
 import { buildAfterOperation } from './utilities/buildAfterOperation.js'
 import { buildBeforeOperation } from './utilities/buildBeforeOperation.js'
@@ -154,34 +157,63 @@ export const findByIDOperation = async <
     // Find by ID
     // /////////////////////////////////////
 
-    let dbSelect = select
-
-    if (
-      collectionConfig.versions?.drafts &&
-      replaceWithVersion &&
-      select &&
-      getSelectMode(select) === 'include'
-    ) {
-      dbSelect = { ...select, createdAt: true, updatedAt: true }
-    }
-
-    const findOneArgs: FindOneArgs = {
-      collection: collectionConfig.slug,
-      draftsEnabled: replaceWithVersion,
-      joins: req.payloadAPI === 'GraphQL' ? false : sanitizedJoins,
-      locale: locale!,
-      req: {
-        transactionID: req.transactionID,
-      } as PayloadRequest,
-      select: dbSelect,
-      where: fullWhere,
-    }
-
-    if (!findOneArgs.where?.and?.[0]?.id) {
+    if (!fullWhere?.and?.[0]?.id) {
       throw new NotFound(t)
     }
 
-    const docFromDB = await req.payload.db.findOne(findOneArgs)
+    const shouldQueryDrafts = !args.data && replaceWithVersion && hasDraftsEnabled(collectionConfig)
+    let docFromDB: DataFromCollectionSlug<TSlug> | null | undefined
+    let query = fullWhere
+
+    if (shouldQueryDrafts) {
+      query = appendVersionToQueryKey(fullWhere)
+
+      await validateQueryPaths({
+        collectionConfig,
+        overrideAccess,
+        req,
+        versionFields: buildVersionCollectionFields(req.payload.config, collectionConfig, true),
+        where: appendVersionToQueryKey(where),
+      })
+
+      const { docs } = await req.payload.db.queryDrafts<DataFromCollectionSlug<TSlug>>({
+        collection: collectionConfig.slug,
+        joins: req.payloadAPI === 'GraphQL' ? false : sanitizedJoins,
+        limit: 1,
+        locale: locale!,
+        pagination: false,
+        req,
+        select: getQueryDraftsSelect({ select }),
+        where: query,
+      })
+
+      docFromDB = docs[0]
+    } else {
+      let dbSelect = select
+
+      if (
+        collectionConfig.versions?.drafts &&
+        replaceWithVersion &&
+        select &&
+        getSelectMode(select) === 'include'
+      ) {
+        dbSelect = { ...select, createdAt: true, updatedAt: true }
+      }
+
+      const findOneArgs: FindOneArgs = {
+        collection: collectionConfig.slug,
+        draftsEnabled: replaceWithVersion,
+        joins: req.payloadAPI === 'GraphQL' ? false : sanitizedJoins,
+        locale: locale!,
+        req: {
+          transactionID: req.transactionID,
+        } as PayloadRequest,
+        select: dbSelect,
+        where: fullWhere,
+      }
+
+      docFromDB = await req.payload.db.findOne(findOneArgs)
+    }
 
     if (!docFromDB && !args.data) {
       if (!disableErrors) {
@@ -260,7 +292,7 @@ export const findByIDOperation = async <
     // Replace document with draft if available
     // /////////////////////////////////////
 
-    if (replaceWithVersion && hasDraftsEnabled(collectionConfig)) {
+    if (!shouldQueryDrafts && replaceWithVersion && hasDraftsEnabled(collectionConfig)) {
       result = await replaceWithDraftIfAvailable({
         accessResult,
         doc: result,
@@ -284,7 +316,7 @@ export const findByIDOperation = async <
             context: req.context,
             doc: result,
             overrideAccess,
-            query: findOneArgs.where,
+            query,
             req,
           })) || result
       }
@@ -324,7 +356,7 @@ export const findByIDOperation = async <
             context: req.context,
             doc: result,
             overrideAccess,
-            query: findOneArgs.where,
+            query,
             req,
           })) || result
       }

--- a/test/versions/collections/Drafts.ts
+++ b/test/versions/collections/Drafts.ts
@@ -5,14 +5,17 @@ import { draftCollectionSlug } from '../slugs.js'
 const DraftPosts: CollectionConfig = {
   slug: draftCollectionSlug,
   access: {
-    update: () => {
-      return {
-        restrictedToUpdate: {
-          not_equals: true,
-        },
+    read: ({ req }) => {
+      if (typeof req.context.draftAccessDescription === 'string') {
+        return {
+          description: {
+            equals: req.context.draftAccessDescription,
+          },
+        }
       }
-    },
-    read: ({ req: { user } }) => {
+
+      const { user } = req
+
       if (user) {
         return true
       }
@@ -33,6 +36,13 @@ const DraftPosts: CollectionConfig = {
       }
     },
     readVersions: ({ req: { user } }) => Boolean(user),
+    update: () => {
+      return {
+        restrictedToUpdate: {
+          not_equals: true,
+        },
+      }
+    },
   },
   admin: {
     components: {

--- a/test/versions/int.spec.ts
+++ b/test/versions/int.spec.ts
@@ -759,6 +759,85 @@ describe('Versions', () => {
       })
     })
 
+    describe('Draft read access', () => {
+      const createdDocumentIDs: (number | string)[] = []
+
+      afterEach(async () => {
+        for (const id of createdDocumentIDs) {
+          await payload.delete({ id, collection: draftCollectionSlug })
+        }
+        createdDocumentIDs.length = 0
+      })
+
+      it('should evaluate findByID access against the latest draft when the base document is denied', async () => {
+        const document = await payload.create({
+          collection: draftCollectionSlug,
+          data: {
+            description: 'base denied',
+            title: 'Draft access allowed',
+          },
+          draft: true,
+        })
+        createdDocumentIDs.push(document.id)
+
+        await payload.update({
+          id: document.id,
+          collection: draftCollectionSlug,
+          data: {
+            description: 'draft allowed',
+          },
+          draft: true,
+        })
+
+        const result = await payload.findByID({
+          id: document.id,
+          collection: draftCollectionSlug,
+          context: {
+            draftAccessDescription: 'draft allowed',
+          },
+          disableErrors: true,
+          draft: true,
+          overrideAccess: false,
+        })
+
+        expect(result?.description).toBe('draft allowed')
+      })
+
+      it('should deny findByID access when only the base document matches', async () => {
+        const document = await payload.create({
+          collection: draftCollectionSlug,
+          data: {
+            description: 'base allowed',
+            title: 'Draft access denied',
+          },
+          draft: true,
+        })
+        createdDocumentIDs.push(document.id)
+
+        await payload.update({
+          id: document.id,
+          collection: draftCollectionSlug,
+          data: {
+            description: 'draft denied',
+          },
+          draft: true,
+        })
+
+        const result = await payload.findByID({
+          id: document.id,
+          collection: draftCollectionSlug,
+          context: {
+            draftAccessDescription: 'base allowed',
+          },
+          disableErrors: true,
+          draft: true,
+          overrideAccess: false,
+        })
+
+        expect(result).toBeNull()
+      })
+    })
+
     describe('Restore', () => {
       afterEach(async () => {
         await cleanupDocuments({


### PR DESCRIPTION
### What?

Backport the `findByID({ draft: true })` fix to `3.x` so it queries the latest draft/version row and applies read access there. Add integration coverage for both access directions: base denied/draft allowed and base allowed/draft denied.

### Why?

Draft-only changes such as tenant assignments are stored in the versions collection. Previously, `findByID` constrained the base collection row before loading a draft, so a newly assigned tenant could not query the document until it was published. The inverse could also return a base row when the latest draft should be denied.

Related: [PYLD-3559](https://linear.app/figma/issue/PYLD-3559/166-tenant-assigned-via-assign-tenant-modal-not-queryable-until)

### How?

When drafts are enabled and requested, route `findByID` through the same `queryDrafts` path used by collection `find`, including version-aware access filters, query validation, joins, localization, and select handling. Preserve the existing non-draft and supplied-data paths.

### Testing

- `pnpm run test:int versions` — 111 passed
- `pnpm run build:core` — 45 packages built successfully
- Prettier, diff check, and ESLint on the changed implementation/config