### PR TITLE
fix(drizzle): align localized status schema with migration

### DIFF
--- a/packages/drizzle/src/schema/traverseFields.ts
+++ b/packages/drizzle/src/schema/traverseFields.ts
@@ -771,6 +771,13 @@ export const traverseFields = ({
 
       case 'radio':
       case 'select': {
+        const isLocalized =
+          Boolean(isFieldLocalized && adapter.payload.config.localization) ||
+          withinLocalizedArrayOrBlock ||
+          forceLocalized
+
+        const isLocalizedVersionStatusField = field.name === '_status' && isLocalized
+
         const enumName = createTableName({
           adapter,
           config: field,
@@ -849,11 +856,6 @@ export const traverseFields = ({
             },
           }
 
-          const isLocalized =
-            Boolean(isFieldLocalized && adapter.payload.config.localization) ||
-            withinLocalizedArrayOrBlock ||
-            forceLocalized
-
           if (isLocalized) {
             baseColumns.locale = {
               name: 'locale',
@@ -914,12 +916,17 @@ export const traverseFields = ({
           }
         } else {
           targetTable[fieldName] = withDefault(
-            {
-              name: columnName,
-              type: 'enum',
-              enumName,
-              options,
-            },
+            isLocalizedVersionStatusField
+              ? {
+                  name: columnName,
+                  type: 'varchar',
+                }
+              : {
+                  name: columnName,
+                  type: 'enum',
+                  enumName,
+                  options,
+                },
             field,
           )
         }

--- a/packages/payload/src/fields/mergeBaseFields.ts
+++ b/packages/payload/src/fields/mergeBaseFields.ts
@@ -3,6 +3,21 @@ import type { Field, FieldWithSubFields } from './config/types.js'
 import { deepMergeWithReactComponents } from '../utilities/deepMerge.js'
 import { fieldAffectsData, fieldHasSubFields } from './config/types.js'
 
+const shouldOverrideMergedOptions = ({
+  baseField,
+  matchedField,
+}: {
+  baseField: Field
+  matchedField: Field
+}) => {
+  return (
+    (baseField.type === 'radio' || baseField.type === 'select') &&
+    (matchedField.type === 'radio' || matchedField.type === 'select') &&
+    'options' in matchedField &&
+    Array.isArray(matchedField.options)
+  )
+}
+
 export const mergeBaseFields = (fields: Field[], baseFields: Field[]): Field[] => {
   const mergedFields = [...(fields || [])]
 
@@ -24,6 +39,10 @@ export const mergeBaseFields = (fields: Field[], baseFields: Field[]): Field[] =
         mergedFields.splice(matchedIndex!, 1)
 
         const mergedField = deepMergeWithReactComponents<Field>(baseField, matchCopy)
+
+        if (shouldOverrideMergedOptions({ baseField, matchedField: matchCopy })) {
+          mergedField.options = matchCopy.options
+        }
 
         if (fieldHasSubFields(baseField) && fieldHasSubFields(matchCopy)) {
           ;(mergedField as FieldWithSubFields).fields = mergeBaseFields(

--- a/packages/payload/src/fields/mergeBaseFields.ts
+++ b/packages/payload/src/fields/mergeBaseFields.ts
@@ -1,22 +1,10 @@
-import type { Field, FieldWithSubFields } from './config/types.js'
+import type { Field, FieldWithSubFields, RadioField, SelectField } from './config/types.js'
 
 import { deepMergeWithReactComponents } from '../utilities/deepMerge.js'
 import { fieldAffectsData, fieldHasSubFields } from './config/types.js'
 
-const shouldOverrideMergedOptions = ({
-  baseField,
-  matchedField,
-}: {
-  baseField: Field
-  matchedField: Field
-}) => {
-  return (
-    (baseField.type === 'radio' || baseField.type === 'select') &&
-    (matchedField.type === 'radio' || matchedField.type === 'select') &&
-    'options' in matchedField &&
-    Array.isArray(matchedField.options)
-  )
-}
+const fieldHasOptions = (field: Field): field is RadioField | SelectField =>
+  (field.type === 'radio' || field.type === 'select') && Array.isArray(field.options)
 
 export const mergeBaseFields = (fields: Field[], baseFields: Field[]): Field[] => {
   const mergedFields = [...(fields || [])]
@@ -40,8 +28,8 @@ export const mergeBaseFields = (fields: Field[], baseFields: Field[]): Field[] =
 
         const mergedField = deepMergeWithReactComponents<Field>(baseField, matchCopy)
 
-        if (shouldOverrideMergedOptions({ baseField, matchedField: matchCopy })) {
-          mergedField.options = matchCopy.options
+        if (fieldHasOptions(baseField) && fieldHasOptions(matchCopy)) {
+          ;(mergedField as RadioField | SelectField).options = matchCopy.options
         }
 
         if (fieldHasSubFields(baseField) && fieldHasSubFields(matchCopy)) {

--- a/test/database/getConfig.ts
+++ b/test/database/getConfig.ts
@@ -51,6 +51,20 @@ export const getConfig: () => Partial<Config> = () => ({
       slug: 'categories',
       fields: [
         {
+          name: '_status',
+          type: 'select',
+          options: [
+            {
+              label: 'Draft',
+              value: 'draft',
+            },
+            {
+              label: 'Published',
+              value: 'published',
+            },
+          ],
+        },
+        {
           name: 'title',
           type: 'text',
         },

--- a/test/database/int.spec.ts
+++ b/test/database/int.spec.ts
@@ -3356,6 +3356,28 @@ test.suite({ config: './config.ts' })('database', () => {
       }
     })
 
+    test('should not duplicate explicitly defined draft status options', async ({ payload }) => {
+      const generatedAdapterName = process.env.PAYLOAD_DATABASE
+      if (!generatedAdapterName?.includes('postgres') && generatedAdapterName !== 'supabase') {
+        return
+      }
+
+      const outputFile = path.resolve(dirname, `${generatedAdapterName}.generated-schema.ts`)
+
+      await payload.db.generateSchema({
+        outputFile,
+      })
+
+      const generatedSchema = fs.readFileSync(outputFile, 'utf-8')
+
+      expect(generatedSchema).not.toMatch(
+        /enum_categories_status[\s\S]*'draft',\s*'published',\s*'draft',\s*'published'/,
+      )
+      expect(generatedSchema).not.toMatch(
+        /enum__categories_v_version_status[\s\S]*'draft',\s*'published',\s*'draft',\s*'published'/,
+      )
+    })
+
     test('should generate Drizzle SQLite schema', async ({ payload }) => {
       const generatedAdapterName = process.env.PAYLOAD_DATABASE
       if (!generatedAdapterName?.includes('sqlite')) {

--- a/test/localization/localizeStatus.int.spec.ts
+++ b/test/localization/localizeStatus.int.spec.ts
@@ -5,12 +5,18 @@ import { sql } from '@payloadcms/db-postgres'
 import { migratePostgresLocalizeStatus } from '@payloadcms/db-postgres/migration-utils'
 import { migrateSqliteLocalizeStatus } from '@payloadcms/db-sqlite/migration-utils'
 import { sql as drizzleSql } from 'drizzle-orm'
+import fs from 'fs/promises'
 import { Types } from 'mongoose'
+import path from 'path'
 import { wait } from 'payload/shared'
 import { fileURLToPath } from 'url'
 import { expect } from 'vitest'
 
 import { test } from '../__helpers/int/vitest.js'
+
+const filename = fileURLToPath(import.meta.url)
+const dirname = path.dirname(filename)
+const generatedSchemaFile = path.resolve(dirname, 'generated-localize-status-schema.ts')
 
 test.suite({ config: './localizeStatus.config.ts' })('localizeStatus migration', () => {
   test.beforeEach(async () => {
@@ -19,6 +25,10 @@ test.suite({ config: './localizeStatus.config.ts' })('localizeStatus migration',
       // "Unable to write to collection due to catalog changes" errors
       await wait(1000)
     }
+  })
+
+  test.afterEach(async () => {
+    await fs.rm(generatedSchemaFile, { force: true })
   })
 
   test.options({ db: (adapter) => adapter === 'postgres' }).describe('PostgreSQL', () => {
@@ -266,6 +276,104 @@ test.suite({ config: './localizeStatus.config.ts' })('localizeStatus migration',
           expect(row._status).toBeDefined()
           expect(['draft', 'published']).toContain(row._status)
         })
+      })
+
+      test('should generate varchar columns for localized status after the Postgres migration', async ({
+        payload,
+      }) => {
+        const db = payload.db
+
+        const articleResult = await db.drizzle.execute(sql`
+          INSERT INTO test_migration_articles (_status, created_at, updated_at)
+          VALUES ('draft', NOW(), NOW())
+          RETURNING id
+        `)
+        const articleId = articleResult.rows[0].id
+
+        await db.drizzle.execute(sql`
+          INSERT INTO test_migration_articles_locales (_locale, _parent_id, title)
+          VALUES
+            ('en', ${articleId}, 'English Title'),
+            ('es', ${articleId}, 'Título Español'),
+            ('de', ${articleId}, 'German Title')
+        `)
+
+        const draftVersionResult = await db.drizzle.execute(sql`
+          INSERT INTO _test_migration_articles_v (parent_id, version__status, created_at, updated_at)
+          VALUES (${articleId}, 'draft', NOW(), NOW())
+          RETURNING id
+        `)
+        const draftVersionId = draftVersionResult.rows[0].id
+
+        for (const locale of ['en', 'es', 'de']) {
+          await db.drizzle.execute(sql`
+            INSERT INTO _test_migration_articles_v_locales (_locale, _parent_id)
+            VALUES (${locale}, ${draftVersionId})
+          `)
+        }
+
+        const publishedVersionResult = await db.drizzle.execute(sql`
+          INSERT INTO _test_migration_articles_v (parent_id, version__status, created_at, updated_at)
+          VALUES (${articleId}, 'published', NOW() + INTERVAL '1 second', NOW() + INTERVAL '1 second')
+          RETURNING id
+        `)
+        const publishedVersionId = publishedVersionResult.rows[0].id
+
+        for (const locale of ['en', 'es', 'de']) {
+          await db.drizzle.execute(sql`
+            INSERT INTO _test_migration_articles_v_locales (_locale, _parent_id)
+            VALUES (${locale}, ${publishedVersionId})
+          `)
+        }
+
+        await migratePostgresLocalizeStatus({
+          collectionSlug: 'testMigrationArticles',
+          db,
+          payload,
+          sql,
+        })
+
+        const columnTypes = await db.drizzle.execute(sql`
+          SELECT table_name, column_name, data_type
+          FROM information_schema.columns
+          WHERE table_schema = 'public'
+            AND (
+              (table_name = 'test_migration_articles_locales' AND column_name = '_status')
+              OR (table_name = '_test_migration_articles_v_locales' AND column_name = 'version__status')
+            )
+          ORDER BY table_name ASC, column_name ASC
+        `)
+
+        expect(columnTypes.rows).toEqual([
+          {
+            column_name: 'version__status',
+            data_type: 'character varying',
+            table_name: '_test_migration_articles_v_locales',
+          },
+          {
+            column_name: '_status',
+            data_type: 'character varying',
+            table_name: 'test_migration_articles_locales',
+          },
+        ])
+
+        await payload.db.generateSchema({
+          log: false,
+          outputFile: generatedSchemaFile,
+        })
+
+        const generatedSchema = await fs.readFile(generatedSchemaFile, 'utf-8')
+
+        expect(generatedSchema).not.toContain('export const enum_test_migration_articles_status')
+        expect(generatedSchema).not.toContain(
+          'export const enum__test_migration_articles_v_version_status',
+        )
+        expect(generatedSchema).toMatch(
+          /'_test_migration_articles_v_locales'[\s\S]*version__status: varchar\('version__status'/,
+        )
+        expect(generatedSchema).toMatch(
+          /'test_migration_articles_locales'[\s\S]*_status: varchar\('_status'/,
+        )
       })
     })
 


### PR DESCRIPTION
Fixes https://github.com/payloadcms/payload/issues/17738

## Summary
- prevent duplicate `_status` enum options when a drafts collection explicitly configures the status field
- generate localized draft status columns as `varchar` to match the Postgres localize-status migration
- add schema-generation and migration regression coverage for #17738

## Testing
- `pnpm run test:int:postgres localization` — 125 passed / 6 skipped
- `pnpm run test:int:postgres` for `test/database/int.spec.ts` — 160 passed / 17 skipped
- `pnpm run test:int:postgres` for `test/versions` + `test/fields` — 315 passed / 10 skipped
- Both new tests verified to fail without the `mergeBaseFields` fix
- `pnpm run build:core`, `pnpm run test:types`, `pnpm exec prettier --check` all pass