### PR TITLE
fix: load authenticated user documents in the request locale

### DIFF
--- a/packages/payload/src/auth/operations/auth.ts
+++ b/packages/payload/src/auth/operations/auth.ts
@@ -1,4 +1,4 @@
-import type { AuthenticatedUser, SanitizedPermissions } from '../../index.js'
+import type { AuthenticatedUser, SanitizedPermissions, TypedLocale } from '../../index.js'
 import type { PayloadRequest } from '../../types/index.js'
 
 import { executeAuthStrategies } from '../executeAuthStrategies.js'
@@ -9,7 +9,17 @@ export type AuthArgs = {
    * Specify if it's possible for auth strategies to set headers within this operation.
    */
   canSetHeaders?: boolean
+  /**
+   * Fallback locale used when loading the authenticated user document.
+   * Applied via `createLocalReq` for Local API calls.
+   */
+  fallbackLocale?: false | TypedLocale
   headers: Request['headers']
+  /**
+   * Locale used when loading the authenticated user document.
+   * Applied via `createLocalReq` for Local API calls.
+   */
+  locale?: 'all' | TypedLocale
   req?: Omit<PayloadRequest, 'user'>
 }
 
@@ -19,14 +29,20 @@ export type AuthResult = {
   user: AuthenticatedUser | null
 }
 
