### PR TITLE
test: revert reset-between-test changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,6 +172,9 @@ Screenshots are saved to `.playwright-mcp/` and displayed inline.
 - Read `payload`, `restClient`, `sdk`, or `cli` from the test or hook arguments
 - Do not initialize Payload manually or add database reset/seed hooks; the fixture initializes
   Payload once per file, resets and seeds before each test that uses it, and destroys it afterward
+- Existing suites that intentionally manage shared state can set `resetBetweenTests: false`. The fixture
+  resets and seeds once for the file, and the suite keeps responsibility for between-test cleanup.
+  New suites should use the default per-test reset behavior.
 - Use `test.suite({})` only for integration tests that do not use Payload
 
 ```typescript

--- a/packages/create-payload-app/src/lib/ast/payload-config.spec.ts
+++ b/packages/create-payload-app/src/lib/ast/payload-config.spec.ts
@@ -314,6 +314,7 @@ export default buildConfig({
     const { configurePayloadConfig } = await import('./payload-config')
     const result = await configurePayloadConfig(filePath, {
       db: { type: 'postgres', envVarName: 'DATABASE_URL' },
+      formatWithPrettier: false,
       storage: 'vercelBlobStorage',
     })
 
@@ -339,6 +340,7 @@ export default buildConfig({
     const { configurePayloadConfig } = await import('./payload-config')
     const result = await configurePayloadConfig(filePath, {
       db: { type: 'mongodb', envVarName: 'MONGO_URL' },
+      formatWithPrettier: false,
     })
 
     expect(result.success).toBe(true)
@@ -365,6 +367,7 @@ export default buildConfig({
 
     const { configurePayloadConfig } = await import('./payload-config')
     const result = await configurePayloadConfig(filePath, {
+      formatWithPrettier: false,
       removeSharp: true,
     })
 
@@ -419,6 +422,7 @@ export default buildConfig({
     const { configurePayloadConfig } = await import('./payload-config')
     const result = await configurePayloadConfig(filePath, {
       db: { type: 'postgres', envVarName: 'DATABASE_URL' },
+      formatWithPrettier: false,
     })
 
     expect(result.success).toBe(true)

--- a/packages/payload-cloud/src/plugin.spec.ts
+++ b/packages/payload-cloud/src/plugin.spec.ts
@@ -149,16 +149,15 @@ describe('plugin', () => {
       it('should allow setting fromName and fromAddress', async () => {
         const defaultFromName = 'Test'
         const defaultFromAddress = 'test@test.com'
-        const configWithPartialEmail = createConfig({
-          email: await nodemailerAdapter({
+        const plugin = payloadCloudPlugin({
+          email: {
             defaultFromAddress,
             defaultFromName,
             skipVerify,
-          }),
+          },
         })
 
-        const plugin = payloadCloudPlugin()
-        const config = await plugin(configWithPartialEmail)
+        const config = await plugin(createConfig())
         const emailConfig = config.email as Awaited<ReturnType<typeof nodemailerAdapter>>
 
         const initializedEmail = emailConfig({ payload: mockedPayload })

--- a/test/__helpers/int/vitest.ts
+++ b/test/__helpers/int/vitest.ts
@@ -22,6 +22,11 @@ type TestOptions = {
 type TestSuiteOptions = {
   config?: string
   cron?: boolean
+  /**
+   * Set to false for suites that manage their own test isolation. The fixture resets and seeds once
+   * before the file's tests, then shares the database state and REST client between those tests.
+   */
+  resetBetweenTests?: boolean
 } & TestOptions
 
 type IntegrationFixtures = {
@@ -30,8 +35,11 @@ type IntegrationFixtures = {
     configPath: null | string
     /** Raw file-scoped instance for suite hooks. Tests should use `payload`. */
     payloadInstance: Payload
+    resetBetweenTests: boolean
     /** Config supplied to `test.suite`, imported automatically before file hooks run. */
     resolvedConfig: null | SanitizedConfig
+    /** Raw file-scoped REST client for suites that intentionally share state across tests. */
+    restClientInstance: NextRESTClient
     testCron: boolean
     testDir: string
   }
@@ -94,21 +102,35 @@ const testWithFixtures = vitestTest.extend<IntegrationFixtures>({
     },
     { scope: 'file' },
   ],
-  payload: async ({ payloadInstance }, use) => {
-    const testDataConfig = getTestDataConfig(payloadInstance.config)
+  payload: async ({ payloadInstance, resetBetweenTests }, use) => {
+    if (resetBetweenTests) {
+      const testDataConfig = getTestDataConfig(payloadInstance.config)
 
-    if (!testDataConfig) {
-      throw new Error('Test suite metadata was not registered by buildConfigWithDefaults.')
+      if (!testDataConfig) {
+        throw new Error('Test suite metadata was not registered by buildConfigWithDefaults.')
+      }
+
+      await resetAndSeed({ payload: payloadInstance, ...testDataConfig })
     }
-
-    await resetAndSeed({ payload: payloadInstance, ...testDataConfig })
     await use(payloadInstance)
   },
   payloadInstance: [
-    async ({ config, testCron }, use) => {
+    async ({ config, resetBetweenTests, testCron }, use) => {
       const payload = await getPayload({ config, cron: testCron })
 
       try {
+        if (!resetBetweenTests) {
+          const testDataConfig = getTestDataConfig(payload.config)
+
+          if (!testDataConfig) {
+            throw new Error('Test suite metadata was not registered by buildConfigWithDefaults.')
+          }
+
+          // This state is used for the whole file, so there is no later reset to restore it into.
+          // Skip creating a snapshot that would never be read.
+          await resetAndSeed({ alwaysSeed: true, payload, ...testDataConfig })
+        }
+
         await use(payload)
       } finally {
         await payload.destroy()
@@ -116,9 +138,13 @@ const testWithFixtures = vitestTest.extend<IntegrationFixtures>({
     },
     { scope: 'file' },
   ],
-  restClient: async ({ payload }, use) => {
-    await use(new NextRESTClient(payload.config))
-  },
+  resetBetweenTests: [
+    // eslint-disable-next-line no-empty-pattern
+    async ({}, use) => {
+      await use(true)
+    },
+    { scope: 'file' },
+  ],
   resolvedConfig: [
     async ({ configPath }, use) => {
       if (configPath === null) {
@@ -133,6 +159,15 @@ const testWithFixtures = vitestTest.extend<IntegrationFixtures>({
       await use(await config)
     },
     { auto: true, scope: 'file' },
+  ],
+  restClient: async ({ payload, resetBetweenTests, restClientInstance }, use) => {
+    await use(resetBetweenTests ? new NextRESTClient(payload.config) : restClientInstance)
+  },
+  restClientInstance: [
+    async ({ payloadInstance }, use) => {
+      await use(new NextRESTClient(payloadInstance.config))
+    },
+    { scope: 'file' },
   ],
   sdk: async ({ payload }, use) => {
     await use(getSDK(payload.config))
@@ -160,8 +195,9 @@ const testWithFixtures = vitestTest.extend<IntegrationFixtures>({
  * imported once before file hooks run. Payload is initialized lazily, once per file, and destroyed
  * afterward. Before every test that uses Payload, REST, or the SDK, the database and upload
  * directories are reset and the suite's optional seed function is run. REST and SDK clients are
- * recreated per test. Standalone integration tests use `test.suite({})` and do not initialize
- * Payload.
+ * recreated per test. Suites that already manage their own isolation can set `resetBetweenTests` to
+ * false to reset and seed once, then share their database state and REST client. Standalone
+ * integration tests use `test.suite({})` and do not initialize Payload.
  *
  * @example
  * test.suite({ config: './config.ts' })('Posts', () => {
@@ -178,8 +214,12 @@ export const test = Object.assign(testWithFixtures, {
       describe: testWithFixtures.describe.runIf(shouldRun),
     })
   },
-  suite(this: typeof testWithFixtures, { config, cron = true, db }: TestSuiteOptions) {
+  suite(
+    this: typeof testWithFixtures,
+    { config, cron = true, db, resetBetweenTests = true }: TestSuiteOptions,
+  ) {
     this.override('configPath', config ? path.resolve(getTestDirectory(), config) : null)
+    this.override('resetBetweenTests', resetBetweenTests)
     this.override('testCron', cron)
 
     return this.describe.runIf(matchesDatabase({ db }))

--- a/test/__helpers/int/vitest.ts
+++ b/test/__helpers/int/vitest.ts
@@ -40,6 +40,8 @@ type IntegrationFixtures = {
     resolvedConfig: null | SanitizedConfig
     /** Raw file-scoped REST client for suites that intentionally share state across tests. */
     restClientInstance: NextRESTClient
+    /** Prepares shared test data once for suites that disable resets between tests. */
+    seedAtStart: void
     testCron: boolean
     testDir: string
   }
@@ -115,22 +117,10 @@ const testWithFixtures = vitestTest.extend<IntegrationFixtures>({
     await use(payloadInstance)
   },
   payloadInstance: [
-    async ({ config, resetBetweenTests, testCron }, use) => {
+    async ({ config, testCron }, use) => {
       const payload = await getPayload({ config, cron: testCron })
 
       try {
-        if (!resetBetweenTests) {
-          const testDataConfig = getTestDataConfig(payload.config)
-
-          if (!testDataConfig) {
-            throw new Error('Test suite metadata was not registered by buildConfigWithDefaults.')
-          }
-
-          // This state is used for the whole file, so there is no later reset to restore it into.
-          // Skip creating a snapshot that would never be read.
-          await resetAndSeed({ alwaysSeed: true, payload, ...testDataConfig })
-        }
-
         await use(payload)
       } finally {
         await payload.destroy()
@@ -172,6 +162,14 @@ const testWithFixtures = vitestTest.extend<IntegrationFixtures>({
   sdk: async ({ payload }, use) => {
     await use(getSDK(payload.config))
   },
+  seedAtStart: [
+    // Overridden by test.suite only when a suite disables resets between tests.
+    // eslint-disable-next-line no-empty-pattern
+    async ({}, use) => {
+      await use(undefined)
+    },
+    { auto: true, scope: 'file' },
+  ],
   testCron: [
     // eslint-disable-next-line no-empty-pattern
     async ({}, use) => {
@@ -221,6 +219,20 @@ export const test = Object.assign(testWithFixtures, {
     this.override('configPath', config ? path.resolve(getTestDirectory(), config) : null)
     this.override('resetBetweenTests', resetBetweenTests)
     this.override('testCron', cron)
+
+    if (!resetBetweenTests) {
+      this.override('seedAtStart', async ({ payloadInstance: payload }) => {
+        const testDataConfig = getTestDataConfig(payload.config)
+
+        if (!testDataConfig) {
+          throw new Error('Test suite metadata was not registered by buildConfigWithDefaults.')
+        }
+
+        // This state is used for the whole file, so there is no later reset to restore it into.
+        // Skip creating a snapshot that would never be read.
+        await resetAndSeed({ alwaysSeed: true, payload, ...testDataConfig })
+      })
+    }
 
     return this.describe.runIf(matchesDatabase({ db }))
   },

--- a/test/access-control/int.spec.ts
+++ b/test/access-control/int.spec.ts
@@ -32,7 +32,7 @@ import {
   slug,
   unrestrictedSlug,
 } from './shared.js'
-test.suite({ config: './config.ts' })('Access Control', () => {
+test.suite({ config: './config.ts', resetBetweenTests: false })('Access Control', () => {
   let post1: Post
   let restricted: FullyRestricted
 
@@ -969,7 +969,7 @@ test.suite({ config: './config.ts' })('Access Control', () => {
     let adminUser: Record<string, unknown>
     let publicUser: Record<string, unknown>
 
-    test.beforeEach(async ({ payload }) => {
+    test.beforeAll(async ({ payloadInstance: payload }) => {
       const { docs: adminDocs } = await payload.find({
         collection: 'users',
         limit: 1,

--- a/test/auth/int.spec.ts
+++ b/test/auth/int.spec.ts
@@ -34,11 +34,11 @@ import {
 
 const { email, password } = devUser
 
-test.suite({ config: './config.ts' })('Auth', () => {
+test.suite({ config: './config.ts', resetBetweenTests: false })('Auth', () => {
   test.describe('GraphQL - admin user', () => {
     let token
     let user
-    test.beforeEach(async ({ restClient }) => {
+    test.beforeAll(async ({ restClientInstance: restClient }) => {
       const { data } = await restClient
         .GRAPHQL_POST({
           body: JSON.stringify({
@@ -264,7 +264,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
       let token: string | undefined
       let loggedInUser: undefined | User
 
-      test.beforeEach(async ({ restClient }) => {
+      test.beforeAll(async ({ restClientInstance: restClient }) => {
         const response = await restClient.POST(`/${slug}/login`, {
           body: JSON.stringify({
             email,
@@ -490,16 +490,6 @@ test.suite({ config: './config.ts' })('Auth', () => {
         payload,
         restClient,
       }) => {
-        await payload.create({
-          collection: slug,
-          data: {
-            apiKey: '987e6543-e21b-12d3-a456-426614174999',
-            email: 'user@example.com',
-            enableAPIKey: true,
-            password: 'Password123',
-          },
-        })
-
         const { token } = await payload.login({
           collection: 'users',
           data: { email: 'user@example.com', password: 'Password123' },
@@ -598,7 +588,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
         const property = 'store'
         let data
 
-        test.beforeEach(async ({ restClient }) => {
+        test.beforeAll(async ({ restClientInstance: restClient }) => {
           const response = await restClient.POST(`/payload-preferences/${key}`, {
             body: JSON.stringify({
               value: { property },
@@ -757,7 +747,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
         let publicUserId: number | string
         const createdIDs: (number | string)[] = []
 
-        test.beforeEach(async ({ payload, restClient }) => {
+        test.beforeAll(async ({ payloadInstance: payload, restClientInstance: restClient }) => {
           // Admin creates preference
           const adminPref = await restClient.POST(`/payload-preferences/${adminKey}`, {
             body: JSON.stringify({ value: { data: 'admin-sensitive' } }),
@@ -877,7 +867,7 @@ test.suite({ config: './config.ts' })('Auth', () => {
           return await res.json()
         }
 
-        test.beforeEach(async ({ restClient }) => {
+        test.beforeAll(async ({ restClientInstance: restClient }) => {
           const response = await restClient.POST(`/${slug}/login`, {
             body: JSON.stringify({
               email,
@@ -1721,19 +1711,6 @@ test.suite({ config: './config.ts' })('Auth', () => {
       })
 
       test('should allow force unlocking of a user', async ({ payload }) => {
-        await payload.db.updateOne({
-          collection: slug,
-          data: {
-            lockUntil: new Date(Date.now() + 60_000).toISOString(),
-            loginAttempts: 2,
-          },
-          where: {
-            email: {
-              equals: devUser.email,
-            },
-          },
-        })
-
         await payload.unlock({
           collection: slug,
           data: {

--- a/test/collections-rest/int.spec.ts
+++ b/test/collections-rest/int.spec.ts
@@ -24,7 +24,7 @@ import {
   relationSlug,
 } from './config.js'
 
-test.suite({ config: './config.ts' })('collections-rest', () => {
+test.suite({ config: './config.ts', resetBetweenTests: false })('collections-rest', () => {
   test.beforeEach(async ({ payload }) => {
     await clearDocs({ payload })
   })

--- a/test/database/int.spec.ts
+++ b/test/database/int.spec.ts
@@ -55,8 +55,8 @@ const collection = postsSlug
 const title = 'title'
 process.env.PAYLOAD_CONFIG_PATH = path.join(dirname, 'config.ts')
 
-test.suite({ config: './config.ts' })('database', () => {
-  test.beforeEach(async ({ payload, restClient }) => {
+test.suite({ config: './config.ts', resetBetweenTests: false })('database', () => {
+  test.beforeAll(async ({ payloadInstance: payload, restClientInstance: restClient }) => {
     payload.db.migrationDir = path.join(dirname, './migrations')
 
     await restClient.login({
@@ -893,7 +893,7 @@ test.suite({ config: './config.ts' })('database', () => {
   })
 
   test.describe('allow ID on create', () => {
-    test.beforeEach(({ payload }) => {
+    test.beforeAll(({ payloadInstance: payload }) => {
       payload.db.allowIDOnCreate = true
       payload.config.db.allowIDOnCreate = true
     })
@@ -2512,7 +2512,7 @@ test.suite({ config: './config.ts' })('database', () => {
 
       test.describe('disableTransaction', () => {
         let disabledTransactionPost
-        test.beforeEach(async ({ payload }) => {
+        test.beforeAll(async ({ payloadInstance: payload }) => {
           disabledTransactionPost = await payload.create({
             collection,
             data: {

--- a/test/fields/int.spec.ts
+++ b/test/fields/int.spec.ts
@@ -42,8 +42,8 @@ import {
 
 let user: any
 
-test.suite({ config: './config.ts' })('Fields', () => {
-  test.beforeEach(async ({ payload, restClient }) => {
+test.suite({ config: './config.ts', resetBetweenTests: false })('Fields', () => {
+  test.beforeAll(async ({ payloadInstance: payload, restClientInstance: restClient }) => {
     await restClient.login({
       slug: 'users',
       credentials: devUser,
@@ -2454,7 +2454,7 @@ test.suite({ config: './config.ts' })('Fields', () => {
     const definitions: Record<string, IndexDirection> = {}
     const options: Record<string, IndexOptions> = {}
 
-    test.beforeEach(({ payload }) => {
+    test.beforeAll(({ payloadInstance: payload }) => {
       indexes = (payload.db as MongooseAdapter).collections['indexed-fields'].schema.indexes() as [
         Record<string, IndexDirection>,
         IndexOptions,

--- a/test/folders/int.spec.ts
+++ b/test/folders/int.spec.ts
@@ -4,7 +4,7 @@ import { expect } from 'vitest'
 import { test } from '../__helpers/int/vitest.js'
 import { folderSlug, postSlug } from './shared.js'
 
-test.suite({ config: './config.ts' })('Folders Helpers', () => {
+test.suite({ config: './config.ts', resetBetweenTests: false })('Folders Helpers', () => {
   test.describe('createFoldersCollection', () => {
     test('should create a collection with hierarchy enabled', ({ payload }) => {
       const foldersCollection = payload.collections[folderSlug].config

--- a/test/form-state/int.spec.ts
+++ b/test/form-state/int.spec.ts
@@ -26,8 +26,8 @@ const DummyReactComponent: React.ReactNode = {
   key: null,
 }
 
-test.suite({ config: './config.ts' })('Form State', () => {
-  test.beforeEach(async ({ restClient }) => {
+test.suite({ config: './config.ts', resetBetweenTests: false })('Form State', () => {
+  test.beforeAll(async ({ restClientInstance: restClient }) => {
     const data = await restClient
       .POST('/users/login', {
         body: JSON.stringify({

--- a/test/hierarchy/int.spec.ts
+++ b/test/hierarchy/int.spec.ts
@@ -5,7 +5,7 @@ import type { Organization } from './payload-types.js'
 
 import { test } from '../__helpers/int/vitest.js'
 
-test.suite({ config: './config.ts' })('Hierarchy', () => {
+test.suite({ config: './config.ts', resetBetweenTests: false })('Hierarchy', () => {
   test.describe('Collection Config Property', () => {
     test('should add virtual path fields to collection', ({ payload }) => {
       const organizationsCollection = payload.collections.organizations.config

--- a/test/hooks/int.spec.ts
+++ b/test/hooks/int.spec.ts
@@ -26,7 +26,7 @@ import { HooksConfig } from './config.js'
 import { dataHooksGlobalSlug } from './globals/Data/index.js'
 import { afterReadSlug, beforeValidateSlug, overrideAccessSlug } from './shared.js'
 
-test.suite({ config: './config.ts' })('Hooks', () => {
+test.suite({ config: './config.ts', resetBetweenTests: false })('Hooks', () => {
   test.options({ db: 'mongo' }).describe('transform actions', () => {
     test('should create and not throw an error', async ({ payload }) => {
       // the collection has hooks that will cause an error if transform actions is not handled properly
@@ -464,7 +464,7 @@ test.suite({ config: './config.ts' })('Hooks', () => {
     let hookUser
     let hookUserToken
 
-    test.beforeEach(async ({ payload }) => {
+    test.beforeAll(async ({ payloadInstance: payload }) => {
       const email = 'dontrefresh@payloadcms.com'
 
       hookUser = await payload.create({

--- a/test/joins/int.spec.ts
+++ b/test/joins/int.spec.ts
@@ -25,7 +25,7 @@ let token: string
 
 const { email, password } = devUser
 
-test.suite({ config: './config.ts' })('Joins Field', () => {
+test.suite({ config: './config.ts', resetBetweenTests: false })('Joins Field', () => {
   let category: Category
   let otherCategory: Category
   let categoryID
@@ -33,7 +33,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
   // --__--__--__--__--__--__--__--__--__
   // Boilerplate test setup/teardown
   // --__--__--__--__--__--__--__--__--__
-  test.beforeEach(async ({ payload, restClient }) => {
+  test.beforeAll(async ({ payloadInstance: payload, restClientInstance: restClient }) => {
     const data = await restClient
       .POST('/users/login', {
         body: JSON.stringify({
@@ -675,7 +675,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
 
   test.describe('`where` filters', () => {
     let categoryWithFilteredPost
-    test.beforeEach(async ({ payload }) => {
+    test.beforeAll(async ({ payloadInstance: payload }) => {
       categoryWithFilteredPost = await payload.create({
         collection: categoriesSlug,
         data: {
@@ -733,7 +733,7 @@ test.suite({ config: './config.ts' })('Joins Field', () => {
   test.describe('Joins with localization', () => {
     let localizedCategory: Category
 
-    test.beforeEach(async ({ payload }) => {
+    test.beforeAll(async ({ payloadInstance: payload }) => {
       localizedCategory = await payload.create({
         collection: 'localized-categories',
         locale: 'en',

--- a/test/live-preview/int.spec.ts
+++ b/test/live-preview/int.spec.ts
@@ -19,7 +19,10 @@ import type { CollectionPopulationRequestHandler } from '../../packages/live-pre
 
 import { test } from '../__helpers/int/vitest.js'
 
-test.suite({ config: './config.ts' })('Collections - Live Preview', () => {
+test.suite({
+  config: './config.ts',
+  resetBetweenTests: false,
+})('Collections - Live Preview', () => {
   const serverURL: string = `http://localhost:${process.env.PORT || 3000}`
 
   let testPost: Post
