### PR TITLE
fix: strip DOCTYPE before root-element check in detectSvgFromXml

### DIFF
--- a/packages/payload/src/uploads/detectSvgFromXml.spec.ts
+++ b/packages/payload/src/uploads/detectSvgFromXml.spec.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+
+import { detectSvgFromXml } from './detectSvgFromXml.js'
+
+const buf = (s: string) => Buffer.from(s, 'utf8')
+
+describe('detectSvgFromXml', () => {
+  it('detects a plain SVG', () => {
+    expect(
+      detectSvgFromXml(
+        buf('<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"></svg>'),
+      ),
+    ).toBe(true)
+  })
+
+  it('detects SVG with an XML declaration', () => {
+    expect(
+      detectSvgFromXml(
+        buf('<?xml version="1.0" encoding="UTF-8"?><svg xmlns="http://www.w3.org/2000/svg"></svg>'),
+      ),
+    ).toBe(true)
+  })
+
+  it('detects SVG with a full SVG 1.1 DOCTYPE (Illustrator/Inkscape export)', () => {
+    expect(
+      detectSvgFromXml(
+        buf(
+          '<?xml version="1.0" encoding="UTF-8" standalone="no"?>\n' +
+            '<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">\n' +
+            '<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"></svg>',
+        ),
+      ),
+    ).toBe(true)
+  })
+
+  it('detects SVG with a bare DOCTYPE', () => {
+    expect(
+      detectSvgFromXml(buf('<!DOCTYPE svg>\n<svg xmlns="http://www.w3.org/2000/svg"></svg>')),
+    ).toBe(true)
+  })
+
+  it('detects SVG with an internal DOCTYPE subset', () => {
+    expect(
+      detectSvgFromXml(
+        buf(
+          '<!DOCTYPE svg [\n  <!ENTITY ns "http://www.w3.org/2000/svg">\n]>\n' +
+            '<svg xmlns="http://www.w3.org/2000/svg"></svg>',
+        ),
+      ),
+    ).toBe(true)
+  })
+
+  it('returns false for non-SVG XML', () => {
+    expect(detectSvgFromXml(buf('<?xml version="1.0"?><root><child/></root>'))).toBe(false)
+  })
+
+  it('returns false when SVG namespace is missing', () => {
+    expect(detectSvgFromXml(buf('<svg width="10"></svg>'))).toBe(false)
+  })
+
+  it('returns false for an empty buffer', () => {
+    expect(detectSvgFromXml(buf(''))).toBe(false)
+  })
+})

--- a/packages/payload/src/uploads/detectSvgFromXml.ts
+++ b/packages/payload/src/uploads/detectSvgFromXml.ts
@@ -16,9 +16,10 @@ export function detectSvgFromXml(buffer: Buffer): boolean {
       return false
     }
 
-    // Remove XML declarations, comments, and processing instructions
+    // Remove XML declarations, DOCTYPE declarations, comments, and processing instructions
     const cleanContent = content
       .replace(/<\?xml[^>]*\?>/gi, '')
+      .replace(/<!DOCTYPE[^>[]*(?:\[[^\]]*\]\s*)?>/gi, '')
       .replace(/<!--[\s\S]*?-->/g, '')
       .replace(/<\?[^>]*\?>/g, '')
       .trim()


### PR DESCRIPTION
## What

SVGs exported from **Illustrator**, **Inkscape**, and **Affinity Designer** — with a leading DOCTYPE declaration — are rejected with `Invalid MIME type: application/xml.` even when `image/svg+xml` is in the collection's `mimeTypes` allow-list. Removing the DOCTYPE line makes the same file upload fine.

Fixes #17958

## Root cause

`detectSvgFromXml` strips XML declarations and processing instructions before checking the root element, but it did **not** strip `<!DOCTYPE ...>`. After cleanup, the buffer started with `<!DOCTYPE svg PUBLIC ...>` instead of `<svg ...>`. The root-element regex `^<(\w+)` cannot match `!`, so the function returned `false`, the `application/xml` → `image/svg+xml` coercion in `checkFileRestrictions` never fired, and the upload was rejected.

## Fix

Add a DOCTYPE strip step to the cleanup chain in `detectSvgFromXml`. The regex handles:
- `<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "...">` (Illustrator/Inkscape)
- `<!DOCTYPE svg>` (bare form)
- `<!DOCTYPE svg [ ... ]>` (internal subset form)

```diff
 const cleanContent = content
   .replace(/<\?xml[^>]*\?>/gi, '')
+  .replace(/<!DOCTYPE[^>[]*(?:\[[^\]]*\]\s*)?>/gi, '')
   .replace(/<!--[\s\S]*?-->/g, '')
   .replace(/<\?[^>]*\?>/g, '')
   .trim()
```

## Tests

Added `detectSvgFromXml.spec.ts` (8 cases): plain SVG, XML-declared SVG, full SVG 1.1 DOCTYPE, bare DOCTYPE, internal-subset DOCTYPE, non-SVG XML, missing namespace, empty buffer. All pass.