### PR TITLE
fix(ui): align top-level group and tabs fields with sidebar (#17851)

### DIFF
--- a/packages/ui/src/elements/DocumentFields/index.scss
+++ b/packages/ui/src/elements/DocumentFields/index.scss
@@ -6,14 +6,14 @@
     display: flex;
     --doc-sidebar-width: 325px;
     --sidebar-gutter-h-right: var(--gutter-h);
-    --sidebar-gutter-h-left: calc(var(--base) * 2);
+    --sidebar-gutter-h-left: var(--gutter-h);
     --main-gutter-h-left: var(--gutter-h);
-    --main-gutter-h-right: calc(var(--base) * 2);
+    --main-gutter-h-right: var(--gutter-h);
 
     [dir='rtl'] &:not(&--force-sidebar-wrap) {
       --sidebar-gutter-h-left: var(--gutter-h);
-      --sidebar-gutter-h-right: calc(var(--base) * 2);
-      --main-gutter-h-left: calc(var(--base) * 2);
+      --sidebar-gutter-h-right: var(--gutter-h);
+      --main-gutter-h-left: var(--gutter-h);
       --main-gutter-h-right: var(--gutter-h);
     }
 
@@ -28,7 +28,7 @@
     &--has-sidebar {
       --main-width: 66.66%;
       --main-border: 1px solid var(--theme-elevation-100);
-      --main-field-margin: calc(var(--base) * -2);
+      --main-field-margin: calc(var(--gutter-h) * -1);
 
       &:has(
           .document-fields__sidebar-wrap .document-fields__sidebar-fields > .render-fields:empty
@@ -63,6 +63,11 @@
           & > .tabs-field,
           & > .group-field {
             margin-right: var(--main-field-margin);
+
+            [dir='rtl'] & {
+              margin-right: calc(var(--gutter-h) * -1);
+              margin-left: var(--main-field-margin);
+            }
           }
         }
       }


### PR DESCRIPTION
## Description
Fixes #17851

When a document has fields in the sidebar (`admin.position: 'sidebar'`), top-level `group` and `tabs` fields lined up on the left but stopped short on the right, causing their inner content to be narrower than sibling fields and leaving a gap before the vertical sidebar divider border.

## Cause
In `packages/ui/src/elements/DocumentFields/index.scss`, `--main-gutter-h-right` and `--sidebar-gutter-h-left` were hardcoded to `calc(var(--base) * 2)` (32px), and `--main-field-margin` was hardcoded to `calc(var(--base) * -2)` (-32px). When `--gutter-h` scaled dynamically on wider viewports or in Live Preview, the hardcoded -32px margin failed to cancel the container padding.

## Solution
- Updated `--main-gutter-h-right` and `--sidebar-gutter-h-left` to use `var(--gutter-h)` (matching responsive variants and the left gutter).
- Updated `--main-field-margin` in `.document-fields--has-sidebar` to `calc(var(--gutter-h) * -1)`.
- Added RTL support for `[dir='rtl']` so margins mirror appropriately when the sidebar is on the left.