### PR TITLE
perf(drizzle): skip ID lookups for simple updateOne queries

### DIFF
--- a/packages/drizzle/src/updateOne.ts
+++ b/packages/drizzle/src/updateOne.ts
@@ -1,3 +1,4 @@
+import type { SQL } from 'drizzle-orm'
 import type { LibSQLDatabase } from 'drizzle-orm/libsql'
 import type { UpdateOne } from 'payload'
 
@@ -8,6 +9,7 @@ import type { DrizzleAdapter } from './types.js'
 import { buildQuery } from './queries/buildQuery.js'
 import { selectDistinct } from './queries/selectDistinct.js'
 import { upsertRow } from './upsertRow/index.js'
+import { shouldUseOptimizedUpsertRow } from './upsertRow/shouldUseOptimizedUpsertRow.js'
 import { getPrimaryDb } from './utilities/getPrimaryDb.js'
 import { getTransaction } from './utilities/getTransaction.js'
 
@@ -29,6 +31,8 @@ export const updateOne: UpdateOne = async function updateOne(
   const collection = this.payload.collections[collectionSlug].config
   const tableName = this.tableNameMap.get(toSnakeCase(collection.slug))
   let idToUpdate = id
+  let limit: 1 | undefined
+  let whereToUse: SQL | undefined
 
   const db = getPrimaryDb(this, await getTransaction(this, req))
 
@@ -41,35 +45,45 @@ export const updateOne: UpdateOne = async function updateOne(
       where: whereArg,
     })
 
-    // selectDistinct will only return if there are joins
-    const selectDistinctResult = await selectDistinct({
-      adapter: this,
-      db,
-      joins,
-      query: ({ query }) => query.limit(1),
-      selectFields,
-      tableName,
-      where,
-    })
+    if (
+      whereArg &&
+      !joins.length &&
+      !options.upsert &&
+      shouldUseOptimizedUpsertRow({ data, fields: collection.flattenedFields })
+    ) {
+      limit = 1
+      whereToUse = where
+    } else {
+      const selectDistinctResult = await selectDistinct({
+        adapter: this,
+        db,
+        joins,
+        query: ({ query }) => query.limit(1),
+        selectFields,
+        tableName,
+        where,
+      })
 
-    if (selectDistinctResult?.[0]?.id) {
-      idToUpdate = selectDistinctResult?.[0]?.id
-      // If id wasn't passed but `where` without any joins, retrieve it with findFirst
-    } else if (whereArg && !joins.length) {
-      const table = this.tables[tableName]
+      if (selectDistinctResult?.[0]?.id) {
+        idToUpdate = selectDistinctResult[0].id
+      } else if (whereArg && !joins.length) {
+        const table = this.tables[tableName]
+        const docsToUpdate = await (db as LibSQLDatabase)
+          .select({ id: table.id })
+          .from(table)
+          .where(where)
+          .limit(1)
 
-      const docsToUpdate = await (db as LibSQLDatabase)
-        .select({
-          id: table.id,
-        })
-        .from(table)
-        .where(where)
-        .limit(1)
-      idToUpdate = docsToUpdate?.[0]?.id
+        idToUpdate = docsToUpdate?.[0]?.id
+
+        if (idToUpdate && !options.upsert) {
+          whereToUse = where
+        }
+      }
     }
   }
 
