### PR TITLE
fix(plugin-ecommerce): don't treat non-customer req.user as a customer

### DIFF
--- a/packages/plugin-ecommerce/src/endpoints/initiatePayment.spec.ts
+++ b/packages/plugin-ecommerce/src/endpoints/initiatePayment.spec.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { CurrenciesConfig, PaymentAdapter } from '../types/index.js'
+
+import { USD } from '../currencies/index.js'
+import { initiatePaymentHandler } from './initiatePayment'
+
+const currenciesConfig: CurrenciesConfig = {
+  defaultCurrency: 'USD',
+  supportedCurrencies: [USD],
+}
+
+const cart = {
+  id: 'cart-1',
+  currency: 'USD',
+  items: [{ product: 'product-1', quantity: 1 }],
+  subtotal: 1000,
+}
+
+const product = {
+  id: 'product-1',
+  priceInUSD: 1000,
+}
+
+const createMockPayload = () => ({
+  findByID: vi.fn(async ({ collection }: { collection: string }) => {
+    if (collection === 'carts') {
+      return cart
+    }
+    if (collection === 'products') {
+      return product
+    }
+    return null
+  }),
+  logger: { error: vi.fn() },
+})
+
+const createMockReq = ({
+  payload,
+  user,
+}: {
+  payload: ReturnType<typeof createMockPayload>
+  user: null | Record<string, unknown>
+}) =>
+  ({
+    data: { cartID: 'cart-1' },
+    payload,
+    user,
+  }) as any
+
+describe('initiatePaymentHandler - customer vs non-customer users', () => {
+  const createHandler = (initiatePayment: PaymentAdapter['initiatePayment']) =>
+    initiatePaymentHandler({
+      currenciesConfig,
+      customersSlug: 'users',
+      paymentMethod: { initiatePayment } as PaymentAdapter,
+    })
+
+  it('should resolve customerEmail from the user when req.user belongs to the customers collection', async () => {
+    const initiatePayment = vi.fn().mockResolvedValue({ message: 'ok' })
+    const payload = createMockPayload()
+    const req = createMockReq({
+      payload,
+      user: { id: 'user-1', collection: 'users', email: 'customer@example.com' },
+    })
+
+    const response = await createHandler(initiatePayment)(req)
+
+    expect(response.status).toBe(200)
+    expect(initiatePayment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ customerEmail: 'customer@example.com' }),
+      }),
+    )
+  })
+
+  it('should use data.customerEmail when req.user is from a non-customer collection', async () => {
+    const initiatePayment = vi.fn().mockResolvedValue({ message: 'ok' })
+    const payload = createMockPayload()
+    const req = createMockReq({
+      payload,
+      user: { id: 'api-key-1', collection: 'api-keys' },
+    })
+    req.data.customerEmail = 'guest@example.com'
+
+    const response = await createHandler(initiatePayment)(req)
+
+    expect(response.status).toBe(200)
+    expect(initiatePayment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ customerEmail: 'guest@example.com' }),
+      }),
+    )
+  })
+
+  it('should reject with 400 when req.user is non-customer and no data.customerEmail is provided', async () => {
+    const initiatePayment = vi.fn()
+    const payload = createMockPayload()
+    const req = createMockReq({
+      payload,
+      user: { id: 'api-key-1', collection: 'api-keys' },
+    })
+
+    const response = await createHandler(initiatePayment)(req)
+
+    expect(response.status).toBe(400)
+    expect(initiatePayment).not.toHaveBeenCalled()
+  })
+})

