### PR TITLE
fix: return 404 for version operations when global versions are disabled

### DIFF
--- a/packages/payload/src/globals/operations/countGlobalVersions.ts
+++ b/packages/payload/src/globals/operations/countGlobalVersions.ts
@@ -4,6 +4,7 @@ import type { PayloadRequest, Where } from '../../types/index.js'
 import { executeAccess } from '../../auth/executeAccess.js'
 import { combineQueries } from '../../database/combineQueries.js'
 import { validateQueryPaths } from '../../database/queryValidation/validateQueryPaths.js'
+import { NotFound } from '../../errors/index.js'
 import {
   buildVersionGlobalFields,
   type GlobalSlug,
@@ -25,6 +26,10 @@ export const countGlobalVersionsOperation = async <TSlug extends GlobalSlug>(
   const { disableErrors, global, overrideAccess, where } = args
   const req = args.req!
   const { payload } = req
+
+  if (!global.versions) {
+    throw new NotFound(req.t)
+  }
 
   // /////////////////////////////////////
   // beforeOperation - Global

--- a/packages/payload/src/globals/operations/findVersionByID.ts
+++ b/packages/payload/src/globals/operations/findVersionByID.ts
@@ -42,6 +42,10 @@ export const findVersionByIDOperation = async <T extends TypeWithVersion<T> = an
     showHiddenFields,
   } = args
 
+  if (!globalConfig.versions) {
+    throw new NotFound(req.t)
+  }
+
   // /////////////////////////////////////
   // Access
   // /////////////////////////////////////

--- a/packages/payload/src/globals/operations/findVersions.ts
+++ b/packages/payload/src/globals/operations/findVersions.ts
@@ -8,6 +8,7 @@ import { executeAccess } from '../../auth/executeAccess.js'
 import { combineQueries } from '../../database/combineQueries.js'
 import { validateQueryPaths } from '../../database/queryValidation/validateQueryPaths.js'
 import { validateSortQuery } from '../../database/queryValidation/validateSortQuery.js'
+import { NotFound } from '../../errors/index.js'
 import { afterRead } from '../../fields/hooks/afterRead/index.js'
 import { resolveSelect } from '../../utilities/resolveSelect.js'
 import { sanitizeInternalFields } from '../../utilities/sanitizeInternalFields.js'
@@ -46,6 +47,10 @@ export const findVersionsOperation = async <T extends TypeWithVersion<T>>(
   } = args
   const req = args.req!
   const { fallbackLocale, locale, payload } = req
+
+  if (!globalConfig.versions) {
+    throw new NotFound(req.t)
+  }
 
   const versionFields = buildVersionGlobalFields(payload.config, globalConfig, true)
 

--- a/packages/payload/src/globals/operations/restoreVersion.ts
+++ b/packages/payload/src/globals/operations/restoreVersion.ts
@@ -28,6 +28,10 @@ export const restoreVersionOperation = async <T extends TypeWithVersion<T> = any
   const req = args.req!
   const { fallbackLocale, locale, payload } = req
 
+  if (!globalConfig.versions) {
+    throw new NotFound(req.t)
+  }
+
   try {
     const shouldCommit = await initTransaction(req)
 

--- a/test/versions/config.ts
+++ b/test/versions/config.ts
@@ -39,6 +39,7 @@ import DraftWithMaxGlobal from './globals/DraftWithMax.js'
 import LocalizedGlobal from './globals/LocalizedGlobal.js'
 import { MaxVersions } from './globals/MaxVersions.js'
 import SimpleDraftGlobal from './globals/SimpleDraft.js'
+import NoVersionsGlobal from './globals/NoVersions.js'
 import { seed } from './seed.js'
 import { BASE_PATH } from './shared.js'
 import { draftWithUploadCloudStorageCollectionSlug } from './slugs.js'
@@ -86,6 +87,7 @@ export default buildConfigWithDefaults({
     MaxVersions,
     DraftUnlimitedGlobal,
     SimpleDraftGlobal,
+    NoVersionsGlobal,
   ],
   indexSortableFields: true,
   localization: {

--- a/test/versions/globals/NoVersions.ts
+++ b/test/versions/globals/NoVersions.ts
@@ -1,0 +1,16 @@
+import type { GlobalConfig } from 'payload'
+
+import { noVersionsGlobalSlug } from '../slugs.js'
+
+export const NoVersionsGlobal: GlobalConfig = {
+  slug: noVersionsGlobalSlug,
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+    },
+  ],
+  versions: false,
+}
+
+export default NoVersionsGlobal

--- a/test/versions/int.spec.ts
+++ b/test/versions/int.spec.ts
@@ -6,7 +6,7 @@ import {
 } from '@payloadcms/ui/utilities/schedulePublishHandler'
 import fs from 'fs'
 import path from 'path'
-import { createLocalReq, getFileByPath, saveVersion, ValidationError } from 'payload'
+import { createLocalReq, getFileByPath, NotFound, saveVersion, ValidationError } from 'payload'
 import { wait } from 'payload/shared'
 import * as qs from 'qs-esm'
 import { fileURLToPath } from 'url'
@@ -36,6 +36,7 @@ import {
   localizedCollectionSlug,
   localizedGlobalSlug,
   nestedArraySelectCollectionSlug,
+  noVersionsGlobalSlug,
   versionCollectionSlug,
 } from './slugs.js'
 
@@ -3129,6 +3130,14 @@ describe('Versions', () => {
   })
 
   describe('Globals - Local', () => {
+    it('should throw NotFound when findGlobalVersions is called for global without versions', async () => {
+      await expect(
+        payload.findGlobalVersions({
+          slug: noVersionsGlobalSlug,
+        }),
+      ).rejects.toThrow(NotFound)
+    })
+
     let globalVersionID: number | string
     beforeEach(async () => {
       const title2 = 'Here is an updated global title in EN'
@@ -4579,6 +4588,11 @@ describe('Versions', () => {
     })
 
     describe('Globals', () => {
+      it('should return HTTP 404 when GET /api/globals/<slug>/versions is called for global without versions', async () => {
+        const response = await restClient.GET(`/globals/${noVersionsGlobalSlug}/versions`)
+        expect(response.status).toBe(404)
+      })
+
       beforeEach(async () => {
         // Clear global data by resetting to empty values
         await cleanupGlobal({

--- a/test/versions/slugs.ts
+++ b/test/versions/slugs.ts
@@ -61,12 +61,15 @@ export const draftUnlimitedGlobalSlug = 'draft-unlimited-global'
 
 export const draftWithMaxGlobalSlug = 'draft-with-max-global'
 
+export const noVersionsGlobalSlug = 'no-versions-global'
+
 export const globalSlugs = [
   autoSaveGlobalSlug,
   draftGlobalSlug,
   simpleDraftGlobalSlug,
   draftUnlimitedGlobalSlug,
   draftWithMaxGlobalSlug,
+  noVersionsGlobalSlug,
 ]
 
 export const localizedCollectionSlug = 'localized-posts'


### PR DESCRIPTION
### Summary of Bug & Root Cause
When requesting `GET /api/globals/<slug>/versions` (or Local API version operations) for a global without versions enabled, `findVersionsOperation` calls `payload.db.findGlobalVersions` without verifying if `globalConfig.versions` is enabled. In database adapters like Drizzle, non-existent version table lookups return `undefined`, causing an uncaught `TypeError` and HTTP 500 error.

### Fix
Added `if (!globalConfig.versions) throw new NotFound(req.t)` guards in global version operations (`findVersions`, `findVersionByID`, `restoreVersion`, `countGlobalVersions`). This ensures that requesting version operations on non-versioned globals returns a clean HTTP 404 Not Found response.

### Tests Added
- Added `NoVersionsGlobal` test fixture to `test/versions/globals/NoVersions.ts`.
- Added integration tests in `test/versions/int.spec.ts` asserting that Local API `payload.findGlobalVersions` throws `NotFound` and REST API `GET /api/globals/<slug>/versions` returns HTTP 404.