### PR TITLE
fix: preserve job handler stack traces

### DIFF
--- a/packages/payload/src/queues/errors/index.ts
+++ b/packages/payload/src/queues/errors/index.ts
@@ -25,17 +25,23 @@ export type WorkflowErrorArgs = {
 
 export class TaskError extends Error {
   args: TaskErrorArgs
-  constructor(args: TaskErrorArgs) {
-    super(args.message)
+  constructor(args: TaskErrorArgs, options?: ErrorOptions) {
+    super(args.message, options)
     this.args = args
+    if (options?.cause instanceof Error && typeof options.cause.stack === 'string') {
+      this.stack = options.cause.stack
+    }
   }
 }
 export class WorkflowError extends Error {
   args: WorkflowErrorArgs
 
-  constructor(args: WorkflowErrorArgs) {
-    super(args.message)
+  constructor(args: WorkflowErrorArgs, options?: ErrorOptions) {
+    super(args.message, options)
     this.args = args
+    if (options?.cause instanceof Error && typeof options.cause.stack === 'string') {
+      this.stack = options.cause.stack
+    }
   }
 }
 

--- a/packages/payload/src/queues/operations/runJobs/runJSONJob/index.ts
+++ b/packages/payload/src/queues/operations/runJobs/runJSONJob/index.ts
@@ -87,14 +87,17 @@ export const runJSONJob = async ({
       error:
         error instanceof WorkflowError
           ? error
-          : new WorkflowError({
-              job,
-              message:
-                typeof error === 'object' && error && 'message' in error
-                  ? (error.message as string)
-                  : 'An unhandled error occurred',
-              workflowConfig,
-            }),
+          : new WorkflowError(
+              {
+                job,
+                message:
+                  typeof error === 'object' && error && 'message' in error
+                    ? (error.message as string)
+                    : 'An unhandled error occurred',
+                workflowConfig,
+              },
+              { cause: error },
+            ),
       silent,
 
       req,

--- a/packages/payload/src/queues/operations/runJobs/runJob/getRunTaskFunction.ts
+++ b/packages/payload/src/queues/operations/runJobs/runJob/getRunTaskFunction.ts
@@ -146,25 +146,35 @@ export const getRunTaskFunction = <TIsInline extends boolean>(
             }),
           })
         )?.output
-      } catch (err: any) {
+      } catch (err: unknown) {
         if (err instanceof JobCancelledError || err instanceof JobRunAbortedError) {
           // Job run aborts are handled by the top-level runner.
           throw err
         }
-        throw new TaskError({
-          executedAt,
-          input: input!,
-          job,
-          message: err.message || 'Task handler threw an error',
-          output,
-          parent,
-          retriesConfig: finalRetriesConfig,
-          taskConfig,
-          taskID,
-          taskSlug,
-          taskStatus,
-          workflowConfig,
-        })
+        throw new TaskError(
+          {
+            executedAt,
+            input: input!,
+            job,
+            message:
+              typeof err === 'object' &&
+              err !== null &&
+              'message' in err &&
+              typeof err.message === 'string' &&
+              err.message
+                ? err.message
+                : 'Task handler threw an error',
+            output,
+            parent,
+            retriesConfig: finalRetriesConfig,
+            taskConfig,
+            taskID,
+            taskSlug,
+            taskStatus,
+            workflowConfig,
+          },
+          { cause: err },
+        )
       }
 
       if (taskConfig?.onSuccess) {

--- a/packages/payload/src/queues/operations/runJobs/runJob/index.spec.ts
+++ b/packages/payload/src/queues/operations/runJobs/runJob/index.spec.ts
@@ -1,0 +1,188 @@
+import type { Job } from '../../../../index.js'
+import type { PayloadRequest } from '../../../../types/index.js'
+import type { TaskConfig } from '../../../config/types/taskTypes.js'
+import type { WorkflowJSON } from '../../../config/types/workflowJSONTypes.js'
+import type { WorkflowConfig } from '../../../config/types/workflowTypes.js'
+import type { UpdateJobFunction } from './getUpdateJobFunction.js'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import { TaskError, WorkflowError } from '../../../errors/index.js'
+import { runJSONJob } from '../runJSONJob/index.js'
+import { runJob } from './index.js'
+
+function createRunContext({ tasks = [] }: { tasks?: TaskConfig<string>[] }) {
+  const job = {
+    id: 'job-id',
+    input: {},
+    log: [],
+    taskStatus: {},
+    totalTried: 0,
+    workflowSlug: 'testWorkflow',
+  } as unknown as Job
+  const loggerError = vi.fn()
+  const req = {
+    payload: {
+      config: {
+        jobs: {
+          tasks,
+        },
+      },
+      logger: {
+        error: loggerError,
+      },
+    },
+  } as unknown as PayloadRequest
+  const updateJob = vi.fn(async () => job) as unknown as UpdateJobFunction
+  const workflowConfig = {
+    handler: () => undefined,
+    slug: 'testWorkflow',
+  } as WorkflowConfig
+
+  return { job, loggerError, req, updateJob, workflowConfig }
+}
+
+function getLoggedError({
+  loggerError,
+}: {
+  loggerError: ReturnType<typeof vi.fn>
+}): TaskError | WorkflowError {
+  const logEntry = loggerError.mock.calls[0]?.[0] as { err?: unknown } | undefined
+
+  if (!(logEntry?.err instanceof Error)) {
+    throw new Error('EXPECTED_JOB_ERROR_LOG_18055')
+  }
+
+  return logEntry.err as TaskError | WorkflowError
+}
+
+describe('job handler errors', () => {
+  it('should preserve a task handler error stack and cause', async () => {
+    let handlerError: Error | undefined
+    function throwFromTaskHandler(): never {
+      handlerError = new Error('task-handler-stack-marker-18055')
+      throw handlerError
+    }
+
+    const taskConfig = {
+      handler: throwFromTaskHandler,
+      retries: 0,
+      slug: 'failingTask',
+    } as unknown as TaskConfig<string>
+    const { job, loggerError, req, updateJob, workflowConfig } = createRunContext({
+      tasks: [taskConfig],
+    })
+
+    await runJob({
+      job,
+      req,
+      updateJob,
+      workflowConfig,
+      workflowHandler: async ({ tasks }) => {
+        await tasks.failingTask!('task-id', { input: {} })
+      },
+    })
+
+    const loggedError = getLoggedError({ loggerError })
+
+    expect(loggedError).toBeInstanceOf(TaskError)
+    expect(loggedError.stack, 'TASK_HANDLER_STACK_MISSING_18055').toContain(
+      'throwFromTaskHandler',
+    )
+    expect(loggedError.cause).toBe(handlerError)
+  })
+
+  it('should preserve a workflow handler error stack and cause', async () => {
+    let handlerError: Error | undefined
+    function throwFromWorkflowHandler(): never {
+      handlerError = new Error('workflow-handler-stack-marker-18055')
+      throw handlerError
+    }
+
+    const { job, loggerError, req, updateJob, workflowConfig } = createRunContext({})
+
+    await runJob({
+      job,
+      req,
+      updateJob,
+      workflowConfig,
+      workflowHandler: throwFromWorkflowHandler,
+    })
+
+    const loggedError = getLoggedError({ loggerError })
+
+    expect(loggedError).toBeInstanceOf(WorkflowError)
+    expect(loggedError.stack, 'WORKFLOW_HANDLER_STACK_MISSING_18055').toContain(
+      'throwFromWorkflowHandler',
+    )
+    expect(loggedError.cause).toBe(handlerError)
+  })
+
+  it('should preserve a JSON task handler error through the workflow wrapper', async () => {
+    let handlerError: Error | undefined
+    function throwFromJSONTaskHandler(): never {
+      handlerError = new Error('json-task-handler-stack-marker-18055')
+      throw handlerError
+    }
+
+    const taskConfig = {
+      handler: throwFromJSONTaskHandler,
+      retries: 0,
+      slug: 'failingJSONTask',
+    } as unknown as TaskConfig<string>
+    const { job, loggerError, req, updateJob, workflowConfig } = createRunContext({
+      tasks: [taskConfig],
+    })
+    const workflowHandler = [
+      {
+        id: 'json-task-id',
+        input: () => ({}),
+        task: 'failingJSONTask',
+      },
+    ] as unknown as WorkflowJSON
+
+    await runJSONJob({
+      job,
+      req,
+      updateJob,
+      workflowConfig,
+      workflowHandler,
+    })
+
+    const loggedError = getLoggedError({ loggerError })
+
+    expect(loggedError).toBeInstanceOf(WorkflowError)
+    expect(loggedError.stack, 'JSON_TASK_HANDLER_STACK_MISSING_18055').toContain(
+      'throwFromJSONTaskHandler',
+    )
+    expect(loggedError.cause).toBeInstanceOf(TaskError)
+    expect((loggedError.cause as TaskError).cause).toBe(handlerError)
+  })
+
+  it('should preserve a non-Error task handler throw as the cause', async () => {
+    const taskConfig = {
+      handler: () => Promise.reject(null),
+      retries: 0,
+      slug: 'failingNonErrorTask',
+    } as unknown as TaskConfig<string>
+    const { job, loggerError, req, updateJob, workflowConfig } = createRunContext({
+      tasks: [taskConfig],
+    })
+
+    await runJob({
+      job,
+      req,
+      updateJob,
+      workflowConfig,
+      workflowHandler: async ({ tasks }) => {
+        await tasks.failingNonErrorTask!('task-id', { input: {} })
+      },
+    })
+
+    const loggedError = getLoggedError({ loggerError })
+
+    expect(loggedError).toBeInstanceOf(TaskError)
+    expect(loggedError.message).toBe('Task handler threw an error')
+    expect(loggedError.cause).toBeNull()
+  })
+})

--- a/packages/payload/src/queues/operations/runJobs/runJob/index.ts
+++ b/packages/payload/src/queues/operations/runJobs/runJob/index.ts
@@ -75,14 +75,17 @@ export const runJob = async ({
       error:
         error instanceof WorkflowError
           ? error
-          : new WorkflowError({
-              job,
-              message:
-                typeof error === 'object' && error && 'message' in error
-                  ? (error.message as string)
-                  : 'An unhandled error occurred',
-              workflowConfig,
-            }),
+          : new WorkflowError(
+              {
+                job,
+                message:
+                  typeof error === 'object' && error && 'message' in error
+                    ? (error.message as string)
+                    : 'An unhandled error occurred',
+                workflowConfig,
+              },
+              { cause: error },
+            ),
       req,
       silent,
       updateJob,


### PR DESCRIPTION
### What?

- Preserve task and workflow handler errors as native causes.
- Keep the original application stack on job errors that are logged or persisted.
- Add focused unit coverage for configured tasks, function workflows, JSON workflows, and non-Error throws.

### Why?

Jobs currently replace handler errors with TaskError or WorkflowError instances whose stacks begin inside Payload. This removes the application frames needed to debug failures.

### How?

TaskError and WorkflowError now accept ErrorOptions, retain the cause, and reuse an Error cause stack. Every handler-wrapping call site supplies the caught value as the cause, while task message extraction safely handles non-Error throws. Existing task, workflow, and JSON-job retry routing remains unchanged.

Fixes #18055