### PR TITLE
chore: backport telemetry updated to v3

### DIFF
--- a/packages/payload/src/utilities/telemetry/featureInfo/getFeatureInfo.ts
+++ b/packages/payload/src/utilities/telemetry/featureInfo/getFeatureInfo.ts
@@ -1,0 +1,332 @@
+import type { SanitizedConfig } from '../../../config/types.js'
+import type { IncomingDrafts } from '../../../versions/types.js'
+import type { FeatureInfo, RichTextFeature } from './types.js'
+
+import { defaultUserCollection } from '../../../auth/defaultUser.js'
+
+export const getFeatureInfo = (config: SanitizedConfig): FeatureInfo => {
+  const telemetryConfig = sanitizeTelemetryConfig(config)
+
+  return Object.assign(
+    {},
+    ...[
+      collectAdminCustomization,
+      collectAuthentication,
+      collectBasicDenominators,
+      collectI18n,
+      collectJobsAndQueues,
+      collectOrdering,
+      collectPreviewAndLivePreview,
+      collectQueryPresets,
+      collectTrash,
+      collectUploadAndMedia,
+      collectVersionsAndDrafts,
+      collectRichTextFeatures,
+    ].map((collect) => safelyCollect(() => collect(telemetryConfig))),
+  )
+}
+
+const safelyCollect = (collect: () => FeatureInfo): FeatureInfo => {
+  try {
+    return collect()
+  } catch (_) {
+    return {}
+  }
+}
+
+// sanitization adds 3 system widgets that we need to account for
+const SYSTEM_WIDGET_COUNT = 3
+const SYSTEM_COLLECTION_SLUGS = [
+  'payload-locked-documents',
+  'payload-migrations',
+  'payload-preferences',
+  'payload-query-presets',
+]
+const SYSTEM_GLOBAL_SLUGS = new Set(['payload-jobs-stats'])
+
+/**
+ * Payload adds internal collections, globals and tasks during config sanitization.
+ * Remove them from the telemetry view so feature metrics represent user config.
+ */
+const sanitizeTelemetryConfig = (config: SanitizedConfig): SanitizedConfig => {
+  try {
+    const collections = config.collections ?? []
+    const systemCollectionSlugs = new Set(SYSTEM_COLLECTION_SLUGS)
+    const kvCollectionSlug = config.kv?.kvCollection?.slug
+
+    if (kvCollectionSlug) {
+      systemCollectionSlugs.add(kvCollectionSlug)
+    }
+
+    if (config.jobs?.enabled) {
+      // uses SYSTEM_COLLECTION_SLUGS (not the Set) to exclude kv slug from position detection
+      const firstCollectionAfterJobs = collections.findIndex(({ slug }) =>
+        SYSTEM_COLLECTION_SLUGS.includes(slug),
+      )
+
+      if (firstCollectionAfterJobs > 0) {
+        systemCollectionSlugs.add(collections[firstCollectionAfterJobs - 1]!.slug)
+      } else {
+        systemCollectionSlugs.add('payload-jobs')
+      }
+    }
+
+    const tasks = [...(config.jobs?.tasks ?? [])]
+
+    if (getDraftEntities(config).some(hasScheduledPublishing)) {
+      for (let index = tasks.length - 1; index >= 0; index--) {
+        if (tasks[index]?.slug === 'schedulePublish') {
+          tasks.splice(index, 1)
+          break
+        }
+      }
+    }
+
+    return {
+      ...config,
+      collections: collections.filter(
+        (collection) =>
+          collection !== defaultUserCollection && !systemCollectionSlugs.has(collection.slug),
+      ),
+      globals: (config.globals ?? []).filter(({ slug }) => !SYSTEM_GLOBAL_SLUGS.has(slug)),
+      jobs: {
+        ...config.jobs,
+        tasks,
+      },
+    }
+  } catch (_) {
+    return config
+  }
+}
+
+const collectAdminCustomization = (config: SanitizedConfig): FeatureInfo => ({
+  adminCustomization: {
+    customAdminComponentCount: countRootAdminComponents(config),
+    customAdminViewCount: Object.keys(config.admin?.components?.views ?? {}).length,
+    customDashboardWidgetCount: Math.max(
+      0,
+      (config.admin?.dashboard?.widgets?.length ?? 0) - SYSTEM_WIDGET_COUNT,
+    ),
+  },
+})
+
+const collectAuthentication = (config: SanitizedConfig): FeatureInfo => {
+  const authCollections = (config.collections ?? []).filter(({ auth }) => Boolean(auth))
+
+  return {
+    authentication: {
+      apiKeyCollectionCount: authCollections.filter(
+        ({ auth }) => isObject(auth) && Boolean(auth.useAPIKey),
+      ).length,
+      authCollectionCount: authCollections.length,
+      customAuthStrategyCount: authCollections.reduce(
+        (count, { auth }) =>
+          count + (isObject(auth) && Array.isArray(auth.strategies) ? auth.strategies.length : 0),
+        0,
+      ),
+      localAuthDisabledCollectionCount: authCollections.filter(
+        ({ auth }) => isObject(auth) && Boolean(auth.disableLocalStrategy),
+      ).length,
+      sessionsDisabledCollectionCount: authCollections.filter(
+        ({ auth }) => isObject(auth) && auth.useSessions === false,
+      ).length,
+      usernameCollectionCount: authCollections.filter(
+        ({ auth }) => isObject(auth) && Boolean(auth.loginWithUsername),
+      ).length,
+      verifiedCollectionCount: authCollections.filter(
+        ({ auth }) => isObject(auth) && Boolean(auth.verify),
+      ).length,
+    },
+  }
+}
+
+const collectBasicDenominators = (config: SanitizedConfig): FeatureInfo => ({
+  basicDenominators: {
+    collectionCount: config.collections?.length ?? 0,
+    globalCount: config.globals?.length ?? 0,
+  },
+})
+
+const collectI18n = (config: SanitizedConfig): FeatureInfo => ({
+  i18n: {
+    hasCustomAdminTranslations: Object.keys(config.i18n?.translations ?? {}).length > 0,
+    supportedAdminLanguageCount: config.i18n?.supportedLanguages
+      ? Object.keys(config.i18n.supportedLanguages).length
+      : 1,
+  },
+})
+
+const collectJobsAndQueues = (config: SanitizedConfig): FeatureInfo => {
+  const tasks = Array.isArray(config.jobs?.tasks) ? config.jobs.tasks : []
+  const workflows = Array.isArray(config.jobs?.workflows) ? config.jobs.workflows : []
+  const tasksAndWorkflows = [...tasks, ...workflows]
+  const scheduledPublishingEntityCount =
+    getDraftEntities(config).filter(hasScheduledPublishing).length
+
+  return {
+    jobsAndQueues: {
+      jobsAutoRunConfigured: config.jobs?.autoRun !== undefined,
+      jobsConcurrencyEnabled: tasksAndWorkflows.some(({ concurrency }) => Boolean(concurrency)),
+      jobsEnabled: tasks.length > 0 || workflows.length > 0 || scheduledPublishingEntityCount > 0,
+      jobsSchedulingEnabled: tasksAndWorkflows.some(({ schedule }) => Boolean(schedule)),
+      taskCount: tasks.length,
+      workflowCount: workflows.length,
+    },
+  }
+}
+
+const collectOrdering = (config: SanitizedConfig): FeatureInfo => ({
+  orderableCollectionCount: (config.collections ?? []).filter(({ orderable }) => Boolean(orderable))
+    .length,
+})
+
+const collectPreviewAndLivePreview = (config: SanitizedConfig): FeatureInfo => {
+  const collections = config.collections ?? []
+  const globals = config.globals ?? []
+  const livePreviewCollections = new Set([
+    ...(config.admin?.livePreview?.collections ?? []),
+    ...collections.filter((c) => c.admin?.livePreview).map((c) => c.slug),
+  ])
+  const livePreviewGlobals = new Set([
+    ...(config.admin?.livePreview?.globals ?? []),
+    ...globals.filter((g) => g.admin?.livePreview).map((g) => g.slug),
+  ])
+
+  return {
+    previewAndLivePreview: {
+      livePreviewCollectionCount: collections.filter(({ slug }) => livePreviewCollections.has(slug))
+        .length,
+      livePreviewGlobalCount: globals.filter(({ slug }) => livePreviewGlobals.has(slug)).length,
+      previewCollectionCount: collections.filter(({ admin }) => Boolean(admin?.preview)).length,
+      previewGlobalCount: globals.filter(({ admin }) => Boolean(admin?.preview)).length,
+    },
+  }
+}
+
+const collectQueryPresets = (config: SanitizedConfig): FeatureInfo => ({
+  queryPresetCollectionCount: (config.collections ?? []).filter(({ enableQueryPresets }) =>
+    Boolean(enableQueryPresets),
+  ).length,
+})
+
+const collectRichTextFeatures = (config: SanitizedConfig): FeatureInfo => {
+  const editor: unknown = config.editor
+  const features =
+    isObject(editor) && isObject(editor.editorConfig) ? editor.editorConfig.features : undefined
+  const raw =
+    isObject(features) && Array.isArray(features.enabledFeatures) ? features.enabledFeatures : []
+  const featureSet = new Set(raw.filter((f): f is string => typeof f === 'string'))
+  // per-field editor overrides are not checked; root editor covers the vast majority of projects
+  return {
+    richTextFeatures: (['blocks', 'table', 'upload', 'relationship'] as const).filter((f) =>
+      featureSet.has(f),
+    ) as RichTextFeature[],
+  }
+}
+
+const collectTrash = (config: SanitizedConfig): FeatureInfo => ({
+  trashCollectionCount: (config.collections ?? []).filter(({ trash }) => Boolean(trash)).length,
+})
+
+const collectUploadAndMedia = (config: SanitizedConfig): FeatureInfo => {
+  const collections = config.collections ?? []
+
+  return {
+    uploadAndMedia: {
+      cropDisabledCollectionCount: collections.filter(
+        ({ upload }) => isObject(upload) && upload.crop === false,
+      ).length,
+      focalPointDisabledCollectionCount: collections.filter(
+        ({ upload }) => isObject(upload) && upload.focalPoint === false,
+      ).length,
+      imageSizesCollectionCount: collections.filter(
+        ({ upload }) => isObject(upload) && Boolean(upload.imageSizes?.length),
+      ).length,
+      mimeRestrictedCollectionCount: collections.filter(
+        ({ upload }) => isObject(upload) && Boolean(upload.mimeTypes?.length),
+      ).length,
+      uploadCollectionCount: collections.filter(({ upload }) => Boolean(upload)).length,
+    },
+  }
+}
+
+const collectVersionsAndDrafts = (config: SanitizedConfig): FeatureInfo => {
+  const collections = config.collections ?? []
+  const globals = config.globals ?? []
+  const draftCollections = collections.filter(hasDrafts)
+  const draftGlobals = globals.filter(hasDrafts)
+  const draftEntities = [...draftCollections, ...draftGlobals]
+
+  return {
+    versionsAndDrafts: {
+      autosaveEntityCount: draftEntities.filter(hasAutosave).length,
+      draftCollectionCount: draftCollections.length,
+      draftGlobalCount: draftGlobals.length,
+      scheduledPublishingEntityCount: draftEntities.filter(hasScheduledPublishing).length,
+      versionsDisabledCollectionCount: collections.filter(({ versions }) => !versions).length,
+      versionsDisabledGlobalCount: globals.filter(({ versions }) => !versions).length,
+    },
+  }
+}
+
+const getDraftEntities = (config: SanitizedConfig) => [
+  ...(config.collections ?? []).filter(hasDrafts),
+  ...(config.globals ?? []).filter(hasDrafts),
+]
+
+const hasDrafts = ({ versions }: { versions?: { drafts?: unknown } | boolean }): boolean =>
+  isObject(versions) && Boolean(versions.drafts)
+
+const getDraftOptions = ({
+  versions,
+}: {
+  versions?: { drafts?: boolean | IncomingDrafts } | boolean
+}): IncomingDrafts | undefined =>
+  isObject(versions) && isObject(versions.drafts) ? versions.drafts : undefined
+
+const hasAutosave = (entity: Parameters<typeof getDraftOptions>[0]): boolean =>
+  Boolean(getDraftOptions(entity)?.autosave)
+
+const hasScheduledPublishing = (entity: Parameters<typeof getDraftOptions>[0]): boolean =>
+  Boolean(getDraftOptions(entity)?.schedulePublish)
+
+const countRootAdminComponents = (config: SanitizedConfig): number => {
+  const admin = config.admin
+  const customAvatarCount = Number(
+    Boolean(admin?.avatar && typeof admin.avatar === 'object' && admin.avatar.Component),
+  )
+  const components = admin?.components
+
+  if (!components) {
+    return customAvatarCount
+  }
+
+  const componentArrays = [
+    components.actions,
+    components.afterDashboard,
+    components.afterLogin,
+    components.afterNav,
+    components.afterNavLinks,
+    components.beforeDashboard,
+    components.beforeLogin,
+    components.beforeNav,
+    components.beforeNavLinks,
+    components.header,
+    components.providers,
+    components.settingsMenu,
+  ]
+  const directComponents = [
+    components.graphics?.Icon,
+    components.graphics?.Logo,
+    components.logout?.Button,
+    components.Nav,
+  ]
+  return (
+    customAvatarCount +
+    componentArrays.reduce((count, items) => count + (items?.length ?? 0), 0) +
+    directComponents.filter(Boolean).length
+  )
+}
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === 'object'

