### PR TITLE
test(jobs): reproduce dropped handler stack traces

### DIFF
--- a/test/job-wrong-backtrace/config.ts
+++ b/test/job-wrong-backtrace/config.ts
@@ -1,0 +1,36 @@
+import { fileURLToPath } from 'node:url'
+import path from 'path'
+
+import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
+import { devUser } from '../credentials.js'
+import { throwFromTaskHandlerTask } from './throwFromTaskHandler.js'
+import { throwFromWorkflowHandlerWorkflow } from './throwFromWorkflowHandler.js'
+
+const filename = fileURLToPath(import.meta.url)
+const dirname = path.dirname(filename)
+
+export default buildConfigWithDefaults({
+  admin: {
+    importMap: {
+      baseDir: path.resolve(dirname),
+    },
+  },
+  jobs: {
+    deleteJobOnComplete: false,
+    shouldAutoRun: () => false,
+    tasks: [throwFromTaskHandlerTask],
+    workflows: [throwFromWorkflowHandlerWorkflow],
+  },
+  onInit: async (payload) => {
+    await payload.create({
+      collection: 'users',
+      data: {
+        email: devUser.email,
+        password: devUser.password,
+      },
+    })
+  },
+  typescript: {
+    outputFile: path.resolve(dirname, 'payload-types.ts'),
+  },
+})

--- a/test/job-wrong-backtrace/int.spec.ts
+++ b/test/job-wrong-backtrace/int.spec.ts
@@ -1,0 +1,70 @@
+import type { Payload } from 'payload'
+
+import path from 'path'
+import { fileURLToPath } from 'url'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
+
+let payload: Payload
+
+const filename = fileURLToPath(import.meta.url)
+const dirname = path.dirname(filename)
+
+/**
+ * Reproduction: Jobs wrap handler errors in TaskError / WorkflowError and drop
+ * the original stack. The persisted job error should include the application
+ * handler frames (`throwFromTaskHandler` / `throwFromWorkflowHandler`), not
+ * only `getRunTaskFunction`.
+ */
+describe('job handler error stack traces', () => {
+  beforeAll(async () => {
+    ;({ payload } = await initPayloadInt(dirname))
+  })
+
+  afterAll(async () => {
+    await payload?.destroy()
+  })
+
+  it('should persist the task handler file in the job log stack', async () => {
+    const job = await payload.jobs.queue({
+      task: 'throwFromTaskHandler',
+      input: {},
+    })
+
+    await payload.jobs.run({ silent: true })
+
+    const jobAfterRun = await payload.findByID({
+      collection: 'payload-jobs',
+      id: job.id,
+    })
+
+    const stack = jobAfterRun.log?.[0]?.error?.stack as string | undefined
+
+    expect(jobAfterRun.hasError).toBe(true)
+    expect(jobAfterRun.log?.[0]?.error?.message).toBe('unique-marker-task-handler-failure')
+    expect(stack).toBeDefined()
+    expect(stack).toMatch(/throwFromTaskHandler/)
+  })
+
+  it('should persist the workflow handler file in the job error stack', async () => {
+    const job = await payload.jobs.queue({
+      workflow: 'throwFromWorkflowHandler',
+      input: {},
+    })
+
+    await payload.jobs.run({ silent: true })
+
+    const jobAfterRun = await payload.findByID({
+      collection: 'payload-jobs',
+      id: job.id,
+    })
+
+    const stack = jobAfterRun.error?.stack as string | undefined
+
+    expect(jobAfterRun.hasError).toBe(true)
+    expect(jobAfterRun.error?.message).toBe('unique-marker-workflow-handler-failure')
+    expect(stack).toBeDefined()
+    expect(stack).toMatch(/throwFromWorkflowHandler/)
+  })
+})

--- a/test/job-wrong-backtrace/throwFromTaskHandler.ts
+++ b/test/job-wrong-backtrace/throwFromTaskHandler.ts
@@ -1,0 +1,18 @@
+import type { TaskConfig } from 'payload'
+
+/**
+ * Distinct filename used as the stack-trace marker for the task-handler reproduction.
+ */
+export function throwFromTaskHandler(): never {
+  throw new Error('unique-marker-task-handler-failure')
+}
+
+export const throwFromTaskHandlerTask: TaskConfig<any> = {
+  retries: 0,
+  slug: 'throwFromTaskHandler',
+  inputSchema: [],
+  outputSchema: [],
+  handler: () => {
+    throwFromTaskHandler()
+  },
+}