-  if (!idToUpdate && !options.upsert) {
+  if (!idToUpdate && !limit && !options.upsert) {
     // TODO: In 4.0, if returning === false, we should differentiate between:
     // - No document found to update
     // - Document found, but returning === false
@@ -85,10 +99,12 @@ export const updateOne: UpdateOne = async function updateOne(
     fields: collection.flattenedFields,
     ignoreResult: returning === false,
     joinQuery,
+    limit,
     operation: 'update',
     req,
     select,
     tableName,
+    where: whereToUse,
   })
 
   if (returning === false) {

--- a/packages/drizzle/src/upsertRow/index.ts
+++ b/packages/drizzle/src/upsertRow/index.ts
@@ -2,7 +2,7 @@ import type { LibSQLDatabase } from 'drizzle-orm/libsql'
 import type { SelectedFields } from 'drizzle-orm/sqlite-core'
 import type { TypeWithID } from 'payload'
 
-import { and, desc, eq, isNull, or } from 'drizzle-orm'
+import { and, desc, eq, inArray, isNull, or } from 'drizzle-orm'
 
 import type { BlockRowToInsert } from '../transform/write/types.js'
 import type { Args } from './types.js'
@@ -47,6 +47,7 @@ export const upsertRow = async <T extends Record<string, unknown> | TypeWithID>(
   // Make a new argument in upsertRow.ts and pass the slug from every operation.
   customID,
   joinQuery: _joinQuery,
+  limit,
   operation,
   path = '',
   req,
@@ -62,7 +63,7 @@ export const upsertRow = async <T extends Record<string, unknown> | TypeWithID>(
   markWrite(adapter)
 
   let insertedRow: Record<string, unknown> = { id }
-  if (id && shouldUseOptimizedUpsertRow({ data, fields })) {
+  if ((id || limit) && shouldUseOptimizedUpsertRow({ data, fields })) {
     try {
       const transformedForWrite = transformForWrite({
         adapter,
@@ -75,23 +76,46 @@ export const upsertRow = async <T extends Record<string, unknown> | TypeWithID>(
       const { arraysToPush } = transformedForWrite
 
       const drizzle = db as LibSQLDatabase
+      const table = adapter.tables[tableName]
+      let updateWhere = id ? and(eq(table.id, id), where) : where
 
-      // First, handle $push arrays
+      if (limit && !id) {
+        // PostgreSQL doesn't support LIMIT directly on an UPDATE.
+        // Put LIMIT on a subquery (a SELECT inside the UPDATE) instead, so we update
+        // at most one row without making a separate database request.
+        const matchingID = drizzle.select({ id: table.id }).from(table).where(where).limit(limit)
 
-      if (arraysToPush && Object.keys(arraysToPush)?.length) {
-        await insertArrays({
-          adapter,
-          arrays: [arraysToPush],
-          db,
-          parentRows: [insertedRow],
-          uuidMap: {},
-        })
+        // Recheck the condition on the row being written in case another writer changed it.
+        updateWhere = and(where, inArray(table.id, matchingID))
+      }
+
+      // A conditional update must match before we append any array rows.
+      const pushArrays = async () => {
+        if (arraysToPush && Object.keys(arraysToPush)?.length) {
+          await insertArrays({
+            adapter,
+            arrays: [arraysToPush],
+            db,
+            parentRows: [insertedRow],
+            uuidMap: {},
+          })
+        }
       }
 
       // If row.updatedAt is not set, delete it to avoid triggering hasDataToUpdate. `updatedAt` may be explicitly set to null to
       // disable triggering hasDataToUpdate.
       if (typeof row.updatedAt === 'undefined' || row.updatedAt === null) {
         delete row.updatedAt
+      }
+
+      /**
+       * Array entries live in a separate table, so there may be no parent fields to update.
+       * We still need to check `where` on the parent document before adding those entries.
+       * Setting the parent's ID to its current value gives us a valid UPDATE that returns its ID.
+       * If nothing matches, we stop without adding any array entries.
+       */
+      if ((where || limit) && !Object.keys(row).length) {
+        row.id = id ?? table.id
       }
 
       const hasDataToUpdate = row && Object.keys(row)?.length
@@ -101,12 +125,18 @@ export const upsertRow = async <T extends Record<string, unknown> | TypeWithID>(
         if (hasDataToUpdate) {
           // Only update row if there is something to update.
           // Example: if the data only consists of a single $push, calling insertArrays is enough - we don't need to update the row.
-          await drizzle
+          ;[insertedRow] = await drizzle
             .update(adapter.tables[tableName])
             .set(row)
-            .where(eq(adapter.tables[tableName].id, id))
+            .where(updateWhere)
+            .returning({ id: table.id })
+
+          if (!insertedRow) {
+            return null
+          }
         }
-        return ignoreResult === 'idOnly' ? ({ id } as T) : null
+        await pushArrays()
+        return ignoreResult === 'idOnly' ? ({ id: insertedRow.id } as T) : null
       }
 
       const findManyArgs = buildFindManyArgs({
@@ -122,6 +152,7 @@ export const upsertRow = async <T extends Record<string, unknown> | TypeWithID>(
       const hasOnlyColumns = Object.keys(findManyArgs.columns || {}).length > 0
 
       if (!hasDataToUpdate) {
+        await pushArrays()
         // Nothing to update => just fetch current row and return
         findManyArgs.where = eq(adapter.tables[tableName].id, insertedRow.id)
 
@@ -153,8 +184,15 @@ export const upsertRow = async <T extends Record<string, unknown> | TypeWithID>(
         const docs = await drizzle
           .update(adapter.tables[tableName])
           .set(row)
-          .where(eq(adapter.tables[tableName].id, id))
+          .where(updateWhere)
           .returning(Object.keys(selectedFields).length ? selectedFields : undefined)
+
+        if (!docs.length) {
+          return null
+        }
+
+        insertedRow = docs[0]
+        await pushArrays()
 
         return transform<T>({
           adapter,
@@ -168,10 +206,17 @@ export const upsertRow = async <T extends Record<string, unknown> | TypeWithID>(
 
       // DB Update that needs the result, potentially with joins => need to update first, then find. returning() does not work with joins.
 
-      await drizzle
+      ;[insertedRow] = await drizzle
         .update(adapter.tables[tableName])
         .set(row)
-        .where(eq(adapter.tables[tableName].id, id))
+        .where(updateWhere)
+        .returning({ id: table.id })
+
+      if (!insertedRow) {
+        return null
+      }
+
+      await pushArrays()
 
       findManyArgs.where = eq(adapter.tables[tableName].id, insertedRow.id)
 
@@ -219,12 +264,12 @@ export const upsertRow = async <T extends Record<string, unknown> | TypeWithID>(
         rowKeys.length > 0 &&
         (hasLocalizedData || !rowKeys.every((key) => key === 'updatedAt' || key === 'createdAt'))
 
-      if (hasMainRowData) {
+      if (hasMainRowData || where) {
         if (id) {
           rowToInsert.row.id = id
           ;[insertedRow] = await adapter.insert({
             db,
-            onConflictDoUpdate: { set: rowToInsert.row, target },
+            onConflictDoUpdate: { set: rowToInsert.row, target, where },
             tableName,
             values: rowToInsert.row,
           })
@@ -239,6 +284,10 @@ export const upsertRow = async <T extends Record<string, unknown> | TypeWithID>(
       } else {
         // No main row data to update, just use the existing ID
         insertedRow = { id }
+      }
+
+      if (!insertedRow) {
+        return null
       }
     } else {
       if (adapter.allowIDOnCreate && data.id) {

--- a/packages/drizzle/src/upsertRow/index.ts
+++ b/packages/drizzle/src/upsertRow/index.ts
@@ -266,13 +266,20 @@ export const upsertRow = async <T extends Record<string, unknown> | TypeWithID>(
 
       if (hasMainRowData || where) {
         if (id) {
+          const table = adapter.tables[tableName]
+
+          /**
+           * The caller supplied this ID or found it by looking up the document with `where`.
+           * We should update that document, keeping any fields the caller left out.
+           * The row may have been deleted since the lookup. In that case, UPDATE returns
+           * no match and we stop below, instead of recreating the document with an upsert.
+           */
           rowToInsert.row.id = id
-          ;[insertedRow] = await adapter.insert({
-            db,
-            onConflictDoUpdate: { set: rowToInsert.row, target, where },
-            tableName,
-            values: rowToInsert.row,
-          })
+          ;[insertedRow] = await (db as LibSQLDatabase)
+            .update(table)
+            .set(rowToInsert.row)
+            .where(and(eq(table.id, id), where))
+            .returning({ id: table.id })
         } else {
           ;[insertedRow] = await adapter.insert({
             db,

--- a/packages/drizzle/src/upsertRow/types.ts
+++ b/packages/drizzle/src/upsertRow/types.ts
@@ -31,6 +31,7 @@ type CreateArgs = {
   customID?: number | string
   id?: never
   joinQuery?: never
+  limit?: never
   operation: 'create'
   select?: SelectType
   upsertTarget?: never
@@ -41,6 +42,8 @@ type UpdateArgs = {
   customID?: never
   id?: number | string
   joinQuery?: JoinQuery
+  /** Limit a direct update to one row when no ID is supplied. */
+  limit?: 1
   operation: 'update'
   select?: SelectType
   upsertTarget?: GenericColumn

--- a/test/database/int.spec.ts
+++ b/test/database/int.spec.ts
@@ -3173,6 +3173,29 @@ test.suite({ config: './config.ts' })('database', () => {
       expect(docs?.[4]?.title).toBe('updated')
     })
 
+    /** Both writers use the same old timestamp. Only one should be allowed to save. */
+    test('should allow only one update using the same timestamp', async ({ payload }) => {
+      const original = await payload.create({ collection: 'simple', data: { text: 'Original' } })
+      const updatedAt = new Date(Date.parse(original.updatedAt) + 1).toISOString()
+      const where = { updatedAt: { equals: original.updatedAt } }
+
+      const results = await Promise.all([
+        payload.db.updateOne({ collection: 'simple', data: { text: 'First', updatedAt }, where }),
+        payload.db.updateOne({
+          collection: 'simple',
+          data: { text: 'Second', updatedAt },
+          where,
+        }),
+      ])
+      const saved = results.filter((result) => result !== null)
+      const stored = await payload.findByID({ collection: 'simple', id: original.id })
+
+      expect(saved).toHaveLength(1)
+      expect(results).toContain(null)
+      expect(['First', 'Second']).toContain(saved[0]?.text)
+      expect(stored).toMatchObject({ text: saved[0]?.text, updatedAt })
+    })
+
     test('ensure updateOne does not create new document if `where` query has no results', async ({
       payload,
     }) => {

--- a/test/database/postgres-logs.int.spec.ts
+++ b/test/database/postgres-logs.int.spec.ts
@@ -8,6 +8,78 @@ import { test } from '../__helpers/int/vitest.js'
 test.suite({ config: './config.postgreslogs.ts', db: (adapter) => adapter.startsWith('postgres') })(
   'database - postgres logs',
   () => {
+    /** A simple where update should find and update one record in a single database request. */
+    test('should update one matching record without a separate ID lookup', async ({ payload }) => {
+      await payload.create({ collection: 'simple', data: { text: 'Original', number: 1 } })
+      await payload.create({ collection: 'simple', data: { text: 'Original', number: 2 } })
+      const queries = vitest.spyOn(console, 'log').mockImplementation(() => {})
+
+      try {
+        const result = await payload.db.updateOne({
+          collection: 'simple',
+          data: { text: 'Updated' },
+          where: { text: { equals: 'Original' } },
+        })
+
+        expect(result.text).toBe('Updated')
+        expect(queries).toHaveBeenCalledTimes(1)
+      } finally {
+        queries.mockRestore()
+      }
+
+      const stored = await payload.find({ collection: 'simple', pagination: false })
+
+      expect(stored.docs.filter((doc) => doc.text === 'Updated')).toHaveLength(1)
+      expect(stored.docs.filter((doc) => doc.text === 'Original')).toHaveLength(1)
+    })
+
+    /** Returning a document with arrays needs an update and a read, but no separate ID lookup first. */
+    test('should return a complex document without a separate ID lookup', async ({ payload }) => {
+      const post = await payload.create({ collection: 'posts', data: { title: 'Original' } })
+      const queries = vitest.spyOn(console, 'log').mockImplementation(() => {})
+
+      try {
+        const result = await payload.db.updateOne({
+          collection: 'posts',
+          data: { title: 'Updated' },
+          where: { title: { equals: 'Original' } },
+        })
+
+        expect(result).toMatchObject({ id: post.id, title: 'Updated' })
+        expect(queries).toHaveBeenCalledTimes(2)
+      } finally {
+        queries.mockRestore()
+      }
+
+      const stored = await payload.findByID({ collection: 'posts', id: post.id })
+
+      expect(stored.title).toBe('Updated')
+    })
+
+    /** Updating one field needs only one database request when the caller does not need the document back. */
+    test('should update without an ID lookup when returning is false', async ({ payload }) => {
+      const post = await payload.create({ collection: 'posts', data: { title: 'Original' } })
+      const queries = vitest.spyOn(console, 'log').mockImplementation(() => {})
+
+      try {
+        const result = await payload.db.updateOne({
+          collection: 'posts',
+          data: { title: 'Updated' },
+          returning: false,
+          where: { title: { equals: 'Original' } },
+        })
+
+        expect(result).toBeNull()
+        expect(queries).toHaveBeenCalledTimes(1)
+      } finally {
+        queries.mockRestore()
+      }
+
+      const stored = await payload.findByID({ collection: 'posts', id: post.id })
+
+      expect(stored.title).toBe('Updated')
+    })
+
     test('ensure simple update uses optimized upsertRow with returning()', async ({ payload }) => {
       const doc = await payload.create({
         collection: 'simple',


### PR DESCRIPTION
Simple `db.updateOne({ where })` calls now use one fewer database request on PostgreSQL and SQLite. Updates also refuse to save if another request has changed the values checked by `where`.

## Motivation

Payload can automatically queue tasks on cron schedules. To decide when the next job should run, it keeps track of when each task's schedule was last checked. The timestamps for all queues live in one database document, the `payload-jobs-stats` global.

Two queues can read the same copy of that document. Queue A saves its new timestamp, then queue B saves its copy, which still contains A's old timestamp. This puts A's timestamp back. A task meant to run every 15 minutes can then be scheduled in the past and run again immediately.

To prevent this, the scheduler needs to say: "Only save if these stats have not changed since I read them." If another queue has already saved, it should read the latest stats and try again.

On PostgreSQL and SQLite, the function `upsertRow` saves both collection documents and globals. This PR makes it check conditions during the actual save, providing the support needed to add conditional global updates in #18112 and use them in the scheduler in #18113. The scheduling changes are still pending. This PR also uses that support to remove a separate ID lookup from `updateOne`.

## How the implementation changes

Previously, updating one post titled "Draft" meant finding its ID in one query, then updating that ID in another.

- **`updateOne` now passes `where` and `limit: 1` to `upsertRow` for simple updates.** Filters that look in other tables, changes such as replacing an array, and updates that might create a missing document still use the separate ID lookup.
- **`upsertRow` already accepted `where`, but only partly used it.** Its normal updates by ID ignored it; only one of its insert-or-update paths applied it. Now it checks the condition during the actual write, since the new path skips the earlier ID lookup.
- **A subquery limits the update to one document.** PostgreSQL does not support `LIMIT` directly on an UPDATE. A SELECT inside the UPDATE chooses one ID, keeping both steps in one database request.
- **An update that matches nothing returns `null` before changing array entries.** Conditional array-only updates use `SET id = id` to check the parent document and get its ID, while keeping that ID unchanged.

## Reliability improvement

Previously, two requests could both find a document using the same old `updatedAt`, then both save by ID. The second save could overwrite the first.

Now, once the first request saves a new timestamp, the second request's old timestamp no longer matches, so it returns `null`. We also pass `where` along after a separate ID lookup: knowing the ID does not mean the condition still matches.

The new `should allow only one update using the same timestamp` test in `test/database/int.spec.ts` runs two updates together and checks that exactly one saves and the other returns `null`.

This protection applies to conditions on the document's own table. Conditions that need another table are still checked in the earlier lookup.

## Queries saved

The three new tests in `test/database/postgres-logs.int.spec.ts` cover:

| Test | Queries on main | Queries now |
| --- | ---: | ---: |
| `should update one matching record without a separate ID lookup` | 2 | 1 |
| `should return a complex document without a separate ID lookup` | 3 | 2 |
| `should update without an ID lookup when returning is false` | 2 | 1 |

Returning a document with fields stored in other tables still needs a read after the update to load the full document.

Written by AI.
