### PR TITLE
test: add additional regression tests for client-upload fields

### DIFF
--- a/packages/payload/src/uploads/getFileFromUploadInstructions.spec.ts
+++ b/packages/payload/src/uploads/getFileFromUploadInstructions.spec.ts
@@ -66,13 +66,21 @@ describe('getFileFromUploadInstructions', () => {
   })
 
   it('streams the fetched file to a temp file instead of buffering it in memory', async () => {
-    const handler = vi.fn(
-      async () =>
-        new Response('some file contents', {
-          headers: { 'Content-Type': 'video/mp4' },
-          status: 200,
-        }),
-    )
+    const response = new Response('some file contents', {
+      headers: { 'Content-Type': 'video/mp4' },
+      status: 200,
+    })
+
+    const arrayBufferTripwire = vi.fn(async () => {
+      throw new Error('Unexpected whole-body buffering')
+    })
+
+    Object.defineProperty(response, 'arrayBuffer', {
+      configurable: true,
+      value: arrayBufferTripwire,
+    })
+
+    const handler = vi.fn(async () => response)
 
     const req = createReq([handler])
     const uploadReferenceFile = createUploadReferenceFile()
@@ -90,6 +98,7 @@ describe('getFileFromUploadInstructions', () => {
     expect(fs.readFileSync(file.tempFilePath!, 'utf8')).toBe('some file contents')
     expect(file.uploadReference).toBe(uploadReferenceFile.uploadReference)
     expect(file.mimetype).toBe('video/mp4')
+    expect(arrayBufferTripwire).not.toHaveBeenCalled()
   })
 
   it('writes the temp file under the configured tempFileDir', async () => {
@@ -124,7 +133,9 @@ describe('getFileFromUploadInstructions', () => {
   })
 
   it('skips fetching entirely when nothing downstream needs the file content', async () => {
-    const handler = vi.fn(async () => new Response('unused', { status: 200 }))
+    const handler = vi.fn(() => {
+      throw new Error('No-content handler was invoked')
+    })
     const req = createReq([handler], {})
 
     const file = await getFileFromUploadInstructions({
@@ -191,29 +202,31 @@ describe('getFileFromUploadInstructions', () => {
   })
 
   it('stops reading once it has enough bytes to probe dimensions, even if the handler ignores the range hint', async () => {
-    const totalSize = HEADER_PROBE_BYTE_LENGTH * 4
-    let cancelled = false
-    let bytesProduced = 0
+    const prefix = Buffer.alloc(HEADER_PROBE_BYTE_LENGTH)
+    MINIMAL_PNG.copy(prefix)
 
-    const stream = new ReadableStream({
-      cancel() {
-        cancelled = true
+    let cancelled = false
+    let hasReadPastBoundary = false
+    let servedPrefix = false
+
+    const stream = new ReadableStream(
+      {
+        cancel() {
+          cancelled = true
+        },
+        pull(controller) {
+          if (!servedPrefix) {
+            servedPrefix = true
+            controller.enqueue(prefix)
+            return
+          }
+
+          hasReadPastBoundary = true
+          controller.error(new Error('Read past header boundary'))
+        },
       },
-      pull(controller) {
-        if (bytesProduced === 0) {
-          controller.enqueue(MINIMAL_PNG)
-          bytesProduced += MINIMAL_PNG.length
-          return
-        }
-        if (bytesProduced >= totalSize) {
-          controller.close()
-          return
-        }
-        const chunkSize = Math.min(64 * 1024, totalSize - bytesProduced)
-        controller.enqueue(new Uint8Array(chunkSize))
-        bytesProduced += chunkSize
-      },
-    })
+      { highWaterMark: 0 },
+    )
 
     const handler = vi.fn(
       async () => new Response(stream, { headers: { 'Content-Type': 'image/png' }, status: 200 }),
@@ -223,16 +236,17 @@ describe('getFileFromUploadInstructions', () => {
     const file = await getFileFromUploadInstructions({
       collectionSlug: 'media',
       file: createUploadReferenceFile({
-        filename: 'photo.png',
+        filename: 'header-boundary-tripwire.png',
         mimeType: 'image/png',
-        size: totalSize,
+        size: HEADER_PROBE_BYTE_LENGTH * 4,
       }),
       req,
     })
 
     expect(file.tempFilePath).toBeUndefined()
-    expect(file.data.length).toBeLessThanOrEqual(HEADER_PROBE_BYTE_LENGTH)
+    expect(file.data.length).toBe(HEADER_PROBE_BYTE_LENGTH)
     expect(cancelled).toBe(true)
+    expect(hasReadPastBoundary).toBe(false)
   })
 
   it('preserves native Request accessors like signal on the request passed to a range-scoped handler', async () => {

--- a/test/storage-azure/client-uploads/collections/MediaHeaderOnly.ts
+++ b/test/storage-azure/client-uploads/collections/MediaHeaderOnly.ts
@@ -2,6 +2,8 @@ import type { CollectionConfig } from 'payload'
 
 export const mediaHeaderOnlySlug = 'media-header-only'
 
+const HEADER_PROBE_BYTE_LENGTH = 1024 * 1024
+
 /**
  * No `resizeOptions`/`formatOptions`/`trimOptions`/`mimeTypes` configured, and
  * `disableLocalStorage: true` - the combination that makes `getFileContentRequirement` choose
@@ -11,6 +13,27 @@ export const mediaHeaderOnlySlug = 'media-header-only'
 export const MediaHeaderOnly: CollectionConfig = {
   slug: mediaHeaderOnlySlug,
   fields: [],
+  hooks: {
+    beforeValidate: [
+      ({ data, req }) => {
+        const file = req.file
+
+        if (file?.name === 'no-content-tripwire.mp3') {
+          if (file.data.length !== 0 || file.tempFilePath) {
+            throw new Error('No-content upload was materialized')
+          }
+        }
+
+        if (file?.name === 'header-only-tripwire.jpg') {
+          if (file.data.length > HEADER_PROBE_BYTE_LENGTH || file.tempFilePath) {
+            throw new Error('Header-only upload exceeded its memory boundary')
+          }
+        }
+
+        return data
+      },
+    ],
+  },
   upload: {
     disableLocalStorage: true,
   },

--- a/test/storage-azure/client-uploads/collections/MediaHeaderOnlyWithSizes.ts
+++ b/test/storage-azure/client-uploads/collections/MediaHeaderOnlyWithSizes.ts
@@ -1,5 +1,7 @@
 import type { CollectionConfig } from 'payload'
 
+import { existsSync } from 'node:fs'
+
 export const mediaHeaderOnlyWithSizesSlug = 'media-header-only-with-sizes'
 
 /**
@@ -13,6 +15,21 @@ export const mediaHeaderOnlyWithSizesSlug = 'media-header-only-with-sizes'
 export const MediaHeaderOnlyWithSizes: CollectionConfig = {
   slug: mediaHeaderOnlyWithSizesSlug,
   fields: [],
+  hooks: {
+    beforeValidate: [
+      ({ data, req }) => {
+        const file = req.file
+
+        if (file?.name === 'large-with-sizes.jpg') {
+          if (file.data.length !== 0 || !file.tempFilePath || !existsSync(file.tempFilePath)) {
+            throw new Error('Full client upload was not staged to disk')
+          }
+        }
+
+        return data
+      },
+    ],
+  },
   upload: {
     disableLocalStorage: true,
     imageSizes: [

--- a/test/storage-azure/client-uploads/int.spec.ts
+++ b/test/storage-azure/client-uploads/int.spec.ts
@@ -6,7 +6,7 @@ import { readFileSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
 import path from 'path'
 import { fileURLToPath } from 'url'
-import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 
 import type { NextRESTClient } from '../../__helpers/shared/NextRESTClient.js'
 
@@ -29,6 +29,49 @@ describe('@payloadcms/storage-azure clientUploads', () => {
     for await (const blob of containerClient.listBlobsFlat()) {
       await containerClient.deleteBlob(blob.name)
     }
+  }
+
+  /**
+   * Completes the browser-equivalent side of a client upload (requesting upload instructions,
+   * then PUTting the file straight to Azure) and returns the form data for the follow-up document
+   * POST. Callers must install any `BlockBlobClient` spies after this resolves, so the browser's
+   * own Azure SDK calls don't pollute server-side read-count assertions.
+   */
+  const stageAzureClientUpload = async ({
+    collectionSlug,
+    file,
+    filename,
+    mimeType,
+  }: {
+    collectionSlug: string
+    file: Buffer
+    filename: string
+    mimeType: string
+  }) => {
+    const instructions = (await restClient
+      .POST('/upload-instructions', {
+        body: JSON.stringify({
+          collectionSlug,
+          filename,
+          filesize: file.length,
+          mimeType,
+        }),
+      })
+      .then((res) => res.json())) as UploadInstructions
+
+    if (instructions.type !== 'dispatch') {
+      throw new Error('Expected dispatch upload instructions')
+    }
+
+    const { url } = instructions.data as { url: string }
+    await new BlockBlobClient(url).uploadData(file, {
+      blobHTTPHeaders: { blobContentType: mimeType },
+    })
+
+    const form = new FormData()
+    form.append('file', JSON.stringify(instructions.file))
+
+    return form
   }
 
   beforeAll(async () => {
@@ -127,8 +170,12 @@ describe('@payloadcms/storage-azure clientUploads', () => {
    * the server cloned the request via `Object.create` to add the range header) - completing the
    * full round trip end to end is the only way to exercise the real handler for this path, since
    * unit tests mock the handler and never see that crash.
+   *
+   * The same collection also covers the `'none'` content requirement: content requirement
+   * depends on the uploaded MIME type as well as collection configuration, so `audio/mpeg`
+   * selects `'none'` while `image/jpeg` selects `'header'`.
    */
-  describe('header-only content requirement (real Azure handler)', () => {
+  describe('header-only and no-content requirements (real Azure handler)', () => {
     const createdIds: (number | string)[] = []
 
     afterEach(async () => {
@@ -138,44 +185,73 @@ describe('@payloadcms/storage-azure clientUploads', () => {
       createdIds.length = 0
     })
 
-    it('creates a document from a client-uploaded image via the real Azure handler', async () => {
-      const file = readFileSync(path.resolve(dirname, '../../uploads/image.png'))
+    it('does not read a client-uploaded non-image when metadata is sufficient', async () => {
+      const file = readFileSync(path.resolve(dirname, '../../uploads/audio.mp3'))
+      expect(file.length).toBe(23_334)
 
-      const instructions = (await restClient
-        .POST('/upload-instructions', {
-          body: JSON.stringify({
-            collectionSlug: mediaHeaderOnlySlug,
-            filename: 'header-only.png',
-            filesize: file.length,
-            mimeType: 'image/png',
-          }),
-        })
-        .then((res) => res.json())) as UploadInstructions
+      const form = await stageAzureClientUpload({
+        collectionSlug: mediaHeaderOnlySlug,
+        file,
+        filename: 'no-content-tripwire.mp3',
+        mimeType: 'audio/mpeg',
+      })
 
-      if (instructions.type !== 'dispatch') {
-        throw new Error('Expected dispatch upload instructions')
+      const getPropertiesSpy = vi.spyOn(BlockBlobClient.prototype, 'getProperties')
+      const downloadSpy = vi.spyOn(BlockBlobClient.prototype, 'download')
+
+      try {
+        const createRes = await restClient.POST(`/${mediaHeaderOnlySlug}`, { body: form })
+        expect(createRes.status).toBe(201)
+
+        const { doc } = await createRes.json()
+        createdIds.push(doc.id)
+
+        expect(doc.filesize).toBe(23_334)
+        expect(doc.mimeType).toBe('audio/mpeg')
+        expect(getPropertiesSpy).not.toHaveBeenCalled()
+        expect(downloadSpy).not.toHaveBeenCalled()
+      } finally {
+        getPropertiesSpy.mockRestore()
+        downloadSpy.mockRestore()
       }
+    })
 
-      const { url } = instructions.data as { url: string }
-      await new BlockBlobClient(url).uploadData(file, {
-        blobHTTPHeaders: { blobContentType: 'image/png' },
+    it('creates a document from a client-uploaded image via the real Azure handler', async () => {
+      const file = readFileSync(path.resolve(dirname, '../../uploads/2mb.jpg'))
+      expect(file.length).toBe(2_215_474)
+
+      const form = await stageAzureClientUpload({
+        collectionSlug: mediaHeaderOnlySlug,
+        file,
+        filename: 'header-only-tripwire.jpg',
+        mimeType: 'image/jpeg',
       })
 
-      const createFormData = new FormData()
-      createFormData.append('file', JSON.stringify(instructions.file))
+      const getPropertiesSpy = vi.spyOn(BlockBlobClient.prototype, 'getProperties')
+      const downloadSpy = vi.spyOn(BlockBlobClient.prototype, 'download')
 
-      const createRes = await restClient.POST(`/${mediaHeaderOnlySlug}`, {
-        body: createFormData,
-      })
+      try {
+        const createRes = await restClient.POST(`/${mediaHeaderOnlySlug}`, { body: form })
+        expect(createRes.status).toBe(201)
 
-      expect(createRes.status).toBe(201)
-      const { doc } = await createRes.json()
-      createdIds.push(doc.id)
+        const { doc } = await createRes.json()
+        createdIds.push(doc.id)
 
-      expect(doc.width).toBe(1600)
-      expect(doc.height).toBe(1600)
-      expect(doc.filesize).toBe(file.length)
-      expect(doc.mimeType).toBe('image/png')
+        expect(doc.width).toBe(9000)
+        expect(doc.height).toBe(9000)
+        expect(doc.filesize).toBe(2_215_474)
+        expect(doc.mimeType).toBe('image/jpeg')
+
+        expect(getPropertiesSpy).toHaveBeenCalledTimes(1)
+        expect(downloadSpy).toHaveBeenCalledTimes(1)
+
+        const [offset, count] = downloadSpy.mock.calls[0]!
+        expect(offset).toBe(0)
+        expect(count).toBe(1024 * 1024)
+      } finally {
+        getPropertiesSpy.mockRestore()
+        downloadSpy.mockRestore()
+      }
     })
   })
 
@@ -198,44 +274,40 @@ describe('@payloadcms/storage-azure clientUploads', () => {
 
     it('creates a document and generates image sizes from a large client-uploaded image via the real Azure handler', async () => {
       const file = readFileSync(path.resolve(dirname, '../../uploads/2mb.jpg'))
-      expect(file.length).toBeGreaterThan(1024 * 1024)
+      expect(file.length).toBe(2_215_474)
 
-      const instructions = (await restClient
-        .POST('/upload-instructions', {
-          body: JSON.stringify({
-            collectionSlug: mediaHeaderOnlyWithSizesSlug,
-            filename: 'large-with-sizes.jpg',
-            filesize: file.length,
-            mimeType: 'image/jpeg',
-          }),
+      const form = await stageAzureClientUpload({
+        collectionSlug: mediaHeaderOnlyWithSizesSlug,
+        file,
+        filename: 'large-with-sizes.jpg',
+        mimeType: 'image/jpeg',
+      })
+
+      const downloadSpy = vi.spyOn(BlockBlobClient.prototype, 'download')
+
+      try {
+        const createRes = await restClient.POST(`/${mediaHeaderOnlyWithSizesSlug}`, {
+          body: form,
         })
-        .then((res) => res.json())) as UploadInstructions
 
-      if (instructions.type !== 'dispatch') {
-        throw new Error('Expected dispatch upload instructions')
+        expect(createRes.status).toBe(201)
+        const { doc } = await createRes.json()
+        createdIds.push(doc.id)
+
+        expect(doc.filesize).toBe(file.length)
+        expect(doc.mimeType).toBe('image/jpeg')
+        expect(doc.sizes.thumbnail.width).toBe(400)
+        expect(doc.sizes.thumbnail.height).toBe(300)
+        expect(doc.sizes.thumbnail.filename).toBeTruthy()
+
+        expect(downloadSpy).toHaveBeenCalledTimes(1)
+
+        const [offset, count] = downloadSpy.mock.calls[0]!
+        expect(offset).toBe(0)
+        expect(count).toBeUndefined()
+      } finally {
+        downloadSpy.mockRestore()
       }
-
-      const { url } = instructions.data as { url: string }
-      await new BlockBlobClient(url).uploadData(file, {
-        blobHTTPHeaders: { blobContentType: 'image/jpeg' },
-      })
-
-      const createFormData = new FormData()
-      createFormData.append('file', JSON.stringify(instructions.file))
-
-      const createRes = await restClient.POST(`/${mediaHeaderOnlyWithSizesSlug}`, {
-        body: createFormData,
-      })
-
-      expect(createRes.status).toBe(201)
-      const { doc } = await createRes.json()
-      createdIds.push(doc.id)
-
-      expect(doc.filesize).toBe(file.length)
-      expect(doc.mimeType).toBe('image/jpeg')
-      expect(doc.sizes.thumbnail.width).toBe(400)
-      expect(doc.sizes.thumbnail.height).toBe(300)
-      expect(doc.sizes.thumbnail.filename).toBeTruthy()
     }, 60000)
   })
 })


### PR DESCRIPTION
## Summary

PR #17856 fixed client uploads so the server reads only the bytes each save operation needs, instead of always downloading the whole file into memory. This PR adds tests that fail if that behavior regresses: if a handler is called when no file content is needed, if a full-file read goes through a whole-body buffering API instead of a stream, or if a header read goes past its byte boundary.

## Why

The original fix was correct, but nothing stopped a future change from reintroducing the same problem. Size-based assertions alone could pass even after a regression, because small test fixtures hide the difference between a bounded read and an unbounded one. These tests catch the regression at its source instead.

## How

- Each unit test tripwire throws the moment a forbidden operation happens, instead of only checking file size afterward. The no-content handler throws if called at all. The full-content response throws if `arrayBuffer()` is read. The header-probe stream throws if pulled past the 1 MiB boundary.
- The Azure integration suite now spies on the real `BlockBlobClient.getProperties` and `download` methods and checks exact call counts and arguments, for the `none`, `header`, and `full` content-requirement paths.
- Spies install only after the browser-equivalent upload finishes, so the client's own PUT to Azure does not get counted as a server-side read.
- Two Azure test collections gained a `beforeValidate` hook that checks `req.file`'s shape (buffered data vs. temp file on disk) for two specific test fixtures, so the document lifecycle itself proves the file was not over-fetched.
- The header-only Azure test now uses `test/uploads/2mb.jpg` instead of a small PNG, so the 1 MiB range request is a true partial read rather than one that happens to cover the whole file.

Written with AI
