### PR TITLE
test: reproduce job scheduling failures

### DIFF
--- a/packages/payload/src/queues/operations/handleSchedules/index.ts
+++ b/packages/payload/src/queues/operations/handleSchedules/index.ts
@@ -11,7 +11,8 @@ import { getQueuesWithSchedules } from './getQueuesWithSchedules.js'
 
 export type HandleSchedulesResult = {
   errored: Queueable[]
-  queued: Queueable[]
+  /** Successfully queued schedules, including the job returned by `payload.jobs.queue()`. */
+  queued: ({ job: Job } & Queueable)[]
   skipped: Queueable[]
 }
 
@@ -89,7 +90,7 @@ export async function handleSchedules({
     }
   }
 
-  const queued: Queueable[] = []
+  const queued: HandleSchedulesResult['queued'] = []
   const skipped: Queueable[] = []
   const errored: Queueable[] = []
 
@@ -98,12 +99,12 @@ export async function handleSchedules({
    * Default constraint (= defaultBeforeSchedule): max. 1 running / scheduled task or workflow per queue
    */
   for (const queueable of queueables) {
-    const { status } = await scheduleQueueable({
+    const result = await scheduleQueueable({
       queueable,
       req,
       stats,
     })
-    switch (status) {
+    switch (result.status) {
       case 'error':
         errored.push(queueable)
         break
@@ -111,7 +112,7 @@ export async function handleSchedules({
         skipped.push(queueable)
         break
       case 'success':
-        queued.push(queueable)
+        queued.push({ ...queueable, job: result.job })
         break
     }
   }
@@ -162,10 +163,7 @@ export async function scheduleQueueable({
   queueable: Queueable
   req: PayloadRequest
   stats: JobStats
-}): Promise<{
-  job?: Job
-  status: 'error' | 'skipped' | 'success'
-}> {
+}): Promise<{ job: Job; status: 'success' } | { status: 'error' | 'skipped' }> {
   if (!queueable.taskConfig && !queueable.workflowConfig) {
     return {
       status: 'error',
@@ -222,6 +220,7 @@ export async function scheduleQueueable({
       status: 'success',
     })
     return {
+      job,
       status: 'success',
     }
   } catch (error) {

--- a/test/queues/config.schedules-concurrent.ts
+++ b/test/queues/config.schedules-concurrent.ts
@@ -1,0 +1,33 @@
+/* eslint-disable no-restricted-exports */
+import { postgresAdapter } from '@payloadcms/db-postgres'
+
+import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
+import { defaultPostgresUrl } from '../dbAdapters.js'
+
+export default buildConfigWithDefaults({
+  config: {
+    collections: [],
+    db: postgresAdapter({
+      pool: {
+        connectionString:
+          process.env.POSTGRES_URL || process.env.DATABASE_URL || defaultPostgresUrl,
+        // Queue queries on one connection so both schedulers read before either writes.
+        max: 1,
+      },
+    }),
+    jobs: {
+      deleteJobOnComplete: false,
+      tasks: [
+        {
+          slug: 'scheduledTask',
+          handler: () => ({ output: {} }),
+          schedule: [
+            { cron: '*/15 * * * *', queue: 'default' },
+            { cron: '*/15 * * * *', queue: 'other' },
+          ],
+        },
+      ],
+    },
+  },
+  suite: 'queues-schedules-concurrent',
+})

--- a/test/queues/schedules-concurrent.int.spec.ts
+++ b/test/queues/schedules-concurrent.int.spec.ts
@@ -12,6 +12,15 @@ test.suite({
     vi.useRealTimers()
   })
 
+  /**
+   * Different queues share one stats document. Each scheduler reads it, changes
+   * its own queue's lastScheduledRun, and writes the whole document back.
+   * If two schedulers do this at the same time, the last write can replace the
+   * other queue's new timestamp with its old one.
+   *
+   * That old timestamp can make a replacement job due at 12:15 again, even though
+   * its 12:15 job already finished. Both replacements should wait until 12:30.
+   */
   test("should run each queue's scheduled task only once per cron interval", async ({
     payload,
   }) => {
@@ -94,6 +103,57 @@ test.suite({
     })
 
     expect(completedJobs.totalDocs).toBe(2)
+  })
+
+  /**
+   * Two schedulers can check the same queue before either creates a job.
+   * Both see "no job exists", so both create a job for the same 12:15 run.
+   * Checking for a job and creating it are separate database calls, so the
+   * check alone does not prevent duplicates.
+   *
+   * One scheduler should queue the job and the other should skip it.
+   * The job should run once and then be deleted when it finishes.
+   */
+  test('should queue only one job when two schedulers handle the same queue concurrently', async ({
+    payload,
+  }) => {
+    const deleteJobOnComplete = payload.config.jobs.deleteJobOnComplete
+
+    payload.config.jobs.deleteJobOnComplete = true
+    vi.useFakeTimers({ toFake: ['Date'] })
+    vi.setSystemTime(atTime('12:00'))
+
+    try {
+      const results = await Promise.all([
+        payload.jobs.handleSchedules({ queue: 'default' }),
+        payload.jobs.handleSchedules({ queue: 'default' }),
+      ])
+
+      for (const result of results) {
+        expect(result.errored).toHaveLength(0)
+      }
+
+      const scheduledJobs = await payload.find({ collection: 'payload-jobs' })
+
+      expect(scheduledJobs.totalDocs).toBe(1)
+      expect(scheduledJobs.docs).toMatchObject([
+        { queue: 'default', taskSlug: 'scheduledTask', waitUntil: atTime('12:15') },
+      ])
+      expect(results.flatMap((result) => result.queued)).toHaveLength(1)
+      expect(results.flatMap((result) => result.skipped)).toHaveLength(1)
+
+      vi.setSystemTime(atTime('12:16'))
+
+      const run = await payload.jobs.run({ queue: 'default', silent: true })
+
+      expect(Object.values(run.jobStatus ?? {})).toEqual([{ status: 'success' }])
+
+      const remainingJobs = await payload.find({ collection: 'payload-jobs' })
+
+      expect(remainingJobs.totalDocs).toBe(0)
+    } finally {
+      payload.config.jobs.deleteJobOnComplete = deleteJobOnComplete
+    }
   })
 })
 

--- a/test/queues/schedules-concurrent.int.spec.ts
+++ b/test/queues/schedules-concurrent.int.spec.ts
@@ -1,0 +1,104 @@
+/* eslint vitest/no-standalone-expect: ["error", { "additionalTestBlockFunctions": ["test"] }] */
+import { expect, vi } from 'vitest'
+
+import { test } from '../__helpers/int/vitest.js'
+
+test.suite({
+  config: './config.schedules-concurrent.ts',
+  cron: false,
+  db: (adapter) => adapter === 'postgres',
+})('Queues - concurrent scheduling', () => {
+  test.afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  test("should run each queue's scheduled task only once per cron interval", async ({
+    payload,
+  }) => {
+    vi.useFakeTimers({ toFake: ['Date'] })
+    vi.setSystemTime(atTime('12:00'))
+
+    // Initialize both queues through the scheduler. Each has one job due at 12:15.
+    await payload.jobs.handleSchedules({ queue: 'default' })
+    await payload.jobs.handleSchedules({ queue: 'other' })
+
+    const scheduledJobs = await payload.find({
+      collection: 'payload-jobs',
+      sort: 'queue',
+    })
+
+    expect(scheduledJobs.totalDocs).toBe(2)
+    expect(scheduledJobs.docs).toMatchObject([
+      { queue: 'default', waitUntil: atTime('12:15') },
+      { queue: 'other', waitUntil: atTime('12:15') },
+    ])
+
+    // The 12:15 jobs already exist, so scheduling must skip both queues.
+    vi.setSystemTime(atTime('12:15:01'))
+
+    const existingSchedules = await Promise.all([
+      payload.jobs.handleSchedules({ queue: 'default' }),
+      payload.jobs.handleSchedules({ queue: 'other' }),
+    ])
+
+    for (const result of existingSchedules) {
+      expect(result.errored).toHaveLength(0)
+      expect(result.queued).toHaveLength(0)
+      expect(result.skipped).toHaveLength(1)
+    }
+
+    const firstRun = await payload.jobs.run({ allQueues: true, silent: true })
+
+    expect(Object.values(firstRun.jobStatus ?? {})).toEqual([
+      { status: 'success' },
+      { status: 'success' },
+    ])
+
+    // The previous jobs are complete. Queue their 12:30 replacements, which cannot run yet.
+    vi.setSystemTime(atTime('12:15:02'))
+
+    const nextSchedules = await Promise.all([
+      payload.jobs.handleSchedules({ queue: 'default' }),
+      payload.jobs.handleSchedules({ queue: 'other' }),
+    ])
+
+    for (const result of nextSchedules) {
+      expect(result.errored).toHaveLength(0)
+      expect(result.queued).toHaveLength(1)
+      expect(result.skipped).toHaveLength(0)
+    }
+
+    const nextJobs = await payload.find({
+      collection: 'payload-jobs',
+      sort: 'queue',
+      where: {
+        completedAt: { exists: false },
+      },
+    })
+
+    expect(nextJobs.totalDocs).toBe(2)
+    expect(nextJobs.docs).toMatchObject([
+      { queue: 'default', waitUntil: atTime('12:30') },
+      { queue: 'other', waitUntil: atTime('12:30') },
+    ])
+
+    const earlyRun = await payload.jobs.run({ allQueues: true, silent: true })
+
+    expect(earlyRun.jobStatus ?? {}).toEqual({})
+
+    const completedJobs = await payload.find({
+      collection: 'payload-jobs',
+      where: {
+        completedAt: { exists: true },
+      },
+    })
+
+    expect(completedJobs.totalDocs).toBe(2)
+  })
+})
+
+function atTime(time: string): string {
+  const [hours, minutes, seconds = '00'] = time.split(':')
+
+  return `2026-01-01T${hours}:${minutes}:${seconds}.000Z`
+}

--- a/test/queues/schedules-concurrent.int.spec.ts
+++ b/test/queues/schedules-concurrent.int.spec.ts
@@ -1,4 +1,3 @@
-/* eslint vitest/no-standalone-expect: ["error", { "additionalTestBlockFunctions": ["test"] }] */
 import { expect, vi } from 'vitest'
 
 import { test } from '../__helpers/int/vitest.js'
@@ -8,8 +7,14 @@ test.suite({
   cron: false,
   db: (adapter) => adapter === 'postgres',
 })('Queues - concurrent scheduling', () => {
-  test.afterEach(() => {
-    vi.useRealTimers()
+  let deleteJobOnComplete: boolean | undefined
+
+  test.beforeEach(({ payload }) => {
+    deleteJobOnComplete = payload.config.jobs.deleteJobOnComplete
+  })
+
+  test.afterEach(({ payload }) => {
+    payload.config.jobs.deleteJobOnComplete = deleteJobOnComplete
   })
 
   /**
@@ -24,85 +29,71 @@ test.suite({
   test("should run each queue's scheduled task only once per cron interval", async ({
     payload,
   }) => {
-    vi.useFakeTimers({ toFake: ['Date'] })
-    vi.setSystemTime(atTime('12:00'))
+    await withSystemTime('12:00', async () => {
+      // Initialize both queues through the scheduler. Each has one job due at 12:15.
+      const defaultSchedule = await payload.jobs.handleSchedules({ queue: 'default' })
+      const otherSchedule = await payload.jobs.handleSchedules({ queue: 'other' })
 
-    // Initialize both queues through the scheduler. Each has one job due at 12:15.
-    await payload.jobs.handleSchedules({ queue: 'default' })
-    await payload.jobs.handleSchedules({ queue: 'other' })
-
-    const scheduledJobs = await payload.find({
-      collection: 'payload-jobs',
-      sort: 'queue',
+      expect(defaultSchedule.queued).toHaveLength(1)
+      expect(otherSchedule.queued).toHaveLength(1)
+      expect([defaultSchedule.queued[0]?.job, otherSchedule.queued[0]?.job]).toMatchObject([
+        { queue: 'default', waitUntil: atTime('12:15') },
+        { queue: 'other', waitUntil: atTime('12:15') },
+      ])
     })
 
-    expect(scheduledJobs.totalDocs).toBe(2)
-    expect(scheduledJobs.docs).toMatchObject([
-      { queue: 'default', waitUntil: atTime('12:15') },
-      { queue: 'other', waitUntil: atTime('12:15') },
-    ])
+    await withSystemTime('12:15:01', async () => {
+      // The 12:15 jobs already exist, so scheduling must skip both queues.
+      const existingSchedules = await Promise.all([
+        payload.jobs.handleSchedules({ queue: 'default' }),
+        payload.jobs.handleSchedules({ queue: 'other' }),
+      ])
 
-    // The 12:15 jobs already exist, so scheduling must skip both queues.
-    vi.setSystemTime(atTime('12:15:01'))
+      for (const result of existingSchedules) {
+        expect(result.errored).toHaveLength(0)
+        expect(result.queued).toHaveLength(0)
+        expect(result.skipped).toHaveLength(1)
+      }
 
-    const existingSchedules = await Promise.all([
-      payload.jobs.handleSchedules({ queue: 'default' }),
-      payload.jobs.handleSchedules({ queue: 'other' }),
-    ])
+      const firstRun = await payload.jobs.run({ allQueues: true, silent: true })
 
-    for (const result of existingSchedules) {
-      expect(result.errored).toHaveLength(0)
-      expect(result.queued).toHaveLength(0)
-      expect(result.skipped).toHaveLength(1)
-    }
-
-    const firstRun = await payload.jobs.run({ allQueues: true, silent: true })
-
-    expect(Object.values(firstRun.jobStatus ?? {})).toEqual([
-      { status: 'success' },
-      { status: 'success' },
-    ])
-
-    // The previous jobs are complete. Queue their 12:30 replacements, which cannot run yet.
-    vi.setSystemTime(atTime('12:15:02'))
-
-    const nextSchedules = await Promise.all([
-      payload.jobs.handleSchedules({ queue: 'default' }),
-      payload.jobs.handleSchedules({ queue: 'other' }),
-    ])
-
-    for (const result of nextSchedules) {
-      expect(result.errored).toHaveLength(0)
-      expect(result.queued).toHaveLength(1)
-      expect(result.skipped).toHaveLength(0)
-    }
-
-    const nextJobs = await payload.find({
-      collection: 'payload-jobs',
-      sort: 'queue',
-      where: {
-        completedAt: { exists: false },
-      },
+      expect(Object.values(firstRun.jobStatus ?? {})).toEqual([
+        { status: 'success' },
+        { status: 'success' },
+      ])
     })
 
-    expect(nextJobs.totalDocs).toBe(2)
-    expect(nextJobs.docs).toMatchObject([
-      { queue: 'default', waitUntil: atTime('12:30') },
-      { queue: 'other', waitUntil: atTime('12:30') },
-    ])
+    await withSystemTime('12:15:02', async () => {
+      // The previous jobs are complete. Queue their 12:30 replacements, which cannot run yet.
+      const nextSchedules = await Promise.all([
+        payload.jobs.handleSchedules({ queue: 'default' }),
+        payload.jobs.handleSchedules({ queue: 'other' }),
+      ])
 
-    const earlyRun = await payload.jobs.run({ allQueues: true, silent: true })
+      for (const result of nextSchedules) {
+        expect(result.errored).toHaveLength(0)
+        expect(result.queued).toHaveLength(1)
+        expect(result.skipped).toHaveLength(0)
+      }
 
-    expect(earlyRun.jobStatus ?? {}).toEqual({})
+      expect(nextSchedules.map((result) => result.queued[0]?.job)).toMatchObject([
+        { queue: 'default', waitUntil: atTime('12:30') },
+        { queue: 'other', waitUntil: atTime('12:30') },
+      ])
 
-    const completedJobs = await payload.find({
-      collection: 'payload-jobs',
-      where: {
-        completedAt: { exists: true },
-      },
+      const earlyRun = await payload.jobs.run({ allQueues: true, silent: true })
+
+      expect(earlyRun.jobStatus ?? {}).toEqual({})
+
+      const completedJobs = await payload.find({
+        collection: 'payload-jobs',
+        where: {
+          completedAt: { exists: true },
+        },
+      })
+
+      expect(completedJobs.totalDocs).toBe(2)
     })
-
-    expect(completedJobs.totalDocs).toBe(2)
   })
 
   /**
@@ -117,13 +108,9 @@ test.suite({
   test('should queue only one job when two schedulers handle the same queue concurrently', async ({
     payload,
   }) => {
-    const deleteJobOnComplete = payload.config.jobs.deleteJobOnComplete
-
     payload.config.jobs.deleteJobOnComplete = true
-    vi.useFakeTimers({ toFake: ['Date'] })
-    vi.setSystemTime(atTime('12:00'))
 
-    try {
+    await withSystemTime('12:00', async () => {
       const results = await Promise.all([
         payload.jobs.handleSchedules({ queue: 'default' }),
         payload.jobs.handleSchedules({ queue: 'default' }),
@@ -133,17 +120,18 @@ test.suite({
         expect(result.errored).toHaveLength(0)
       }
 
-      const scheduledJobs = await payload.find({ collection: 'payload-jobs' })
+      const queued = results.flatMap((result) => result.queued)
 
-      expect(scheduledJobs.totalDocs).toBe(1)
-      expect(scheduledJobs.docs).toMatchObject([
-        { queue: 'default', taskSlug: 'scheduledTask', waitUntil: atTime('12:15') },
-      ])
-      expect(results.flatMap((result) => result.queued)).toHaveLength(1)
+      expect(queued).toHaveLength(1)
+      expect(queued[0]?.job).toMatchObject({
+        queue: 'default',
+        taskSlug: 'scheduledTask',
+        waitUntil: atTime('12:15'),
+      })
       expect(results.flatMap((result) => result.skipped)).toHaveLength(1)
+    })
 
-      vi.setSystemTime(atTime('12:16'))
-
+    await withSystemTime('12:16', async () => {
       const run = await payload.jobs.run({ queue: 'default', silent: true })
 
       expect(Object.values(run.jobStatus ?? {})).toEqual([{ status: 'success' }])
@@ -151,11 +139,120 @@ test.suite({
       const remainingJobs = await payload.find({ collection: 'payload-jobs' })
 
       expect(remainingJobs.totalDocs).toBe(0)
-    } finally {
-      payload.config.jobs.deleteJobOnComplete = deleteJobOnComplete
-    }
+    })
+  })
+
+  /**
+   * Check schedules at 12:00, wait until 12:16, run the job, then immediately
+   * check schedules again. The task should wait until 12:30 to run again.
+   */
+  test('should not run a scheduled task again immediately after it finishes', async ({
+    payload,
+  }) => {
+    payload.config.jobs.deleteJobOnComplete = true
+
+    await withSystemTime('12:00', async () => {
+      const firstSchedule = await payload.jobs.handleSchedules({ queue: 'default' })
+
+      expect(firstSchedule.queued).toHaveLength(1)
+      expect(firstSchedule.queued[0]?.job).toMatchObject({
+        queue: 'default',
+        taskSlug: 'scheduledTask',
+        waitUntil: atTime('12:15'),
+      })
+    })
+
+    await withSystemTime('12:16', async () => {
+      // Run the job due at 12:15.
+      const firstRun = await payload.jobs.run({ queue: 'default', silent: true })
+      const remainingJobs = await payload.find({ collection: 'payload-jobs' })
+
+      expect(Object.values(firstRun.jobStatus ?? {})).toEqual([{ status: 'success' }])
+      expect(remainingJobs.totalDocs).toBe(0)
+
+      // Still 12:16: scheduling again should not make the task run again yet.
+      const nextSchedule = await payload.jobs.handleSchedules({ queue: 'default' })
+
+      expect(nextSchedule.queued).toHaveLength(1)
+      expect(nextSchedule.queued[0]?.job).toMatchObject({
+        queue: 'default',
+        taskSlug: 'scheduledTask',
+        waitUntil: atTime('12:30'),
+      })
+
+      const secondRun = await payload.jobs.run({ queue: 'default', silent: true })
+
+      expect(Object.values(secondRun.jobStatus ?? {})).toEqual([])
+    })
+  })
+
+  /**
+   * autoRun checks schedules before every run. At 12:16, that extra check sees
+   * the waiting job and saves 12:16 as the last check time before the job runs.
+   * Scheduling again after it finishes then queues the next job for 12:30,
+   * so the task does not run twice.
+   */
+  test('should not run a scheduled task twice when checking schedules before every run', async ({
+    payload,
+  }) => {
+    payload.config.jobs.deleteJobOnComplete = true
+
+    await withSystemTime('12:00', async () => {
+      const firstSchedule = await payload.jobs.handleSchedules({ queue: 'default' })
+
+      expect(firstSchedule.queued).toHaveLength(1)
+      expect(firstSchedule.queued[0]?.job).toMatchObject({
+        queue: 'default',
+        taskSlug: 'scheduledTask',
+        waitUntil: atTime('12:15'),
+      })
+
+      const earlyRun = await payload.jobs.run({ queue: 'default', silent: true })
+
+      expect(Object.values(earlyRun.jobStatus ?? {})).toEqual([])
+    })
+
+    await withSystemTime('12:16', async () => {
+      // Check schedules before running the job due at 12:15.
+      const existingSchedule = await payload.jobs.handleSchedules({ queue: 'default' })
+
+      expect(existingSchedule.queued).toHaveLength(0)
+      expect(existingSchedule.skipped).toHaveLength(1)
+
+      const firstRun = await payload.jobs.run({ queue: 'default', silent: true })
+      const remainingJobs = await payload.find({ collection: 'payload-jobs' })
+
+      expect(Object.values(firstRun.jobStatus ?? {})).toEqual([{ status: 'success' }])
+      expect(remainingJobs.totalDocs).toBe(0)
+
+      // Still 12:16: scheduling again should not make the task run again yet.
+      const nextSchedule = await payload.jobs.handleSchedules({ queue: 'default' })
+
+      expect(nextSchedule.queued).toHaveLength(1)
+      expect(nextSchedule.queued[0]?.job).toMatchObject({
+        queue: 'default',
+        taskSlug: 'scheduledTask',
+        waitUntil: atTime('12:30'),
+      })
+
+      const secondRun = await payload.jobs.run({ queue: 'default', silent: true })
+
+      expect(Object.values(secondRun.jobStatus ?? {})).toEqual([])
+    })
   })
 })
+
+/** Freeze Date for this block, then restore real time even if an assertion fails. */
+async function withSystemTime(time: string, run: () => Promise<void>): Promise<void> {
+  vi.useFakeTimers({ toFake: ['Date'] })
+  vi.setSystemTime(atTime(time))
+
+  try {
+    await run()
+  } finally {
+    vi.useRealTimers()
+  }
+}
 
 function atTime(time: string): string {
   const [hours, minutes, seconds = '00'] = time.split(':')


### PR DESCRIPTION
Adds examples of scheduled jobs running too often. **This draft contains the failing tests; the scheduling fix is still pending.**

## Three cases that should work

Each example uses a task scheduled every 15 minutes: 12:15, 12:30, and so on. All three tests currently fail.

### 1. Two different queues check their schedules together

Both queues save their scheduling timestamps in the same `payload-jobs-stats` global. Each reads the global, changes its own queue's timestamp, and saves the whole value. The last save can put the other queue's old timestamp back.

After both 12:15 jobs finish, their next jobs should wait until 12:30. Instead, one gets a `waitUntil` of 12:15, which is already in the past, so it can run again immediately.

### 2. Two schedule checks happen together for the same queue

Both checks see that no job exists yet, so both create one. We expect one job for 12:15, but get two.

### 3. Run a job, delete it, then check schedules again

Check schedules at 12:00 to create a job due at 12:15. Run it at 12:16 and delete it when it finishes, then immediately check schedules again.

The next job should wait until 12:30. Instead, it gets the old 12:15 time and can run immediately.

## A case that already works

A fourth test checks schedules immediately before running the job at 12:16. That check updates the saved timestamp. After the job finishes, the next job correctly waits until 12:30. This test passes.

## Returned job details

Each entry in `handleSchedules().queued` now includes the created job. This lets the tests check its ID and `waitUntil` directly.

Written by AI.
