### PR TITLE
fix: return 404 instead of 500 when global versions not enabled

### DIFF
--- a/packages/payload/src/globals/operations/findVersionByID.ts
+++ b/packages/payload/src/globals/operations/findVersionByID.ts
@@ -58,6 +58,14 @@ export const findVersionByIDOperation = async <T extends TypeWithVersion<T> = an
     return null!
   }
 
+  // Guard: versions must be enabled on this global
+  if (!globalConfig.versions) {
+    if (!disableErrors) {
+      throw new NotFound(req.t)
+    }
+    return null!
+  }
+
   const hasWhereAccess = typeof accessResults === 'object'
 
   const select = sanitizeSelect({

--- a/packages/payload/src/globals/operations/findVersions.ts
+++ b/packages/payload/src/globals/operations/findVersions.ts
@@ -8,6 +8,7 @@ import { executeAccess } from '../../auth/executeAccess.js'
 import { combineQueries } from '../../database/combineQueries.js'
 import { validateQueryPaths } from '../../database/queryValidation/validateQueryPaths.js'
 import { validateSortQuery } from '../../database/queryValidation/validateSortQuery.js'
+import { NotFound } from '../../errors/index.js'
 import { afterRead } from '../../fields/hooks/afterRead/index.js'
 import { resolveSelect } from '../../utilities/resolveSelect.js'
 import { sanitizeInternalFields } from '../../utilities/sanitizeInternalFields.js'
@@ -72,6 +73,14 @@ export const findVersionsOperation = async <T extends TypeWithVersion<T>>(
     sort,
     versionFields,
   })
+
+  // /////////////////////////////////////
+  // Guard: versions must be enabled
+  // /////////////////////////////////////
+
+  if (!globalConfig.versions) {
+    throw new NotFound(req.t)
+  }
 
   const fullWhere = combineQueries(where!, accessResults)
 

--- a/packages/payload/src/globals/operations/restoreVersion.ts
+++ b/packages/payload/src/globals/operations/restoreVersion.ts
@@ -58,6 +58,14 @@ export const restoreVersionOperation = async <T extends TypeWithVersion<T> = any
     }
 
     // /////////////////////////////////////
+    // Guard: versions must be enabled
+    // /////////////////////////////////////
+
+    if (!globalConfig.versions) {
+      throw new NotFound(req.t)
+    }
+
+    // /////////////////////////////////////
     // Retrieve original raw version
     // /////////////////////////////////////
 


### PR DESCRIPTION
## What

When `versions` is not configured on a global, the following endpoints all produced a **500 Internal Server Error** instead of a proper 404:

- `GET /api/globals/:slug/versions`
- `GET /api/globals/:slug/versions/:id`
- `POST /api/globals/:slug/versions/:id` (restore)

The error originates in the database adapter because the versions table/collection doesn't exist for that global, causing a `TypeError` that propagates as a 500.

## Root Cause

`findVersionsOperation`, `findVersionByIDOperation`, and `restoreVersionOperation` all unconditionally call `payload.db.findGlobalVersions(...)` without first checking whether `globalConfig.versions` is enabled. If versions aren't configured, the adapter fails trying to look up a table that doesn't exist.

## Fix

Add an early `NotFound` guard in each operation before touching the database, consistent with the pattern used throughout the rest of the codebase:

```ts
if (!globalConfig.versions) {
  throw new NotFound(req.t)
}
```

- `findVersionsOperation`: guards before the `Find` section
- `findVersionByIDOperation`: guards after access control (respects `disableErrors` — returns `null` instead of throwing)
- `restoreVersionOperation`: guards before `Retrieve original raw version`

Closes #18056

## Testing

Reproduce with any global that does **not** have `versions` configured, then `GET /api/globals/:slug/versions`. Before: `500 TypeError: Cannot read properties of undefined`. After: `404 Not Found`.