### PR TITLE
fix: support value fallback and validate locales in localization config (#17858)

### DIFF
--- a/packages/payload/src/config/sanitize.ts
+++ b/packages/payload/src/config/sanitize.ts
@@ -6,15 +6,7 @@ import { deepMergeSimple } from '@payloadcms/translations/utilities'
 import type { OrderableJoinInfo } from '../fields/config/sanitizeJoinField.js'
 import type { CollectionSlug, GlobalSlug, SanitizedCollectionConfig } from '../index.js'
 import type { SanitizedJobsConfig } from '../queues/config/types/index.js'
-import type {
-  Config,
-  LocalizationConfigWithLabels,
-  LocalizationConfigWithNoLabels,
-  SanitizedConfig,
-  Timezone,
-  Widget,
-  WidgetInstance,
-} from './types.js'
+import type { Config, Locale, SanitizedConfig, Timezone, Widget, WidgetInstance } from './types.js'
 
 import { defaultUserCollection } from '../auth/defaultUser.js'
 import { authRootEndpoints } from '../auth/endpoints/index.js'
@@ -128,32 +120,56 @@ export const sanitizeConfig = async (incomingConfig: Config): Promise<SanitizedC
   }
 
   if (config.localization && config.localization.locales?.length > 0) {
-    // clone localization config so to not break everything
-    const firstLocale = config.localization.locales[0]
-    if (typeof firstLocale === 'string') {
-      config.localization.localeCodes = [
-        ...(config.localization as unknown as LocalizationConfigWithNoLabels).locales,
-      ]
+    const locales: Locale[] = (
+      config.localization.locales as Array<Locale | Record<string, unknown> | string>
+    ).map((locale) => {
+      if (typeof locale === 'string') {
+        return {
+          code: locale,
+          label: locale,
+          rtl: false,
+          toString: () => locale,
+        }
+      }
 
-      // is string[], so convert to Locale[]
-      config.localization.locales = (
-        config.localization as unknown as LocalizationConfigWithNoLabels
-      ).locales.map((locale) => ({
-        code: locale,
-        label: locale,
-        rtl: false,
-        toString: () => locale,
-      }))
-    } else {
-      // is Locale[], so convert to string[] for localeCodes
-      config.localization.localeCodes = config.localization.locales.map((locale) => locale.code)
+      const code =
+        typeof locale === 'object' && locale !== null
+          ? locale.code ||
+            ('value' in locale && typeof locale.value === 'string' ? locale.value : undefined)
+          : undefined
 
-      config.localization.locales = (
-        config.localization as LocalizationConfigWithLabels
-      ).locales.map((locale) => ({
+      if (!code || typeof code !== 'string') {
+        throw new InvalidConfiguration(
+          `Locale object must contain a valid "code" string property. Received: ${JSON.stringify(locale)}`,
+        )
+      }
+
+      const label: Locale['label'] =
+        typeof locale === 'object' &&
+        locale !== null &&
+        'label' in locale &&
+        (typeof locale.label === 'string' ||
+          (typeof locale.label === 'object' && locale.label !== null))
+          ? (locale.label as Locale['label'])
+          : code
+
+      return {
         ...locale,
-        toString: () => locale.code,
-      }))
+        code,
+        label,
+        toString: () => code,
+      }
+    })
+
+    config.localization.localeCodes = locales.map((locale) => locale.code)
+    config.localization.locales = locales
+
+    if (!config.localization.defaultLocale) {
+      config.localization.defaultLocale = config.localization.localeCodes[0]!
+    } else if (!config.localization.localeCodes.includes(config.localization.defaultLocale)) {
+      throw new InvalidConfiguration(
+        `localization.defaultLocale "${config.localization.defaultLocale}" must be one of the configured locale codes: ${config.localization.localeCodes.join(', ')}`,
+      )
     }
 
     // Default fallback to true if not provided

--- a/packages/payload/src/config/types.ts
+++ b/packages/payload/src/config/types.ts
@@ -510,11 +510,15 @@ export type Locale = {
    * label of supported locale
    * @example "English"
    */
-  label: Record<string, string> | string
+  label?: Record<string, string> | string
   /**
    * if true, defaults textAligmnent on text fields to RTL
    */
   rtl?: boolean
+  /**
+   * @deprecated Use `code` instead.
+   */
+  value?: string
 }
 
 export type BaseLocalizationConfig = {
@@ -563,11 +567,11 @@ export type LocalizationConfigWithLabels = Prettify<
      * List of supported locales with labels
      * @example {
      *  label: 'English',
-     *  value: 'en',
+     *  code: 'en',
      *  rtl: false
      * }
      */
-    locales: Locale[]
+    locales: (({ value: string } & Record<string, any>) | Locale)[]
   } & BaseLocalizationConfig
 >
 
@@ -578,7 +582,8 @@ export type SanitizedLocalizationConfig = Prettify<
      * @example `["en", "es", "fr", "nl", "de", "jp"]`
      */
     localeCodes: string[]
-  } & LocalizationConfigWithLabels
+    locales: Locale[]
+  } & BaseLocalizationConfig
 >
 
 /**

--- a/packages/payload/src/utilities/configToJSONSchema.spec.ts
+++ b/packages/payload/src/utilities/configToJSONSchema.spec.ts
@@ -1,9 +1,11 @@
 import type { JSONSchema4 } from 'json-schema'
+import { compile } from 'json-schema-to-typescript'
 import { describe, it, expect } from 'vitest'
 
 import type { Config } from '../config/types.js'
 
 import { sanitizeConfig } from '../config/sanitize.js'
+import { InvalidConfiguration } from '../errors/index.js'
 import { configToJSONSchema } from './configToJSONSchema.js'
 import type { Block, BlocksField, RichTextField } from '../fields/config/types.js'
 
@@ -509,5 +511,69 @@ describe('configToJSONSchema', () => {
     ).oneOf![0]
     expect(grpBlocksInline).not.toHaveProperty('$ref')
     expect(grpBlocksInline.properties?.blockType).toStrictEqual({ const: 'myBlock' })
+  })
+
+  it('should handle object-form localization.locales with value fallback and generate valid schema for types', async () => {
+    // @ts-expect-error
+    const config: Config = {
+      collections: [
+        {
+          slug: 'posts',
+          fields: [{ name: 'title', type: 'text', localized: true }],
+        },
+      ],
+      localization: {
+        locales: [
+          { label: 'English', value: 'en' },
+          { label: 'French', value: 'fr' },
+        ],
+        defaultLocale: 'en',
+        fallback: true,
+      },
+    }
+
+    const sanitizedConfig = await sanitizeConfig(config)
+    expect(sanitizedConfig.localization).toBeDefined()
+    if (sanitizedConfig.localization) {
+      expect(sanitizedConfig.localization.localeCodes).toEqual(['en', 'fr'])
+      expect(sanitizedConfig.localization.locales[0].code).toBe('en')
+      expect(sanitizedConfig.localization.locales[1].code).toBe('fr')
+    }
+
+    const schema = configToJSONSchema(sanitizedConfig, 'text')
+    expect((schema.properties?.locale as JSONSchema4)?.enum).toEqual(['en', 'fr'])
+    expect(
+      ((schema.properties?.fallbackLocale as JSONSchema4)?.oneOf?.[3] as JSONSchema4)?.enum,
+    ).toEqual(['en', 'fr'])
+
+    // Ensure json-schema-to-typescript compiles without crashing
+    const compiled = await compile(schema, 'Config')
+    expect(compiled).toMatch(/locale: ['"]en['"] \| ['"]fr['"]/)
+  })
+
+  it('should throw InvalidConfiguration if locale object lacks code and value', async () => {
+    // @ts-expect-error
+    const config: Config = {
+      collections: [{ slug: 'posts', fields: [] }],
+      localization: {
+        locales: [{ label: 'English' }],
+        defaultLocale: 'en',
+      },
+    }
+
+    await expect(sanitizeConfig(config)).rejects.toThrow(InvalidConfiguration)
+  })
+
+  it('should throw InvalidConfiguration if defaultLocale is not in configured locales', async () => {
+    // @ts-expect-error
+    const config: Config = {
+      collections: [{ slug: 'posts', fields: [] }],
+      localization: {
+        locales: [{ label: 'English', code: 'en' }],
+        defaultLocale: 'fr',
+      },
+    }
+
+    await expect(sanitizeConfig(config)).rejects.toThrow(InvalidConfiguration)
   })
 })

--- a/packages/payload/src/utilities/configToJSONSchema.ts
+++ b/packages/payload/src/utilities/configToJSONSchema.ts
@@ -235,13 +235,17 @@ function generateLocaleEntitySchemas(localization: SanitizedConfig['localization
   if (localization && 'locales' in localization && localization?.locales) {
     const localesFromConfig = localization?.locales
 
-    const locales = [...localesFromConfig].map((locale) => {
-      return locale.code
-    }, [])
+    const locales = [...localesFromConfig]
+      .map((locale) => {
+        return typeof locale === 'string' ? locale : locale?.code
+      })
+      .filter((code): code is string => typeof code === 'string' && code.length > 0)
 
-    return {
-      type: 'string',
-      enum: locales,
+    if (locales.length > 0) {
+      return {
+        type: 'string',
+        enum: locales,
+      }
     }
   }
 
@@ -254,18 +258,20 @@ function generateFallbackLocaleEntitySchemas(
   localization: SanitizedConfig['localization'],
 ): JSONSchema4 {
   if (localization && 'localeCodes' in localization && localization?.localeCodes) {
-    const localeCodes = [...localization.localeCodes].map((localeCode) => {
-      return localeCode
-    }, [])
+    const localeCodes = [...localization.localeCodes].filter(
+      (localeCode): localeCode is string => typeof localeCode === 'string' && localeCode.length > 0,
+    )
 
-    return {
-      oneOf: [
-        { type: 'string', enum: ['false', 'none', 'null'] },
-        { type: 'boolean', enum: [false] },
-        { type: 'null' },
-        { type: 'string', enum: localeCodes },
-        { type: 'array', items: { type: 'string', enum: localeCodes } },
-      ],
+    if (localeCodes.length > 0) {
+      return {
+        oneOf: [
+          { type: 'string', enum: ['false', 'none', 'null'] },
+          { type: 'boolean', enum: [false] },
+          { type: 'null' },
+          { type: 'string', enum: localeCodes },
+          { type: 'array', items: { type: 'string', enum: localeCodes } },
+        ],
+      }
     }
   }
 


### PR DESCRIPTION
## Description
Fixes #17858.

When defining `localization.locales` using the object format with `{ label, value }` (which was also previously shown as the `@example` in `LocalizationConfigWithLabels`), `payload generate:types` crashed with:
```
TypeError: Cannot read properties of undefined (reading 'endsWith')
```
inside `json-schema-to-typescript`.

### Root Cause
1. In `sanitize.ts`, when `firstLocale` was an object, `config.localization.localeCodes` was mapped directly from `locale.code`. If `code` was omitted (e.g. user supplied `value`), `locale.code` became `undefined`, yielding `localeCodes: [undefined, undefined]`.
2. `configToJSONSchema.ts` placed these values into JSON Schema `enum: locales`. `json-schema-to-typescript` then crashed while formatting enum strings (`.endsWith()`).
3. In `LocalizationConfigWithLabels`, the `@example` in the JSDoc showed `value: 'en'` instead of `code: 'en'`.
4. `defaultLocale` was not validated to ensure it matches one of the configured `localeCodes`.

### Changes
- In `packages/payload/src/config/sanitize.ts`:
  - Support `value` as fallback to `code` (`locale.code || locale.value`) when locales are provided in object form.
  - Ensure `code` is set and default `label` to `code` if omitted.
  - Validate that `code` is a valid non-empty string; throw descriptive `InvalidConfiguration` if missing or invalid.
  - Default `defaultLocale` to the first configured locale if omitted, and validate that `defaultLocale` exists within `localeCodes` (throwing `InvalidConfiguration` if not).
- In `packages/payload/src/config/types.ts`:
  - Updated JSDoc example from `value: 'en'` to `code: 'en'`.
  - Added optional `value?: string` on `Locale` marked `@deprecated Use code instead`.
  - Allowed `{ value: string }` object shape in `LocalizationConfigWithLabels`.
- In `packages/payload/src/utilities/configToJSONSchema.ts`:
  - Defensively filter out falsy / non-string items from `enum` arrays in `generateLocaleEntitySchemas` and `generateFallbackLocaleEntitySchemas`.
- Added unit tests covering:
  - Object-form locales with `{ label, value }` and schema generation + `compile` from `json-schema-to-typescript`.
  - Throwing `InvalidConfiguration` when a locale lacks both `code` and `value`.
  - Throwing `InvalidConfiguration` when `defaultLocale` is not in configured `localeCodes`.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update