### PR TITLE
fix: handle disabled global versions requests

### DIFF
--- a/packages/payload/src/globals/operations/findVersions.ts
+++ b/packages/payload/src/globals/operations/findVersions.ts
@@ -1,3 +1,5 @@
+import { status as httpStatus } from 'http-status'
+
 import type { FindOptions } from '../../collections/operations/local/find.js'
 import type { PaginatedDocs } from '../../database/types.js'
 import type { PayloadRequest, PopulateType, SelectType, Sort, Where } from '../../types/index.js'
@@ -8,6 +10,7 @@ import { executeAccess } from '../../auth/executeAccess.js'
 import { combineQueries } from '../../database/combineQueries.js'
 import { validateQueryPaths } from '../../database/queryValidation/validateQueryPaths.js'
 import { validateSortQuery } from '../../database/queryValidation/validateSortQuery.js'
+import { APIError } from '../../errors/index.js'
 import { afterRead } from '../../fields/hooks/afterRead/index.js'
 import { killTransaction } from '../../utilities/killTransaction.js'
 import { sanitizeInternalFields } from '../../utilities/sanitizeInternalFields.js'
@@ -58,6 +61,13 @@ export const findVersionsOperation = async <T extends TypeWithVersion<T>>(
     const accessResults = !overrideAccess
       ? await executeAccess({ req }, globalConfig.access.readVersions)
       : true
+
+    if (!globalConfig.versions) {
+      throw new APIError(
+        `Versions are not enabled for global "${globalConfig.slug}".`,
+        httpStatus.BAD_REQUEST,
+      )
+    }
 
     await validateQueryPaths({
       globalConfig,

--- a/test/globals/int.spec.ts
+++ b/test/globals/int.spec.ts
@@ -62,6 +62,12 @@ describe('globals', () => {
       expect(globalDoc).toMatchObject(data)
     })
 
+    it('should return 400 when reading versions without versions enabled', async () => {
+      const response = await restClient.GET(`/globals/${slug}/versions`)
+
+      expect(response.status).toEqual(400)
+    })
+
     it('should update with localization', async () => {
       const array = [
         {


### PR DESCRIPTION
### What?

Return an HTTP 400 response when global versions are requested for a global that does not have versions enabled.

### Why?

The operation currently reaches the database adapter even though no versions table or model exists. SQL adapters can dereference a missing versions table, while MongoDB reports a missing model; both failures surface as an internal server error instead of explaining that the endpoint is unavailable for this global.

### How?

- Preserve the existing `readVersions` access check.
- Reject disabled global versions before query validation and adapter access.
- Add a REST regression test using the existing non-versioned global fixture.

Fixes #18056

### Testing

- `pnpm run test:int globals` — 14 passed
- `pnpm run build:payload` — successful
- Prettier check on both changed files — passed
- ESLint on the changed production file — 0 errors (1 pre-existing warning)