-export const auth = async (args: Required<AuthArgs>): Promise<AuthResult> => {
+export const auth = async (args: {
+  canSetHeaders?: boolean
+  headers: Request['headers']
+  req: PayloadRequest
+}): Promise<AuthResult> => {
   const { canSetHeaders, headers } = args
-  const req = args.req as PayloadRequest
+  const req = args.req
   const { payload } = req
 
   const { responseHeaders, user } = await executeAuthStrategies({
     canSetHeaders,
+    fallbackLocale: req.fallbackLocale,
     headers,
+    locale: req.locale,
     payload,
   })
 

--- a/packages/payload/src/auth/operations/auth.ts
+++ b/packages/payload/src/auth/operations/auth.ts
@@ -9,16 +9,8 @@ export type AuthArgs = {
    * Specify if it's possible for auth strategies to set headers within this operation.
    */
   canSetHeaders?: boolean
-  /**
-   * Fallback locale used when loading the authenticated user document.
-   * Applied via `createLocalReq` for Local API calls.
-   */
   fallbackLocale?: false | TypedLocale
   headers: Request['headers']
-  /**
-   * Locale used when loading the authenticated user document.
-   * Applied via `createLocalReq` for Local API calls.
-   */
   locale?: 'all' | TypedLocale
   req?: Omit<PayloadRequest, 'user'>
 }

--- a/packages/payload/src/auth/operations/local/auth.ts
+++ b/packages/payload/src/auth/operations/local/auth.ts
@@ -10,6 +10,6 @@ export const authLocal = async (payload: Payload, options: AuthArgs): Promise<Au
   return await authOperation({
     canSetHeaders: Boolean(options.canSetHeaders),
     headers,
-    req: await createLocalReq({ fallbackLocale, locale, req }, payload),
+    req: await createLocalReq({ fallbackLocale, locale: locale ?? undefined, req }, payload),
   })
 }

--- a/packages/payload/src/auth/operations/local/auth.ts
+++ b/packages/payload/src/auth/operations/local/auth.ts
@@ -5,11 +5,11 @@ import { createLocalReq } from '../../../utilities/createLocalReq.js'
 import { auth as authOperation } from '../auth.js'
 
 export const authLocal = async (payload: Payload, options: AuthArgs): Promise<AuthResult> => {
-  const { headers, req } = options
+  const { fallbackLocale, headers, locale, req } = options
 
   return await authOperation({
     canSetHeaders: Boolean(options.canSetHeaders),
     headers,
-    req: await createLocalReq({ req }, payload),
+    req: await createLocalReq({ fallbackLocale, locale, req }, payload),
   })
 }

--- a/packages/payload/src/auth/strategies/apiKey.ts
+++ b/packages/payload/src/auth/strategies/apiKey.ts
@@ -7,7 +7,7 @@ import type { AuthStrategyFunction } from '../index.js'
 
 export const APIKeyAuthentication =
   (collectionConfig: SanitizedCollectionConfig): AuthStrategyFunction =>
-  async ({ headers, isGraphQL = false, payload }) => {
+  async ({ fallbackLocale, headers, isGraphQL = false, locale, payload }) => {
     const authHeader = headers.get('Authorization')
 
     if (authHeader?.startsWith(`${collectionConfig.slug} API-Key `)) {
@@ -41,7 +41,9 @@ export const APIKeyAuthentication =
         const userQuery = await payload.find({
           collection: collectionConfig.slug,
           depth: isGraphQL ? 0 : collectionConfig.auth.depth,
+          fallbackLocale,
           limit: 1,
+          locale,
           overrideAccess: true,
           pagination: false,
           where,

--- a/packages/payload/src/auth/strategies/jwt.ts
+++ b/packages/payload/src/auth/strategies/jwt.ts
@@ -1,7 +1,11 @@
 import { jwtVerify } from 'jose'
 
 import type { Payload, Where } from '../../types/index.js'
-import type { AuthStrategyFunction, AuthStrategyResult } from '../index.js'
+import type {
+  AuthStrategyFunction,
+  AuthStrategyFunctionArgs,
+  AuthStrategyResult,
+} from '../index.js'
 
 import { extractJWT } from '../extractJWT.js'
 
@@ -39,11 +43,15 @@ async function verifyWithKeyring({
 }
 
 async function autoLogin({
+  fallbackLocale,
   isGraphQL,
+  locale,
   payload,
   strategyName = 'local-jwt',
 }: {
+  fallbackLocale?: AuthStrategyFunctionArgs['fallbackLocale']
   isGraphQL: boolean
+  locale?: AuthStrategyFunctionArgs['locale']
   payload: Payload
   strategyName?: string
 }): Promise<{
@@ -81,7 +89,9 @@ async function autoLogin({
     await payload.find({
       collection: collection!.config.slug,
       depth: isGraphQL ? 0 : collection!.config.auth.depth,
+      fallbackLocale,
       limit: 1,
+      locale,
       pagination: false,
       where,
     })
@@ -102,8 +112,10 @@ async function autoLogin({
  * Authentication strategy function for JWT tokens
  */
 export const JWTAuthentication: AuthStrategyFunction = async ({
+  fallbackLocale,
   headers,
   isGraphQL = false,
+  locale,
   payload,
   strategyName = 'local-jwt',
 }) => {
@@ -112,7 +124,7 @@ export const JWTAuthentication: AuthStrategyFunction = async ({
 
     if (!token) {
       if (headers.get('DisableAutologin') !== 'true') {
-        return await autoLogin({ isGraphQL, payload, strategyName })
+        return await autoLogin({ fallbackLocale, isGraphQL, locale, payload, strategyName })
       }
       return { user: null }
     }
@@ -127,6 +139,8 @@ export const JWTAuthentication: AuthStrategyFunction = async ({
       id: decodedPayload.id,
       collection: decodedPayload.collection,
       depth: isGraphQL ? 0 : collection!.config.auth.depth,
+      fallbackLocale,
+      locale,
     })) as AuthStrategyResult['user']
 
     if (user && (!collection!.config.auth.verify || user._verified)) {
@@ -149,13 +163,13 @@ export const JWTAuthentication: AuthStrategyFunction = async ({
       }
     } else {
       if (headers.get('DisableAutologin') !== 'true') {
-        return await autoLogin({ isGraphQL, payload, strategyName })
+        return await autoLogin({ fallbackLocale, isGraphQL, locale, payload, strategyName })
       }
       return { user: null }
     }
   } catch (ignore) {
     if (headers.get('DisableAutologin') !== 'true') {
-      return await autoLogin({ isGraphQL, payload, strategyName })
+      return await autoLogin({ fallbackLocale, isGraphQL, locale, payload, strategyName })
     }
     return { user: null }
   }

--- a/packages/payload/src/auth/types.ts
+++ b/packages/payload/src/auth/types.ts
@@ -1,4 +1,11 @@
-import type { CollectionSlug, GlobalSlug, Payload, User } from '../index.js'
+import type {
+  CollectionSlug,
+  GlobalSlug,
+  Payload,
+  TypedFallbackLocale,
+  TypedLocale,
+  User,
+} from '../index.js'
 import type { PayloadRequest, Where } from '../types/index.js'
 
 /**
@@ -179,8 +186,18 @@ export type AuthStrategyFunctionArgs = {
    * Specifies whether or not response headers can be set from this strategy.
    */
   canSetHeaders?: boolean
+  /**
+   * Fallback locale to use when a localized field is missing in `locale`.
+   * Forwarded to Local API user lookups inside strategies.
+   */
+  fallbackLocale?: TypedFallbackLocale
   headers: Request['headers']
   isGraphQL?: boolean
+  /**
+   * Locale used when loading the authenticated user document.
+   * Forwarded to Local API user lookups inside strategies.
+   */
+  locale?: 'all' | TypedLocale
   payload: Payload
   /**
    * The AuthStrategy name property from the payload config.

--- a/packages/payload/src/auth/types.ts
+++ b/packages/payload/src/auth/types.ts
@@ -186,17 +186,9 @@ export type AuthStrategyFunctionArgs = {
    * Specifies whether or not response headers can be set from this strategy.
    */
   canSetHeaders?: boolean
-  /**
-   * Fallback locale to use when a localized field is missing in `locale`.
-   * Forwarded to Local API user lookups inside strategies.
-   */
   fallbackLocale?: TypedFallbackLocale
   headers: Request['headers']
   isGraphQL?: boolean
-  /**
-   * Locale used when loading the authenticated user document.
-   * Forwarded to Local API user lookups inside strategies.
-   */
   locale?: 'all' | TypedLocale
   payload: Payload
   /**

--- a/packages/payload/src/utilities/createPayloadRequest.ts
+++ b/packages/payload/src/utilities/createPayloadRequest.ts
@@ -124,8 +124,10 @@ export const createPayloadRequest = async ({
 
   const { responseHeaders, user } = await executeAuthStrategies({
     canSetHeaders,
+    fallbackLocale: fallbackLocale || undefined,
     headers: req.headers,
     isGraphQL,
+    locale: locale || undefined,
     payload,
   })
 

--- a/packages/tanstack-start/src/utilities/initReq.server.ts
+++ b/packages/tanstack-start/src/utilities/initReq.server.ts
@@ -59,13 +59,6 @@ export async function initReq({
     language: languageCode,
   })
 
-  const { responseHeaders, user } = await executeAuthStrategies({
-    headers,
-    payload,
-  })
-
-  const { req: reqOverrides, ...optionsOverrides } = overrides || {}
-
   // Parse the active URL's query string so that `req.query` (and thus
   // `getRequestLocale`, access checks, etc.) reflect things like `?locale=es`
   // even when the caller (e.g. the root layout loader) hasn't explicitly
@@ -83,6 +76,16 @@ export async function initReq({
   } catch {
     queryFromUrl = undefined
   }
+
+  const queryLocale = typeof queryFromUrl?.locale === 'string' ? queryFromUrl.locale : undefined
+
+  const { responseHeaders, user } = await executeAuthStrategies({
+    headers,
+    locale: queryLocale,
+    payload,
+  })
+
+  const { req: reqOverrides, ...optionsOverrides } = overrides || {}
 
   const req = await createLocalReq(
     {

--- a/packages/ui/src/utilities/initReq.ts
+++ b/packages/ui/src/utilities/initReq.ts
@@ -69,6 +69,7 @@ export const initReq = async function ({
     const { responseHeaders, user } = await executeAuthStrategies({
       canSetHeaders,
       headers,
+      locale: typeof overrides?.locale === 'string' ? overrides.locale : undefined,
       payload,
     })
 

--- a/test/localization/auth.int.spec.ts
+++ b/test/localization/auth.int.spec.ts
@@ -1,0 +1,98 @@
+import type { Payload } from 'payload'
+
+import path from 'path'
+import { createLocalReq } from 'payload'
+import { fileURLToPath } from 'url'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import type { NextRESTClient } from '../__helpers/shared/NextRESTClient.js'
+
+import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
+import { devUser } from '../credentials.js'
+import { spanishLocale, usersSlug } from './shared.js'
+
+const englishName = 'English Name'
+const spanishName = 'Nombre Español'
+
+let payload: Payload
+let restClient: NextRESTClient
+let token: string
+let userId: number | string
+
+const filename = fileURLToPath(import.meta.url)
+const dirname = path.dirname(filename)
+
+describe('Auth localization', () => {
+  beforeAll(async () => {
+    ;({ payload, restClient } = await initPayloadInt(dirname))
+
+    const user = (
+      await payload.find({
+        collection: usersSlug,
+        limit: 1,
+        where: { email: { equals: devUser.email } },
+      })
+    ).docs[0]
+
+    if (!user) {
+      throw new Error('Expected localization seed to create the dev user')
+    }
+
+    userId = user.id
+
+    await payload.update({
+      id: userId,
+      collection: usersSlug,
+      data: { name: englishName },
+      locale: 'en',
+    })
+
+    await payload.update({
+      id: userId,
+      collection: usersSlug,
+      data: { name: spanishName },
+      locale: spanishLocale,
+    })
+
+    const login = await restClient.login({ slug: usersSlug })
+    token = login.token
+  })
+
+  afterAll(async () => {
+    await payload.destroy()
+  })
+
+  it('returns localized user fields from payload.auth() when req.locale is set', async () => {
+    const req = await createLocalReq({ locale: spanishLocale }, payload)
+    const { user } = await payload.auth({
+      headers: new Headers({
+        Authorization: `JWT ${token}`,
+      }),
+      req,
+    })
+
+    expect(user?.name).toBe(spanishName)
+  })
+
+  it('returns localized user fields from payload.auth() when locale is passed on AuthArgs', async () => {
+    const { user } = await payload.auth({
+      headers: new Headers({
+        Authorization: `JWT ${token}`,
+      }),
+      locale: spanishLocale,
+    })
+
+    expect(user?.name).toBe(spanishName)
+  })
+
+  it('loads req.user in the request locale on HTTP requests', async () => {
+    const data = await restClient
+      .GET('/whoami', {
+        query: { locale: spanishLocale },
+      })
+      .then((res) => res.json())
+
+    expect(data.locale).toBe(spanishLocale)
+    expect(data.name).toBe(spanishName)
+  })
+})

--- a/test/localization/config.ts
+++ b/test/localization/config.ts
@@ -64,6 +64,17 @@ export default buildConfigWithDefaults({
       baseDir: path.resolve(dirname),
     },
   },
+  endpoints: [
+    {
+      handler: (req) =>
+        Response.json({
+          locale: req.locale,
+          name: req.user && 'name' in req.user ? req.user.name : null,
+        }),
+      method: 'get',
+      path: '/whoami',
+    },
+  ],
   collections: [
     RichTextCollection,
     BlocksCollection,
@@ -81,6 +92,7 @@ export default buildConfigWithDefaults({
         {
           name: 'name',
           label: { en: 'Full name' },
+          localized: true,
           type: 'text',
         },
         {


### PR DESCRIPTION
### What?

`payload.auth()` and `req.user` now return localized fields on the auth collection in the request locale instead of always using `defaultLocale`.

### Why?

JWT and API-key strategies loaded the user with a bare `findByID` / `find` and never received `locale`. `auth()` / `createPayloadRequest` already knew the locale on `req`, but did not pass it into `executeAuthStrategies`. `AuthStrategyFunctionArgs` had no locale fields.

That meant `createLocalReq({ locale: 'es' })` and `?locale=es` were ignored for the authenticated user document. `/me` already worked because `meOperation` re-fetches with `req`.

Fixes #18081

### How?

- Add `locale` and `fallbackLocale` to `AuthStrategyFunctionArgs`
- Forward them from `auth()`, `createPayloadRequest`, TanStack `initReq` (`?locale=`), and admin `initReq` (overrides)
- Pass them through JWT `findByID` / autologin `find` and API-key `find`
- Accept `locale` / `fallbackLocale` on Local API `payload.auth()` via `createLocalReq`

```ts
const { user } = await payload.auth({
  headers,
  locale: 'es',
})
```

### Test plan

- [x] `pnpm test:int localization/auth` — `payload.auth({ req })`, `payload.auth({ locale })`, and HTTP `req.user` (`GET /api/whoami?locale=es`)
- [x] `pnpm test:int field-access-context` — existing `payload.auth()` callers still work

Made with [Cursor](https://cursor.com)