### PR TITLE
fix: me endpoint reads depth instead of draft from URLSearchParams

### DIFF
--- a/packages/payload/src/auth/endpoints/me.spec.ts
+++ b/packages/payload/src/auth/endpoints/me.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from 'vitest'
+
+// Intercept meOperation before the module under test imports it
+vi.mock('../operations/me.js', () => ({
+  meOperation: vi.fn().mockResolvedValue({ user: { id: '1' }, token: 'tok' }),
+}))
+
+vi.mock('../../utilities/getRequestEntity.js', () => ({
+  getRequestCollection: vi.fn().mockReturnValue({
+    config: { auth: { removeTokenFromResponses: false } },
+  }),
+}))
+
+vi.mock('../extractJWT.js', () => ({ extractJWT: vi.fn().mockReturnValue('tok') }))
+vi.mock('../../utilities/headersWithCors.js', () => ({
+  headersWithCors: vi.fn().mockReturnValue(new Headers()),
+}))
+vi.mock('../../utilities/sanitizeJoinParams.js', () => ({ sanitizeJoinParams: vi.fn() }))
+vi.mock('../../utilities/sanitizePopulateParam.js', () => ({ sanitizePopulateParam: vi.fn() }))
+vi.mock('../../utilities/sanitizeSelectParam.js', () => ({ sanitizeSelectParam: vi.fn() }))
+
+import { meOperation } from '../operations/me.js'
+import { meHandler } from './me.js'
+
+const makeReq = (search: string) =>
+  ({
+    searchParams: new URLSearchParams(search),
+    query: {},
+    t: (k: string) => k,
+    headers: new Headers(),
+    payload: { config: {} },
+  }) as any
+
+describe('meHandler — searchParams parsing', () => {
+  it('passes draft=true when ?draft=true is in searchParams', async () => {
+    await meHandler(makeReq('draft=true'), {} as any)
+    expect(meOperation).toHaveBeenCalledWith(expect.objectContaining({ draft: true }))
+  })
+
+  it('passes draft=false when ?draft is absent', async () => {
+    await meHandler(makeReq(''), {} as any)
+    expect(meOperation).toHaveBeenCalledWith(expect.objectContaining({ draft: false }))
+  })
+
+  it('passes draft=false when only ?depth is present (regression: was reading depth for draft)', async () => {
+    await meHandler(makeReq('depth=2'), {} as any)
+    expect(meOperation).toHaveBeenCalledWith(expect.objectContaining({ draft: false }))
+  })
+})

--- a/packages/payload/src/auth/endpoints/me.ts
+++ b/packages/payload/src/auth/endpoints/me.ts
@@ -17,7 +17,7 @@ export const meHandler: PayloadHandler = async (req) => {
   const collection = getRequestCollection(req)
   const currentToken = extractJWT(req)
   const depthFromSearchParams = searchParams.get('depth')
-  const draftFromSearchParams = searchParams.get('depth')
+  const draftFromSearchParams = searchParams.get('draft')
 
   const {
     depth: depthFromQuery,


### PR DESCRIPTION
## What

The `meHandler` always passed `draft: false` to `meOperation` when `draft` was supplied through `URLSearchParams` rather than `req.query`. Adapters that populate the standard `URLSearchParams` interface without duplicating values into `req.query` were silently broken.

Fixes #18072

## Root cause

Copy-paste typo on line 20 of `packages/payload/src/auth/endpoints/me.ts` — both search-param reads pulled from `'depth'`:

```ts
// Before (line 19-20)
const depthFromSearchParams = searchParams.get('depth')
const draftFromSearchParams = searchParams.get('depth')  // ← wrong key

// After
const depthFromSearchParams = searchParams.get('depth')
const draftFromSearchParams = searchParams.get('draft')  // ← correct
```

## Tests

Adds `me.spec.ts` with three cases:
- `?draft=true` in `searchParams` → `meOperation` receives `draft: true`
- No `draft` param → `draft: false`
- `?depth=2` only → `draft: false` (regression guard for the original typo)

All three pass.