### PR TITLE
fix(plugin-ecommerce): preserve user i18n overrides

### DIFF
--- a/packages/plugin-ecommerce/src/index.spec.ts
+++ b/packages/plugin-ecommerce/src/index.spec.ts
@@ -1,0 +1,43 @@
+import type { Config } from 'payload'
+
+import { describe, expect, it, vitest } from 'vitest'
+
+import { ecommercePlugin } from './index.js'
+
+describe('ecommercePlugin i18n translations', () => {
+  const mockAccessConfig = {
+    adminOnlyFieldAccess: vitest.fn(),
+    adminOrPublishedStatus: vitest.fn(),
+    customerOnlyFieldAccess: vitest.fn(),
+    isAdmin: vitest.fn(),
+    isAuthenticated: vitest.fn(),
+    isDocumentOwner: vitest.fn(),
+  }
+
+  it('should preserve user-provided translations for the plugin-ecommerce namespace', async () => {
+    const plugin = ecommercePlugin({
+      access: mockAccessConfig,
+      customers: { slug: 'users' },
+    })
+
+    const incomingConfig = {
+      collections: [],
+      i18n: {
+        translations: {
+          en: {
+            'plugin-ecommerce': {
+              cart: 'MY CART OVERRIDE',
+            },
+          },
+        },
+      },
+    } as unknown as Config
+
+    const result = await plugin(incomingConfig)
+
+    // User override wins...
+    expect((result.i18n?.translations?.en as any)['plugin-ecommerce'].cart).toBe('MY CART OVERRIDE')
+    // ...while other plugin defaults for the namespace are still present.
+    expect((result.i18n?.translations?.en as any)['plugin-ecommerce'].customer).toBe('Customer')
+  })
+})

--- a/packages/plugin-ecommerce/src/index.ts
+++ b/packages/plugin-ecommerce/src/index.ts
@@ -318,8 +318,8 @@ export const ecommercePlugin = definePlugin<EcommercePluginConfig | undefined>({
     /**
      * Merge plugin translations — only for languages the user has enabled.
      * Plugins run before sanitize, so `supportedLanguages` may be undefined; sanitize will
-     * default it to `{ en }`, so we mirror that here. Plugin-ecommerce translations always
-     * win over user-provided ones for the `plugin-ecommerce` namespace.
+     * default it to `{ en }`, so we mirror that here. User-provided translations for the
+     * `plugin-ecommerce` namespace win over the plugin defaults.
      */
     const supportedLanguageKeys = incomingConfig.i18n?.supportedLanguages
       ? Object.keys(incomingConfig.i18n.supportedLanguages)
@@ -337,7 +337,10 @@ export const ecommercePlugin = definePlugin<EcommercePluginConfig | undefined>({
       >
       incomingConfig.i18n.translations[typedLocale] = {
         ...existing,
-        'plugin-ecommerce': pluginEntry.translations['plugin-ecommerce'],
+        'plugin-ecommerce': {
+          ...pluginEntry.translations['plugin-ecommerce'],
+          ...(existing['plugin-ecommerce'] as object | undefined),
+        },
       } as PluginDefaultTranslationsObject
     }
 


### PR DESCRIPTION
### What?

The `plugin-ecommerce` config step that merges plugin translations into `incomingConfig.i18n.translations` unconditionally overwrote the whole `plugin-ecommerce` namespace with the plugin's own defaults, discarding
any translations the user had supplied for that namespace.

### Why?

Plugin defaults are now spread first, then the user's existing entries on top, so user overrides win while any keys the user didn't override still fall back to the plugin defaults.

### How?

Added a unit test in `packages/plugin-ecommerce/src/index.spec.ts` that calls the plugin directly with a preset `i18n.translations` override and asserts it survives the merge. Verified it fails against the previous implementation and passes with the fix.

Fixes #16502