--- a/packages/payload/src/utilities/telemetry/featureInfo/types.ts
+++ b/packages/payload/src/utilities/telemetry/featureInfo/types.ts
@@ -1,0 +1,62 @@
+export type RichTextFeature = 'blocks' | 'relationship' | 'table' | 'upload'
+
+type CompleteFeatureInfo = {
+  adminCustomization: {
+    customAdminComponentCount: number
+    customAdminViewCount: number
+    customDashboardWidgetCount: number
+  }
+  authentication: {
+    apiKeyCollectionCount: number
+    authCollectionCount: number
+    customAuthStrategyCount: number
+    localAuthDisabledCollectionCount: number
+    sessionsDisabledCollectionCount: number
+    usernameCollectionCount: number
+    verifiedCollectionCount: number
+  }
+  basicDenominators: {
+    collectionCount: number
+    globalCount: number
+  }
+  i18n: {
+    hasCustomAdminTranslations: boolean
+    supportedAdminLanguageCount: number
+  }
+  jobsAndQueues: {
+    jobsAutoRunConfigured: boolean
+    jobsConcurrencyEnabled: boolean
+    jobsEnabled: boolean
+    jobsSchedulingEnabled: boolean
+    taskCount: number
+    workflowCount: number
+  }
+  orderableCollectionCount: number
+  previewAndLivePreview: {
+    livePreviewCollectionCount: number
+    livePreviewGlobalCount: number
+    previewCollectionCount: number
+    previewGlobalCount: number
+  }
+  queryPresetCollectionCount: number
+  richTextFeatures: RichTextFeature[]
+  trashCollectionCount: number
+  uploadAndMedia: {
+    cropDisabledCollectionCount: number
+    focalPointDisabledCollectionCount: number
+    imageSizesCollectionCount: number
+    mimeRestrictedCollectionCount: number
+    uploadCollectionCount: number
+  }
+  versionsAndDrafts: {
+    autosaveEntityCount: number
+    draftCollectionCount: number
+    draftGlobalCount: number
+    scheduledPublishingEntityCount: number
+    versionsDisabledCollectionCount: number
+    versionsDisabledGlobalCount: number
+  }
+}
+
+/** Feature families are omitted individually if their collection fails. */
+export type FeatureInfo = Partial<CompleteFeatureInfo>