--- a/test/job-wrong-backtrace/throwFromWorkflowHandler.ts
+++ b/test/job-wrong-backtrace/throwFromWorkflowHandler.ts
@@ -1,0 +1,17 @@
+import type { WorkflowConfig } from 'payload'
+
+/**
+ * Distinct filename used as the stack-trace marker for the workflow-handler reproduction.
+ */
+export function throwFromWorkflowHandler(): never {
+  throw new Error('unique-marker-workflow-handler-failure')
+}
+
+export const throwFromWorkflowHandlerWorkflow: WorkflowConfig<any> = {
+  slug: 'throwFromWorkflowHandler',
+  inputSchema: [],
+  retries: 0,
+  handler: () => {
+    throwFromWorkflowHandler()
+  },
+}

--- a/test/job-wrong-backtrace/tsconfig.eslint.json
+++ b/test/job-wrong-backtrace/tsconfig.eslint.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["./**/*.ts", "./**/*.tsx"]
+}

--- a/test/job-wrong-backtrace/tsconfig.json
+++ b/test/job-wrong-backtrace/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["./**/*.ts", "./**/*.tsx"]
+}


### PR DESCRIPTION
## What?

Jobs wrap thrown handler errors in a new `TaskError` / `WorkflowError` that copies only `err.message`. The original `stack` (and `cause`) are discarded, so logs and persisted job errors always point at `getRunTaskFunction` instead of the application handler.

This PR adds a failing reproduction in `test/job-wrong-backtrace/` (run with `pnpm test:int job-wrong-backtrace`). It does not include the fix yet — the tests document the expected stack frames.

Reproduction branch: https://github.com/MurzNN/payload/tree/repro/job-wrong-backtrace

## Why?

When a task handler throws (e.g. `Cannot read properties of undefined (reading 'id')`), the observed stack is:

```text
Error: Cannot read properties of undefined (reading 'id')
    at Object.handleAiConversationTask (.../payload/dist/queues/operations/runJobs/runJob/getRunTaskFunction.js:83:23)
    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
    at async handler (.../payload/dist/queues/operations/runJobs/index.js:260:25)
```

The first frame is always the wrapper `throw new TaskError(...)`. The handler file never appears. That makes Jobs failures hard to debug, especially under Next.js where stacks are already compiled.

This is not a source-map problem. Source maps cannot recover frames that were never kept.

## How?

Root cause in `packages/payload/src/queues/operations/runJobs/runJob/getRunTaskFunction.ts`:

```ts
} catch (err: any) {
  if (err instanceof JobCancelledError) {
    throw err
  }
  throw new TaskError({
    message: err.message || 'Task handler threw an error',
    // no cause, no stack
  })
}
```

`TaskError` is `super(args.message)` only, so V8 captures a new stack at the wrapper. The persisted JSON in `handleTaskError.ts` / `handleWorkflowError.ts` stores `error.stack`, i.e. that wrapper stack.

The same wrap-without-cause happens in:

- `packages/payload/src/queues/operations/runJobs/runJob/index.ts` (`new WorkflowError({ message: error.message })`)
- `packages/payload/src/queues/operations/runJobs/runJSONJob/index.ts` (same; JSON jobs also wrap a `TaskError` in `WorkflowError` without `instanceof TaskError` handling)

`APIError` already uses `super(message, { cause })`.

### Proposed fix

1. Accept `ErrorOptions` on `TaskError` / `WorkflowError` and pass `{ cause: err }`.
2. Copy `cause.stack` onto the wrapper so job logs, pino (`logger.error({ err })`), and the admin UI keep showing the handler frames (they all read `.stack`, not `cause`).
3. Keep the reproduction tests (or fold them into `test/queues`).

```ts
export class TaskError extends Error {
  args: TaskErrorArgs
  constructor(args: TaskErrorArgs, options?: ErrorOptions) {
    super(args.message, options)
    this.name = 'TaskError'
    this.args = args
    if (options?.cause instanceof Error && typeof options.cause.stack === 'string') {
      this.stack = options.cause.stack
    }
  }
}
```

```ts
} catch (err: unknown) {
  if (err instanceof JobCancelledError) throw err
  throw new TaskError(
    {
      /* existing args */
      message: err instanceof Error ? err.message : 'Task handler threw an error',
    },
    { cause: err },
  )
}
```

Same `{ cause: error }` at both `new WorkflowError(...)` call sites.

Mapping those frames to TypeScript paths is a Next.js / `--enable-source-maps` concern and can stay out of this change.

## Test plan

- [ ] `pnpm test:int job-wrong-backtrace` — currently fails (missing handler frames); should pass after the proposed fix
- [ ] Confirm a thrown task error's `payload-jobs.log[].error.stack` includes the handler file
- [ ] Confirm a thrown workflow error's `payload-jobs.error.stack` includes the handler file
- [ ] Existing `test/queues` job error tests still pass (`can tasks throw error`, workflow handler throws)


Made with [Cursor](https://cursor.com)