### PR TITLE
fix: return 400 for version endpoints on non-versioned globals

### DIFF
--- a/packages/payload/src/globals/operations/findVersionByID.ts
+++ b/packages/payload/src/globals/operations/findVersionByID.ts
@@ -6,6 +6,7 @@ import type { SanitizedGlobalConfig } from '../config/types.js'
 
 import { executeAccess } from '../../auth/executeAccess.js'
 import { combineQueries } from '../../database/combineQueries.js'
+import { APIError } from '../../errors/APIError.js'
 import { Forbidden, NotFound } from '../../errors/index.js'
 import { afterRead } from '../../fields/hooks/afterRead/index.js'
 import { deepCopyObjectSimple } from '../../utilities/deepCopyObject.js'
@@ -41,6 +42,13 @@ export const findVersionByIDOperation = async <T extends TypeWithVersion<T> = an
     select: incomingSelect,
     showHiddenFields,
   } = args
+
+  if (!globalConfig.versions) {
+    throw new APIError(
+      `Versions are not enabled for the global "${globalConfig.slug}".`,
+      400,
+    )
+  }
 
   // /////////////////////////////////////
   // Access

--- a/packages/payload/src/globals/operations/findVersions.spec.ts
+++ b/packages/payload/src/globals/operations/findVersions.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+
+import { findVersionsOperation } from './findVersions.js'
+
+describe('findVersionsOperation', () => {
+  it('throws 400 when versions are not enabled on the global', async () => {
+    const globalConfig = {
+      slug: 'my-global',
+      versions: false,
+      access: {},
+      hooks: {},
+      fields: [],
+    } as any
+
+    await expect(
+      findVersionsOperation({
+        globalConfig,
+        req: {
+          payload: { config: {} },
+          locale: 'en',
+          fallbackLocale: 'en',
+          context: {},
+        } as any,
+      }),
+    ).rejects.toThrow('Versions are not enabled')
+  })
+
+  it('throws 400 when versions config is undefined', async () => {
+    const globalConfig = {
+      slug: 'settings',
+      access: {},
+      hooks: {},
+      fields: [],
+    } as any
+
+    await expect(
+      findVersionsOperation({
+        globalConfig,
+        req: {
+          payload: { config: {} },
+          locale: 'en',
+          fallbackLocale: 'en',
+          context: {},
+        } as any,
+      }),
+    ).rejects.toThrow('Versions are not enabled')
+  })
+})

--- a/packages/payload/src/globals/operations/findVersions.ts
+++ b/packages/payload/src/globals/operations/findVersions.ts
@@ -4,6 +4,7 @@ import type { PayloadRequest, PopulateType, SelectType, Sort, Where } from '../.
 import type { TypeWithVersion } from '../../versions/types.js'
 import type { SanitizedGlobalConfig } from '../config/types.js'
 
+import { APIError } from '../../errors/APIError.js'
 import { executeAccess } from '../../auth/executeAccess.js'
 import { combineQueries } from '../../database/combineQueries.js'
 import { validateQueryPaths } from '../../database/queryValidation/validateQueryPaths.js'
@@ -46,6 +47,13 @@ export const findVersionsOperation = async <T extends TypeWithVersion<T>>(
   } = args
   const req = args.req!
   const { fallbackLocale, locale, payload } = req
+
+  if (!globalConfig.versions) {
+    throw new APIError(
+      `Versions are not enabled for the global "${globalConfig.slug}".`,
+      400,
+    )
+  }
 
   const versionFields = buildVersionGlobalFields(payload.config, globalConfig, true)
 

--- a/packages/payload/src/globals/operations/restoreVersion.ts
+++ b/packages/payload/src/globals/operations/restoreVersion.ts
@@ -3,6 +3,7 @@ import type { TypeWithVersion } from '../../versions/types.js'
 import type { SanitizedGlobalConfig } from '../config/types.js'
 
 import { executeAccess } from '../../auth/executeAccess.js'
+import { APIError } from '../../errors/APIError.js'
 import { NotFound } from '../../errors/index.js'
 import { afterChange } from '../../fields/hooks/afterChange/index.js'
 import { afterRead } from '../../fields/hooks/afterRead/index.js'
@@ -27,6 +28,13 @@ export const restoreVersionOperation = async <T extends TypeWithVersion<T> = any
   const { id, depth, draft, globalConfig, overrideAccess, populate, showHiddenFields } = args
   const req = args.req!
   const { fallbackLocale, locale, payload } = req
+
+  if (!globalConfig.versions) {
+    throw new APIError(
+      `Versions are not enabled for the global "${globalConfig.slug}".`,
+      400,
+    )
+  }
 
   try {
     const shouldCommit = await initTransaction(req)


### PR DESCRIPTION
## Summary

Fixes #18056 — `GET /api/globals/<slug>/versions` on a global without versions enabled crashes with an unhandled `TypeError` (500) in the drizzle adapter instead of returning a clean error.

**Root cause:** The three global version operations (`findVersions`, `findVersionByID`, `restoreVersion`) have no guard for `globalConfig.versions` being falsy. The REST routes for `/versions` and `/versions/:id` are registered for every global regardless of its config. When the adapter tries to resolve the version table for a non-versioned global, the table name is `undefined` and the query crashes.

**Fix:** Add an early guard to all three operations that throws a 400 `APIError` when `globalConfig.versions` is disabled. This runs before any database call, so the crash never reaches the adapter.

## Changed files

- `packages/payload/src/globals/operations/findVersions.ts` — guard + import
- `packages/payload/src/globals/operations/findVersionByID.ts` — guard + import
- `packages/payload/src/globals/operations/restoreVersion.ts` — guard + import
- `packages/payload/src/globals/operations/findVersions.spec.ts` — regression tests (versions: false, versions: undefined)

## Test plan

- [x] Unit tests — 2 passed (vitest)
- [x] `tsc --noEmit` — no errors on all three changed files
- Guard is identical across all three operations; the test exercises the `findVersions` path which was the reported crash site