### PR TITLE
fix(drizzle): align localized status schema with migration

### DIFF
--- a/packages/drizzle/src/schema/traverseFields.ts
+++ b/packages/drizzle/src/schema/traverseFields.ts
@@ -768,6 +768,13 @@ export const traverseFields = ({
 
       case 'radio':
       case 'select': {
+        const isLocalized =
+          Boolean(isFieldLocalized && adapter.payload.config.localization) ||
+          withinLocalizedArrayOrBlock ||
+          forceLocalized
+
+        const isLocalizedVersionStatusField = field.name === '_status' && isLocalized
+
         const enumName = createTableName({
           adapter,
           config: field,
@@ -846,11 +853,6 @@ export const traverseFields = ({
             },
           }
 
-          const isLocalized =
-            Boolean(isFieldLocalized && adapter.payload.config.localization) ||
-            withinLocalizedArrayOrBlock ||
-            forceLocalized
-
           if (isLocalized) {
             baseColumns.locale = {
               name: 'locale',
@@ -911,12 +913,17 @@ export const traverseFields = ({
           }
         } else {
           targetTable[fieldName] = withDefault(
-            {
-              name: columnName,
-              type: 'enum',
-              enumName,
-              options,
-            },
+            isLocalizedVersionStatusField
+              ? {
+                  name: columnName,
+                  type: 'varchar',
+                }
+              : {
+                  name: columnName,
+                  type: 'enum',
+                  enumName,
+                  options,
+                },
             field,
           )
         }

--- a/packages/payload/src/fields/mergeBaseFields.ts
+++ b/packages/payload/src/fields/mergeBaseFields.ts
@@ -3,6 +3,21 @@ import type { Field, FieldWithSubFields } from './config/types.js'
 import { deepMergeWithReactComponents } from '../utilities/deepMerge.js'
 import { fieldAffectsData, fieldHasSubFields } from './config/types.js'
 
+const shouldOverrideMergedOptions = ({
+  baseField,
+  matchedField,
+}: {
+  baseField: Field
+  matchedField: Field
+}) => {
+  return (
+    (baseField.type === 'radio' || baseField.type === 'select') &&
+    (matchedField.type === 'radio' || matchedField.type === 'select') &&
+    'options' in matchedField &&
+    Array.isArray(matchedField.options)
+  )
+}
+
 export const mergeBaseFields = (fields: Field[], baseFields: Field[]): Field[] => {
   const mergedFields = [...(fields || [])]
 
@@ -24,6 +39,10 @@ export const mergeBaseFields = (fields: Field[], baseFields: Field[]): Field[] =
         mergedFields.splice(matchedIndex!, 1)
 
         const mergedField = deepMergeWithReactComponents<Field>(baseField, matchCopy)
+
+        if (shouldOverrideMergedOptions({ baseField, matchedField: matchCopy })) {
+          mergedField.options = matchCopy.options
+        }
 
         if (fieldHasSubFields(baseField) && fieldHasSubFields(matchCopy)) {
           ;(mergedField as FieldWithSubFields).fields = mergeBaseFields(

--- a/packages/payload/src/fields/mergeBaseFields.ts
+++ b/packages/payload/src/fields/mergeBaseFields.ts
@@ -1,22 +1,10 @@
-import type { Field, FieldWithSubFields } from './config/types.js'
+import type { Field, FieldWithSubFields, RadioField, SelectField } from './config/types.js'
 
 import { deepMergeWithReactComponents } from '../utilities/deepMerge.js'
 import { fieldAffectsData, fieldHasSubFields } from './config/types.js'
 
-const shouldOverrideMergedOptions = ({
-  baseField,
-  matchedField,
-}: {
-  baseField: Field
-  matchedField: Field
-}) => {
-  return (
-    (baseField.type === 'radio' || baseField.type === 'select') &&
-    (matchedField.type === 'radio' || matchedField.type === 'select') &&
-    'options' in matchedField &&
-    Array.isArray(matchedField.options)
-  )
-}
+const fieldHasOptions = (field: Field): field is RadioField | SelectField =>
+  (field.type === 'radio' || field.type === 'select') && Array.isArray(field.options)
 
 export const mergeBaseFields = (fields: Field[], baseFields: Field[]): Field[] => {
   const mergedFields = [...(fields || [])]
@@ -40,8 +28,8 @@ export const mergeBaseFields = (fields: Field[], baseFields: Field[]): Field[] =
 
         const mergedField = deepMergeWithReactComponents<Field>(baseField, matchCopy)
 
-        if (shouldOverrideMergedOptions({ baseField, matchedField: matchCopy })) {
-          mergedField.options = matchCopy.options
+        if (fieldHasOptions(baseField) && fieldHasOptions(matchCopy)) {
+          ;(mergedField as RadioField | SelectField).options = matchCopy.options
         }
 
         if (fieldHasSubFields(baseField) && fieldHasSubFields(matchCopy)) {

--- a/test/database/getConfig.ts
+++ b/test/database/getConfig.ts
@@ -51,6 +51,20 @@ export const getConfig: () => Partial<Config> = () => ({
       versions: { drafts: true },
       fields: [
         {
+          name: '_status',
+          type: 'select',
+          options: [
+            {
+              label: 'Draft',
+              value: 'draft',
+            },
+            {
+              label: 'Published',
+              value: 'published',
+            },
+          ],
+        },
+        {
           type: 'text',
           name: 'title',
         },

--- a/test/database/int.spec.ts
+++ b/test/database/int.spec.ts
@@ -3198,6 +3198,28 @@ describe('database', () => {
       }
     })
 
+    it('should not duplicate explicitly defined draft status options', async () => {
+      const generatedAdapterName = process.env.PAYLOAD_DATABASE
+      if (!generatedAdapterName?.includes('postgres') && generatedAdapterName !== 'supabase') {
+        return
+      }
+
+      const outputFile = path.resolve(dirname, `${generatedAdapterName}.generated-schema.ts`)
+
+      await payload.db.generateSchema({
+        outputFile,
+      })
+
+      const generatedSchema = fs.readFileSync(outputFile, 'utf-8')
+
+      expect(generatedSchema).not.toMatch(
+        /enum_categories_status[\s\S]*'draft',\s*'published',\s*'draft',\s*'published'/,
+      )
+      expect(generatedSchema).not.toMatch(
+        /enum__categories_v_version_status[\s\S]*'draft',\s*'published',\s*'draft',\s*'published'/,
+      )
+    })
+
     it('should generate Drizzle SQLite schema', async () => {
       const generatedAdapterName = process.env.PAYLOAD_DATABASE
       if (!generatedAdapterName?.includes('sqlite')) {


### PR DESCRIPTION
Backport https://github.com/payloadcms/payload/pull/18089 to `3.x`

## Summary
- prevent duplicate `_status` enum options when a drafts collection explicitly configures the status field
- generate localized draft status columns as `varchar` to match the Postgres localize-status migration
- add schema-generation regression coverage for #17738

## Testing
- `pnpm run test:int:postgres` for `test/database/int.spec.ts` — 155 passed / 17 skipped, including the new `should not duplicate explicitly defined draft status options` test
- `pnpm turbo build --filter payload --force` passes
- `pnpm exec prettier --check` passes