--- a/packages/payload/src/utilities/telemetry/getProjectContext.ts
+++ b/packages/payload/src/utilities/telemetry/getProjectContext.ts
@@ -1,0 +1,53 @@
+import type { Payload } from '../../types/index.js'
+
+export type ProjectCohort = 'cloud' | 'enterprise' | 'oss'
+
+type Args = {
+  env?: NodeJS.ProcessEnv
+  packages?: string[]
+  payload: Payload
+  plugins: string[]
+}
+
+export const enterprisePackageNames = new Set([
+  '@payloadcms/ai-model-adapter',
+  '@payloadcms/plugin-ab-testing',
+  '@payloadcms/plugin-admin-only',
+  '@payloadcms/plugin-ai-embeddings',
+  '@payloadcms/plugin-ai-translate',
+  '@payloadcms/plugin-audit-logs',
+  '@payloadcms/plugin-csm',
+  '@payloadcms/plugin-email-builder',
+  '@payloadcms/plugin-environments',
+  '@payloadcms/plugin-oauth2',
+  '@payloadcms/plugin-publication-workflows',
+  '@payloadcms/plugin-visual-editing',
+  '@payloadcms/visual-editing',
+])
+
+export const getProjectContext = ({
+  env = process.env,
+  packages = [],
+  payload,
+  plugins,
+}: Args): { projectCohorts: ProjectCohort[] } => {
+  const projectCohorts: ProjectCohort[] = []
+
+  if ([...packages, ...plugins].some((name) => enterprisePackageNames.has(name))) {
+    projectCohorts.push('enterprise')
+  }
+
+  const hasPayloadCloudConfig = payload.config.globals.some(
+    (global) => global.slug === 'payload-cloud-instance',
+  )
+
+  if (env.PAYLOAD_CLOUD === 'true' && hasPayloadCloudConfig) {
+    projectCohorts.push('cloud')
+  }
+
+  if (projectCohorts.length === 0) {
+    projectCohorts.push('oss')
+  }
+
+  return { projectCohorts }
+}