@@ -34,7 +37,7 @@ test.suite({ config: './config.ts' })('Collections - Live Preview', () => {
   ) => Promise<Record<string, any>> = mergeDataImport as any
   let createPageWithInitialData: (initialData: Partial<Page>) => Promise<Page>
 
-  test.beforeEach(async ({ payload, restClient }) => {
+  test.beforeAll(async ({ payloadInstance: payload, restClientInstance: restClient }) => {
     const requestHandler: CollectionPopulationRequestHandler = ({ data, endpoint }) => {
       const url = `/${endpoint}`
       const headers: Record<string, string> = {

--- a/test/localization/int.spec.ts
+++ b/test/localization/int.spec.ts
@@ -1042,6 +1042,23 @@ test.suite({ config: './config.ts', resetBetweenTests: false })('Localization', 
     test.describe('Localized - GraphQL', () => {
       let token
 
+      test.beforeAll(async ({ restClientInstance: restClient }) => {
+        const query = `mutation {
+          loginUser(email: "dev@payloadcms.com", password: "test") {
+            token
+          }
+        }`
+
+        const { data } = await restClient
+          .GRAPHQL_POST({
+            body: JSON.stringify({ query }),
+            query: { locale: 'en' },
+          })
+          .then((res) => res.json())
+
+        token = data.loginUser.token
+      })
+
       test('should allow user to login and retrieve populated localized field', async ({
         restClient,
       }) => {
@@ -1066,8 +1083,6 @@ test.suite({ config: './config.ts', resetBetweenTests: false })('Localization', 
 
         expect(typeof result.token).toStrictEqual('string')
         expect(typeof result.user.relation.title).toStrictEqual('string')
-
-        token = result.token
       })
 
       test('should allow retrieval of populated localized fields within meUser', async ({

--- a/test/localization/int.spec.ts
+++ b/test/localization/int.spec.ts
@@ -51,12 +51,12 @@ import {
 const collection = localizedPostsSlug
 const global = 'global-text'
 
-test.suite({ config: './config.ts' })('Localization', () => {
+test.suite({ config: './config.ts', resetBetweenTests: false })('Localization', () => {
   test.describe('Localization with fallback true', () => {
     let post1: LocalizedPost
     let postWithLocalizedData: LocalizedPost
 
-    test.beforeEach(async ({ payload }) => {
+    test.beforeAll(async ({ payloadInstance: payload }) => {
       post1 = await payload.create({
         collection,
         data: {
@@ -216,7 +216,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
         let spanishData
         let localizedDoc
 
-        test.beforeEach(async ({ payload }) => {
+        test.beforeAll(async ({ payloadInstance: payload }) => {
           englishData = {
             localizedCheckbox: false,
           }
@@ -503,9 +503,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
     test.describe('Localized Sort Count', () => {
       const expectedTotalDocs = 5
       const posts: LocalizedSort[] = []
-      test.beforeEach(async ({ payload }) => {
-        posts.length = 0
-
+      test.beforeAll(async ({ payloadInstance: payload }) => {
         for (let i = 1; i <= expectedTotalDocs; i++) {
           const post = await payload.create({
             collection: localizedSortSlug,
@@ -679,7 +677,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
       let localizedRelation2: LocalizedPost
       let withRelationship: WithLocalizedRelationship
 
-      test.beforeEach(async ({ payload }) => {
+      test.beforeAll(async ({ payloadInstance: payload }) => {
         localizedRelation = await createLocalizedPost(
           { payload },
           {
@@ -1044,28 +1042,6 @@ test.suite({ config: './config.ts' })('Localization', () => {
     test.describe('Localized - GraphQL', () => {
       let token
 
-      test.beforeEach(async ({ restClient }) => {
-        const query = `mutation {
-          loginUser(email: "dev@payloadcms.com", password: "test") {
-            token
-            user {
-              relation {
-                title
-              }
-            }
-          }
-        }`
-
-        const { data } = await restClient
-          .GRAPHQL_POST({
-            body: JSON.stringify({ query }),
-            query: { locale: 'en' },
-          })
-          .then((res) => res.json())
-
-        token = data.loginUser.token
-      })
-
       test('should allow user to login and retrieve populated localized field', async ({
         restClient,
       }) => {
@@ -1090,6 +1066,8 @@ test.suite({ config: './config.ts' })('Localization', () => {
 
         expect(typeof result.token).toStrictEqual('string')
         expect(typeof result.user.relation.title).toStrictEqual('string')
+
+        token = result.token
       })
 
       test('should allow retrieval of populated localized fields within meUser', async ({
@@ -1225,7 +1203,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
     test.describe('Localized - Arrays', () => {
       let docID
 
-      test.beforeEach(async ({ payload }) => {
+      test.beforeAll(async ({ payloadInstance: payload }) => {
         const englishDoc = await payload.create({
           collection: arrayCollectionSlug,
           data: {
@@ -3062,7 +3040,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
     test.describe('Copying To Locale', () => {
       let user: User
 
-      test.beforeEach(async ({ payload }) => {
+      test.beforeAll(async ({ payloadInstance: payload }) => {
         user = (
           await payload.find({
             collection: 'users',
@@ -3769,7 +3747,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
     let post1: LocalizedPost
     let postWithLocalizedData: LocalizedPost
 
-    test.beforeEach(async ({ payload }) => {
+    test.beforeAll(async ({ payloadInstance: payload }) => {
       if (payload.config.localization) {
         payload.config.localization.fallback = false
       }
@@ -4594,7 +4572,7 @@ test.suite({ config: './config.ts' })('Localization', () => {
     test.describe('fallback behavior', () => {
       let allFieldsPostWithLocalizedData: any
 
-      test.beforeEach(async ({ payload }) => {
+      test.beforeAll(async ({ payloadInstance: payload }) => {
         allFieldsPostWithLocalizedData = await payload.create({
           collection: allFieldsLocalizedSlug,
           data: {

--- a/test/locked-documents/int.spec.ts
+++ b/test/locked-documents/int.spec.ts
@@ -14,13 +14,13 @@ import { pagesSlug, postsSlug } from './slugs.js'
 
 const lockedDocumentCollection = 'payload-locked-documents'
 
-test.suite({ config: './config.ts' })('Locked documents', () => {
+test.suite({ config: './config.ts', resetBetweenTests: false })('Locked documents', () => {
   let post: Post
   let user: any
   let user2: any
   let postConfig: SanitizedCollectionConfig
 
-  test.beforeEach(async ({ payload }) => {
+  test.beforeAll(async ({ payloadInstance: payload }) => {
     postConfig = payload.config.collections.find(
       ({ slug }) => slug === postsSlug,
     ) as SanitizedCollectionConfig
@@ -313,7 +313,7 @@ test.suite({ config: './config.ts' })('Locked documents', () => {
     })
 
     // Should not allow update - expect data not to change
-    expect(updatedGlobalMenu.globalText).toEqual('global text')
+    expect(updatedGlobalMenu.globalText).toEqual('global text 2')
   })
 
   // Try to delete locked document (collection)

--- a/test/plugin-ecommerce/int.spec.ts
+++ b/test/plugin-ecommerce/int.spec.ts
@@ -42,7 +42,7 @@ async function createGuestCartWithItems(
   return { cartId, cartSecret }
 }
 
-test.suite({ config: './config.ts' })('ecommerce', () => {
+test.suite({ config: './config.ts', resetBetweenTests: false })('ecommerce', () => {
   test('should add a variants collection', async ({ payload }) => {
     const variants = await payload.find({
       collection: 'variants',
@@ -282,7 +282,7 @@ test.suite({ config: './config.ts' })('ecommerce', () => {
     let productId: string
     let variantId: string
 
-    test.beforeEach(async ({ payload }) => {
+    test.beforeAll(async ({ payloadInstance: payload }) => {
       // Get an existing product and variant from seed data
       const products = await payload.find({
         collection: 'products',
@@ -744,7 +744,7 @@ test.suite({ config: './config.ts' })('ecommerce', () => {
     let productId: string
     let variantId: string
 
-    test.beforeEach(async ({ payload }) => {
+    test.beforeAll(async ({ payloadInstance: payload }) => {
       const products = await payload.find({
         collection: 'products',
         limit: 1,
@@ -1037,7 +1037,7 @@ test.suite({ config: './config.ts' })('ecommerce', () => {
   test.describe('authenticated user cart operations', () => {
     let productId: string
 
-    test.beforeEach(async ({ payload }) => {
+    test.beforeAll(async ({ payloadInstance: payload }) => {
       const products = await payload.find({
         collection: 'products',
         limit: 1,
@@ -1167,7 +1167,7 @@ test.suite({ config: './config.ts' })('ecommerce', () => {
   test.describe('cart transfer to user', () => {
     let productId: string
 
-    test.beforeEach(async ({ payload }) => {
+    test.beforeAll(async ({ payloadInstance: payload }) => {
       const products = await payload.find({
         collection: 'products',
         limit: 1,

--- a/test/plugin-form-builder/int.spec.ts
+++ b/test/plugin-form-builder/int.spec.ts
@@ -21,8 +21,11 @@ const testImagePath = path.resolve(dirname, '../uploads/image.png')
 const testPdfPath = path.resolve(dirname, '../uploads/test-pdf.pdf')
 let form: Form
 
-test.suite({ config: './config.ts' })('@payloadcms/plugin-form-builder', () => {
-  test.beforeEach(async ({ payload }) => {
+test.suite({
+  config: './config.ts',
+  resetBetweenTests: false,
+})('@payloadcms/plugin-form-builder', () => {
+  test.beforeAll(async ({ payloadInstance: payload }) => {
     const formConfig: Omit<Form, 'createdAt' | 'id' | 'updatedAt'> = {
       confirmationType: 'message',
       confirmationMessage: {

--- a/test/plugin-import-export/int.spec.ts
+++ b/test/plugin-import-export/int.spec.ts
@@ -20,8 +20,11 @@ let restrictedUser: any
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
-test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => {
-  test.beforeEach(async ({ payload }) => {
+test.suite({
+  config: './config.ts',
+  resetBetweenTests: false,
+})('@payloadcms/plugin-import-export', () => {
+  test.beforeAll(async ({ payloadInstance: payload }) => {
     const loginResult = await payload.login({
       collection: 'users',
       data: {
@@ -8586,7 +8589,7 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-import-export', () => 
       const createdPostIds: (number | string)[] = []
       let userWithDynamicLimit: any
 
-      test.beforeEach(async ({ payload }) => {
+      test.beforeAll(async ({ payloadInstance: payload }) => {
         // Find the dev user and set their limit to 7
         const devUserDocs = await payload.find({
           collection: 'users',

--- a/test/plugin-mcp/helpers/mcpFixtures.ts
+++ b/test/plugin-mcp/helpers/mcpFixtures.ts
@@ -15,83 +15,92 @@ import { createMcpClient } from './mcpClient.js'
 type McpSetup = {
   getApiKey: (rbac?: TestRBAC) => Promise<string>
   getLimitedApiKey: () => Promise<string>
-  limitedUserId: string
-  userId: string
+  limitedUserId: number | string
+  userId: number | string
 }
 
-type McpTestContext = McpSetup & {
+type McpTestContext = {
   mcp: McpClient
   payload: Payload
   protocolEra: ProtocolEra
   restClient: NextRESTClient
-}
+} & McpSetup
 
 type McpTestFunction = (context: McpTestContext) => Promise<void> | void
 
-const payloadTest = base.extend<'mcpSetup', McpSetup>(
-  'mcpSetup',
-  { auto: true },
-  async ({ payload, restClient }) => {
-    const loginResponse: { user: { id: string } } = await restClient
-      .POST('/users/login', {
-        body: JSON.stringify({ email: devUser.email, password: devUser.password }),
-      })
-      .then((res) => res.json())
-    const userId = loginResponse.user.id
+const payloadTest = base.extend<{ $file: { mcpSetup: McpSetup } }>({
+  mcpSetup: [
+    async ({ payloadInstance: payload, restClientInstance: restClient }, use) => {
+      const loginResponse: { user: { id: number | string } } = await restClient
+        .POST('/users/login', {
+          body: JSON.stringify({ email: devUser.email, password: devUser.password }),
+        })
+        .then((res) => res.json())
+      const userId = loginResponse.user.id
 
-    const limitedUser = await payload.create({
-      collection: 'users',
-      data: {
-        email: 'limited-mcp-user@payloadcms.com',
-        password: randomUUID(),
-        rbac: {
-          globals: {
-            'site-settings': {
-              update: false,
+      const limitedUser = await payload.create({
+        collection: 'users',
+        data: {
+          email: 'limited-mcp-user@payloadcms.com',
+          password: randomUUID(),
+          rbac: {
+            globals: {
+              'site-settings': {
+                update: false,
+              },
             },
+          } satisfies TestRBAC,
+        },
+        overrideAccess: true,
+      })
+      const limitedUserId = limitedUser.id
+
+      const getApiKey = async (rbac: TestRBAC = {}): Promise<string> => {
+        const apiKey = randomUUID()
+
+        await payload.update({
+          id: userId,
+          collection: 'users',
+          data: {
+            apiKey,
+            enableAPIKey: true,
+            rbac,
           },
-        } satisfies TestRBAC,
-      },
-      overrideAccess: true,
-    })
-    const limitedUserId = limitedUser.id
+          overrideAccess: true,
+        })
 
-    const getApiKey = async (rbac: TestRBAC = {}): Promise<string> => {
-      const apiKey = randomUUID()
+        return apiKey
+      }
 
-      await payload.update({
-        id: userId,
-        collection: 'users',
-        data: {
-          apiKey,
-          enableAPIKey: true,
-          rbac,
-        },
-        overrideAccess: true,
-      })
+      const getLimitedApiKey = async (): Promise<string> => {
+        const apiKey = randomUUID()
 
-      return apiKey
-    }
+        await payload.update({
+          id: limitedUserId,
+          collection: 'users',
+          data: {
+            apiKey,
+            enableAPIKey: true,
+          },
+          overrideAccess: true,
+        })
 
-    const getLimitedApiKey = async (): Promise<string> => {
-      const apiKey = randomUUID()
+        return apiKey
+      }
 
-      await payload.update({
-        id: limitedUserId,
-        collection: 'users',
-        data: {
-          apiKey,
-          enableAPIKey: true,
-        },
-        overrideAccess: true,
-      })
-
-      return apiKey
-    }
-
-    return { getApiKey, getLimitedApiKey, limitedUserId, userId }
-  },
-)
+      try {
+        await use({ getApiKey, getLimitedApiKey, limitedUserId, userId })
+      } finally {
+        await payload.delete({
+          id: limitedUserId,
+          collection: 'users',
+          overrideAccess: true,
+        })
+      }
+    },
+    { auto: true, scope: 'file' },
+  ],
+})
 
 const protocolEras: Array<{ label: string; protocolEra: ProtocolEra }> = [
   { label: '2025 legacy', protocolEra: 'legacy' },
@@ -105,15 +114,15 @@ export const test = Object.assign(payloadTest, {
 /** Registers every MCP integration test independently against both protocol eras. */
 export function it(name: string, testFunction: McpTestFunction, timeout?: number): void {
   for (const { label, protocolEra } of protocolEras) {
-    registerMcpTest({ label, name, protocolEra, testFunction, timeout })
+    registerMcpTest({ name, label, protocolEra, testFunction, timeout })
   }
 }
 
 /** Registers an integration test for behavior that exists only in the modern era. */
 export function itModern(name: string, testFunction: McpTestFunction, timeout?: number): void {
   registerMcpTest({
-    label: '2026 modern',
     name,
+    label: '2026 modern',
     protocolEra: 'modern',
     testFunction,
     timeout,
@@ -121,8 +130,8 @@ export function itModern(name: string, testFunction: McpTestFunction, timeout?: 
 }
 
 const registerMcpTest = ({
-  label,
   name,
+  label,
   protocolEra,
   testFunction,
   timeout,

--- a/test/plugin-mcp/helpers/mcpFixtures.ts
+++ b/test/plugin-mcp/helpers/mcpFixtures.ts
@@ -28,79 +28,78 @@ type McpTestContext = {
 
 type McpTestFunction = (context: McpTestContext) => Promise<void> | void
 
-const payloadTest = base.extend<{ $file: { mcpSetup: McpSetup } }>({
-  mcpSetup: [
-    async ({ payloadInstance: payload, restClientInstance: restClient }, use) => {
-      const loginResponse: { user: { id: number | string } } = await restClient
-        .POST('/users/login', {
-          body: JSON.stringify({ email: devUser.email, password: devUser.password }),
-        })
-        .then((res) => res.json())
-      const userId = loginResponse.user.id
+const payloadTest = base.extend<'mcpSetup', McpSetup>(
+  'mcpSetup',
+  { auto: true, scope: 'file' },
+  async ({ payloadInstance: payload, restClientInstance: restClient }, { onCleanup }) => {
+    const loginResponse: { user: { id: number | string } } = await restClient
+      .POST('/users/login', {
+        body: JSON.stringify({ email: devUser.email, password: devUser.password }),
+      })
+      .then((res) => res.json())
+    const userId = loginResponse.user.id
 
-      const limitedUser = await payload.create({
+    const limitedUser = await payload.create({
+      collection: 'users',
+      data: {
+        email: 'limited-mcp-user@payloadcms.com',
+        password: randomUUID(),
+        rbac: {
+          globals: {
+            'site-settings': {
+              update: false,
+            },
+          },
+        } satisfies TestRBAC,
+      },
+      overrideAccess: true,
+    })
+    const limitedUserId = limitedUser.id
+
+    const getApiKey = async (rbac: TestRBAC = {}): Promise<string> => {
+      const apiKey = randomUUID()
+
+      await payload.update({
+        id: userId,
         collection: 'users',
         data: {
-          email: 'limited-mcp-user@payloadcms.com',
-          password: randomUUID(),
-          rbac: {
-            globals: {
-              'site-settings': {
-                update: false,
-              },
-            },
-          } satisfies TestRBAC,
+          apiKey,
+          enableAPIKey: true,
+          rbac,
         },
         overrideAccess: true,
       })
-      const limitedUserId = limitedUser.id
 
-      const getApiKey = async (rbac: TestRBAC = {}): Promise<string> => {
-        const apiKey = randomUUID()
+      return apiKey
+    }
 
-        await payload.update({
-          id: userId,
-          collection: 'users',
-          data: {
-            apiKey,
-            enableAPIKey: true,
-            rbac,
-          },
-          overrideAccess: true,
-        })
+    const getLimitedApiKey = async (): Promise<string> => {
+      const apiKey = randomUUID()
 
-        return apiKey
-      }
+      await payload.update({
+        id: limitedUserId,
+        collection: 'users',
+        data: {
+          apiKey,
+          enableAPIKey: true,
+        },
+        overrideAccess: true,
+      })
 
-      const getLimitedApiKey = async (): Promise<string> => {
-        const apiKey = randomUUID()
+      return apiKey
+    }
 
-        await payload.update({
-          id: limitedUserId,
-          collection: 'users',
-          data: {
-            apiKey,
-            enableAPIKey: true,
-          },
-          overrideAccess: true,
-        })
+    onCleanup(() =>
+      payload.delete({
+        id: limitedUserId,
+        collection: 'users',
+        overrideAccess: true,
+      }),
+    )
 
-        return apiKey
-      }
-
-      try {
-        await use({ getApiKey, getLimitedApiKey, limitedUserId, userId })
-      } finally {
-        await payload.delete({
-          id: limitedUserId,
-          collection: 'users',
-          overrideAccess: true,
-        })
-      }
-    },
-    { auto: true, scope: 'file' },
-  ],
-})
+    return { getApiKey, getLimitedApiKey, limitedUserId, userId }
+  },
+)
 
 const protocolEras: Array<{ label: string; protocolEra: ProtocolEra }> = [
   { label: '2025 legacy', protocolEra: 'legacy' },
@@ -114,15 +113,15 @@ export const test = Object.assign(payloadTest, {
 /** Registers every MCP integration test independently against both protocol eras. */
 export function it(name: string, testFunction: McpTestFunction, timeout?: number): void {
   for (const { label, protocolEra } of protocolEras) {
-    registerMcpTest({ name, label, protocolEra, testFunction, timeout })
+    registerMcpTest({ label, name, protocolEra, testFunction, timeout })
   }
 }
 
 /** Registers an integration test for behavior that exists only in the modern era. */
 export function itModern(name: string, testFunction: McpTestFunction, timeout?: number): void {
   registerMcpTest({
-    name,
     label: '2026 modern',
+    name,
     protocolEra: 'modern',
     testFunction,
     timeout,
@@ -130,8 +129,8 @@ export function itModern(name: string, testFunction: McpTestFunction, timeout?: 
 }
 
 const registerMcpTest = ({
-  name,
   label,
+  name,
   protocolEra,
   testFunction,
   timeout,

--- a/test/plugin-mcp/int.spec.ts
+++ b/test/plugin-mcp/int.spec.ts
@@ -100,7 +100,7 @@ function draft2020Violations(schema: unknown, rootPath: string): string[] {
   walk(schema, rootPath)
   return errors
 }
-test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
+test.suite({ config: './config.ts', resetBetweenTests: false })('@payloadcms/plugin-mcp', () => {
   test.afterEach(() => {
     vi.unstubAllEnvs()
   })
@@ -839,10 +839,23 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
     })
   })
   test.describe('Collections', () => {
+    const createdMediaIDs: Array<number | string> = []
+    const createdPostIDs: Array<number | string> = []
     const uploadServers: TestFileServer[] = []
-    test.afterEach(async () => {
+
+    test.afterEach(async ({ payload }) => {
       await Promise.all(uploadServers.map(({ close }) => close()))
       uploadServers.length = 0
+
+      for (const id of createdMediaIDs) {
+        await payload.delete({ collection: 'media', id })
+      }
+      createdMediaIDs.length = 0
+
+      for (const id of createdPostIDs) {
+        await payload.delete({ collection: 'posts', id })
+      }
+      createdPostIDs.length = 0
     })
     it('getCollectionSchema returns collection fields for createDocuments', async ({
       mcp,
@@ -945,6 +958,8 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
         id: number | string
       }>(callResponse)
 
+      createdPostIDs.push(createdPost.id)
+
       expect(createdPost).toMatchObject({
         _status: 'draft',
         content: 'Incomplete draft',
@@ -972,6 +987,8 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
         docs: Array<{ id: number | string; index: number }>
         errors: Array<{ index: number; message: string }>
       }>(callResponse)
+
+      createdPostIDs.push(...result.docs.map(({ id }) => id))
 
       expect(callResponse.isError).not.toBe(true)
       expect(result.docs).toEqual([
@@ -1022,6 +1039,8 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
         errors: Array<{ index: number; message: string }>
       }>(callResponse)
 
+      createdMediaIDs.push(...result.docs.map(({ id }) => id))
+
       const [storedPNG, storedJPEG] = await Promise.all(
         result.docs.map(({ id }) => payload.findByID({ collection: 'media', id })),
       )
@@ -1064,6 +1083,8 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
       const createdMedia = getCreatedDocument<{
         id: number | string
       }>(callResponse)
+      createdMediaIDs.push(createdMedia.id)
+
       const storedMedia = await payload.findByID({
         id: createdMedia.id,
         collection: 'media',
@@ -1081,6 +1102,8 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
         },
         filePath: path.resolve(dirname, '../uploads/image.jpg'),
       })
+      createdMediaIDs.push(media.id)
+
       const image = await readFile(path.resolve(dirname, '../uploads/image.png'))
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
@@ -1235,6 +1258,8 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
       const createdPost = getCreatedDocument<{
         id: number | string
       }>(callResponse)
+      createdPostIDs.push(createdPost.id)
+
       const storedPost = await payload.findByID({
         id: createdPost.id,
         collection: 'posts',
@@ -1314,6 +1339,8 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
       const createdMedia = getCreatedDocument<{
         id: number | string
       }>(callResponse)
+      createdMediaIDs.push(createdMedia.id)
+
       const storedMedia = await payload.findByID({
         id: createdMedia.id,
         collection: 'media',
@@ -1331,6 +1358,8 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
           title: 'Test Post for Finding',
         },
       })
+      createdPostIDs.push(post.id)
+
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
       const callResponse = await client.callTool({
@@ -2866,6 +2895,15 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
     })
   })
   test.describe('Minified JSON responses', () => {
+    const createdIDs: string[] = []
+
+    test.afterEach(async ({ payload }) => {
+      for (const id of createdIDs) {
+        await payload.delete({ collection: 'posts', id })
+      }
+      createdIDs.length = 0
+    })
+
     it('should return minified JSON without newlines or indentation in resource responses', async ({
       mcp,
       getApiKey,
@@ -2878,6 +2916,8 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
           content: 'Content for minified test.',
         },
       })
+      createdIDs.push(doc.id)
+
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
       const callResponse = await client.callTool({
@@ -2928,6 +2968,8 @@ test.suite({ config: './config.ts' })('@payloadcms/plugin-mcp', () => {
           content: 'Content for findByID minified test.',
         },
       })
+      createdIDs.push(doc.id)
+
       const apiKey = await getApiKey()
       const client = await mcp.connect(apiKey)
       const callResponse = await client.callTool({

--- a/test/plugin-multi-tenant/int.spec.ts
+++ b/test/plugin-multi-tenant/int.spec.ts
@@ -17,8 +17,11 @@ import {
 
 let token: string
 
-test.suite({ config: './config.ts' })('@payloadcms/plugin-multi-tenant', () => {
-  test.beforeEach(async ({ restClient }) => {
+test.suite({
+  config: './config.ts',
+  resetBetweenTests: false,
+})('@payloadcms/plugin-multi-tenant', () => {
+  test.beforeAll(async ({ restClientInstance: restClient }) => {
     const data = await restClient
       .POST('/users/login', {
         body: JSON.stringify({

--- a/test/query-presets/int.spec.ts
+++ b/test/query-presets/int.spec.ts
@@ -11,8 +11,8 @@ let adminUser: User
 let editorUser: User
 let publicUser: User
 
-test.suite({ config: './config.ts' })('Query Presets', () => {
-  test.beforeEach(async ({ payload }) => {
+test.suite({ config: './config.ts', resetBetweenTests: false })('Query Presets', () => {
+  test.beforeAll(async ({ payloadInstance: payload }) => {
     adminUser = await payload
       .login({
         collection: 'users',

--- a/test/sdk/int.spec.ts
+++ b/test/sdk/int.spec.ts
@@ -21,8 +21,8 @@ const testUserCredentials = {
   password: '123456',
 }
 
-test.suite({ config: './config.ts' })('@payloadcms/sdk', () => {
-  test.beforeEach(async ({ payload }) => {
+test.suite({ config: './config.ts', resetBetweenTests: false })('@payloadcms/sdk', () => {
+  test.beforeAll(async ({ payloadInstance: payload }) => {
     post = await payload.create({ collection: 'posts', data: { number: 1, number2: 3 } })
     postTrash = await payload.create({
       collection: 'posts',

--- a/test/select/int.spec.ts
+++ b/test/select/int.spec.ts
@@ -24,7 +24,7 @@ import { devUser } from '../credentials.js'
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
-test.suite({ config: './config.ts' })('Select', () => {
+test.suite({ config: './config.ts', resetBetweenTests: false })('Select', () => {
   test.describe('Local API - Base', () => {
     let post: Post
     let postId: number | string
@@ -32,7 +32,7 @@ test.suite({ config: './config.ts' })('Select', () => {
     let point: Point
     let pointId: number | string
 
-    test.beforeEach(async ({ payload }) => {
+    test.beforeAll(async ({ payloadInstance: payload }) => {
       post = await createPost({ payload })
       postId = post.id
 
@@ -729,7 +729,7 @@ test.suite({ config: './config.ts' })('Select', () => {
     let post: LocalizedPost
     let postId: number | string
 
-    test.beforeEach(async ({ payload }) => {
+    test.beforeAll(async ({ payloadInstance: payload }) => {
       post = await createLocalizedPost({ payload })
       postId = post.id
     })
@@ -1373,7 +1373,7 @@ test.suite({ config: './config.ts' })('Select', () => {
     let post: DeepPost
     let postId: number | string
 
-    test.beforeEach(async ({ payload }) => {
+    test.beforeAll(async ({ payloadInstance: payload }) => {
       post = await createDeepPost({ payload })
       postId = post.id
     })
@@ -1459,7 +1459,7 @@ test.suite({ config: './config.ts' })('Select', () => {
     let post: VersionedPost
     let postId: number | string
 
-    test.beforeEach(async ({ payload }) => {
+    test.beforeAll(async ({ payloadInstance: payload }) => {
       post = await createVersionedPost({ payload })
       postId = post.id
     })
@@ -1689,7 +1689,7 @@ test.suite({ config: './config.ts' })('Select', () => {
 
   test.describe('Local API - Globals', () => {
     let globalPost: GlobalPost
-    test.beforeEach(async ({ payload }) => {
+    test.beforeAll(async ({ payloadInstance: payload }) => {
       globalPost = await payload.updateGlobal({
         slug: 'global-post',
         data: {
@@ -1842,7 +1842,7 @@ test.suite({ config: './config.ts' })('Select', () => {
     let post: Post
     let postId: number | string
 
-    test.beforeEach(async ({ payload }) => {
+    test.beforeAll(async ({ payloadInstance: payload }) => {
       post = await createPost({ payload })
       postId = post.id
     })
@@ -2011,7 +2011,7 @@ test.suite({ config: './config.ts' })('Select', () => {
   test.describe('REST API - Logged in', () => {
     let token: string | undefined
 
-    test.beforeEach(async ({ restClient }) => {
+    test.beforeAll(async ({ restClientInstance: restClient }) => {
       const response = await restClient.POST(`/users/login`, {
         body: JSON.stringify({
           email: devUser.email,
@@ -2085,7 +2085,7 @@ test.suite({ config: './config.ts' })('Select', () => {
       slug: string
     }
     let expectedHomePageOverride: { additional: string; id: number | string }
-    test.beforeEach(async ({ payload }) => {
+    test.beforeAll(async ({ payloadInstance: payload }) => {
       homePage = await payload.create({
         collection: 'pages',
         data: {

--- a/test/sort/int.spec.ts
+++ b/test/sort/int.spec.ts
@@ -12,9 +12,9 @@ import { nonUniqueSortSlug } from './collections/NonUniqueSort/index.js'
 import { orderableSlug } from './collections/Orderable/index.js'
 import { orderableJoinSlug } from './collections/OrderableJoin/index.js'
 
-test.suite({ config: './config.ts' })('Sort', () => {
+test.suite({ config: './config.ts', resetBetweenTests: false })('Sort', () => {
   test.describe('Local API', () => {
-    test.beforeEach(async ({ payload }) => {
+    test.beforeAll(async ({ payloadInstance: payload }) => {
       await createData(payload, 'posts', [
         { text: 'Post 1', number: 1, number2: 10, group: { number: 100 } },
         { text: 'Post 2', number: 2, number2: 10, group: { number: 200 } },
@@ -29,6 +29,11 @@ test.suite({ config: './config.ts' })('Sort', () => {
         { text: 'Post default-5 a', number: 5 },
         { text: 'Post default-1', number: 1 },
       ])
+    })
+
+    test.afterAll(async ({ payloadInstance }) => {
+      await payloadInstance.delete({ collection: 'posts', where: {} })
+      await payloadInstance.delete({ collection: 'default-sort', where: {} })
     })
 
     test.describe('Default sort', () => {
@@ -313,7 +318,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
     })
 
     test.describe('Sort with drafts', () => {
-      test.beforeEach(async ({ payload }) => {
+      test.beforeAll(async ({ payloadInstance: payload }) => {
         const testData1 = await payload.create({
           collection: 'drafts',
           data: { text: 'Post 1 draft', number: 10 },
@@ -410,7 +415,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
     })
 
     test.describe('Localized sort', () => {
-      test.beforeEach(async ({ payload }) => {
+      test.beforeAll(async ({ payloadInstance: payload }) => {
         const testData1 = await payload.create({
           collection: 'localized',
           data: { text: 'Post 1 english', number: 10 },
@@ -465,7 +470,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
       let orderable2: Orderable
       let orderableDraft1: Draft
       let orderableDraft2: Draft
-      test.beforeEach(async ({ payload }) => {
+      test.beforeAll(async ({ payloadInstance: payload }) => {
         orderable1 = await payload.create({
           collection: orderableSlug,
           data: {
@@ -915,7 +920,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
       let orderable2: Orderable
       let orderable3: Orderable
 
-      test.beforeEach(async ({ payload }) => {
+      test.beforeAll(async ({ payloadInstance: payload }) => {
         related = await payload.create({
           collection: orderableJoinSlug,
           data: {
@@ -1244,7 +1249,7 @@ test.suite({ config: './config.ts' })('Sort', () => {
   })
 
   test.describe('REST API', () => {
-    test.beforeEach(async ({ payload }) => {
+    test.beforeAll(async ({ payloadInstance: payload }) => {
       await createData(payload, 'posts', [
         { text: 'Post 1', number: 1, number2: 10 },
         { text: 'Post 2', number: 2, number2: 10 },

--- a/test/storage-azure/int.spec.ts
+++ b/test/storage-azure/int.spec.ts
@@ -13,7 +13,7 @@ import { mediaSlug, mediaWithPrefixSlug, prefix } from './shared.js'
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
-test.suite({ config: './config.ts' })('@payloadcms/storage-azure', () => {
+test.suite({ config: './config.ts', resetBetweenTests: false })('@payloadcms/storage-azure', () => {
   let TEST_CONTAINER: string
   let client: ContainerClient
 
@@ -23,7 +23,7 @@ test.suite({ config: './config.ts' })('@payloadcms/storage-azure', () => {
     }
   }
 
-  test.beforeEach(async () => {
+  test.beforeAll(async () => {
     TEST_CONTAINER = process.env.AZURE_STORAGE_CONTAINER_NAME!
 
     const blobServiceClient = BlobServiceClient.fromConnectionString(

--- a/test/trash/int.spec.ts
+++ b/test/trash/int.spec.ts
@@ -17,7 +17,7 @@ import { usersSlug } from './collections/Users/index.js'
 
 let user: any
 
-test.suite({ config: './config.ts' })('trash', () => {
+test.suite({ config: './config.ts', resetBetweenTests: false })('trash', () => {
   let restrictedCollectionDoc: RestrictedCollection
   let postsDocOne: Post
   let postsDocTwo: Post
@@ -131,7 +131,7 @@ test.suite({ config: './config.ts' })('trash', () => {
     let adminUser: any
     const createdDocIds: (number | string)[] = []
 
-    test.beforeEach(async ({ payload }) => {
+    test.beforeAll(async ({ payloadInstance: payload }) => {
       // Login as admin user
       adminUser = await payload.login({
         collection: usersSlug,

--- a/test/uploads/int.spec.ts
+++ b/test/uploads/int.spec.ts
@@ -51,8 +51,8 @@ const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 const stat = promisify(fs.stat)
 
-test.suite({ config: './config.ts' })('Collections - Uploads', () => {
-  test.beforeEach(async ({ restClient }) => {
+test.suite({ config: './config.ts', resetBetweenTests: false })('Collections - Uploads', () => {
+  test.beforeAll(async ({ restClientInstance: restClient }) => {
     await restClient.login({ slug: usersSlug })
   })
 
@@ -2098,7 +2098,7 @@ test.suite({ config: './config.ts' })('Collections - Uploads', () => {
     let uploadedFilename: string
     let fileSize: number
 
-    test.beforeEach(async ({ payload }) => {
+    test.beforeAll(async ({ payloadInstance: payload }) => {
       // Upload a test file for range request testing
       const filePath = path.join(dirname, './audio.mp3')
       const file = await getFileByPath(filePath)

--- a/test/versions/int.spec.ts
+++ b/test/versions/int.spec.ts
@@ -49,10 +49,10 @@ const dirname = path.dirname(filename)
 const formatGraphQLID = ({ payload }: { payload: Payload }, id: number | string) =>
   payload.db.defaultIDType === 'number' ? id : `"${id}"`
 
-test.suite({ config: './config.ts' })('Versions', () => {
+test.suite({ config: './config.ts', resetBetweenTests: false })('Versions', () => {
   let user: JsonObject
 
-  test.beforeEach(async ({ restClient }) => {
+  test.beforeAll(async ({ restClientInstance: restClient }) => {
     const { user: loggedInUser } = await restClient.login({
       slug: 'users',
       credentials: devUser,
@@ -2505,11 +2505,6 @@ test.suite({ config: './config.ts' })('Versions', () => {
     }
 
     test.beforeEach(async ({ payload }) => {
-      await cleanupDocuments({
-        collectionSlugs: [draftCollectionSlug],
-        payload,
-      })
-
       await createPostWithVersions({ payload })
     })
 
@@ -2893,7 +2888,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
       const updatedTitle2 = 'updated title'
       let localPostID: number | string
 
-      test.beforeEach(async ({ payload, restClient }) => {
+      test.beforeAll(async ({ payloadInstance: payload, restClientInstance: restClient }) => {
         const post = await createAutoSavePostHelper(
           { restClient },
           {
@@ -2973,7 +2968,7 @@ test.suite({ config: './config.ts' })('Versions', () => {
     test.describe('Restore', () => {
       let postID: number | string
       let versionID: number | string
-      test.beforeEach(async ({ restClient }) => {
+      test.beforeAll(async ({ restClientInstance: restClient }) => {
         const autosavePost = await createAutoSavePostHelper(
           { restClient },
           {


### PR DESCRIPTION
In the #17987–#17992 stack, we introduced new, cleaner int test fixtures and made every int test reset and reseed its db state. Previously, this reset-and-reseed step was only done manually for a handful of test suites.

This slowed down int tests in our monorepo by about 15%, which was worth the additional test isolation, eliminated risk of tests depending on other tests, and clean data guarantees.
However, when using the content API, this increased test runner time by about 78%, because our restore-from-snapshot mechanism is not supported by the content API. Instead, it had to re-run the seed script, which uses local API calls, over and over again.

Until we add support for snapshots and we further optimize the performance of our int tests, we have to revert this change.

This PR reverts the test reset-and-seed changes to the state before the #17992 stack, while keeping the new, clean fixture API.


| Period | Total job runtime | Integration tests |
|---|---:|---:|
| Before the stack  | 17m 45s | 15m 50s |
| After the stack | 30m 45s - timed out | Stopped at suite 48/51 |
| After this PR | 18m 43s | 16m 12s |


_Written by human_