### PR TITLE
fix(plugin-multi-tenant): preserve form after refused tenant save

### DIFF
--- a/packages/plugin-multi-tenant/src/providers/TenantSelectionProvider/index.client.tsx
+++ b/packages/plugin-multi-tenant/src/providers/TenantSelectionProvider/index.client.tsx
@@ -184,7 +184,15 @@ export const TenantSelectionProviderClient = ({
       const result = await req.json()
 
       if (result.tenantOptions && userID) {
-        setTenantOptions(result.tenantOptions)
+        setTenantOptions((prev) => {
+          if (
+            prev.length === result.tenantOptions.length &&
+            prev.every((opt, i) => opt.value === result.tenantOptions[i]?.value)
+          ) {
+            return prev
+          }
+          return result.tenantOptions
+        })
 
         if (result.tenantOptions.length === 1) {
           setSelectedTenantID(result.tenantOptions[0].value)


### PR DESCRIPTION
Fixes #18122 

## What?

Prevent the tenant selector from refreshing the route when tenant options are synchronized but have not changed.

## Why?

When no tenant is selected, saving a tenant document that fails validation triggers `syncTenants()`. The refreshed tenant options array changed the `setTenant` callback identity, causing the provider effect to call `router.refresh()`. This refreshed the create page and cleared the user's form values.

## How?

Updated `syncTenants()` to compare tenant option IDs before updating state. When the IDs are unchanged, the existing options array is preserved, keeping the callback identity stable and preventing the unnecessary route refresh.

This preserves the entered form values after a refused save while retaining the existing tenant synchronization behavior.

## Testing

- Verified no language-service errors in the modified file.
- Package lint and type build were attempted but could not complete because the local environment uses Node 22 while the repository requires Node 24.15 or later.