--- a/packages/payload/src/utilities/telemetry/index.ts
+++ b/packages/payload/src/utilities/telemetry/index.ts
@@ -8,9 +8,13 @@ import { fileURLToPath } from 'url'
 import type { Payload } from '../../types/index.js'
 import type { AdminInitEvent } from './events/adminInit.js'
 import type { ServerInitEvent } from './events/serverInit.js'
+import type { FeatureInfo } from './featureInfo/types.js'
+import type { ProjectCohort } from './getProjectContext.js'
 
 import { findUp } from '../findUp.js'
 import { Conf } from './conf/index.js'
+import { getFeatureInfo } from './featureInfo/getFeatureInfo.js'
+import { getProjectContext } from './getProjectContext.js'
 import { oneWayHash } from './oneWayHash.js'
 
 export type BaseEvent = {
@@ -18,6 +22,7 @@ export type BaseEvent = {
   dbAdapter: string
   emailAdapter: null | string
   envID: string
+  frameworkAdapter: 'next' | 'tanstack-start' | 'unknown'
   isCI: boolean
   locales: string[]
   localizationDefaultLocale: null | string
@@ -25,10 +30,12 @@ export type BaseEvent = {
   nodeEnv: string
   nodeVersion: string
   payloadVersion: string
+  plugins: string[]
+  projectCohorts: ProjectCohort[]
   projectID: string
   projectIDSource: 'cwd' | 'git' | 'packageJSON' | 'serverURL'
   uploadAdapters: string[]
-}
+} & FeatureInfo
 
 type PackageJSON = {
   dependencies: Record<string, string | undefined>
@@ -52,6 +59,8 @@ export const sendEvent = async ({ event, payload }: Args): Promise<void> => {
       // Only generate the base event once
       if (!baseEvent) {
         const { projectID, source: projectIDSource } = getProjectID(payload, packageJSON!)
+        const plugins = getInstalledPluginSlugs(payload)
+        const packages = Object.keys(packageJSON!.dependencies ?? {})
         baseEvent = {
           ciName: ciInfo.isCI ? ciInfo.name : null,
           envID: getEnvID(),
@@ -61,9 +70,13 @@ export const sendEvent = async ({ event, payload }: Args): Promise<void> => {
           payloadVersion: getPayloadVersion(packageJSON!),
           projectID,
           projectIDSource,
+          ...getProjectContext({ packages, payload, plugins }),
+          frameworkAdapter: getFrameworkAdapter(packages),
+          ...getFeatureInfo(payload.config),
           ...getLocalizationInfo(payload),
           dbAdapter: payload.db.name,
           emailAdapter: payload.email?.name || null,
+          plugins,
           uploadAdapters: payload.config.upload.adapters,
         }
       }
@@ -171,6 +184,23 @@ const getPackageJSONID = (payload: Payload, packageJSON: PackageJSON): string =>
 export const getPayloadVersion = (packageJSON: PackageJSON): string => {
   return packageJSON?.dependencies?.payload ?? ''
 }
+
+const getFrameworkAdapter = (packages: string[]): 'next' | 'tanstack-start' | 'unknown' => {
+  if (packages.includes('@payloadcms/tanstack-start')) {
+    return 'tanstack-start'
+  }
+
+  if (packages.includes('@payloadcms/next')) {
+    return 'next'
+  }
+
+  return 'unknown'
+}
+
+export const getInstalledPluginSlugs = (payload: Payload): string[] =>
+  (payload.config.plugins ?? [])
+    .map((plugin) => plugin.slug)
+    .filter((slug): slug is string => typeof slug === 'string' && slug.startsWith('@payloadcms/'))
 
 export const getLocalizationInfo = (
   payload: Payload,


### PR DESCRIPTION
This is a V3 backport of the following V4 telemetry PRs:
https://github.com/payloadcms/payload/pull/17948
https://github.com/payloadcms/payload/pull/17948

The following metrics have intentionally been excluded as they are not relevant for V3:
- Figma product / cohort
- Hierarchy count

This will only allow us to capture the additional metrics from the v3 version this PR gets released in - but it is still deemed worth capturing.