### PR TITLE
fix(plugin-ecommerce): use constructEventAsync for Stripe webhook verification (Workers/edge runtimes)

### DIFF
--- a/packages/plugin-ecommerce/src/payments/adapters/stripe/endpoints/webhooks.ts
+++ b/packages/plugin-ecommerce/src/payments/adapters/stripe/endpoints/webhooks.ts
@@ -37,7 +37,7 @@ export const webhooksEndpoint: (props: Props) => Endpoint = (props) => {
         let event: Stripe.Event | undefined
 
         try {
-          event = stripe.webhooks.constructEvent(body, stripeSignature, webhookSecret)
+          event = await stripe.webhooks.constructEventAsync(body, stripeSignature, webhookSecret)
         } catch (err: unknown) {
           const msg: string = err instanceof Error ? err.message : JSON.stringify(err)
           req.payload.logger.error(`Error constructing Stripe event: ${msg}`)


### PR DESCRIPTION
### What?

One line in the Stripe adapter's webhooks endpoint:

```diff
-        event = stripe.webhooks.constructEvent(body, stripeSignature, webhookSecret)
+        event = await stripe.webhooks.constructEventAsync(body, stripeSignature, webhookSecret)
```

### Why?

`webhooksEndpoint` verifies the Stripe signature with the **synchronous**
`stripe.webhooks.constructEvent(...)`. On Workers runtimes (workerd) the Stripe SDK selects
`SubtleCryptoProvider`, whose HMAC is async-only, so the call throws before any handler runs:

```
Error constructing Stripe event: SubtleCryptoProvider cannot be used in a synchronous context.
Use `await constructEventAsync(...)` instead of `constructEvent(...)`
```

The catch block sets `returnStatus = 400`, but the response body is still `{"received": true}`. So on
Workers **every** Stripe webhook is rejected while looking superficially healthy: Stripe retries, then
gives up, and no registered `webhooks[event.type]` handler ever fires. A paid order is never confirmed.

### How?

The handler is already `async` and the call already sits inside the `try`, so the fix is one line and
a rejected promise still lands in the same 400 branch. No signature, type, or control-flow change.

### Measured

Against `@payloadcms/plugin-ecommerce@3.88.0` on a built OpenNext/Cloudflare Worker
(`opennextjs-cloudflare build` + `wrangler dev`, local D1), with `stripe@22.6.1` resolved through its
`workerd` export condition, and a real Stripe **test** key. A `payment_intent.succeeded` body was
signed in Node with `stripe.webhooks.generateTestHeaderString({ payload, secret })` and the identical
bytes POSTed to `/api/payments/stripe/webhooks`:

| build | request | result |
|---|---|---|
| without this change | valid signature | **HTTP 400** — log: `SubtleCryptoProvider cannot be used in a synchronous context. Use await constructEventAsync(...) instead of constructEvent(...)` |
| with this change | valid signature | **HTTP 200** |
| with this change | corrupted signature | **HTTP 400** — log: `No signatures found matching the expected signature for payload.` |

The third row is what makes the second mean something: it shows the 200 is a real verification rather
than a handler that stopped checking. A fourth control, with `webhookSecret` unset, returns a bare 200
for **both** a valid and a corrupted signature — that is the existing short-circuit at the top of the
handler, unchanged by this PR.

**Not measured:** behaviour on Node. Every run above was on workerd. `constructEventAsync` is
documented as the Workers-safe form of the same verification and the call is already inside the
existing try/catch, but this PR carries no Node before/after, so it should not be described as
verified-unchanged there.

### Notes

- This PR targets `main` (v4). The identical synchronous call is also present on `3.x` at the same
  line of the same file, if you want the fix backported there as maintenance.
- Related: #17201 — the payments half of the same Workers story, which is a bundler export-condition
  issue rather than a plugin bug, so this PR does not close it.
