### PR TITLE
fix(plugin-mcp): strip cross-locale row ids when updating localized arrays

### DIFF
--- a/packages/plugin-mcp/src/mcp/builtin/collections/updateTool.ts
+++ b/packages/plugin-mcp/src/mcp/builtin/collections/updateTool.ts
@@ -10,6 +10,10 @@ import {
   stripVirtualFields,
 } from '../../../utils/getVirtualFieldNames.js'
 import { getCollectionInputSchema } from '../../../utils/schemaConversion/getEntityInputSchema.js'
+import {
+  entityHasLocalizedRowContainers,
+  stripCrossLocaleRowIDs,
+} from '../../../utils/stripCrossLocaleRowIDs.js'
 import { transformPointDataToPayload } from '../../../utils/transformPointDataToPayload.js'
 import { whereSchema } from '../../../utils/whereSchema.js'
 import { validateCollectionData } from '../validateEntityData.js'
@@ -133,6 +137,47 @@ export const updateDocumentTool = defineCollectionTool({
 
     const parsedData = transformPointDataToPayload(inputData)
     const file = await resolveFile({ collectionSlug, input: fileInput, req })
+
+    // Row ids inside localized arrays/blocks belong to one locale. A client that read the
+    // document in another locale echoes that locale's row ids back here; drop the ones that
+    // don't exist in the locale being updated so Payload generates fresh ids instead of
+    // storing one row id under two locales (a unique constraint violation on relational
+    // adapters). For updates by `where`, one data payload applies to many documents, so
+    // there is no reference document and every such row id is dropped.
+    const collectionConfig = payload.collections[collectionSlug]?.config
+    if (
+      collectionConfig &&
+      locale !== 'all' &&
+      entityHasLocalizedRowContainers({
+        blocks: payload.config.blocks,
+        fields: collectionConfig.flattenedFields,
+      })
+    ) {
+      let existingDoc: Record<string, unknown> | undefined
+      if (id) {
+        try {
+          existingDoc = (await payload.findByID({
+            id,
+            collection: collectionSlug,
+            depth: 0,
+            draft,
+            fallbackLocale: false,
+            overrideAccess: authorizedMCP.overrideAccess,
+            req,
+            ...(locale ? { locale } : {}),
+          })) as Record<string, unknown>
+        } catch {
+          // Missing document or no read access — strip all ids and let the update
+          // operation report its own error.
+        }
+      }
+      stripCrossLocaleRowIDs({
+        blocks: payload.config.blocks,
+        data: parsedData,
+        existingDoc,
+        fields: collectionConfig.flattenedFields,
+      })
+    }
 
     const whereClause: Where = where ?? {}
 

--- a/packages/plugin-mcp/src/mcp/builtin/globals/updateTool.ts
+++ b/packages/plugin-mcp/src/mcp/builtin/globals/updateTool.ts
@@ -9,6 +9,10 @@ import {
   getGlobalVirtualFieldNames,
   stripVirtualFields,
 } from '../../../utils/getVirtualFieldNames.js'
+import {
+  entityHasLocalizedRowContainers,
+  stripCrossLocaleRowIDs,
+} from '../../../utils/stripCrossLocaleRowIDs.js'
 import { transformPointDataToPayload } from '../../../utils/transformPointDataToPayload.js'
 import { validateGlobalData } from '../validateEntityData.js'
 
@@ -74,6 +78,39 @@ export const updateGlobalTool = defineGlobalTool({
     }
 
     const parsedData = transformPointDataToPayload(inputData)
+
+    // See the collection update tool: row ids echoed from a read of another locale must not be
+    // written into the locale being updated.
+    const globalConfig = payload.config.globals.find((global) => global.slug === globalSlug)
+    if (
+      globalConfig &&
+      locale !== 'all' &&
+      entityHasLocalizedRowContainers({
+        blocks: payload.config.blocks,
+        fields: globalConfig.flattenedFields,
+      })
+    ) {
+      let existingDoc: Record<string, unknown> | undefined
+      try {
+        existingDoc = (await payload.findGlobal({
+          slug: globalSlug,
+          depth: 0,
+          draft,
+          fallbackLocale: false,
+          overrideAccess: authorizedMCP.overrideAccess,
+          req,
+          ...(locale ? { locale } : {}),
+        })) as Record<string, unknown>
+      } catch {
+        // No read access — strip all ids and let the update operation report its own error.
+      }
+      stripCrossLocaleRowIDs({
+        blocks: payload.config.blocks,
+        data: parsedData,
+        existingDoc,
+        fields: globalConfig.flattenedFields,
+      })
+    }
 
     const updateOptions: Parameters<typeof payload.updateGlobal>[0] = {
       slug: globalSlug,

--- a/packages/plugin-mcp/src/utils/stripCrossLocaleRowIDs.spec.ts
+++ b/packages/plugin-mcp/src/utils/stripCrossLocaleRowIDs.spec.ts
@@ -1,0 +1,153 @@
+import type { FlattenedBlock, FlattenedField } from 'payload'
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  entityHasLocalizedRowContainers,
+  stripCrossLocaleRowIDs,
+} from './stripCrossLocaleRowIDs.js'
+
+const text = (name: string, localized?: boolean): FlattenedField =>
+  ({ name, type: 'text', ...(localized ? { localized } : {}) }) as FlattenedField
+
+const array = (
+  name: string,
+  flattenedFields: FlattenedField[],
+  localized?: boolean,
+): FlattenedField =>
+  ({
+    name,
+    type: 'array',
+    flattenedFields,
+    ...(localized ? { localized } : {}),
+  }) as FlattenedField
+
+const localizedItemsFields: FlattenedField[] = [
+  text('title'),
+  array('items', [text('label'), text('id')], true),
+  array('rows', [text('label', true), text('id')]),
+]
+
+describe('stripCrossLocaleRowIDs', () => {
+  it('should strip row ids of a localized array that do not exist in the target locale', () => {
+    const data = {
+      items: [
+        { id: 'from-other-locale', label: 'one' },
+        { id: 'existing-in-locale', label: 'two' },
+      ],
+    }
+
+    stripCrossLocaleRowIDs({
+      data,
+      existingDoc: { items: [{ id: 'existing-in-locale', label: 'old' }] },
+      fields: localizedItemsFields,
+    })
+
+    expect(data.items).toEqual([{ label: 'one' }, { id: 'existing-in-locale', label: 'two' }])
+  })
+
+  it('should strip every localized row id when there is no reference document', () => {
+    const data = { items: [{ id: 'from-some-doc', label: 'one' }] }
+
+    stripCrossLocaleRowIDs({ data, fields: localizedItemsFields })
+
+    expect(data.items).toEqual([{ label: 'one' }])
+  })
+
+  it('should keep row ids of non-localized arrays', () => {
+    const data = { rows: [{ id: 'shared-row', label: 'one' }] }
+
+    stripCrossLocaleRowIDs({ data, existingDoc: { rows: [] }, fields: localizedItemsFields })
+
+    expect(data.rows).toEqual([{ id: 'shared-row', label: 'one' }])
+  })
+
+  it('should strip row ids of arrays nested inside a localized group', () => {
+    const fields: FlattenedField[] = [
+      {
+        name: 'hero',
+        type: 'group',
+        flattenedFields: [array('links', [text('label'), text('id')])],
+        localized: true,
+      } as FlattenedField,
+    ]
+    const data = { hero: { links: [{ id: 'from-other-locale', label: 'one' }] } }
+
+    stripCrossLocaleRowIDs({ data, existingDoc: { hero: { links: [] } }, fields })
+
+    expect(data.hero.links).toEqual([{ label: 'one' }])
+  })
+
+  it('should strip block row ids of a localized blocks field, matching nested fields by blockType', () => {
+    const heroBlock = {
+      slug: 'hero',
+      flattenedFields: [array('ctas', [text('label'), text('id')])],
+    } as unknown as FlattenedBlock
+    const fields: FlattenedField[] = [
+      {
+        name: 'layout',
+        type: 'blocks',
+        blocks: ['hero'],
+        localized: true,
+      } as unknown as FlattenedField,
+    ]
+    const data = {
+      layout: [
+        {
+          id: 'block-from-other-locale',
+          blockType: 'hero',
+          ctas: [{ id: 'cta-from-other-locale', label: 'one' }],
+        },
+      ],
+    }
+
+    stripCrossLocaleRowIDs({ blocks: [heroBlock], data, existingDoc: { layout: [] }, fields })
+
+    expect(data.layout).toEqual([{ blockType: 'hero', ctas: [{ label: 'one' }] }])
+  })
+
+  it('should keep nested row ids when the parent row exists in the target locale', () => {
+    const fields: FlattenedField[] = [
+      array('items', [array('nested', [text('label'), text('id')]), text('id')], true),
+    ]
+    const data = {
+      items: [{ id: 'row-1', nested: [{ id: 'nested-1', label: 'one' }] }],
+    }
+
+    stripCrossLocaleRowIDs({
+      data,
+      existingDoc: { items: [{ id: 'row-1', nested: [{ id: 'nested-1', label: 'old' }] }] },
+      fields,
+    })
+
+    expect(data.items).toEqual([{ id: 'row-1', nested: [{ id: 'nested-1', label: 'one' }] }])
+  })
+})
+
+describe('entityHasLocalizedRowContainers', () => {
+  it('should detect a localized array', () => {
+    expect(entityHasLocalizedRowContainers({ fields: localizedItemsFields })).toBe(true)
+  })
+
+  it('should return false when no array or blocks field stores per-locale rows', () => {
+    const fields: FlattenedField[] = [
+      text('title', true),
+      array('rows', [text('label', true), text('id')]),
+    ]
+
+    expect(entityHasLocalizedRowContainers({ fields })).toBe(false)
+  })
+
+  it('should detect an array nested inside a localized group', () => {
+    const fields: FlattenedField[] = [
+      {
+        name: 'hero',
+        type: 'group',
+        flattenedFields: [array('links', [text('label'), text('id')])],
+        localized: true,
+      } as FlattenedField,
+    ]
+
+    expect(entityHasLocalizedRowContainers({ fields })).toBe(true)
+  })
+})

--- a/packages/plugin-mcp/src/utils/stripCrossLocaleRowIDs.ts
+++ b/packages/plugin-mcp/src/utils/stripCrossLocaleRowIDs.ts
@@ -1,0 +1,215 @@
+import type { FlattenedBlock, FlattenedField } from 'payload'
+
+/**
+ * Removes array/block row `id`s from incoming update data when the id does not belong to a row of
+ * the locale being updated.
+ *
+ * Rows of a localized array/blocks field (or one nested inside a localized parent) exist once per
+ * locale, keyed by row id. An MCP client that reads a document in one locale and then updates
+ * another echoes the first locale's row ids back. Keeping them would store the same row id under
+ * two locales — a unique constraint violation on the relational adapters (the update fails with
+ * "The following field is invalid: id") and silently duplicated row ids on MongoDB. Ids that do
+ * exist in the target locale are kept, so partial row updates still merge with existing row data.
+ *
+ * `existingDoc` must be the current document in the target locale with fallback disabled; pass
+ * `undefined` when there is no reference document (e.g. a bulk update by `where`), which strips
+ * every row id inside localized containers.
+ *
+ * Mutates and returns `data`.
+ */
+export function stripCrossLocaleRowIDs({
+  blocks,
+  data,
+  existingDoc,
+  fields,
+  parentIsLocalized = false,
+}: {
+  blocks?: FlattenedBlock[]
+  data: Record<string, unknown>
+  existingDoc?: Record<string, unknown>
+  fields: FlattenedField[]
+  parentIsLocalized?: boolean
+}): Record<string, unknown> {
+  for (const field of fields) {
+    if (!('name' in field) || !field.name) {
+      continue
+    }
+
+    const value = data[field.name]
+
+    if (value === null || typeof value !== 'object') {
+      continue
+    }
+
+    const existingValue = existingDoc?.[field.name]
+    const isLocalized = parentIsLocalized || Boolean('localized' in field && field.localized)
+
+    switch (field.type) {
+      case 'array': {
+        if (Array.isArray(value)) {
+          stripRowIDs({
+            blocks,
+            existingRows: existingValue,
+            isLocalized,
+            resolveFields: () => field.flattenedFields,
+            rows: value,
+          })
+        }
+        break
+      }
+
+      case 'blocks': {
+        if (Array.isArray(value)) {
+          stripRowIDs({
+            blocks,
+            existingRows: existingValue,
+            isLocalized,
+            resolveFields: (row) => {
+              for (const blockOrReference of field.blocks) {
+                const block =
+                  typeof blockOrReference === 'string'
+                    ? blocks?.find(({ slug }) => slug === blockOrReference)
+                    : blockOrReference
+                if (block && block.slug === row.blockType) {
+                  return block.flattenedFields
+                }
+              }
+              return []
+            },
+            rows: value,
+          })
+        }
+        break
+      }
+
+      case 'group':
+      case 'tab': {
+        if (!Array.isArray(value)) {
+          stripCrossLocaleRowIDs({
+            blocks,
+            data: value as Record<string, unknown>,
+            existingDoc:
+              existingValue && typeof existingValue === 'object' && !Array.isArray(existingValue)
+                ? (existingValue as Record<string, unknown>)
+                : undefined,
+            fields: field.flattenedFields,
+            parentIsLocalized: isLocalized,
+          })
+        }
+        break
+      }
+    }
+  }
+
+  return data
+}
+
+/**
+ * Strips unknown ids from one set of array/block rows and recurses into each row's nested fields.
+ * A row id is unknown when `existingRows` (the target locale's current rows) has no row with it.
+ */
+const stripRowIDs = ({
+  blocks,
+  existingRows,
+  isLocalized,
+  resolveFields,
+  rows,
+}: {
+  blocks?: FlattenedBlock[]
+  existingRows: unknown
+  isLocalized: boolean
+  resolveFields: (row: Record<string, unknown>) => FlattenedField[]
+  rows: unknown[]
+}): void => {
+  for (const row of rows) {
+    if (row === null || typeof row !== 'object' || Array.isArray(row)) {
+      continue
+    }
+
+    const rowData = row as Record<string, unknown>
+    const existingRow = Array.isArray(existingRows)
+      ? existingRows.find(
+          (candidate) =>
+            candidate !== null &&
+            typeof candidate === 'object' &&
+            'id' in candidate &&
+            rowData.id !== undefined &&
+            (candidate as Record<string, unknown>).id === rowData.id,
+        )
+      : undefined
+
+    if (isLocalized && rowData.id !== undefined && !existingRow) {
+      delete rowData.id
+    }
+
+    stripCrossLocaleRowIDs({
+      blocks,
+      data: rowData,
+      existingDoc: existingRow as Record<string, unknown> | undefined,
+      fields: resolveFields(rowData),
+      parentIsLocalized: isLocalized,
+    })
+  }
+}
+
+/**
+ * Whether any array/blocks field of the entity stores per-locale rows — i.e. is localized itself or
+ * sits inside a localized group/tab/array/blocks. Only then can incoming row ids collide across
+ * locales, so callers skip the reference-document fetch entirely otherwise.
+ */
+export function entityHasLocalizedRowContainers({
+  blocks,
+  fields,
+  parentIsLocalized = false,
+}: {
+  blocks?: FlattenedBlock[]
+  fields: FlattenedField[]
+  parentIsLocalized?: boolean
+}): boolean {
+  return fields.some((field) => {
+    const isLocalized = parentIsLocalized || Boolean('localized' in field && field.localized)
+
+    switch (field.type) {
+      case 'array': {
+        return (
+          isLocalized ||
+          entityHasLocalizedRowContainers({
+            blocks,
+            fields: field.flattenedFields,
+            parentIsLocalized: isLocalized,
+          })
+        )
+      }
+      case 'blocks': {
+        return (
+          isLocalized ||
+          field.blocks.some((blockOrReference) => {
+            const block =
+              typeof blockOrReference === 'string'
+                ? blocks?.find(({ slug }) => slug === blockOrReference)
+                : blockOrReference
+            return (
+              block &&
+              entityHasLocalizedRowContainers({
+                blocks,
+                fields: block.flattenedFields,
+                parentIsLocalized: isLocalized,
+              })
+            )
+          })
+        )
+      }
+      case 'group':
+      case 'tab': {
+        return entityHasLocalizedRowContainers({
+          blocks,
+          fields: field.flattenedFields,
+          parentIsLocalized: isLocalized,
+        })
+      }
+      default: {
+        return false
+      }
+    }
+  })
+}

--- a/test/plugin-mcp/collections/LocalizedItems.ts
+++ b/test/plugin-mcp/collections/LocalizedItems.ts
@@ -1,0 +1,46 @@
+import type { CollectionConfig } from 'payload'
+
+export const LocalizedItems: CollectionConfig = {
+  slug: 'localized-items',
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+    },
+    // Array field that is localized as a whole — each locale has its own rows
+    {
+      name: 'items',
+      type: 'array',
+      fields: [
+        {
+          name: 'label',
+          type: 'text',
+        },
+        {
+          name: 'rel',
+          type: 'relationship',
+          relationTo: 'users',
+        },
+      ],
+      localized: true,
+    },
+    // Non-localized array with a localized subfield — rows shared across locales,
+    // so row ids must be preserved on update
+    {
+      name: 'rows',
+      type: 'array',
+      fields: [
+        {
+          name: 'label',
+          type: 'text',
+          localized: true,
+        },
+        {
+          name: 'rel',
+          type: 'relationship',
+          relationTo: 'users',
+        },
+      ],
+    },
+  ],
+}

--- a/test/plugin-mcp/config.ts
+++ b/test/plugin-mcp/config.ts
@@ -8,6 +8,7 @@ import * as z from 'zod'
 import { testRBACPlugin } from '../__helpers/plugins/rbac/index.js'
 import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
 import { FieldTypes } from './collections/FieldTypes.js'
+import { LocalizedItems } from './collections/LocalizedItems.js'
 import { DispatchMedia, Media } from './collections/Media.js'
 import { ModifiedPrompts } from './collections/ModifiedPrompts.js'
 import { Pages } from './collections/Pages.js'
@@ -46,6 +47,7 @@ export default buildConfigWithDefaults({
     ReturnedResources,
     Pages,
     FieldTypes,
+    LocalizedItems,
   ],
   localization: {
     defaultLocale: 'en',

--- a/test/plugin-mcp/localizedArrays.int.spec.ts
+++ b/test/plugin-mcp/localizedArrays.int.spec.ts
@@ -1,0 +1,265 @@
+import { describe, expect } from 'vitest'
+
+import { getToolDoc } from './helpers/mcpClient.js'
+import { getApiKey, it, payload } from './helpers/mcpFixtures.js'
+
+type LocalizedItemsAllLocales = {
+  id: number | string
+  items?: Record<string, Array<{ id: string; label: string; rel: number | string }>>
+  rows?: Array<{ id: string; label: Record<string, string>; rel: number | string }>
+  title?: string
+}
+
+const collectionSlug = 'localized-items'
+
+describe('localized arrays', () => {
+  it('should keep other locales intact when updating a localized array in one locale', async ({
+    mcp,
+  }) => {
+    const user = await payload.create({
+      collection: 'users',
+      data: { email: `localized-array-user-1-${Date.now()}@example.com`, password: 'test1234' },
+      overrideAccess: true,
+    })
+    const doc = await payload.create({
+      collection: collectionSlug,
+      data: { items: [{ label: 'english label', rel: user.id }], title: 'localized array' },
+      locale: 'en',
+    })
+
+    const apiKey = await getApiKey()
+    const client = await mcp.connect(apiKey)
+    const updateResponse = await client.callTool({
+      name: 'updateDocument',
+      arguments: {
+        id: doc.id,
+        collectionSlug,
+        data: { items: [{ label: 'spanish label', rel: user.id }] },
+        locale: 'es',
+      },
+    })
+
+    expect(updateResponse.isError).toBeFalsy()
+
+    const allLocales = (await payload.findByID({
+      id: doc.id,
+      collection: collectionSlug,
+      depth: 0,
+      locale: 'all',
+    })) as unknown as LocalizedItemsAllLocales
+
+    expect(allLocales.items?.en?.[0]?.label).toBe('english label')
+    expect(allLocales.items?.en?.[0]?.rel).toBe(user.id)
+    expect(allLocales.items?.es?.[0]?.label).toBe('spanish label')
+    expect(allLocales.items?.es?.[0]?.rel).toBe(user.id)
+
+    await payload.delete({ id: doc.id, collection: collectionSlug })
+    await payload.delete({ id: user.id, collection: 'users' })
+  })
+
+  it('should generate new row ids when an update echoes row ids read from another locale', async ({
+    mcp,
+  }) => {
+    const user = await payload.create({
+      collection: 'users',
+      data: { email: `localized-array-user-2-${Date.now()}@example.com`, password: 'test1234' },
+      overrideAccess: true,
+    })
+    const doc = await payload.create({
+      collection: collectionSlug,
+      data: { items: [{ label: 'english label', rel: user.id }], title: 'echoed row ids' },
+      locale: 'en',
+    })
+
+    const apiKey = await getApiKey()
+    const client = await mcp.connect(apiKey)
+
+    // Read without a locale — returns the default locale's rows including their row ids
+    const findResponse = await client.callTool({
+      name: 'findDocuments',
+      arguments: { id: doc.id, collectionSlug, depth: 0 },
+    })
+    const findText = (findResponse.content as Array<{ text: string; type: string }>)[0]!.text
+    const found = JSON.parse(findText.slice(findText.indexOf('{'))) as {
+      items: Array<{ id: string; label: string; rel: number | string }>
+    }
+
+    // Update another locale echoing those row ids back, the way an MCP client naturally does
+    const updateResponse = await client.callTool({
+      name: 'updateDocument',
+      arguments: {
+        id: doc.id,
+        collectionSlug,
+        data: { items: found.items.map((row) => ({ ...row, label: 'spanish label' })) },
+        locale: 'es',
+      },
+    })
+
+    expect(updateResponse.isError).toBeFalsy()
+
+    const allLocales = (await payload.findByID({
+      id: doc.id,
+      collection: collectionSlug,
+      depth: 0,
+      locale: 'all',
+    })) as unknown as LocalizedItemsAllLocales
+
+    expect(allLocales.items?.en?.[0]?.label).toBe('english label')
+    expect(allLocales.items?.en?.[0]?.rel).toBe(user.id)
+    expect(allLocales.items?.es?.[0]?.label).toBe('spanish label')
+    expect(allLocales.items?.es?.[0]?.rel).toBe(user.id)
+    // The echoed en row id must not be stored under es as well
+    expect(allLocales.items?.es?.[0]?.id).not.toBe(allLocales.items?.en?.[0]?.id)
+
+    await payload.delete({ id: doc.id, collection: collectionSlug })
+    await payload.delete({ id: user.id, collection: 'users' })
+  })
+
+  it('should keep row ids that belong to the locale being updated', async ({ mcp }) => {
+    const user = await payload.create({
+      collection: 'users',
+      data: { email: `localized-array-user-3-${Date.now()}@example.com`, password: 'test1234' },
+      overrideAccess: true,
+    })
+    const doc = await payload.create({
+      collection: collectionSlug,
+      data: { items: [{ label: 'english label', rel: user.id }], title: 'same locale row ids' },
+      locale: 'en',
+    })
+    const created = (await payload.findByID({
+      id: doc.id,
+      collection: collectionSlug,
+      depth: 0,
+      locale: 'en',
+    })) as unknown as { items: Array<{ id: string }> }
+    const rowId = created.items[0]!.id
+
+    const apiKey = await getApiKey()
+    const client = await mcp.connect(apiKey)
+    // Partial row update in the same locale — omitted subfields merge from the existing row
+    const updateResponse = await client.callTool({
+      name: 'updateDocument',
+      arguments: {
+        id: doc.id,
+        collectionSlug,
+        data: { items: [{ id: rowId, label: 'english label v2' }] },
+        locale: 'en',
+      },
+    })
+
+    expect(updateResponse.isError).toBeFalsy()
+
+    const updated = getToolDoc<{
+      items: Array<{ id: string; label: string; rel: number | string }>
+    }>(updateResponse)
+
+    expect(updated.items[0]?.id).toBe(rowId)
+    expect(updated.items[0]?.label).toBe('english label v2')
+    expect(updated.items[0]?.rel).toBe(user.id)
+
+    await payload.delete({ id: doc.id, collection: collectionSlug })
+    await payload.delete({ id: user.id, collection: 'users' })
+  })
+
+  it('should keep row ids of non-localized arrays so localized subfields stay merged', async ({
+    mcp,
+  }) => {
+    const user = await payload.create({
+      collection: 'users',
+      data: { email: `localized-array-user-4-${Date.now()}@example.com`, password: 'test1234' },
+      overrideAccess: true,
+    })
+    const doc = await payload.create({
+      collection: collectionSlug,
+      data: { rows: [{ label: 'english row label', rel: user.id }], title: 'shared rows' },
+      locale: 'en',
+    })
+    const created = (await payload.findByID({
+      id: doc.id,
+      collection: collectionSlug,
+      depth: 0,
+      locale: 'en',
+    })) as unknown as { rows: Array<{ id: string }> }
+    const rowId = created.rows[0]!.id
+
+    const apiKey = await getApiKey()
+    const client = await mcp.connect(apiKey)
+    const updateResponse = await client.callTool({
+      name: 'updateDocument',
+      arguments: {
+        id: doc.id,
+        collectionSlug,
+        data: { rows: [{ id: rowId, label: 'spanish row label', rel: user.id }] },
+        locale: 'es',
+      },
+    })
+
+    expect(updateResponse.isError).toBeFalsy()
+
+    const allLocales = (await payload.findByID({
+      id: doc.id,
+      collection: collectionSlug,
+      depth: 0,
+      locale: 'all',
+    })) as unknown as LocalizedItemsAllLocales
+
+    expect(allLocales.rows?.[0]?.id).toBe(rowId)
+    expect(allLocales.rows?.[0]?.label?.en).toBe('english row label')
+    expect(allLocales.rows?.[0]?.label?.es).toBe('spanish row label')
+    expect(allLocales.rows?.[0]?.rel).toBe(user.id)
+
+    await payload.delete({ id: doc.id, collection: collectionSlug })
+    await payload.delete({ id: user.id, collection: 'users' })
+  })
+
+  it('should strip row ids inside localized arrays when updating by where clause', async ({
+    mcp,
+  }) => {
+    const user = await payload.create({
+      collection: 'users',
+      data: { email: `localized-array-user-5-${Date.now()}@example.com`, password: 'test1234' },
+      overrideAccess: true,
+    })
+    const doc = await payload.create({
+      collection: collectionSlug,
+      data: { items: [{ label: 'english label', rel: user.id }], title: 'bulk update' },
+      locale: 'en',
+    })
+    const created = (await payload.findByID({
+      id: doc.id,
+      collection: collectionSlug,
+      depth: 0,
+      locale: 'en',
+    })) as unknown as { items: Array<{ id: string }> }
+
+    const apiKey = await getApiKey()
+    const client = await mcp.connect(apiKey)
+    const updateResponse = await client.callTool({
+      name: 'updateDocument',
+      arguments: {
+        collectionSlug,
+        data: {
+          items: [{ id: created.items[0]!.id, label: 'spanish label', rel: user.id }],
+        },
+        locale: 'es',
+        where: { title: { equals: 'bulk update' } },
+      },
+    })
+
+    expect(updateResponse.isError).toBeFalsy()
+
+    const allLocales = (await payload.findByID({
+      id: doc.id,
+      collection: collectionSlug,
+      depth: 0,
+      locale: 'all',
+    })) as unknown as LocalizedItemsAllLocales
+
+    expect(allLocales.items?.en?.[0]?.label).toBe('english label')
+    expect(allLocales.items?.es?.[0]?.label).toBe('spanish label')
+    expect(allLocales.items?.es?.[0]?.id).not.toBe(allLocales.items?.en?.[0]?.id)
+
+    await payload.delete({ id: doc.id, collection: collectionSlug })
+    await payload.delete({ id: user.id, collection: 'users' })
+  })
+})

--- a/test/plugin-mcp/payload-types.ts
+++ b/test/plugin-mcp/payload-types.ts
@@ -77,6 +77,7 @@ export interface Config {
     'returned-resources': ReturnedResource;
     pages: Page;
     'field-types': FieldType;
+    'localized-items': LocalizedItem;
     'payload-kv': PayloadKv;
     'payload-locked-documents': PayloadLockedDocument;
     'payload-preferences': PayloadPreference;
@@ -94,6 +95,7 @@ export interface Config {
     'returned-resources': ReturnedResourcesSelect<false> | ReturnedResourcesSelect<true>;
     pages: PagesSelect<false> | PagesSelect<true>;
     'field-types': FieldTypesSelect<false> | FieldTypesSelect<true>;
+    'localized-items': LocalizedItemsSelect<false> | LocalizedItemsSelect<true>;
     'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
     'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>;
@@ -451,6 +453,30 @@ export interface FieldType {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "localized-items".
+ */
+export interface LocalizedItem {
+  id: string;
+  title?: string | null;
+  items?:
+    | {
+        label?: string | null;
+        rel?: (string | null) | User;
+        id?: string | null;
+      }[]
+    | null;
+  rows?:
+    | {
+        label?: string | null;
+        rel?: (string | null) | User;
+        id?: string | null;
+      }[]
+    | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-kv".
  */
 export interface PayloadKv {
@@ -512,6 +538,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'field-types';
         value: string | FieldType;
+      } | null)
+    | ({
+        relationTo: 'localized-items';
+        value: string | LocalizedItem;
       } | null);
   globalSlug?: string | null;
   user: {
@@ -747,6 +777,29 @@ export interface FieldTypesSelect<T extends boolean = true> {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "localized-items_select".
+ */
+export interface LocalizedItemsSelect<T extends boolean = true> {
+  title?: T;
+  items?:
+    | T
+    | {
+        label?: T;
+        rel?: T;
+        id?: T;
+      };
+  rows?:
+    | T
+    | {
+        label?: T;
+        rel?: T;
+        id?: T;
+      };
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-kv_select".
  */
 export interface PayloadKvSelect<T extends boolean = true> {
@@ -850,7 +903,8 @@ export interface CollectionQueryWidget {
       | 'modified-prompts'
       | 'returned-resources'
       | 'pages'
-      | 'field-types';
+      | 'field-types'
+      | 'localized-items';
     where?:
       | {
           [k: string]: unknown;
@@ -884,6 +938,7 @@ export interface ActivityWidget {
           | 'returned-resources'
           | 'pages'
           | 'field-types'
+          | 'localized-items'
         )[]
       | null;
   };


### PR DESCRIPTION
### What?

Makes the MCP `updateDocument` / `updateGlobal` tools safe against array/block row ids that were read from a different locale: row ids inside **localized** arrays/blocks that don't belong to a row of the locale being updated are now stripped before calling `payload.update`, so Payload generates fresh ids instead of writing one row id under two locales.

### Why?

Fixes #18063.

Rows of a localized array/blocks field exist once per locale, keyed by row id — on the relational adapters they share one table whose primary key is the row id, with a `_locale` column. The natural MCP client loop (`findDocuments` → modify → `updateDocument` with another `locale`) echoes the first locale's row ids into the second locale:

- on Postgres/SQLite the update fails with the misleading `The following field is invalid: id` (unique constraint `23505` mapped by `handleUpsertError`), and the model's follow-up retries can destroy the other locale's rows and relationships;
- on MongoDB the same id is silently stored under two locales — corrupt data.

Nothing in the tool schema tells a client that row ids are per-locale (`findDocuments` returns them, and the input schema declares `id` as settable), so the plugin has to handle this, the same way it already strips virtual fields from incoming data.

### How?

- New `stripCrossLocaleRowIDs` util: walks incoming update data alongside the entity's `flattenedFields` (arrays, blocks — matched by `blockType`, groups, named tabs) and, inside any localized container, deletes row ids that don't exist in the target locale's current rows. Ids that **do** belong to the target locale are kept, so partial row updates still merge with existing row data (`getExistingRowDoc`), and ids of non-localized arrays are never touched — they're required to keep localized subfields attached to their rows.
- The collection/global update tools fetch the current document in the target locale (`depth: 0`, `fallbackLocale: false`, same `draft`/access as the update) as the reference — only when the entity actually has localized row containers (`entityHasLocalizedRowContainers`), and skip everything for `locale: "all"`. For bulk updates by `where`, one data payload applies to many documents, so there is no reference document and every such row id is stripped.
- Unit tests for the util (`stripCrossLocaleRowIDs.spec.ts`) and integration tests (`test/plugin-mcp/localizedArrays.int.spec.ts`) covering: other locales staying intact, the echoed-id repro, same-locale ids being kept, non-localized array ids being kept, and the `where` bulk path.

Without the fix, the new integration tests fail on Postgres with `The following field is invalid: id` and the row-id assertions fail on MongoDB; with it, `pnpm run test:int plugin-mcp` and `pnpm run test:int:postgres plugin-mcp` pass (233 tests each).
