### PR TITLE
fix(ui): preserve custom field paths in bulk edit

### DIFF
--- a/packages/ui/src/elements/EditMany/DrawerContent.tsx
+++ b/packages/ui/src/elements/EditMany/DrawerContent.tsx
@@ -20,6 +20,7 @@ import type { EditManyProps } from './index.js'
 
 import { useForm } from '../../forms/Form/context.js'
 import { Form } from '../../forms/Form/index.js'
+import { FieldPathContext } from '../../forms/RenderFields/context.js'
 import { RenderField } from '../../forms/RenderFields/RenderField.js'
 import { FormSubmit } from '../../forms/Submit/index.js'
 import { ChevronIcon } from '../../icons/Chevron/index.js'
@@ -407,15 +408,16 @@ export const EditManyDrawerContent: React.FC<EditManyDrawerContentProps> = (prop
                     } = option
 
                     return (
-                      <RenderField
-                        clientFieldConfig={field}
-                        indexPath=""
-                        key={`${path}-${i}`}
-                        parentPath=""
-                        parentSchemaPath=""
-                        path={path}
-                        permissions={fieldPermissions}
-                      />
+                      <FieldPathContext key={`${path}-${i}`} value={path}>
+                        <RenderField
+                          clientFieldConfig={field}
+                          indexPath=""
+                          parentPath=""
+                          parentSchemaPath=""
+                          path={path}
+                          permissions={fieldPermissions}
+                        />
+                      </FieldPathContext>
                     )
                   })}
                 </div>

--- a/test/bulk-edit/components/CustomField.tsx
+++ b/test/bulk-edit/components/CustomField.tsx
@@ -2,13 +2,20 @@
 
 import type { TextFieldClientComponent } from 'payload'
 
-import { TextField } from '@payloadcms/ui'
+import { TextInput, useField } from '@payloadcms/ui'
 import React from 'react'
 
-export const CustomField: TextFieldClientComponent = (props) => {
+export const CustomField: TextFieldClientComponent = ({ field }) => {
+  const { path, setValue, value } = useField<string>()
+
   return (
     <div data-testid="custom-field">
-      <TextField {...props} />
+      <TextInput
+        label={field.label}
+        onChange={(event: React.ChangeEvent<HTMLInputElement>) => setValue(event.target.value)}
+        path={path}
+        value={value}
+      />
     </div>
   )
 }

--- a/test/bulk-edit/e2e.spec.ts
+++ b/test/bulk-edit/e2e.spec.ts
@@ -992,6 +992,51 @@ test.describe('Bulk Edit', () => {
     await expect(modal.locator('[data-testid="custom-field"]')).toBeVisible()
   })
 
+  test('should bulk edit values from custom Field components', async () => {
+    await deleteAllPosts()
+    await Promise.all([createPost({ title: 'Post 1' }), createPost({ title: 'Post 2' })])
+
+    await page.goto(postsUrl.list)
+    // Wait until page has limit in the url, to ensure it is fully loaded
+    await expect.poll(() => page.url(), { timeout: POLL_TOPASS_TIMEOUT }).toContain('limit=')
+
+    await selectAllAndEditMany(page)
+
+    const { modal } = await selectFieldToEdit(page, {
+      fieldID: 'fieldWithCustomField',
+      fieldLabel: 'Field With Custom Field',
+    })
+
+    const field = modal.locator('[data-testid="custom-field"] input')
+
+    await expect(field).toHaveAttribute('id', 'field-fieldWithCustomField')
+    await field.fill('Bulk edited custom field')
+    await modal.locator('.form-submit button[type="submit"].edit-many__publish').click()
+
+    await expect(page.locator('.payload-toast-container .toast-success')).toContainText(
+      'Updated 2 Posts successfully.',
+    )
+
+    await expect
+      .poll(
+        async () => {
+          const updatedPosts = await payload.find({
+            collection: postsSlug,
+            limit: 2,
+          })
+
+          return (
+            updatedPosts.docs.length === 2 &&
+            updatedPosts.docs.every(
+              (post) => post.fieldWithCustomField === 'Bulk edited custom field',
+            )
+          )
+        },
+        { timeout: POLL_TOPASS_TIMEOUT },
+      )
+      .toBe(true)
+  })
+
   test('should preserve values of previously selected fields when selecting another field', async () => {
     await deleteAllPosts()
     await createPost({ title: 'Post 1' })


### PR DESCRIPTION
### What?

Wrap fields rendered directly by the bulk edit drawer in `FieldPathContext`.

### Why?

Custom field components such as the fields provided by `@payloadcms/plugin-seo` call `useField()` without an explicit path. Unlike the normal document form, `EditMany/DrawerContent` rendered `RenderField` without the context provider, so those components resolved an undefined path. The bulk update still returned success, but the custom field value was silently discarded.

### How?

- provide each selected field's path through `FieldPathContext`
- update the existing custom-field fixture to exercise the no-argument `useField()` pattern
- add an end-to-end regression test that verifies the rendered path and the values persisted to both selected documents

### Testing

- regression test fails without the provider (`field-undefined`; values are not persisted)
- focused regression: 1 passed
- adjacent bulk-edit custom-component tests: 3 passed
- `pnpm run build:ui`
- ESLint, Prettier, and `git diff --check`

Fixes #18116
