### PR TITLE
perf(drizzle): avoid redundant countDistinct when page 1 returns fewer docs than limit

### DIFF
--- a/packages/drizzle/src/find/findMany.ts
+++ b/packages/drizzle/src/find/findMany.ts
@@ -183,25 +183,29 @@ export const findMany = async function find({
   }
 
   const findPromise = db.query[tableName].findMany(findManyArgs)
+  const rawDocs = await findPromise
+
+  // sort rawDocs from selectQuery
+  if (Object.keys(orderedIDMap).length > 0) {
+    rawDocs.sort((a, b) => orderedIDMap[a.id] - orderedIDMap[b.id])
+  }
 
   if (pagination !== false && (orderedIDs ? orderedIDs?.length <= limit : true)) {
-    totalDocs = await adapter.countDistinct({
-      db,
-      joins,
-      tableName,
-      where,
-    })
+    if (page === 1 && typeof limit === 'number' && limit > 0 && rawDocs.length < limit) {
+      totalDocs = rawDocs.length
+    } else {
+      totalDocs = await adapter.countDistinct({
+        db,
+        joins,
+        tableName,
+        where,
+      })
+    }
 
     totalPages = typeof limit === 'number' && limit !== 0 ? Math.ceil(totalDocs / limit) : 1
     hasPrevPage = page > 1
     hasNextPage = totalPages > page
     pagingCounter = (page - 1) * limit + 1
-  }
-
-  const rawDocs = await findPromise
-  // sort rawDocs from selectQuery
-  if (Object.keys(orderedIDMap).length > 0) {
-    rawDocs.sort((a, b) => orderedIDMap[a.id] - orderedIDMap[b.id])
   }
 
   if (pagination === false || !totalDocs) {


### PR DESCRIPTION
## Description

In \indMany\ for Drizzle adapter, when querying the first page (\page === 1\) and the returned records count is less than the requested \limit\, the total number of documents is definitively \awDocs.length\.

Previously, an additional \dapter.countDistinct\ query was always issued regardless, doubling database round-trips for small collections or filtered queries.

### Changes
- Execute \indPromise\ first to obtain \awDocs\.
- If \page === 1\ and \awDocs.length < limit\, directly assign \	otalDocs = rawDocs.length\.
- Otherwise, execute \dapter.countDistinct\ as before.
