### PR TITLE
fix: read draft query in me endpoint

### DIFF
--- a/packages/payload/src/auth/endpoints/me.spec.ts
+++ b/packages/payload/src/auth/endpoints/me.spec.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { PayloadRequest } from '../../types/index.js'
+
+const { meOperationMock } = vi.hoisted(() => ({
+  meOperationMock: vi.fn(),
+}))
+
+vi.mock('../../utilities/getRequestEntity.js', () => ({
+  getRequestCollection: () => ({
+    config: {
+      auth: {
+        removeTokenFromResponses: false,
+      },
+    },
+  }),
+}))
+
+vi.mock('../../utilities/headersWithCors.js', () => ({
+  headersWithCors: () => new Headers(),
+}))
+
+vi.mock('../extractJWT.js', () => ({
+  extractJWT: () => 'token',
+}))
+
+vi.mock('../operations/me.js', () => ({
+  meOperation: meOperationMock,
+}))
+
+import { meHandler } from './me.js'
+
+describe('meHandler', () => {
+  beforeEach(() => {
+    meOperationMock.mockReset()
+    meOperationMock.mockResolvedValue({ user: {} })
+  })
+
+  it('should read draft from URL search parameters', async () => {
+    const req = {
+      query: {},
+      searchParams: new URLSearchParams('draft=true'),
+      t: () => 'account',
+    } as unknown as PayloadRequest
+
+    await meHandler(req)
+
+    expect(meOperationMock).toHaveBeenCalledWith(expect.objectContaining({ draft: true }))
+  })
+})

--- a/packages/payload/src/auth/endpoints/me.ts
+++ b/packages/payload/src/auth/endpoints/me.ts
@@ -17,7 +17,7 @@ export const meHandler: PayloadHandler = async (req) => {
   const collection = getRequestCollection(req)
   const currentToken = extractJWT(req)
   const depthFromSearchParams = searchParams.get('depth')
-  const draftFromSearchParams = searchParams.get('depth')
+  const draftFromSearchParams = searchParams.get('draft')
 
   const {
     depth: depthFromQuery,


### PR DESCRIPTION
### What?

- Corrects the authenticated `me` endpoint's URL search-parameter fallback for `draft`
- Adds a unit regression test covering requests where `draft` is present in `URLSearchParams` but not `req.query`

### Why?

The handler initialized `draftFromSearchParams` with `searchParams.get('depth')`. Adapters that rely on the standard search-parameter representation therefore passed `draft: false` to `meOperation` for `?draft=true`.

### How?

The fallback now reads `searchParams.get('draft')`. The regression test invokes the handler with `new URLSearchParams('draft=true')` and verifies that `meOperation` receives `draft: true`.

Validation:

- Focused regression test passed
- Full unit suite passed: 214 files, 2,259 tests (4 skipped)
- Payload package and translation dependency build passed through `pnpm build:payload`
- ESLint, Prettier, and `git diff --check` passed for the changed files

The same typo is present on `3.x`; this PR targets `main` per the repository's v4 development guidance and can be backported separately.

Fixes #18072
