### PR TITLE
fix: allow duplicating select locales when the active locale is excluded

### DIFF
--- a/packages/payload/src/collections/operations/create.ts
+++ b/packages/payload/src/collections/operations/create.ts
@@ -237,7 +237,16 @@ export const createOperation = async <
       operation: 'create',
       overrideAccess,
       req,
-      skipValidation: isSavingDraft && !hasDraftValidationEnabled(collectionConfig),
+      skipValidation:
+        (isSavingDraft && !hasDraftValidationEnabled(collectionConfig)) ||
+        // When duplicating into a subset of locales that excludes the active one,
+        // `duplicatedFromDoc` is empty at `req.locale` by design: nothing is written
+        // there. `beforeChange` validates that one locale, so required fields would
+        // always fail. The selected locales travel in `docWithLocales`, which
+        // validation never reads.
+        Boolean(
+          duplicateFromID && selectedLocales?.length && locale && !selectedLocales.includes(locale),
+        ),
     })
 
     // When locale='all' or when beforeChange doesn't convert the string (e.g. no locale hook ran),

--- a/test/localization/int.spec.ts
+++ b/test/localization/int.spec.ts
@@ -1653,6 +1653,49 @@ describe('Localization', () => {
         expect(allLocales?.title?.es).toBe(spanishTitle)
         expect(allLocales?.description).toBe('keep me')
       })
+
+      it('should duplicate select locales when a required localized field is unselected', async () => {
+        const doc = await payload.create({
+          collection: withRequiredLocalizedFields,
+          data: {
+            nav: {
+              layout: [{ blockType: 'text', text: 'english text' }],
+            },
+            title: 'hello',
+          },
+          locale: defaultLocale,
+        })
+
+        await payload.update({
+          id: doc.id,
+          collection: withRequiredLocalizedFields,
+          data: {
+            nav: {
+              layout: [{ blockType: 'text', text: 'texto espanol' }],
+            },
+            title: 'hola',
+          },
+          locale: spanishLocale,
+        })
+
+        const duplicated = await payload.duplicate({
+          id: doc.id,
+          collection: withRequiredLocalizedFields,
+          locale: spanishLocale,
+          selectedLocales: [defaultLocale],
+        })
+
+        const allLocales: any = await payload.findByID({
+          id: duplicated.id,
+          collection: withRequiredLocalizedFields,
+          locale: 'all',
+        })
+
+        expect(allLocales.title.en).toBe('hello')
+        expect(allLocales.title.es).toBeUndefined()
+        expect(allLocales.nav.layout.en[0].text).toBe('english text')
+        expect(allLocales.nav.layout.es ?? null).toBeNull()
+      })
     })
 
     describe('Localized group and tabs', () => {


### PR DESCRIPTION
### What?

`payload.duplicate()` with `selectedLocales` throws when the active locale is not among the selected ones and the collection has a required localized field. Reproduced on `main` with `withRequiredLocalizedFields` from `test/localization`:

```
ValidationError: The following field is invalid: Title
  ❯ beforeChange packages/payload/src/fields/hooks/beforeChange/index.ts:77:11
  ❯ createOperation packages/payload/src/collections/operations/create.ts:230:29
```

On a collection with no required localized field the same call does not throw, it just leaves the active locale empty, which is the symptom reported in #17562.

### Why?

`getDuplicateDocumentData` filters `duplicatedFromDocWithLocales` down to the selected locales, then builds `duplicatedFromDoc` through `afterRead` at `req.locale` with `fallbackLocale: null`. When the active locale was filtered out there is nothing left to read there, so `duplicatedFromDoc` comes back empty.

`beforeChange` then validates one locale, not the document. Its docblock says the input `data` is the normal document for one locale, and the gate in `fields/hooks/beforeChange/promise.ts` reads `siblingData`, with the validate context built from `doc` and `siblingDoc`. Both are that empty `duplicatedFromDoc`. The selected locales travel separately in `docWithLocales`, which validation never reads.

So a required field is being validated against a locale that is empty on purpose. Resolving the read at a locale that survives the filter does clear the error, but it copies selected-locale content into an unselected locale and breaks `should retain non-localized fields when duplicating select locales`. The empty `duplicatedFromDoc` is doing two jobs: it is the validation subject and it is the source `beforeChange` writes at `req.locale`. Only the first one needs to go.

### How?

Widen `skipValidation` for exactly that precondition: a duplicate, carrying `selectedLocales`, whose active locale is not among them. The write path is untouched, and nothing that was previously validated stops being validated, because `req.locale` was the only locale under validation and it is empty by construction.

One caveat worth a reviewer's eye. `duplicateOperation` calls create with `data: incomingArgs?.data || {}`, so a caller that supplies `data` on the same call would have that data skip validation too. The admin Duplicate action sends none, but the API allows it. Adding an empty-`data` condition to the new clause would close that if you want it closed.

### Testing

One regression test added to the `Duplicate Collection` describe.

```
test/localization/int.spec.ts   121 pass, 0 fail
```

Without the `create.ts` change and with the test in place, the same file gives 120 passing and that one failing on the `ValidationError` above, so the test earns its place.

Verified on MongoDB. Not verified on Postgres, so the `db-postgres` half of the report in the issue is still open.

Fixes #17562
