### PR TITLE
chore: cleanup stale todo

### DIFF
--- a/packages/ui/src/providers/TableColumns/buildColumnState/index.tsx
+++ b/packages/ui/src/providers/TableColumns/buildColumnState/index.tsx
@@ -194,8 +194,7 @@ export const buildColumnState = (args: BuildColumnStateArgs): Column[] => {
           ? serverField.admin.components.Label
           : undefined
 
-      // TODO: customComponent will be optional in v4
-      const clientProps: Omit<ClientComponentProps, 'customComponents'> = {
+      const clientProps: ClientComponentProps = {
         field: clientField,
       }
 


### PR DESCRIPTION
Cleans up V4 todo that is no longer necessary because:

- `ClientComponentProps.customComponents` has already been optional since v3.18.0
- The current v3.88.0 and v4 code both declare `customComponents?` as optional