### PR TITLE
fix(plugin-import-export): translate localized field labels in export fields, sort and preview

### DIFF
--- a/packages/plugin-import-export/src/components/ExportPreview/index.tsx
+++ b/packages/plugin-import-export/src/components/ExportPreview/index.tsx
@@ -14,7 +14,7 @@ import {
   useFormFields,
   useTranslation,
 } from '@payloadcms/ui'
-import React, { useEffect, useRef, useState, useTransition } from 'react'
+import React, { useEffect, useMemo, useRef, useState, useTransition } from 'react'
 
 import type {
   PluginImportExportTranslationKeys,
@@ -24,6 +24,7 @@ import type { ExportPreviewResponse } from '../../types.js'
 
 import { DEFAULT_PREVIEW_LIMIT, PREVIEW_LIMIT_OPTIONS } from '../../constants.js'
 import './index.scss'
+import { reduceFields } from '../FieldsToExport/reduceFields.js'
 import { useImportExport } from '../ImportExportProvider/index.js'
 
 const baseClass = 'export-preview'
@@ -34,6 +35,7 @@ export const ExportPreview: React.FC = () => {
   const {
     config,
     config: { routes },
+    getEntityConfig,
   } = useConfig()
   const { collectionSlug } = useDocumentInfo()
   const { draft, fields, format, limit, locale, sort, where } = useFormFields(([fields]) => {
@@ -85,6 +87,23 @@ export const ExportPreview: React.FC = () => {
   }, [draft, fields, format, limit, locale, sort, where])
 
   const targetCollectionSlug = typeof collection === 'string' && collection
+
+  const targetCollectionConfig = targetCollectionSlug
+    ? getEntityConfig({ collectionSlug: targetCollectionSlug })
+    : undefined
+
+  // Map column keys (dot paths for JSON, underscore-flattened paths for CSV)
+  // to the translated label of the field they belong to
+  const fieldLabels = useMemo(() => {
+    const labels = new Map<string, string>()
+
+    reduceFields({ fields: targetCollectionConfig?.fields ?? [], i18n }).forEach((option) => {
+      labels.set(option.value, option.fieldLabel)
+      labels.set(option.value.replace(/\./g, '_'), option.fieldLabel)
+    })
+
+    return labels
+  }, [i18n, targetCollectionConfig?.fields])
 
   const isCSV = format === 'csv'
 
@@ -145,7 +164,7 @@ export const ExportPreview: React.FC = () => {
             accessor: key,
             active: true,
             field: { name: key } as ClientField,
-            Heading: getTranslation(key, i18n),
+            Heading: fieldLabels.get(key) ?? getTranslation(key, i18n),
             renderedCells: docs.map((doc: Record<string, unknown>) => {
               const val = doc[key]
 
@@ -196,6 +215,7 @@ export const ExportPreview: React.FC = () => {
       collectionSlug,
       draft,
       fields,
+      fieldLabels,
       format,
       i18n,
       limit,

--- a/packages/plugin-import-export/src/components/FieldsToExport/index.tsx
+++ b/packages/plugin-import-export/src/components/FieldsToExport/index.tsx
@@ -10,6 +10,7 @@ import {
   useDocumentInfo,
   useField,
   useListQuery,
+  useTranslation,
 } from '@payloadcms/ui'
 import React, { useEffect } from 'react'
 
@@ -25,6 +26,7 @@ export const FieldsToExport: SelectFieldClientComponent = (props) => {
   const { getEntityConfig } = useConfig()
   const { collection } = useImportExport()
   const { query } = useListQuery()
+  const { i18n } = useTranslation()
 
   const collectionConfig = getEntityConfig({ collectionSlug: collectionSlug ?? collection })
 
@@ -34,6 +36,7 @@ export const FieldsToExport: SelectFieldClientComponent = (props) => {
   const fieldOptions = reduceFields({
     disabledFields,
     fields: collectionConfig?.fields,
+    i18n,
   })
 
   useEffect(() => {

--- a/packages/plugin-import-export/src/components/FieldsToExport/reduceFields.spec.ts
+++ b/packages/plugin-import-export/src/components/FieldsToExport/reduceFields.spec.ts
@@ -1,3 +1,4 @@
+import type { I18nClient } from '@payloadcms/translations'
 import type { ClientField } from 'payload'
 
 import { describe, expect, it } from 'vitest'
@@ -144,6 +145,88 @@ describe('reduceFields', () => {
 
       expect(result).toContain('meta.title')
       expect(result).not.toContain('meta.description')
+    })
+  })
+
+  describe('labels', () => {
+    const i18n = {
+      fallbackLanguage: 'en',
+      language: 'de',
+      t: (key: string) => key,
+    } as unknown as I18nClient
+
+    it('should translate localized labels into the current admin language', () => {
+      const fields: ClientField[] = [
+        { name: 'title', type: 'text', label: { de: 'Titel', en: 'Title' } },
+      ]
+
+      const [option] = reduceFields({ fields, i18n })
+
+      expect(option?.fieldLabel).toBe('Titel')
+      expect(option?.displayLabel).toBe('Titel')
+    })
+
+    it('should fall back to the fallback language when the current language is missing', () => {
+      const fields: ClientField[] = [{ name: 'title', type: 'text', label: { en: 'Title' } }]
+
+      const [option] = reduceFields({ fields, i18n })
+
+      expect(option?.fieldLabel).toBe('Title')
+    })
+
+    it('should keep string labels and fall back to the field name without a label', () => {
+      const fields: ClientField[] = [
+        { name: 'title', type: 'text', label: 'Headline' },
+        { name: 'slug', type: 'text' },
+      ]
+
+      const result = reduceFields({ fields, i18n })
+
+      expect(result.map((f) => f.fieldLabel)).toEqual(['Headline', 'slug'])
+    })
+
+    it('should use the field name for localized labels when no i18n is provided', () => {
+      const fields: ClientField[] = [
+        { name: 'title', type: 'text', label: { de: 'Titel', en: 'Title' } },
+      ]
+
+      const [option] = reduceFields({ fields })
+
+      expect(option?.fieldLabel).toBe('title')
+    })
+
+    it('should translate group and named tab prefixes', () => {
+      const fields: ClientField[] = [
+        {
+          name: 'meta',
+          type: 'group',
+          label: { de: 'Meta', en: 'Meta' },
+          fields: [{ name: 'title', type: 'text', label: { de: 'Titel', en: 'Title' } }],
+        },
+        {
+          type: 'tabs',
+          tabs: [
+            {
+              name: 'seo',
+              label: { de: 'Suchmaschinen', en: 'SEO' },
+              fields: [
+                {
+                  name: 'description',
+                  type: 'text',
+                  label: { de: 'Beschreibung', en: 'Description' },
+                },
+              ],
+            },
+          ],
+        },
+      ]
+
+      const result = reduceFields({ fields, i18n })
+
+      expect(result.map((f) => [f.value, f.displayLabel, f.fieldLabel])).toEqual([
+        ['meta.title', 'Meta > Titel', 'Titel'],
+        ['seo.description', 'Suchmaschinen > Beschreibung', 'Beschreibung'],
+      ])
     })
   })
 })

--- a/packages/plugin-import-export/src/components/FieldsToExport/reduceFields.tsx
+++ b/packages/plugin-import-export/src/components/FieldsToExport/reduceFields.tsx
@@ -1,7 +1,19 @@
+import type { I18nClient } from '@payloadcms/translations'
 import type { ClientField } from 'payload'
 
+import { getTranslation } from '@payloadcms/translations'
 import { fieldAffectsData, fieldHasSubFields } from 'payload/shared'
 import React, { Fragment } from 'react'
+
+export type ReducedField = {
+  /** Translated, prefix-aware label as plain text, e.g. `Group > Title` */
+  displayLabel: string
+  /** Translated label of the field itself without any parent prefix */
+  fieldLabel: string
+  id: string
+  label: React.ReactNode
+  value: string
+}
 
 const createNestedClientFieldPath = (parentPath: string, field: ClientField): string => {
   if (parentPath) {
@@ -18,12 +30,45 @@ const createNestedClientFieldPath = (parentPath: string, field: ClientField): st
   return ''
 }
 
-const combineLabel = ({
+const getFieldLabel = ({ field, i18n }: { field: ClientField; i18n?: I18nClient }): string => {
+  if ('label' in field && field.label) {
+    if (typeof field.label === 'string') {
+      return field.label
+    }
+    if (i18n && typeof field.label === 'object') {
+      return getTranslation(field.label, i18n)
+    }
+  }
+
+  return ('name' in field && field.name) || ''
+}
+
+const combineLabelText = ({
   field,
+  i18n,
   prefix,
 }: {
   field: ClientField
-  prefix?: React.ReactNode
+  i18n?: I18nClient
+  prefix?: string
+}): string => {
+  const label = getFieldLabel({ field, i18n })
+
+  if (prefix && label) {
+    return `${prefix} > ${label}`
+  }
+
+  return prefix || label
+}
+
+const combineLabel = ({
+  field,
+  i18n,
+  prefix,
+}: {
+  field: ClientField
+  i18n?: I18nClient
+  prefix?: string
 }): React.ReactNode => {
   return (
     <Fragment>
@@ -34,9 +79,7 @@ const combineLabel = ({
         </Fragment>
       ) : null}
       <span style={{ display: 'inline-block' }}>
-        {'label' in field && typeof field.label === 'string'
-          ? field.label
-          : (('name' in field && field.name) ?? 'unnamed field')}
+        {getFieldLabel({ field, i18n }) || 'unnamed field'}
       </span>
     </Fragment>
   )
@@ -46,96 +89,101 @@ export const reduceFields = ({
   disabledFields = [],
   excludeUnsortable = false,
   fields,
-  labelPrefix = null,
+  i18n,
+  labelPrefix = '',
   path = '',
 }: {
   disabledFields?: string[]
   excludeUnsortable?: boolean
   fields: ClientField[]
-  labelPrefix?: React.ReactNode
+  /**
+   * When provided, localized field labels (`{ en: 'Title', de: 'Titel' }`) are
+   * translated into the current admin language instead of falling back to the field name.
+   */
+  i18n?: I18nClient
+  labelPrefix?: string
   path?: string
-}): { id: string; label: React.ReactNode; value: string }[] => {
+}): ReducedField[] => {
   if (!fields) {
     return []
   }
 
-  return fields.reduce<{ id: string; label: React.ReactNode; value: string }[]>(
-    (fieldsToUse, field) => {
-      const isArrayOrBlocks = field.type === 'array' || field.type === 'blocks'
+  return fields.reduce<ReducedField[]>((fieldsToUse, field) => {
+    const isArrayOrBlocks = field.type === 'array' || field.type === 'blocks'
 
-      // escape for a variety of reasons, include ui fields as they have `name`.
-      if (field.type === 'ui' || (excludeUnsortable && isArrayOrBlocks)) {
-        return fieldsToUse
-      }
+    // escape for a variety of reasons, include ui fields as they have `name`.
+    if (field.type === 'ui' || (excludeUnsortable && isArrayOrBlocks)) {
+      return fieldsToUse
+    }
 
-      if (!isArrayOrBlocks && fieldHasSubFields(field)) {
-        return [
-          ...fieldsToUse,
-          ...reduceFields({
-            disabledFields,
-            excludeUnsortable,
-            fields: field.fields,
-            labelPrefix: combineLabel({ field, prefix: labelPrefix }),
-            path: createNestedClientFieldPath(path, field),
-          }),
-        ]
-      }
+    if (!isArrayOrBlocks && fieldHasSubFields(field)) {
+      return [
+        ...fieldsToUse,
+        ...reduceFields({
+          disabledFields,
+          excludeUnsortable,
+          fields: field.fields,
+          i18n,
+          labelPrefix: combineLabelText({ field, i18n, prefix: labelPrefix }),
+          path: createNestedClientFieldPath(path, field),
+        }),
+      ]
+    }
 
-      if (field.type === 'tabs' && 'tabs' in field) {
-        return [
-          ...fieldsToUse,
-          ...field.tabs.reduce<{ id: string; label: React.ReactNode; value: string }[]>(
-            (tabFields, tab) => {
-              if ('fields' in tab) {
-                const isNamedTab = 'name' in tab && tab.name
+    if (field.type === 'tabs' && 'tabs' in field) {
+      return [
+        ...fieldsToUse,
+        ...field.tabs.reduce<ReducedField[]>((tabFields, tab) => {
+          if ('fields' in tab) {
+            const isNamedTab = 'name' in tab && tab.name
 
-                const newPath = isNamedTab ? `${path}${path ? '.' : ''}${tab.name}` : path
+            const newPath = isNamedTab ? `${path}${path ? '.' : ''}${tab.name}` : path
 
-                return [
-                  ...tabFields,
-                  ...reduceFields({
-                    disabledFields,
-                    excludeUnsortable,
-                    fields: tab.fields,
-                    labelPrefix: isNamedTab
-                      ? combineLabel({
-                          field: {
-                            name: tab.name,
-                            label: tab.label ?? tab.name,
-                          } as any,
-                          prefix: labelPrefix,
-                        })
-                      : labelPrefix,
-                    path: newPath,
-                  }),
-                ]
-              }
-              return tabFields
-            },
-            [],
-          ),
-        ]
-      }
+            return [
+              ...tabFields,
+              ...reduceFields({
+                disabledFields,
+                excludeUnsortable,
+                fields: tab.fields,
+                i18n,
+                labelPrefix: isNamedTab
+                  ? combineLabelText({
+                      field: {
+                        name: tab.name,
+                        label: tab.label ?? tab.name,
+                      } as any,
+                      i18n,
+                      prefix: labelPrefix,
+                    })
+                  : labelPrefix,
+                path: newPath,
+              }),
+            ]
+          }
+          return tabFields
+        }, []),
+      ]
+    }
 
-      const val = createNestedClientFieldPath(path, field)
+    const val = createNestedClientFieldPath(path, field)
 
-      // If the field is disabled, skip it
-      if (
-        disabledFields.some(
-          (disabledField) => val === disabledField || val.startsWith(`${disabledField}.`),
-        )
-      ) {
-        return fieldsToUse
-      }
+    // If the field is disabled, skip it
+    if (
+      disabledFields.some(
+        (disabledField) => val === disabledField || val.startsWith(`${disabledField}.`),
+      )
+    ) {
+      return fieldsToUse
+    }
 
-      const formattedField = {
-        id: val,
-        label: combineLabel({ field, prefix: labelPrefix }),
-        value: val,
-      }
+    const formattedField: ReducedField = {
+      id: val,
+      displayLabel: combineLabelText({ field, i18n, prefix: labelPrefix }) || val,
+      fieldLabel: getFieldLabel({ field, i18n }) || val,
+      label: combineLabel({ field, i18n, prefix: labelPrefix }),
+      value: val,
+    }
 
-      return [...fieldsToUse, formattedField]
-    },
-    [],
-  )
+    return [...fieldsToUse, formattedField]
+  }, [])
 }

--- a/packages/plugin-import-export/src/components/SortBy/index.tsx
+++ b/packages/plugin-import-export/src/components/SortBy/index.tsx
@@ -10,6 +10,7 @@ import {
   useDocumentInfo,
   useField,
   useListQuery,
+  useTranslation,
 } from '@payloadcms/ui'
 import React, { useEffect, useMemo, useRef, useState } from 'react'
 
@@ -35,6 +36,7 @@ export const SortBy: SelectFieldClientComponent = (props) => {
   const { query } = useListQuery()
   const { getEntityConfig } = useConfig()
   const { collection } = useImportExport()
+  const { i18n } = useTranslation()
 
   // ReactSelect's displayed option
   const [displayedValue, setDisplayedValue] = useState<{
@@ -45,8 +47,8 @@ export const SortBy: SelectFieldClientComponent = (props) => {
 
   const collectionConfig = getEntityConfig({ collectionSlug: collectionSlug ?? collection })
   const fieldOptions = useMemo(
-    () => reduceFields({ excludeUnsortable: true, fields: collectionConfig?.fields }),
-    [collectionConfig?.fields],
+    () => reduceFields({ excludeUnsortable: true, fields: collectionConfig?.fields, i18n }),
+    [collectionConfig?.fields, i18n],
   )
 
   // Normalize the stored value for display (strip the '-') and pick the option

--- a/test/plugin-import-export/e2e.spec.ts
+++ b/test/plugin-import-export/e2e.spec.ts
@@ -200,6 +200,66 @@ test.describe('Import Export Plugin', () => {
       await expect(localeField.locator('.rs__single-value')).toHaveText('Spanish')
     })
 
+    test('should show translated field labels in export fields, sort and preview', async () => {
+      const setAdminLanguage = async (language: string) => {
+        await page.goto(`${serverURL}/admin/account`)
+        const languageField = page.locator('.payload-settings__language .react-select')
+        await expect(languageField).toBeVisible()
+        await languageField.click()
+        await page.locator('.rs__option', { hasText: language }).click()
+        await expect(languageField).toContainText(language)
+      }
+
+      const expectTitleLabel = async ({
+        exportButton,
+        label,
+      }: {
+        exportButton: string
+        label: string
+      }) => {
+        await page.goto(postsURL.list)
+        await expect(page.locator('.collection-list')).toBeVisible()
+
+        const listMenuButton = page.locator('#list-menu')
+        await expect(listMenuButton).toBeVisible()
+        await listMenuButton.click()
+
+        const createExportButton = page.locator('.popup__scroll-container button', {
+          hasText: exportButton,
+        })
+        await expect(createExportButton).toBeVisible()
+        await createExportButton.click()
+
+        // Export preview table heading uses the translated label instead of the field name
+        await expect(async () => {
+          await expect(page.locator('.export-preview table')).toBeVisible()
+          await expect(
+            page.locator('.export-preview table thead th', { hasText: label }),
+          ).toBeVisible()
+        }).toPass({ timeout: POLL_TOPASS_TIMEOUT })
+
+        // Fields to export selected values use the translated label
+        await expect(
+          page.locator('.fields-to-export .multi-value-label', { hasText: label }),
+        ).toBeVisible()
+
+        // Sort by options use the translated label
+        await page.locator('.sort-by-fields .rs__control').click()
+        await expect(page.locator('.rs__menu .rs__option', { hasText: label })).toBeVisible()
+        await page.keyboard.press('Escape')
+      }
+
+      // Posts.title is labelled { en: 'Title', es: 'Título', de: 'Titel' }
+      await expectTitleLabel({ exportButton: 'Export Posts', label: 'Title' })
+
+      await setAdminLanguage('Español')
+      try {
+        await expectTitleLabel({ exportButton: 'Exportar Posts', label: 'Título' })
+      } finally {
+        await setAdminLanguage('English')
+      }
+    })
+
     test('should download directly in the browser', async () => {
       await page.goto(exportsURL.create)
       await expect(page.locator('.collection-edit')).toBeVisible()
@@ -493,16 +553,17 @@ test.describe('Import Export Plugin', () => {
         const uniqueHeaders = new Set(normalizedHeaders)
         expect(uniqueHeaders.size).toBe(normalizedHeaders.length)
 
-        // Verify expected columns are present (id, title, createdAt, updatedAt)
+        // Verify expected columns are present (id, title, createdAt, updatedAt).
+        // Timestamp headings show the translated field label ("Created At") rather than the key.
         expect(normalizedHeaders).toContain('id')
         expect(normalizedHeaders).toContain('title')
-        expect(normalizedHeaders).toContain('createdat')
-        expect(normalizedHeaders).toContain('updatedat')
+        expect(normalizedHeaders).toContain('created at')
+        expect(normalizedHeaders).toContain('updated at')
 
         // Verify we don't have duplicates of these key columns
         const idCount = normalizedHeaders.filter((h) => h === 'id').length
-        const createdAtCount = normalizedHeaders.filter((h) => h === 'createdat').length
-        const updatedAtCount = normalizedHeaders.filter((h) => h === 'updatedat').length
+        const createdAtCount = normalizedHeaders.filter((h) => h === 'created at').length
+        const updatedAtCount = normalizedHeaders.filter((h) => h === 'updated at').length
 
         expect(idCount).toBe(1)
         expect(createdAtCount).toBe(1)


### PR DESCRIPTION
### What?

The Export drawer of `@payloadcms/plugin-import-export` now shows the translated field label in the current admin language for the **Fields to export** select, the **Sort by** select and the **export preview** table headings.

### Why?

`reduceFields` only used `field.label` when it was a plain string. A localized label such as `{ en: 'Title', de: 'Titel' }` was ignored and the raw field name (`title`) was displayed instead, and the preview table headings always showed the raw column key. Any collection that localizes its labels therefore got an untranslated export UI while the rest of the Admin panel was translated.

### How?

- `reduceFields` accepts an optional `i18n` and resolves labels through `getTranslation`, so string labels, localized label objects and label-less fields all produce a readable label. Group and named-tab prefixes are translated the same way. Each option now also exposes `fieldLabel` (label without prefix) and `displayLabel` (prefixed plain text) alongside the existing React `label`.
- `FieldsToExport` and `SortBy` pass the admin `i18n` from `useTranslation()`.
- `ExportPreview` builds a map from the target collection's field paths (dot form for JSON, underscore-flattened form for CSV columns) to the translated label and uses it for the table `Heading`, falling back to the previous `getTranslation(key, i18n)` behaviour for derived or unknown columns.
- Unit tests cover string, localized, fallback-language, label-less and nested (group / named tab) labels. An e2e test switches the admin language to Spanish and checks the preview heading, the selected export field and the sort option all read `Título` for the `title` field of the `posts` test collection.

The plugin's technical column keys in the generated CSV / JSON files are unchanged; only what the Admin UI displays is affected.

**Behaviour note:** because `createdAt` / `updatedAt` already carry translated labels, the preview headings for those columns now read `Created At` / `Updated At` (matching the list view) instead of the raw keys. The existing custom-ID preview e2e assertion was updated accordingly.

Validated locally on the `3.x` branch with `pnpm vitest run --project unit` for `reduceFields.spec.ts`, `tsc --noEmit` and `eslint` for the plugin package, and `pnpm test:e2e plugin-import-export` (sqlite + local S3 emulator) for the new case plus every existing export-preview case.
