### PR TITLE
fix(ui): report only the documents that actually moved in bulk folder move

### DIFF
--- a/packages/ui/src/providers/Folders/index.tsx
+++ b/packages/ui/src/providers/Folders/index.tsx
@@ -32,6 +32,17 @@ export type FileCardData = {
   url: string
 }
 
+/**
+ * The outcome of a `moveToFolder` call. Bulk moves are issued as one request per
+ * collection group, and the server can report some documents moved and others
+ * failed (e.g. a locked document) within the same batch. `movedCount` reflects
+ * only what the server actually confirmed moved, never the number requested.
+ */
+export type MoveToFolderResult = {
+  hasErrors: boolean
+  movedCount: number
+}
+
 export type FolderContextValue = {
   /**
    * The collection slugs that a view can be filtered by
@@ -63,7 +74,7 @@ export type FolderContextValue = {
   moveToFolder: (args: {
     itemsToMove: FolderOrDocument[]
     toFolderID?: number | string
-  }) => Promise<void>
+  }) => Promise<MoveToFolderResult>
   onItemClick: (args: { event: React.MouseEvent; index: number; item: FolderOrDocument }) => void
   onItemKeyPress: (args: {
     event: React.KeyboardEvent
@@ -102,7 +113,7 @@ const Context = React.createContext<FolderContextValue>({
   getSelectedItems: () => [],
   isDragging: false,
   itemKeysToMove: undefined,
-  moveToFolder: () => Promise.resolve(undefined),
+  moveToFolder: () => Promise.resolve({ hasErrors: false, movedCount: 0 }),
   onItemClick: () => undefined,
   onItemKeyPress: () => undefined,
   refineFolderData: () => undefined,
@@ -666,21 +677,27 @@ export function FolderProvider({
   )
 
   /**
-   * Makes requests to the server to update the folder field on passed in documents
+   * Makes requests to the server to update the folder field on passed in documents.
    *
-   * Might rewrite this in the future to return the promises so errors can be handled contextually
+   * Returns how many items the server actually confirmed as moved, rather than the
+   * number requested — a bulk PATCH can report some documents moved and others
+   * failed (e.g. a locked document) within the same batch, so the caller must not
+   * assume the whole selection succeeded just because the request didn't throw.
    */
   const moveToFolder: FolderContextValue['moveToFolder'] = React.useCallback(
     async (args) => {
       const { itemsToMove: items, toFolderID } = args
       if (!items.length) {
-        return
+        return { hasErrors: false, movedCount: 0 }
       }
 
       const movingCurrentFolder =
         items.length === 1 &&
         items[0].relationTo === folderCollectionSlug &&
         items[0].value.id === folderID
+
+      let movedCount = 0
+      let hasErrors = false
 
       if (movingCurrentFolder) {
         const queryParams = qs.stringify(
@@ -706,7 +723,10 @@ export function FolderProvider({
             method: 'PATCH',
           },
         )
-        if (req.status !== 200) {
+        if (req.status === 200) {
+          movedCount = 1
+        } else {
+          hasErrors = true
           toast.error(t('general:error'))
         }
       } else {
@@ -727,7 +747,7 @@ export function FolderProvider({
             },
           )
           try {
-            await fetch(
+            const response = await fetch(
               formatAdminURL({
                 apiRoute: routes.api,
                 path: `/${collectionSlug}${queryParams}`,
@@ -741,7 +761,24 @@ export function FolderProvider({
                 method: 'PATCH',
               },
             )
+
+            // A partial failure is still reported as a 400 (the bulk update
+            // endpoint only returns 200 when nothing failed), and that 400
+            // body still carries `docs` for whatever succeeded alongside
+            // `errors` for whatever didn't — so the body must be parsed on
+            // both statuses, not skipped on failure.
+            const json: { docs?: unknown[]; errors?: unknown[] } = await response
+              .json()
+              .catch(() => ({}))
+
+            movedCount += json?.docs?.length ?? 0
+
+            if (response.status >= 400 || json?.errors?.length) {
+              hasErrors = true
+              toast.error(t('general:error'))
+            }
           } catch (error) {
+            hasErrors = true
             toast.error(t('general:error'))
             // eslint-disable-next-line no-console
             console.error(error)
@@ -751,6 +788,8 @@ export function FolderProvider({
       }
 
       clearSelections()
+
+      return { hasErrors, movedCount }
     },
     [folderID, clearSelections, folderCollectionSlug, folderFieldName, routes.api, t, localeCode],
   )

--- a/packages/ui/src/views/CollectionFolder/ListSelection/index.tsx
+++ b/packages/ui/src/views/CollectionFolder/ListSelection/index.tsx
@@ -146,26 +146,30 @@ export const ListSelection: React.FC<ListSelectionProps> = ({
               fromFolderName={currentFolder?.value?._folderOrDocumentTitle}
               itemsToMove={getSelectedItems()}
               onConfirm={async ({ id, name }) => {
-                await moveToFolder({
+                const { movedCount } = await moveToFolder({
                   itemsToMove: getSelectedItems(),
                   toFolderID: id,
                 })
 
-                if (id) {
-                  // moved to folder
-                  toast.success(
-                    t('folder:itemsMovedToFolder', {
-                      folderName: `"${name}"`,
-                      title: `${count} ${count > 1 ? t('general:items') : t('general:item')}`,
-                    }),
-                  )
-                } else {
-                  // moved to root
-                  toast.success(
-                    t('folder:itemsMovedToRoot', {
-                      title: `${count} ${count > 1 ? t('general:items') : t('general:item')}`,
-                    }),
-                  )
+                // Only report what the server actually confirmed moved — the
+                // selection count is what was requested, not what succeeded.
+                if (movedCount > 0) {
+                  if (id) {
+                    // moved to folder
+                    toast.success(
+                      t('folder:itemsMovedToFolder', {
+                        folderName: `"${name}"`,
+                        title: `${movedCount} ${movedCount > 1 ? t('general:items') : t('general:item')}`,
+                      }),
+                    )
+                  } else {
+                    // moved to root
+                    toast.success(
+                      t('folder:itemsMovedToRoot', {
+                        title: `${movedCount} ${movedCount > 1 ? t('general:items') : t('general:item')}`,
+                      }),
+                    )
+                  }
                 }
 
                 clearRouteCache()

--- a/test/folders/collections/Posts/index.ts
+++ b/test/folders/collections/Posts/index.ts
@@ -1,6 +1,8 @@
-import type { CollectionConfig } from 'payload'
+import { APIError, type CollectionConfig } from 'payload'
 
 import { postSlug } from '../../shared.js'
+
+export const throwingMoveHookError = 'Post is not allowed to be moved'
 
 export const Posts: CollectionConfig = {
   slug: postSlug,
@@ -24,5 +26,23 @@ export const Posts: CollectionConfig = {
       type: 'relationship',
       relationTo: 'autosave',
     },
+    {
+      name: 'shouldFailMove',
+      type: 'checkbox',
+      admin: {
+        description:
+          'When enabled, the beforeChange hook throws whenever this document is updated. Used to reproduce a partial failure within a bulk folder move.',
+      },
+      defaultValue: false,
+    },
   ],
+  hooks: {
+    beforeChange: [
+      ({ operation, originalDoc }) => {
+        if (operation === 'update' && originalDoc?.shouldFailMove) {
+          throw new APIError(throwingMoveHookError, 400, null, true)
+        }
+      },
+    ],
+  },
 }

--- a/test/folders/e2e.spec.ts
+++ b/test/folders/e2e.spec.ts
@@ -811,6 +811,81 @@ test.describe('Folders', () => {
     })
   })
 
+  test.describe('Bulk move partial failure', () => {
+    test('should report only the documents that actually moved when one document in the batch fails', async () => {
+      // Documents only render in the folder-view UI once they're inside a
+      // folder — a collection's folder-view root never lists its own
+      // unfoldered documents (only subfolders). So the three Posts need a
+      // home folder before we can select them from the file-card grid.
+      const sourceFolder = await payload.create({
+        collection: 'payload-folders',
+        data: { name: 'Bulk Move Source', folderType: [postSlug] },
+        overrideAccess: true,
+      })
+
+      await payload.create({
+        collection: postSlug,
+        data: { title: 'Bulk Move Item 1', folder: sourceFolder.id },
+        overrideAccess: true,
+      })
+      await payload.create({
+        collection: postSlug,
+        data: { shouldFailMove: true, title: 'Bulk Move Item 2', folder: sourceFolder.id },
+        overrideAccess: true,
+      })
+      await payload.create({
+        collection: postSlug,
+        data: { title: 'Bulk Move Item 3', folder: sourceFolder.id },
+        overrideAccess: true,
+      })
+
+      await page.goto(postURL.byFolder)
+      await clickFolderCard({ folderName: 'Bulk Move Source', page, doubleClick: true })
+
+      // The move-to-folder drawer starts browsing from whatever folder is
+      // currently open (see `fromFolderID={folderID}` in ListSelection), so
+      // create the destination as a child of the source folder — that way
+      // it's listed immediately in the drawer without extra navigation.
+      await createFolder({ folderName: 'Bulk Move Destination', fromDropdown: true, page })
+
+      const firstOkCard = page.locator('.folder-file-card', { hasText: 'Bulk Move Item 1' })
+      const failingCard = page.locator('.folder-file-card', { hasText: 'Bulk Move Item 2' })
+      const secondOkCard = page.locator('.folder-file-card', { hasText: 'Bulk Move Item 3' })
+
+      // Shift-click from the first to the last card selects all three,
+      // including the failing one in the middle.
+      await page.keyboard.up('Shift')
+      await firstOkCard.click()
+      await page.keyboard.down('Shift')
+      await secondOkCard.click()
+      await page.keyboard.up('Shift')
+
+      const moveButton = page.locator('.list-selection__actions button', {
+        hasText: 'Move',
+      })
+      await moveButton.click()
+      const destinationFolder = page.locator('dialog#move-to-folder--list .folder-file-card', {
+        hasText: 'Bulk Move Destination',
+      })
+      await destinationFolder.click()
+      await selectFolderAndConfirmMove({ page })
+
+      // The toast must report only what the server confirmed moved (2 of the
+      // 3 selected) — never the originally selected count. This is the exact
+      // regression this test guards: a bulk move reporting success on
+      // partial failure.
+      await expect(page.locator('.payload-toast-container')).toContainText('2 items moved')
+      await expect(page.locator('.payload-toast-container')).not.toContainText('3 items moved')
+      await closeAllToasts(page)
+
+      // The document whose hook threw must still be in the source folder —
+      // it was never actually moved, regardless of what the toast said.
+      await expect(failingCard).toBeVisible()
+      await expect(firstOkCard).toBeHidden()
+      await expect(secondOkCard).toBeHidden()
+    })
+  })
+
   test.describe('should inherit folderType select values from parent folder', () => {
     test('should scope folderType select options for: scoped > child folder', async () => {
       await page.goto(formatAdminURL({ adminRoute, path: '/browse-by-folder', serverURL }))

--- a/test/folders/payload-types.ts
+++ b/test/folders/payload-types.ts
@@ -150,6 +150,7 @@ export interface Post {
   title?: string | null;
   heroImage?: (string | null) | Media;
   relatedAutosave?: (string | null) | Autosave;
+  shouldFailMove?: boolean | null;
   folder?: (string | null) | FolderInterface;
   updatedAt: string;
   createdAt: string;


### PR DESCRIPTION
## What

Selecting multiple documents in the folder-view list and using the bulk **Move** action always toasted the originally-selected count as moved, even when the server rejected some of them. If document B in a 3-document move fails (a locked document, a `beforeChange` hook throwing, etc.), the UI still says "3 items moved": B never actually moved, but nothing tells the user that.

## Why the endpoint's response shape hides this

The bulk-update REST endpoint (`packages/payload/src/collections/endpoints/update.ts`) returns **HTTP 400** whenever `result.errors.length > 0`, and **200** only when it's `0`:

```ts
if (result.errors.length === 0) {
  // ...
  return Response.json({ ...result, message }, { headers, status: httpStatus.OK })
}
// ...
return Response.json({ ...result, message }, { headers, status: httpStatus.BAD_REQUEST })
```

Critically, `result` (and therefore `result.docs`, the array of documents that *did* update successfully) is included in the body on **both** branches: 400 isn't "nothing happened", it's "some of this batch failed". The client-side `moveToFolder()` in `packages/ui/src/providers/Folders/index.tsx` didn't know that: it looped over each affected collection, PATCHed it, and discarded the response entirely unless the status was in the 2xx range. On a 400 it just moved on, so the caller (`ListSelection` in `packages/ui/src/views/CollectionFolder/ListSelection/index.tsx`) had no way to know how many documents the server actually confirmed moved, and fell back to toasting the number of documents that were *selected*.

## The fix

`moveToFolder()` now parses the JSON body on both 200 and 400, and returns `{ hasErrors, movedCount }` where `movedCount` is `json.docs.length`, the number of documents the server actually confirmed moved, not the number selected. `ListSelection` only shows the success toast, with that real count, when `movedCount > 0`.

## Test

Added an e2e test (`test/folders/e2e.spec.ts` → `Bulk move partial failure`) that puts 3 Posts in a folder, gives the middle one a `shouldFailMove` flag whose `beforeChange` hook throws on update, bulk-selects all 3, and moves them. It asserts the toast reads "2 items moved" (not 3), and that the failing document is still in its original folder.

To confirm this test actually guards the regression (and doesn't just pass along with the fix vacuously), I ran it both with the fix applied and with only the two source files reverted to `3.x`:

**With the fix:**
```
✓ should report only the documents that actually moved when one document in the batch fails (11.9s)
1 passed (57.9s)
```

**With `packages/ui/src/providers/Folders/index.tsx` and `packages/ui/src/views/CollectionFolder/ListSelection/index.tsx` reverted, test unchanged:**
```
✘ should report only the documents that actually moved when one document in the batch fails
Error: expect(locator).toContainText(expected) failed
Locator: locator('.payload-toast-container')
Expected substring: "2 items moved"
Error: element(s) not found
Call log:
  - unexpected value "3 items moved to "Bulk Move Destination""
1 failed.
```

That's the bug, reproduced directly: the toast claims all 3 moved when only 2 actually did.

One setup detail worth flagging for review: the test's 3 Posts live inside a folder rather than at the collection root. `getFolderData()` (`packages/payload/src/folders/utils/getFolderData.ts`) always returns `documents: []` when browsing a collection's folder-view root, only subfolders are queried there (`getOrphanedDocs` against the `payload-folders` collection itself). A collection's own unfoldered documents never render at that root view, so a test staged at root would time out on setup regardless of whether the fix is present. This isn't a workaround for the bug under test, it's just how the feature is supposed to behave, but it's easy to miss if you're not expecting it, so I wanted to call it out explicitly rather than leave it implicit in the test.
