### PR TITLE
fix(ui): use the latest IntersectionObserver entry in useIntersect

### DIFF
--- a/packages/ui/src/elements/Table/DefaultCell/fields/Relationship/index.tsx
+++ b/packages/ui/src/elements/Table/DefaultCell/fields/Relationship/index.tsx
@@ -48,7 +48,10 @@ export const RelationshipCell: React.FC<RelationshipCellProps> = ({
   const [hasRequested, setHasRequested] = useState(false)
   const { i18n, t } = useTranslation()
 
-  const isAboveViewport = canUseDOM ? entry?.boundingClientRect?.top < window.innerHeight : false
+  const isAboveViewport =
+    canUseDOM && entry
+      ? entry.isIntersecting || entry.boundingClientRect.top < window.innerHeight
+      : false
 
   useEffect(() => {
     if ((cellData || typeof cellData === 'number') && isAboveViewport && !hasRequested) {

--- a/packages/ui/src/hooks/useIntersect.ts
+++ b/packages/ui/src/hooks/useIntersect.ts
@@ -19,7 +19,7 @@ export const useIntersect = (
 
   const observer = useRef(
     typeof window !== 'undefined' && 'IntersectionObserver' in window && !disable
-      ? new window.IntersectionObserver(([ent]) => updateEntry(ent), {
+      ? new window.IntersectionObserver((entries) => updateEntry(entries[entries.length - 1]), {
           root,
           rootMargin,
           threshold,


### PR DESCRIPTION
### What?

Two small changes that together stop list-view relationship cells from getting stuck on `<No Reference>`:

1. `useIntersect` stores the **last** entry delivered by the `IntersectionObserver` callback instead of the first one.
2. `RelationshipCell` treats an entry with `isIntersecting: true` as "in view" instead of relying only on the strict `boundingClientRect.top < window.innerHeight` comparison.

### Why?

`RelationshipCell` requests the related document's title only once its `useIntersect` entry says the cell is in (or above) the viewport. Two independent defects can leave that check permanently `false`, and because the cell then stays visible, no further observer callback ever arrives to correct it:

- **Stale first entry.** `IntersectionObserver` delivers entries oldest-first, and a single callback can carry several entries for the same target when it crossed the threshold more than once between deliveries (hydration layout shifts, scrolling during load). `useIntersect` destructured `([ent])`, so it kept the outdated "not intersecting" entry and dropped the current one.
- **Off-by-one at the viewport edge.** A row whose top edge sits exactly on the viewport bottom (`top === window.innerHeight`) is reported as `isIntersecting: true`, but `top < window.innerHeight` is `false`. With 44px rows this hits the same row on every load for a given window height, which is how it was found: one specific row stuck on `<No Reference>` while every row below it loaded fine after scrolling.

`<No Reference>` is the "not requested yet" placeholder (`general:noLabel`), not the "document not found" state (`Untitled - ID: n`), so the symptom is easy to mistake for a data problem. Any relationship column in any list view can be affected. `Tooltip` and `RenderIfInViewport` share the hook and benefit from change 1.

Reproduces on both `main` and `3.x` (the code is identical) — a backport to `3.x` would be appreciated.

Related: #17473 (a different `RenderIfInViewport`/`forceRender` issue in the same lazy-rendering area).

### How?

- `packages/ui/src/hooks/useIntersect.ts`: `updateEntry(entries[entries.length - 1])`.
- `packages/ui/src/elements/Table/DefaultCell/fields/Relationship/index.tsx`: `isAboveViewport = entry.isIntersecting || entry.boundingClientRect.top < window.innerHeight`.

Deterministic reproduction for the first defect in DevTools on any list view with a relationship column:

1. Wrap `window.IntersectionObserver` to capture the callbacks and observed targets.
2. Remount the table via client-side navigation (open another collection from the sidebar and come back).
3. Invoke each captured callback for a `.relationship-cell` target with two synthetic entries: `[{ isIntersecting: false, boundingClientRect: { top: 1200 } }, { isIntersecting: true, boundingClientRect: { top: 500 } }]`.

Before the fix every `.relationship-cell` stays at `<No Reference>` and no `/api/<collection>?where[id][in]=…` request is made. After the fix all cells go through `Loading...` and render their titles.

The second defect was confirmed by reading the stuck cell's state in React DevTools: the stored entry had `isIntersecting: true` and `boundingClientRect.top === 948` with `window.innerHeight === 948`, `values` was empty and `hasRequested` was `false`. See #18108 for details.

Fixes #18108
