### PR TITLE
fix(ui): stop toWords crashing on numeric relationship IDs in query preset cells (#18083)

### DIFF
--- a/packages/payload/src/utilities/formatLabels.spec.ts
+++ b/packages/payload/src/utilities/formatLabels.spec.ts
@@ -38,5 +38,18 @@ describe('formatLabels', () => {
     it('should allow no separator (used for building GraphQL label from name)', () => {
       expect(toWords('myGraphField', true)).toBe('MyGraphField')
     })
+
+    it('should not throw on numeric input (Postgres relationship IDs from query presets)', () => {
+      expect(toWords(5)).toBe('5')
+    })
+
+    it('should render an array of numeric IDs the way QueryPresetsWhereCell does', () => {
+      expect([5, 12].map((val) => toWords(val)).join(' or ')).toBe('5 or 12')
+    })
+
+    it('should fall back to empty string for nullish input', () => {
+      expect(toWords(null)).toBe('')
+      expect(toWords(undefined)).toBe('')
+    })
   })
 })

--- a/packages/payload/src/utilities/formatLabels.ts
+++ b/packages/payload/src/utilities/formatLabels.ts
@@ -4,8 +4,8 @@ const { isPlural, singular } = pluralize
 const capitalizeFirstLetter = (string: string): string =>
   string.charAt(0).toUpperCase() + string.slice(1)
 
-const toWords = (inputString: string, joinWords = false): string => {
-  const notNullString = inputString || ''
+const toWords = (inputString: number | string | null | undefined, joinWords = false): string => {
+  const notNullString = typeof inputString === 'string' ? inputString : String(inputString ?? '')
   const trimmedString = notNullString.trim()
   const arrayOfStrings = trimmedString.split(/[\s-]/)
 

--- a/packages/payload/src/utilities/formatLabels.ts
+++ b/packages/payload/src/utilities/formatLabels.ts
@@ -4,7 +4,7 @@ const { isPlural, singular } = pluralize
 const capitalizeFirstLetter = (string: string): string =>
   string.charAt(0).toUpperCase() + string.slice(1)
 
-const toWords = (inputString: number | string | null | undefined, joinWords = false): string => {
+const toWords = (inputString: null | number | string | undefined, joinWords = false): string => {
   const notNullString = typeof inputString === 'string' ? inputString : String(inputString ?? '')
   const trimmedString = notNullString.trim()
   const arrayOfStrings = trimmedString.split(/[\s-]/)


### PR DESCRIPTION
## Summary

Fixes #18083 - on Postgres, a Query Preset filtering a `hasMany` relationship stores numeric IDs (`equals: [5]`); `QueryPresetsWhereCell` passes them raw into `toWords()`, which calls `.trim()` on a number and white-screens the entire admin for every user who can read the collection's presets.

**Live repro** (pristine `payload@3.88.0` from npm, no app, no DB):

```
node --input-type=module -e "
  import { toWords } from './node_modules/payload/dist/utilities/formatLabels.js';
  toWords(5); "
# TypeError: notNullString.trim is not a function   <-- reproduced
```

**Fix:** coerce inside `toWords` - `typeof inputString === 'string' ? inputString : String(inputString ?? '')` - one change covers every caller. Signature widened to `number | string | null | undefined`; nullish keeps the previous `|| ''` behavior.

**Why here and not in WhereCell:** the write side (relationship condition `onChange` emitting raw numeric `option.values`) is valid - `@payloadcms/drizzle` already accepts `equals: [5]` server-side (coerced to `in` in 3.88.0). The display path was the only place that assumed string; hardening the shared utility fixes this cell and every future one.

**Verified live against patched dist:** `toWords(5)` -> `"5"`, `[5,12].map(toWords)` -> `"5 or 12"`, `toWords(null)` -> `""`, `toWords('camelCaseItems')` -> `"Camel Case Items"`, joinWords and empty-string unchanged.

**Tests:** 3 new regression tests in `formatLabels.spec.ts` (numeric input, the exact WhereCell numeric-array render path, nullish fallback) - full file 9/9 green under vitest locally. Full RCA in the issue thread.

Follow-up worth considering (not in this PR to keep it minimal): an error boundary around preset cells so one malformed preset can never take down the whole admin again.

> Built by breken, your AI support engineer - breken.ai - this one's on us.