### PR TITLE
fix: preserve original error as cause on TaskError and WorkflowError

### DIFF
--- a/packages/payload/src/queues/errors/index.ts
+++ b/packages/payload/src/queues/errors/index.ts
@@ -3,6 +3,7 @@ import type { RetryConfig, TaskConfig } from '../config/types/taskTypes.js'
 import type { TaskParent } from '../operations/runJobs/runJob/getRunTaskFunction.js'
 
 export type TaskErrorArgs = {
+  cause?: unknown
   executedAt: Date
   input?: object
   job: Job
@@ -18,6 +19,7 @@ export type TaskErrorArgs = {
 }
 
 export type WorkflowErrorArgs = {
+  cause?: unknown
   job: Job
   message: string
   workflowConfig: WorkflowConfig
@@ -26,7 +28,7 @@ export type WorkflowErrorArgs = {
 export class TaskError extends Error {
   args: TaskErrorArgs
   constructor(args: TaskErrorArgs) {
-    super(args.message)
+    super(args.message, args.cause !== undefined ? { cause: args.cause } : undefined)
     this.args = args
   }
 }
@@ -34,7 +36,7 @@ export class WorkflowError extends Error {
   args: WorkflowErrorArgs
 
   constructor(args: WorkflowErrorArgs) {
-    super(args.message)
+    super(args.message, args.cause !== undefined ? { cause: args.cause } : undefined)
     this.args = args
   }
 }

--- a/packages/payload/src/queues/operations/runJobs/runJSONJob/index.ts
+++ b/packages/payload/src/queues/operations/runJobs/runJSONJob/index.ts
@@ -88,6 +88,7 @@ export const runJSONJob = async ({
         error instanceof WorkflowError
           ? error
           : new WorkflowError({
+              cause: error,
               job,
               message:
                 typeof error === 'object' && error && 'message' in error

--- a/packages/payload/src/queues/operations/runJobs/runJob/getRunTaskFunction.ts
+++ b/packages/payload/src/queues/operations/runJobs/runJob/getRunTaskFunction.ts
@@ -152,6 +152,7 @@ export const getRunTaskFunction = <TIsInline extends boolean>(
           throw err
         }
         throw new TaskError({
+          cause: err,
           executedAt,
           input: input!,
           job,

--- a/packages/payload/src/queues/operations/runJobs/runJob/index.ts
+++ b/packages/payload/src/queues/operations/runJobs/runJob/index.ts
@@ -76,6 +76,7 @@ export const runJob = async ({
         error instanceof WorkflowError
           ? error
           : new WorkflowError({
+              cause: error,
               job,
               message:
                 typeof error === 'object' && error && 'message' in error


### PR DESCRIPTION
## What

When a task or workflow handler throws, Payload wraps the error in a new `TaskError` / `WorkflowError` using only `err.message`. V8 captures a new stack at the `throw new TaskError(...)` site, so logs and `payload-jobs.log[].error` always point at Payload internals instead of the handler file.

Fixes #18055

## Root cause

`TaskError` and `WorkflowError` extend `Error` but called `super(message)` without a `cause`. The original error was discarded.

## Fix

- Add `cause?: unknown` to `TaskErrorArgs` and `WorkflowErrorArgs`
- Pass `{ cause: args.cause }` to `super()` in both constructors (ES2022 error chaining — Node 16.9+, supported by all current Payload targets)
- Thread `cause: err` at all three throw sites: `getRunTaskFunction` (task handler catch), `runJob/index` (unhandled workflow error), `runJSONJob/index` (unhandled workflow error)

After this change, `error.cause` holds the original handler error with its original stack. pino, winston, and `console.error` all surface the cause chain automatically.

```
TaskError: Cannot read properties of undefined (reading 'id')
    at getRunTaskFunction.ts:154
    ...Payload internals...
  [cause]: TypeError: Cannot read properties of undefined (reading 'id')
    at myTaskHandler (app/jobs/myTask.ts:42:18)   ← now visible
    at async runner (...)
```