### PR TITLE
fix: harden dropDatabase, JWT strategy, Stripe webhooks, sessions and reset token

### DIFF
--- a/packages/db-mongodb/src/connect.ts
+++ b/packages/db-mongodb/src/connect.ts
@@ -82,7 +82,7 @@ export const connect: Connect = async function connect(
     }
 
     if (!hotReload) {
-      if (process.env.PAYLOAD_DROP_DATABASE === 'true') {
+      if (process.env.NODE_ENV !== 'production' && process.env.PAYLOAD_DROP_DATABASE === 'true') {
         this.payload.logger.info('---- DROPPING DATABASE ----')
         await this.connection.dropDatabase()
 

--- a/packages/db-postgres/src/connect.ts
+++ b/packages/db-postgres/src/connect.ts
@@ -87,7 +87,7 @@ export const connect: Connect = async function connect(
     }
 
     if (!hotReload) {
-      if (process.env.PAYLOAD_DROP_DATABASE === 'true') {
+      if (process.env.NODE_ENV !== 'production' && process.env.PAYLOAD_DROP_DATABASE === 'true') {
         this.payload.logger.info(`---- DROPPING TABLES SCHEMA(${this.schemaName || 'public'}) ----`)
         await this.dropDatabase({ adapter: this })
         this.payload.logger.info('---- DROPPED TABLES ----')

--- a/packages/payload/src/auth/operations/resetPassword.ts
+++ b/packages/payload/src/auth/operations/resetPassword.ts
@@ -1,3 +1,4 @@
+import crypto from 'crypto'
 import { status as httpStatus } from 'http-status'
 
 import type { Collection, DataFromCollectionSlug } from '../../collections/config/types.js'
@@ -91,7 +92,19 @@ export const resetPasswordOperation = async <TSlug extends AuthCollectionSlug>(
       where,
     })
 
-    if (!user) {
+    const tokenMatches = (() => {
+      if (!user || typeof user.resetPasswordToken !== 'string') {
+        return false
+      }
+      const providedBuffer = Buffer.from(data.token)
+      const storedBuffer = Buffer.from(user.resetPasswordToken)
+      if (providedBuffer.length !== storedBuffer.length) {
+        return false
+      }
+      return crypto.timingSafeEqual(providedBuffer, storedBuffer)
+    })()
+
+    if (!user || !tokenMatches) {
       throw new APIError('Token is either invalid or has expired.', httpStatus.FORBIDDEN)
     }
 

--- a/packages/payload/src/auth/sessions.ts
+++ b/packages/payload/src/auth/sessions.ts
@@ -46,6 +46,15 @@ export const addSessionToUser = async ({
     } else {
       user.sessions = removeExpiredSessions(user.sessions)
       user.sessions.push(session)
+
+      const maxSessions = collectionConfig.auth.maxSessions
+      if (
+        typeof maxSessions === 'number' &&
+        maxSessions > 0 &&
+        user.sessions.length > maxSessions
+      ) {
+        user.sessions = user.sessions.slice(-maxSessions)
+      }
     }
 
     await payload.db.updateOne({

--- a/packages/payload/src/auth/strategies/jwt.ts
+++ b/packages/payload/src/auth/strategies/jwt.ts
@@ -123,14 +123,18 @@ export const JWTAuthentication: AuthStrategyFunction = async ({
     const decodedPayload = await verifyWithKeyring({ payload, token })
     const collection = payload.collections[decodedPayload.collection]
 
+    if (!collection) {
+      return { user: null }
+    }
+
     const user = (await payload.findByID({
       id: decodedPayload.id,
       collection: decodedPayload.collection,
-      depth: isGraphQL ? 0 : collection!.config.auth.depth,
+      depth: isGraphQL ? 0 : collection.config.auth.depth,
     })) as AuthStrategyResult['user']
 
-    if (user && (!collection!.config.auth.verify || user._verified)) {
-      if (collection!.config.auth.useSessions) {
+    if (user && (!collection.config.auth.verify || user._verified)) {
+      if (collection.config.auth.useSessions) {
         const existingSession = (user.sessions || []).find(({ id }) => id === decodedPayload.sid)
 
         if (!existingSession || !decodedPayload.sid) {
@@ -142,7 +146,7 @@ export const JWTAuthentication: AuthStrategyFunction = async ({
         user._sid = decodedPayload.sid
       }
 
-      user.collection = collection!.config.slug
+      user.collection = collection.config.slug
       user._strategy = strategyName
       return {
         user,

--- a/packages/payload/src/auth/types.ts
+++ b/packages/payload/src/auth/types.ts
@@ -270,6 +270,11 @@ export interface IncomingAuthType {
    * Only allow a user to attempt logging in X amount of times. Automatically locks out a user from authenticating if this limit is passed. Set to 0 to disable.
    */
   maxLoginAttempts?: number
+  /**
+   * Maximum number of active sessions to retain per user. Older sessions are evicted when exceeded.
+   * @default 20
+   */
+  maxSessions?: number
   /***
    * Set to true if you want to remove the token from the returned authentication API responses such as login or refresh.
    */
@@ -323,6 +328,7 @@ export interface Auth
       | 'lockTime'
       | 'loginWithUsername'
       | 'maxLoginAttempts'
+      | 'maxSessions'
       | 'strategies'
       | 'tokenExpiration'
       | 'useSessions'
@@ -334,6 +340,7 @@ export interface Auth
         | 'forgotPassword'
         | 'lockTime'
         | 'maxLoginAttempts'
+        | 'maxSessions'
         | 'strategies'
         | 'tokenExpiration'
         | 'useSessions'

--- a/packages/payload/src/collections/config/defaults.ts
+++ b/packages/payload/src/collections/config/defaults.ts
@@ -136,6 +136,7 @@ export const addDefaultsToAuthConfig = (auth: IncomingAuthType): Auth => {
       )
     : false
   auth.maxLoginAttempts = auth.maxLoginAttempts ?? 5
+  auth.maxSessions = auth.maxSessions ?? 20
   auth.tokenExpiration = auth.tokenExpiration ?? 7200
   auth.useSessions = auth.useSessions ?? true
   auth.verify = auth.verify ?? false

--- a/packages/plugin-stripe/src/routes/webhooks.ts
+++ b/packages/plugin-stripe/src/routes/webhooks.ts
@@ -17,33 +17,65 @@ export const stripeWebhooks = async (args: {
 
   const { stripeSecretKey, stripeWebhooksEndpointSecret, webhooks } = pluginConfig
 
-  if (stripeWebhooksEndpointSecret) {
-    const stripe = new Stripe(stripeSecretKey, {
-      // api version can only be the latest, stripe recommends ts ignoring it
-      apiVersion: '2022-08-01',
-      appInfo: {
-        name: 'Stripe Payload Plugin',
-        url: 'https://payloadcms.com',
-      },
-    })
+  if (!stripeWebhooksEndpointSecret) {
+    req.payload.logger.error('Stripe webhook error: stripeWebhooksEndpointSecret is not configured')
+    return Response.json({ error: 'Webhook secret is not configured' }, { status: 400 })
+  }
 
-    const body = await req.text!()
-    const stripeSignature = req.headers.get('stripe-signature')
+  const stripe = new Stripe(stripeSecretKey, {
+    // api version can only be the latest, stripe recommends ts ignoring it
+    apiVersion: '2022-08-01',
+    appInfo: {
+      name: 'Stripe Payload Plugin',
+      url: 'https://payloadcms.com',
+    },
+  })
 
-    if (stripeSignature) {
-      let event: Stripe.Event | undefined
+  const body = await req.text!()
+  const stripeSignature = req.headers.get('stripe-signature')
 
-      try {
-        event = stripe.webhooks.constructEvent(body, stripeSignature, stripeWebhooksEndpointSecret)
-      } catch (err: unknown) {
-        const msg: string = err instanceof Error ? err.message : JSON.stringify(err)
-        req.payload.logger.error(`Error constructing Stripe event: ${msg}`)
-        returnStatus = 400
+  if (!stripeSignature) {
+    req.payload.logger.error('Stripe webhook error: Missing stripe-signature header')
+    return Response.json({ error: 'Missing stripe-signature header' }, { status: 400 })
+  }
+
+  let event: Stripe.Event | undefined
+
+  try {
+    event = stripe.webhooks.constructEvent(body, stripeSignature, stripeWebhooksEndpointSecret)
+  } catch (err: unknown) {
+    const msg: string = err instanceof Error ? err.message : JSON.stringify(err)
+    req.payload.logger.error(`Error constructing Stripe event: ${msg}`)
+    returnStatus = 400
+  }
+
+  if (event) {
+    const fireWebhooks = async () => {
+      await handleWebhooks({
+        config,
+        event,
+        payload: req.payload,
+        pluginConfig,
+        req,
+        stripe,
+      })
+
+      // Fire external webhook handlers if they exist
+      if (typeof webhooks === 'function') {
+        await webhooks({
+          config,
+          event,
+          payload: req.payload,
+          pluginConfig,
+          req,
+          stripe,
+        })
       }
 
-      if (event) {
-        const fireWebhooks = async () => {
-          await handleWebhooks({
+      if (typeof webhooks === 'object') {
+        const webhookEventHandler = webhooks[event.type]
+        if (typeof webhookEventHandler === 'function') {
+          await webhookEventHandler({
             config,
             event,
             payload: req.payload,
@@ -51,61 +83,35 @@ export const stripeWebhooks = async (args: {
             req,
             stripe,
           })
-
-          // Fire external webhook handlers if they exist
-          if (typeof webhooks === 'function') {
-            await webhooks({
-              config,
-              event,
-              payload: req.payload,
-              pluginConfig,
-              req,
-              stripe,
-            })
-          }
-
-          if (typeof webhooks === 'object') {
-            const webhookEventHandler = webhooks[event.type]
-            if (typeof webhookEventHandler === 'function') {
-              await webhookEventHandler({
-                config,
-                event,
-                payload: req.payload,
-                pluginConfig,
-                req,
-                stripe,
-              })
-            }
-          }
         }
-
-        /**
-         * Run webhook handlers asynchronously. This allows the request to immediately return a 2xx status code to Stripe without waiting for the webhook handlers to complete.
-         * This is because webhooks can be potentially slow if performing database queries or other slow API requests.
-         * This is important because Stripe will retry the webhook if it doesn't receive a 2xx status code within the 10-20 second timeout window.
-         * When a webhook fails, Stripe will retry it, causing duplicate events and potential data inconsistencies.
-         *
-         * To do this in Vercel environments, conditionally import the `waitUntil` function from `@vercel/functions`.
-         * If it exists, use it to wrap the `fireWebhooks` function to ensure it completes after the response is sent.
-         * Otherwise, run the `fireWebhooks` function directly and void the promise to prevent the response from waiting.
-         * {@link https://docs.stripe.com/webhooks#acknowledge-events-immediately}
-         */
-        void (async () => {
-          let waitUntil: (promise: Promise<void>) => Promise<void> | void = (promise) => promise
-
-          try {
-            const { waitUntil: importedWaitUntil } = await dynamicImport<{
-              waitUntil: (promise: Promise<void>) => void
-            }>('@vercel/functions')
-            waitUntil = importedWaitUntil
-          } catch (_err) {
-            // silently fail - @vercel/functions is not installed
-          }
-
-          void waitUntil(fireWebhooks())
-        })()
       }
     }
+
+    /**
+     * Run webhook handlers asynchronously. This allows the request to immediately return a 2xx status code to Stripe without waiting for the webhook handlers to complete.
+     * This is because webhooks can be potentially slow if performing database queries or other slow API requests.
+     * This is important because Stripe will retry the webhook if it doesn't receive a 2xx status code within the 10-20 second timeout window.
+     * When a webhook fails, Stripe will retry it, causing duplicate events and potential data inconsistencies.
+     *
+     * To do this in Vercel environments, conditionally import the `waitUntil` function from `@vercel/functions`.
+     * If it exists, use it to wrap the `fireWebhooks` function to ensure it completes after the response is sent.
+     * Otherwise, run the `fireWebhooks` function directly and void the promise to prevent the response from waiting.
+     * {@link https://docs.stripe.com/webhooks#acknowledge-events-immediately}
+     */
+    void (async () => {
+      let waitUntil: (promise: Promise<void>) => Promise<void> | void = (promise) => promise
+
+      try {
+        const { waitUntil: importedWaitUntil } = await dynamicImport<{
+          waitUntil: (promise: Promise<void>) => void
+        }>('@vercel/functions')
+        waitUntil = importedWaitUntil
+      } catch (_err) {
+        // silently fail - @vercel/functions is not installed
+      }
+
+      void waitUntil(fireWebhooks())
+    })()
   }
 
   return Response.json(


### PR DESCRIPTION
## Description

This PR consolidates critical and high-priority security fixes:

1. **Database Safety**: Add \process.env.NODE_ENV !== 'production'\ guard before dropping tables in Postgres and MongoDB adapters when \PAYLOAD_DROP_DATABASE='true'\.
2. **JWT Strategy**: Guard against non-existent collection slugs before dereferencing \collection.config\ to avoid unhandled TypeError.
3. **Stripe Webhook**: Reject unauthenticated webhook requests with 400 Bad Request if webhook secret or stripe-signature header is missing.
4. **Session Management (H3)**: Bound active sessions per user (\maxSessions\, defaults to 20) with FIFO eviction to prevent Document/BSON size overflow attacks.
5. **Reset Password Timing Safety (H5)**: Use \crypto.timingSafeEqual\ to verify \esetPasswordToken\ against side-channel timing attacks.
