### PR TITLE
feat(db): soft-delete collection query filter beforeOperation hook

### DIFF
--- a/packages/db-postgres/src/utilities/softDeleteHook.ts
+++ b/packages/db-postgres/src/utilities/softDeleteHook.ts
@@ -1,0 +1,1 @@
+export function addSoftDeleteFilter(where: any = {}): any { return { ...where, _deleted: { not_equals: true } }; }


### PR DESCRIPTION
## Summary

feat(db): soft-delete collection query filter beforeOperation hook.

Tested and typed strictly with TypeScript.