### PR TITLE
fix: honour ?joins=false instead of iterating the string

### DIFF
--- a/packages/payload/src/utilities/sanitizeJoinParams.spec.ts
+++ b/packages/payload/src/utilities/sanitizeJoinParams.spec.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+
+import { sanitizeJoinParams } from './sanitizeJoinParams.js'
+
+describe('sanitizeJoinParams', () => {
+  it('should disable every join when passed the string "false"', () => {
+    // Over REST the query string makes `?joins=false` the string 'false', not a boolean.
+    expect(sanitizeJoinParams('false' as never)).toBe(false)
+  })
+
+  it('should disable every join when passed the boolean false', () => {
+    expect(sanitizeJoinParams(false)).toBe(false)
+  })
+
+  it('should not build a join query out of the characters of "false"', () => {
+    // `Object.keys('false')` is ['0','1','2','3','4'], so iterating the string produced
+    // a join query keyed by character index that matched no field and disabled nothing.
+    const result = sanitizeJoinParams('false' as never)
+
+    expect(result).not.toHaveProperty('0')
+    expect(result).not.toHaveProperty('1')
+  })
+
+  it('should still disable a single join field addressed by name', () => {
+    expect(sanitizeJoinParams({ relatedItems: 'false' as never })).toEqual({
+      relatedItems: false,
+    })
+    expect(sanitizeJoinParams({ relatedItems: false })).toEqual({
+      relatedItems: false,
+    })
+  })
+
+  it('should coerce the per-field options it is given', () => {
+    expect(
+      sanitizeJoinParams({
+        relatedItems: {
+          count: 'true',
+          limit: '10',
+          page: '2',
+          sort: '-createdAt',
+          where: { title: { equals: 'hello' } },
+        },
+      } as never),
+    ).toEqual({
+      relatedItems: {
+        count: true,
+        limit: 10,
+        page: 2,
+        sort: '-createdAt',
+        where: { title: { equals: 'hello' } },
+      },
+    })
+  })
+
+  it('should return an empty join query when given nothing', () => {
+    expect(sanitizeJoinParams()).toEqual({})
+  })
+})

--- a/packages/payload/src/utilities/sanitizeJoinParams.ts
+++ b/packages/payload/src/utilities/sanitizeJoinParams.ts
@@ -3,8 +3,10 @@ import type { JoinQuery } from '../types/index.js'
 import { isNumber } from './isNumber.js'
 
 export type JoinParams =
+  | 'false'
   | {
       [schemaPath: string]:
+        | 'false'
         | {
             limit?: unknown
             sort?: string
@@ -19,6 +21,16 @@ export type JoinParams =
  * @param joins
  */
 export const sanitizeJoinParams = (_joins: JoinParams = {}): JoinQuery => {
+  // `?joins=false` disables every join field. Over REST the query string makes that the
+  // string 'false' rather than a boolean, and neither form survives the loop below:
+  // `Object.keys('false')` is ['0','1','2','3','4'], so the string was walked character
+  // by character into a join query keyed by index that matched no field and disabled
+  // nothing, while `Object.keys(false)` is [] and produced an empty query with the same
+  // effect. Both are the whole-query form, which `JoinQuery` expresses as `false`.
+  if (_joins === false || _joins === 'false') {
+    return false
+  }
+
   const joinQuery: Record<string, any> = {}
   const joins = _joins as Record<string, any>
 


### PR DESCRIPTION
Fixes #17929.

## What

`?joins=false` is documented in `docs/fields/join.mdx` as the way to switch off every Join Field for performance, but it had no effect over REST — the response still carried every joined document.

**Cause.** Over REST the query string makes the parameter the *string* `'false'`, not a boolean, and `sanitizeJoinParams` went straight to `Object.keys()` on it:

```ts
Object.keys(joins).forEach((schemaPath) => {
  if (joins[schemaPath] === 'false' || joins[schemaPath] === false) {
```

`Object.keys('false')` is `['0','1','2','3','4']`, so the string was walked character by character into a join query keyed by index. No key ever named a real join field, so nothing was disabled.

The boolean form failed too, for the opposite reason: `Object.keys(false)` is `[]`, producing an empty query with the same net effect.

Reverting the fix shows both, straight out of the assertion:

```
expected { '0': { count: false, …(4) }, …(4) } to be false   // '?joins=false' over REST
expected {} to be false                                       // joins: false
```

## Fix

Both are the whole-query form, which `JoinQuery` already expresses as `false` and which `buildJoinAggregation` already checks for (`joins === false`, `packages/db-mongodb/src/utilities/buildJoinAggregation.ts:53`). The function now returns `false` for either, so the value reaching the database adapter is the one it already understands.

The per-field form (`?joins[relatedItems]=false`) was never affected — there the value really is `'false'` at a key naming a field — and is unchanged.

`JoinParams` now admits `'false'` alongside `false`, since that is what actually arrives over REST.

## Tests

Added `packages/payload/src/utilities/sanitizeJoinParams.spec.ts`. There wasn't one, although `parseParams/index.spec.ts:189` already says *"actual sanitization logic is tested in sanitizeJoinParams tests"*.

| test | fails without the fix |
| --- | --- |
| the string `'false'` disables every join | **yes** |
| the boolean `false` disables every join | **yes** |
| no join query is built from the characters of `'false'` | **yes** |
| a single field addressed by name still disables | no — guard |
| per-field options are still coerced (`count`/`limit`/`page`/`sort`/`where`) | no — guard |
| no argument still yields `{}` | no — guard |

The three guards pin the behaviour the fix must not disturb.

```
vitest --run packages/payload/src/utilities  -> 28 files, 452 passed
eslint on both files                         -> 0 errors
prettier                                     -> unchanged
```

`tsc --noEmit` in `packages/payload` reports 103 `TS6305` errors both with and without this change (workspace deps not built, since I installed with `--ignore-scripts`) — none in the files touched here.

## Note

I've kept this to the runtime behaviour. #17904 is open and covers the TypeScript type for the same parameter; this doesn't conflict with it, though the `JoinParams` change here overlaps slightly and may be worth reconciling when that lands.

AI was used to help write this change; I verified the cause, the downstream `joins === false` handling, and the tests myself.