--- a/packages/plugin-ecommerce/src/endpoints/initiatePayment.ts
+++ b/packages/plugin-ecommerce/src/endpoints/initiatePayment.ts
@@ -1,6 +1,7 @@
 import { addDataAndFileToRequest, type DefaultDocumentIDType, type Endpoint } from 'payload'
 
 import type {
+  Cart,
   CurrenciesConfig,
   PaymentAdapter,
   ProductsValidation,
@@ -69,14 +70,16 @@ export const initiatePaymentHandler: InitiatePayment =
 
     let currency: string = currenciesConfig.defaultCurrency
     let cartID: DefaultDocumentIDType = data?.cartID
-    let cart: any = undefined
+    let cart: Cart | undefined
     const billingAddress = data?.billingAddress
     const shippingAddress = data?.shippingAddress
     const cartSecret = data?.secret
 
-    let customerEmail: string = user?.email ?? ''
+    const isCustomer = user?.collection === customersSlug
 
-    if (user) {
+    let customerEmail: string = isCustomer ? (user?.email ?? '') : ''
+
+    if (isCustomer && user) {
       if (user.cart?.docs && Array.isArray(user.cart.docs) && user.cart.docs.length > 0) {
         if (!cartID && user.cart.docs[0]) {
           // Use the user's cart instead
@@ -89,7 +92,7 @@ export const initiatePaymentHandler: InitiatePayment =
         }
       }
     } else {
-      // Get the email from the data if user is not available
+      // Get the email from the data if the requester is not a customer
       if (data?.customerEmail && typeof data.customerEmail === 'string') {
         customerEmail = data.customerEmail
       } else {
@@ -215,7 +218,7 @@ export const initiatePaymentHandler: InitiatePayment =
         if (!product) {
           return Response.json(
             {
-              message: `Product with ID ${item.product} not found.`,
+              message: `Product with ID ${id} not found.`,
             },
             {
               status: 404,

--- a/packages/plugin-ecommerce/src/payments/adapters/stripe/initiatePayment.spec.ts
+++ b/packages/plugin-ecommerce/src/payments/adapters/stripe/initiatePayment.spec.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockCustomersList = vi.fn()
+const mockCustomersCreate = vi.fn()
+const mockPaymentIntentsCreate = vi.fn()
+
+vi.mock('stripe', () => {
+  const MockStripe = function () {
+    return {
+      customers: {
+        list: mockCustomersList,
+        create: mockCustomersCreate,
+      },
+      paymentIntents: {
+        create: mockPaymentIntentsCreate,
+      },
+    }
+  }
+
+  return { default: MockStripe }
+})
+
+import { initiatePayment } from './initiatePayment'
+
+const cart = {
+  id: 'cart-123',
+  items: [{ product: 'product-1', quantity: 1 }],
+  subtotal: 1000,
+}
+
+const createMockPayload = () => ({
+  create: vi.fn().mockResolvedValue({ id: 'transaction-123' }),
+  logger: { error: vi.fn() },
+})
+
+describe('stripe initiatePayment - customer vs non-customer users', () => {
+  const secretKey = 'sk_test_123'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    mockCustomersList.mockResolvedValue({ data: [{ id: 'cus-123' }] })
+    mockPaymentIntentsCreate.mockResolvedValue({
+      id: 'pi-123',
+      amount: 1000,
+      client_secret: 'secret',
+      currency: 'usd',
+    })
+  })
+
+  it('should attach `customer` when req.user belongs to the customers collection', async () => {
+    const payload = createMockPayload()
+    const req = {
+      payload,
+      user: { id: 'user-1', collection: 'users' },
+    } as any
+
+    await initiatePayment({ secretKey })({
+      customersSlug: 'users',
+      data: {
+        billingAddress: undefined,
+        cart,
+        currency: 'usd',
+        customerEmail: 'customer@example.com',
+      },
+      req,
+      transactionsSlug: 'transactions',
+    })
+
+    expect(payload.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ customer: 'user-1' }),
+      }),
+    )
+  })
+
+  it('should attach `customerEmail` instead of `customer` when req.user is from a non-customer collection', async () => {
+    const payload = createMockPayload()
+    const req = {
+      payload,
+      user: { id: 'api-key-1', collection: 'api-keys' },
+    } as any
+
+    await initiatePayment({ secretKey })({
+      customersSlug: 'users',
+      data: {
+        billingAddress: undefined,
+        cart,
+        currency: 'usd',
+        customerEmail: 'guest@example.com',
+      },
+      req,
+      transactionsSlug: 'transactions',
+    })
+
+    const writtenData = payload.create.mock.calls[0]?.[0]?.data
+
+    expect(writtenData.customer).toBeUndefined()
+    expect(writtenData.customerEmail).toBe('guest@example.com')
+  })
+})

--- a/packages/plugin-ecommerce/src/payments/adapters/stripe/initiatePayment.ts
+++ b/packages/plugin-ecommerce/src/payments/adapters/stripe/initiatePayment.ts
@@ -11,7 +11,7 @@ type Props = {
 
 export const initiatePayment: (props: Props) => NonNullable<PaymentAdapter>['initiatePayment'] =
   (props) =>
-  async ({ data, req, transactionsSlug }) => {
+  async ({ customersSlug, data, req, transactionsSlug }) => {
     const payload = req.payload
     const { apiVersion, appInfo, secretKey } = props || {}
 
@@ -103,10 +103,12 @@ export const initiatePayment: (props: Props) => NonNullable<PaymentAdapter>['ini
       })
 
       // Create a transaction for the payment intent in the database
-      const transaction = await payload.create({
+      await payload.create({
         collection: transactionsSlug,
         data: {
-          ...(req.user ? { customer: req.user.id } : { customerEmail }),
+          ...(req.user && req.user.collection === customersSlug
+            ? { customer: req.user.id }
+            : { customerEmail }),
           amount: paymentIntent.amount,
           billingAddress: billingAddressFromData,
           cart: cart.id,


### PR DESCRIPTION
### What?

`initiatePayment`'s endpoint and its Stripe adapter assumed any truthy `req.user` was a customer doc. When a request authenticates with an API key from a different, non-customer auth collection, `req.user` is truthy but has no
`email` and is not a valid `customers`-collection reference:

- The endpoint's `if (user)` branch skipped the `data.customerEmail` fallback the guest branch has, so `customerEmail` stayed `''`.
- The Stripe adapter wrote `customer: req.user.id` onto the transaction for any truthy `req.user`, even when that id belongs to a non-customer collection, breaking the `transactions.customer` relationship.

### Why?

Gate both call sites on `req.user.collection === customersSlug` instead of a truthy check, falling back to the existing guest/`customerEmail` path otherwise.

### How?

Added unit tests for both the endpoint handler (`initiatePayment.spec.ts`) and the Stripe adapter (`stripe/initiatePayment.spec.ts`), covering the customer and non-customer `req.user` cases. Verified both fail against the previous implementation and pass with the fix.

Fixes #16377