### PR TITLE
docs: add eusend to a Community Email Adapters section

### DIFF
--- a/docs/email/overview.mdx
+++ b/docs/email/overview.mdx
@@ -34,6 +34,12 @@ An email adapter will require at least the following fields:
 | Nodemailer | [@payloadcms/email-nodemailer](https://www.npmjs.com/package/@payloadcms/email-nodemailer) | Use any [Nodemailer transport](https://nodemailer.com/transports), including SMTP, Resend, SendGrid, and more. This was provided by default in Payload 2.x. This is the easiest migration path. |
 | Resend     | [@payloadcms/email-resend](https://www.npmjs.com/package/@payloadcms/email-resend)         | Resend email via their REST API. This is preferred for serverless platforms such as Vercel because it is much more lightweight than the nodemailer adapter.                                     |
 
+### Community Email Adapters
+
+| Name   | Package                                                                              | Description                                                                                                                                                      |
+| ------ | ------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| eusend | [@eusend_dev/payload-email](https://www.npmjs.com/package/@eusend_dev/payload-email) | Send email via the [eusend](https://eusend.dev) REST API, hosted in the EU. Lightweight enough for serverless, and supports attachments, tags and inline images. |
+
 ## Nodemailer Configuration
 
 | Option                 | Description                                                                                                                                                                            |


### PR DESCRIPTION
Adds a **Community Email Adapters** section under the official table, with one entry: [`@eusend_dev/payload-email`](https://www.npmjs.com/package/@eusend_dev/payload-email).

Disclosure: I wrote this adapter. It implements the `EmailAdapter` contract over the [eusend](https://eusend.dev) REST API — like the Resend adapter, it is light enough for serverless, where the nodemailer transport is awkward. It is MIT licensed, supports Payload 3 and 4, and maps nodemailer's message shape including attachments (raw bytes, remote URLs, local paths and `cid` inline images).

**On the section itself:** two open PRs already propose the same heading — #16758 (Keplars, May) and #17617 (SuperSend TX) — so this will conflict with whichever lands first. I am happy to close this in favour of either, or to rebase onto one and add just a row, whichever is easiest for you. If you would rather the email docs simply point at the `payload-plugin` GitHub topic the way the plugins docs do, that works too and I will send that instead.

The docs currently give no signal that non-official adapters exist, which is why three people have independently reached for the same edit.

Only `docs/email/overview.mdx` changes; the table follows the existing prettier column formatting.
