### PR TITLE
fix(graphql): keep select projection for aliased and nested relationships

### DIFF
--- a/packages/graphql/src/schema/fieldToSchemaMap.ts
+++ b/packages/graphql/src/schema/fieldToSchemaMap.ts
@@ -62,16 +62,22 @@ function formattedNameResolver({
   Context,
   any
 > {
-  if ('name' in field) {
-    if (formatName(field.name) !== field.name) {
-      return {
-        ...rest,
-        extensions: { ...rest.extensions, field },
-        resolve: (parent) => parent[field.name],
-      }
-    }
+  // Always attach `extensions.field` so that `resolveSelect`'s path traversal
+  // can recognize this GraphQL field and map its response key back to the
+  // underlying data field. Without it, sub-fields whose GraphQL name already
+  // matches their data name (e.g. fields inside arrays/blocks/uploads) are
+  // skipped during select resolution, and any relationship reached through them
+  // loses its projection and falls back to a full, unprojected fetch.
+  const config: GraphQLFieldConfig<any, Context, any> = {
+    ...rest,
+    extensions: { ...rest.extensions, field },
   }
-  return rest
+
+  if ('name' in field && formatName(field.name) !== field.name) {
+    config.resolve = (parent) => parent[field.name]
+  }
+
+  return config
 }
 
 type SharedArgs = {

--- a/packages/graphql/src/utilities/select.ts
+++ b/packages/graphql/src/utilities/select.ts
@@ -18,7 +18,16 @@ export function resolveSelect(info: GraphQLResolveInfo, select: SelectType): Sel
       const pathType = info.schema.getType(path.typename) as GraphQLObjectType
 
       if (pathType) {
-        const field = pathType?.getFields()?.[pathKey]?.extensions?.field as
+        // `path.key` is the response key, i.e. the alias when the field is aliased
+        // in the query, whereas the schema field map is keyed by the real field
+        // name. For the field currently being resolved (the leaf of `info.path`,
+        // which is always the relationship `resolveSelect` runs for) recover the
+        // real name from `info.fieldName` — graphql-js never puts the alias there.
+        // Without this, aliased relationship fields fall back to an id-only fetch
+        // instead of projecting their sub-selection. No-op when the field is not
+        // aliased (`info.fieldName === pathKey`).
+        const lookupKey = path === info.path ? info.fieldName : pathKey
+        const field = pathType?.getFields()?.[lookupKey]?.extensions?.field as
           | JoinField
           | RelationshipField
 
@@ -32,6 +41,15 @@ export function resolveSelect(info: GraphQLResolveInfo, select: SelectType): Sel
         }
         if (field) {
           traversePath.unshift(field.name)
+        }
+
+        // Block types nested in a blocks union have their sub-selection nested
+        // under the block slug in the select tree built by `buildSelectTree`.
+        // Mirror that here so the traversal path lines up with the built tree,
+        // keeping the projection for relationships reached through a block.
+        const blockSlug = pathType.extensions?.blockSlug as string | undefined
+        if (blockSlug) {
+          traversePath.unshift(blockSlug)
         }
       }
 
@@ -53,7 +71,9 @@ function buildSelect(info: GraphQLResolveInfo) {
   const returnType = getNamedType(info.returnType) as GraphQLObjectType
   const selectionSet = info.fieldNodes[0].selectionSet
 
-  if (!returnType) {return}
+  if (!returnType) {
+    return
+  }
 
   return buildSelectTree(info, selectionSet, returnType)
 }
@@ -74,8 +94,12 @@ function buildSelectTree(
         const field = fieldSchema?.extensions?.field as FieldBase
         const fieldNameOriginal = field?.name || fieldName
 
-        if (fieldName === '__typename') {continue}
-        if (fieldSchema == undefined) {continue}
+        if (fieldName === '__typename') {
+          continue
+        }
+        if (fieldSchema == undefined) {
+          continue
+        }
 
         if (selection.selectionSet) {
           const type = getNamedType(fieldSchema.type) as GraphQLObjectType

--- a/test/collections-graphql/config.ts
+++ b/test/collections-graphql/config.ts
@@ -43,6 +43,8 @@ export const pointSlug = 'point'
 
 export const errorOnHookSlug = 'error-on-hooks'
 
+export const nestedRelationsSlug = 'nested-relations'
+
 export default buildConfigWithDefaults({
   admin: {
     importMap: {
@@ -400,6 +402,47 @@ export default buildConfigWithDefaults({
         {
           name: 'number',
           type: 'number',
+        },
+      ],
+    },
+    {
+      slug: nestedRelationsSlug,
+      access: openAccess,
+      fields: [
+        // Top-level relationship, queried through an alias in the tests
+        {
+          name: 'topLevelRelation',
+          type: 'relationship',
+          relationTo: relationSlug,
+        },
+        // Relationship nested inside an array
+        {
+          name: 'array',
+          type: 'array',
+          fields: [
+            {
+              name: 'link',
+              type: 'relationship',
+              relationTo: relationSlug,
+            },
+          ],
+        },
+        // Relationship nested inside a block
+        {
+          name: 'blocks',
+          type: 'blocks',
+          blocks: [
+            {
+              slug: 'content',
+              fields: [
+                {
+                  name: 'link',
+                  type: 'relationship',
+                  relationTo: relationSlug,
+                },
+              ],
+            },
+          ],
         },
       ],
     },

--- a/test/collections-graphql/int.spec.ts
+++ b/test/collections-graphql/int.spec.ts
@@ -11,7 +11,7 @@ import type { Post } from './payload-types.js'
 
 import { idToString } from '../__helpers/shared/idToString.js'
 import { initPayloadInt } from '../__helpers/shared/initPayloadInt.js'
-import { errorOnHookSlug, pointSlug, relationSlug, slug } from './config.js'
+import { errorOnHookSlug, nestedRelationsSlug, pointSlug, relationSlug, slug } from './config.js'
 
 const formatID = (id: number | string) => (typeof id === 'number' ? id : `"${id}"`)
 
@@ -1374,6 +1374,46 @@ describe('collections-graphql', () => {
       expect(errors[0].path[0]).toEqual('QueryWithInternalError')
       expect(errors[0].extensions.statusCode).toEqual(500)
       expect(errors[0].extensions.name).toEqual('Error')
+    })
+  })
+
+  describe('select projection', () => {
+    // A relationship's sub-selection must survive the select projection derived
+    // from the GraphQL query, including when the field is aliased or nested in
+    // an array/block. Regression test for dropped sub-selections.
+    it('keeps sub-selection for aliased and array/block-nested relationships', async () => {
+      const rel1 = await payload.create({ collection: relationSlug, data: { name: 'top-level' } })
+      const rel2 = await payload.create({ collection: relationSlug, data: { name: 'in-array' } })
+      const rel3 = await payload.create({ collection: relationSlug, data: { name: 'in-block' } })
+
+      const doc = await payload.create({
+        collection: nestedRelationsSlug,
+        data: {
+          array: [{ link: rel2.id }],
+          blocks: [{ blockType: 'content', link: rel3.id }],
+          topLevelRelation: rel1.id,
+        },
+      })
+
+      // `select: true` makes the resolver derive a projection from the query,
+      // which is the path that runs `resolveSelect` for each relationship.
+      const query = `query {
+        NestedRelation(id: ${formatID(doc.id)}, select: true) {
+          aliased: topLevelRelation { id name }
+          array { link { id name } }
+          blocks { ... on Content { link { id name } } }
+        }
+      }`
+
+      const { data } = await restClient
+        .GRAPHQL_POST({ body: JSON.stringify({ query }) })
+        .then((res) => res.json())
+
+      const result = data.NestedRelation
+
+      expect(result.aliased).toMatchObject({ id: rel1.id, name: 'top-level' })
+      expect(result.array[0].link).toMatchObject({ id: rel2.id, name: 'in-array' })
+      expect(result.blocks[0].link).toMatchObject({ id: rel3.id, name: 'in-block' })
     })
   })
 })

--- a/test/collections-graphql/payload-types.ts
+++ b/test/collections-graphql/payload-types.ts
@@ -80,6 +80,7 @@ export interface Config {
     'cyclical-relationship': CyclicalRelationship;
     media: Media;
     sort: Sort;
+    'nested-relations': NestedRelation;
     'payload-kv': PayloadKv;
     'payload-locked-documents': PayloadLockedDocument;
     'payload-preferences': PayloadPreference;
@@ -100,6 +101,7 @@ export interface Config {
     'cyclical-relationship': CyclicalRelationshipSelect<false> | CyclicalRelationshipSelect<true>;
     media: MediaSelect<false> | MediaSelect<true>;
     sort: SortSelect<false> | SortSelect<true>;
+    'nested-relations': NestedRelationsSelect<false> | NestedRelationsSelect<true>;
     'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
     'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>;
@@ -112,6 +114,9 @@ export interface Config {
   globals: {};
   globalsSelect: {};
   locale: 'en' | 'es';
+  widgets: {
+    collections: CollectionsWidget;
+  };
   user: User;
   jobs: {
     tasks: unknown;
@@ -350,6 +355,30 @@ export interface Sort {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "nested-relations".
+ */
+export interface NestedRelation {
+  id: string;
+  topLevelRelation?: (string | null) | Relation;
+  array?:
+    | {
+        link?: (string | null) | Relation;
+        id?: string | null;
+      }[]
+    | null;
+  blocks?:
+    | {
+        link?: (string | null) | Relation;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'content';
+      }[]
+    | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-kv".
  */
 export interface PayloadKv {
@@ -423,6 +452,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'sort';
         value: string | Sort;
+      } | null)
+    | ({
+        relationTo: 'nested-relations';
+        value: string | NestedRelation;
       } | null);
   globalSlug?: string | null;
   user: {
@@ -657,6 +690,32 @@ export interface SortSelect<T extends boolean = true> {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "nested-relations_select".
+ */
+export interface NestedRelationsSelect<T extends boolean = true> {
+  topLevelRelation?: T;
+  array?:
+    | T
+    | {
+        link?: T;
+        id?: T;
+      };
+  blocks?:
+    | T
+    | {
+        content?:
+          | T
+          | {
+              link?: T;
+              id?: T;
+              blockName?: T;
+            };
+      };
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-kv_select".
  */
 export interface PayloadKvSelect<T extends boolean = true> {
@@ -694,6 +753,16 @@ export interface PayloadMigrationsSelect<T extends boolean = true> {
   batch?: T;
   updatedAt?: T;
   createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "collections_widget".
+ */
+export interface CollectionsWidget {
+  data?: {
+    [k: string]: unknown;
+  };
+  width: 'full';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/test/collections-graphql/schema.graphql
+++ b/test/collections-graphql/schema.graphql
@@ -59,6 +59,10 @@ type Query {
   Sorts(draft: Boolean, where: Sort_where, fallbackLocale: FallbackLocaleInputType, locale: LocaleInputType, limit: Int, page: Int, pagination: Boolean, select: Boolean, sort: String, trash: Boolean): Sorts
   countSorts(draft: Boolean, trash: Boolean, where: Sort_where, locale: LocaleInputType): countSorts
   docAccessSort(id: Int!): sortDocAccess
+  NestedRelation(id: Int!, draft: Boolean, fallbackLocale: FallbackLocaleInputType, locale: LocaleInputType, select: Boolean, trash: Boolean): NestedRelation
+  NestedRelations(draft: Boolean, where: NestedRelation_where, fallbackLocale: FallbackLocaleInputType, locale: LocaleInputType, limit: Int, page: Int, pagination: Boolean, select: Boolean, sort: String, trash: Boolean): NestedRelations
+  countNestedRelations(draft: Boolean, trash: Boolean, where: NestedRelation_where, locale: LocaleInputType): countNestedRelations
+  docAccessNestedRelation(id: Int!): nested_relationsDocAccess
   PayloadKv(id: Int!, draft: Boolean, fallbackLocale: FallbackLocaleInputType, locale: LocaleInputType, select: Boolean, trash: Boolean): PayloadKv
   PayloadKvs(draft: Boolean, where: PayloadKv_where, fallbackLocale: FallbackLocaleInputType, locale: LocaleInputType, limit: Int, page: Int, pagination: Boolean, select: Boolean, sort: String, trash: Boolean): PayloadKvs
   countPayloadKvs(draft: Boolean, trash: Boolean, where: PayloadKv_where, locale: LocaleInputType): countPayloadKvs
@@ -5161,6 +5165,344 @@ type SortDeleteDocAccess {
   where: JSONObject
 }
 
+type NestedRelation {
+  id: Int!
+  topLevelRelation(draft: Boolean, locale: LocaleInputType, fallbackLocale: FallbackLocaleInputType): Relation
+  array: [NestedRelation_Array!]
+  blocks: [NestedRelation_Blocks!]
+  updatedAt: DateTime
+  createdAt: DateTime
+}
+
+type NestedRelation_Array {
+  link(draft: Boolean, locale: LocaleInputType, fallbackLocale: FallbackLocaleInputType): Relation
+  id: String
+}
+
+union NestedRelation_Blocks = Content
+
+type Content {
+  link(draft: Boolean, locale: LocaleInputType, fallbackLocale: FallbackLocaleInputType): Relation
+  id: String
+  blockName: String
+  blockType: String
+}
+
+type NestedRelations {
+  docs: [NestedRelation!]!
+  hasNextPage: Boolean!
+  hasPrevPage: Boolean!
+  limit: Int!
+  nextPage: Int
+  offset: Int
+  page: Int!
+  pagingCounter: Int!
+  prevPage: Int
+  totalDocs: Int!
+  totalPages: Int!
+}
+
+input NestedRelation_where {
+  topLevelRelation: NestedRelation_topLevelRelation_operator
+  array__link: NestedRelation_array__link_operator
+  array__id: NestedRelation_array__id_operator
+  updatedAt: NestedRelation_updatedAt_operator
+  createdAt: NestedRelation_createdAt_operator
+  id: NestedRelation_id_operator
+  AND: [NestedRelation_where_and]
+  OR: [NestedRelation_where_or]
+}
+
+input NestedRelation_topLevelRelation_operator {
+  equals: JSON
+  not_equals: JSON
+  in: [JSON]
+  not_in: [JSON]
+  all: [JSON]
+  exists: Boolean
+}
+
+input NestedRelation_array__link_operator {
+  equals: JSON
+  not_equals: JSON
+  in: [JSON]
+  not_in: [JSON]
+  all: [JSON]
+  exists: Boolean
+}
+
+input NestedRelation_array__id_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input NestedRelation_updatedAt_operator {
+  equals: DateTime
+  not_equals: DateTime
+  greater_than_equal: DateTime
+  greater_than: DateTime
+  less_than_equal: DateTime
+  less_than: DateTime
+  like: DateTime
+  exists: Boolean
+}
+
+input NestedRelation_createdAt_operator {
+  equals: DateTime
+  not_equals: DateTime
+  greater_than_equal: DateTime
+  greater_than: DateTime
+  less_than_equal: DateTime
+  less_than: DateTime
+  like: DateTime
+  exists: Boolean
+}
+
+input NestedRelation_id_operator {
+  equals: Int
+  not_equals: Int
+  greater_than_equal: Int
+  greater_than: Int
+  less_than_equal: Int
+  less_than: Int
+  exists: Boolean
+}
+
+input NestedRelation_where_and {
+  topLevelRelation: NestedRelation_topLevelRelation_operator
+  array__link: NestedRelation_array__link_operator
+  array__id: NestedRelation_array__id_operator
+  updatedAt: NestedRelation_updatedAt_operator
+  createdAt: NestedRelation_createdAt_operator
+  id: NestedRelation_id_operator
+  AND: [NestedRelation_where_and]
+  OR: [NestedRelation_where_or]
+}
+
+input NestedRelation_where_or {
+  topLevelRelation: NestedRelation_topLevelRelation_operator
+  array__link: NestedRelation_array__link_operator
+  array__id: NestedRelation_array__id_operator
+  updatedAt: NestedRelation_updatedAt_operator
+  createdAt: NestedRelation_createdAt_operator
+  id: NestedRelation_id_operator
+  AND: [NestedRelation_where_and]
+  OR: [NestedRelation_where_or]
+}
+
+type countNestedRelations {
+  totalDocs: Int
+}
+
+type nested_relationsDocAccess {
+  fields: NestedRelationsDocAccessFields
+  create: NestedRelationsCreateDocAccess
+  read: NestedRelationsReadDocAccess
+  update: NestedRelationsUpdateDocAccess
+  delete: NestedRelationsDeleteDocAccess
+}
+
+type NestedRelationsDocAccessFields {
+  topLevelRelation: NestedRelationsDocAccessFields_topLevelRelation
+  array: NestedRelationsDocAccessFields_array
+  blocks: NestedRelationsDocAccessFields_blocks
+  updatedAt: NestedRelationsDocAccessFields_updatedAt
+  createdAt: NestedRelationsDocAccessFields_createdAt
+}
+
+type NestedRelationsDocAccessFields_topLevelRelation {
+  create: NestedRelationsDocAccessFields_topLevelRelation_Create
+  read: NestedRelationsDocAccessFields_topLevelRelation_Read
+  update: NestedRelationsDocAccessFields_topLevelRelation_Update
+  delete: NestedRelationsDocAccessFields_topLevelRelation_Delete
+}
+
+type NestedRelationsDocAccessFields_topLevelRelation_Create {
+  permission: Boolean!
+}
+
+type NestedRelationsDocAccessFields_topLevelRelation_Read {
+  permission: Boolean!
+}
+
+type NestedRelationsDocAccessFields_topLevelRelation_Update {
+  permission: Boolean!
+}
+
+type NestedRelationsDocAccessFields_topLevelRelation_Delete {
+  permission: Boolean!
+}
+
+type NestedRelationsDocAccessFields_array {
+  create: NestedRelationsDocAccessFields_array_Create
+  read: NestedRelationsDocAccessFields_array_Read
+  update: NestedRelationsDocAccessFields_array_Update
+  delete: NestedRelationsDocAccessFields_array_Delete
+  fields: NestedRelationsDocAccessFields_array_Fields
+}
+
+type NestedRelationsDocAccessFields_array_Create {
+  permission: Boolean!
+}
+
+type NestedRelationsDocAccessFields_array_Read {
+  permission: Boolean!
+}
+
+type NestedRelationsDocAccessFields_array_Update {
+  permission: Boolean!
+}
+
+type NestedRelationsDocAccessFields_array_Delete {
+  permission: Boolean!
+}
+
+type NestedRelationsDocAccessFields_array_Fields {
+  link: NestedRelationsDocAccessFields_array_link
+  id: NestedRelationsDocAccessFields_array_id
+}
+
+type NestedRelationsDocAccessFields_array_link {
+  create: NestedRelationsDocAccessFields_array_link_Create
+  read: NestedRelationsDocAccessFields_array_link_Read
+  update: NestedRelationsDocAccessFields_array_link_Update
+  delete: NestedRelationsDocAccessFields_array_link_Delete
+}
+
+type NestedRelationsDocAccessFields_array_link_Create {
+  permission: Boolean!
+}
+
+type NestedRelationsDocAccessFields_array_link_Read {
+  permission: Boolean!
+}
+
+type NestedRelationsDocAccessFields_array_link_Update {
+  permission: Boolean!
+}
+
+type NestedRelationsDocAccessFields_array_link_Delete {
+  permission: Boolean!
+}
+
+type NestedRelationsDocAccessFields_array_id {
+  create: NestedRelationsDocAccessFields_array_id_Create
+  read: NestedRelationsDocAccessFields_array_id_Read
+  update: NestedRelationsDocAccessFields_array_id_Update
+  delete: NestedRelationsDocAccessFields_array_id_Delete
+}
+
+type NestedRelationsDocAccessFields_array_id_Create {
+  permission: Boolean!
+}
+
+type NestedRelationsDocAccessFields_array_id_Read {
+  permission: Boolean!
+}
+
+type NestedRelationsDocAccessFields_array_id_Update {
+  permission: Boolean!
+}
+
+type NestedRelationsDocAccessFields_array_id_Delete {
+  permission: Boolean!
+}
+
+type NestedRelationsDocAccessFields_blocks {
+  create: NestedRelationsDocAccessFields_blocks_Create
+  read: NestedRelationsDocAccessFields_blocks_Read
+  update: NestedRelationsDocAccessFields_blocks_Update
+  delete: NestedRelationsDocAccessFields_blocks_Delete
+}
+
+type NestedRelationsDocAccessFields_blocks_Create {
+  permission: Boolean!
+}
+
+type NestedRelationsDocAccessFields_blocks_Read {
+  permission: Boolean!
+}
+
+type NestedRelationsDocAccessFields_blocks_Update {
+  permission: Boolean!
+}
+
+type NestedRelationsDocAccessFields_blocks_Delete {
+  permission: Boolean!
+}
+
+type NestedRelationsDocAccessFields_updatedAt {
+  create: NestedRelationsDocAccessFields_updatedAt_Create
+  read: NestedRelationsDocAccessFields_updatedAt_Read
+  update: NestedRelationsDocAccessFields_updatedAt_Update
+  delete: NestedRelationsDocAccessFields_updatedAt_Delete
+}
+
+type NestedRelationsDocAccessFields_updatedAt_Create {
+  permission: Boolean!
+}
+
+type NestedRelationsDocAccessFields_updatedAt_Read {
+  permission: Boolean!
+}
+
+type NestedRelationsDocAccessFields_updatedAt_Update {
+  permission: Boolean!
+}
+
+type NestedRelationsDocAccessFields_updatedAt_Delete {
+  permission: Boolean!
+}
+
+type NestedRelationsDocAccessFields_createdAt {
+  create: NestedRelationsDocAccessFields_createdAt_Create
+  read: NestedRelationsDocAccessFields_createdAt_Read
+  update: NestedRelationsDocAccessFields_createdAt_Update
+  delete: NestedRelationsDocAccessFields_createdAt_Delete
+}
+
+type NestedRelationsDocAccessFields_createdAt_Create {
+  permission: Boolean!
+}
+
+type NestedRelationsDocAccessFields_createdAt_Read {
+  permission: Boolean!
+}
+
+type NestedRelationsDocAccessFields_createdAt_Update {
+  permission: Boolean!
+}
+
+type NestedRelationsDocAccessFields_createdAt_Delete {
+  permission: Boolean!
+}
+
+type NestedRelationsCreateDocAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type NestedRelationsReadDocAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type NestedRelationsUpdateDocAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type NestedRelationsDeleteDocAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
 type PayloadKv {
   id: Int!
   key: String!
@@ -5321,7 +5663,7 @@ type PayloadLockedDocument {
   id: Int!
   document(draft: Boolean, locale: LocaleInputType, fallbackLocale: FallbackLocaleInputType): PayloadLockedDocument_Document_Relationship
   globalSlug: String
-  user(locale: LocaleInputType, fallbackLocale: FallbackLocaleInputType): PayloadLockedDocument_User_Relationship!
+  user(locale: LocaleInputType, fallbackLocale: FallbackLocaleInputType): PayloadLockedDocument_User_Relationship
   updatedAt: DateTime
   createdAt: DateTime
 }
@@ -5345,9 +5687,10 @@ enum PayloadLockedDocument_Document_RelationTo {
   cyclical_relationship
   media
   sort
+  nested_relations
 }
 
-union PayloadLockedDocument_Document = User | Point | Post | CustomId | Relation | Dummy | ErrorOnHook | PayloadApiTestOne | PayloadApiTestTwo | ContentType | CyclicalRelationship | Media | Sort
+union PayloadLockedDocument_Document = User | Point | Post | CustomId | Relation | Dummy | ErrorOnHook | PayloadApiTestOne | PayloadApiTestTwo | ContentType | CyclicalRelationship | Media | Sort | NestedRelation
 
 type PayloadLockedDocument_User_Relationship {
   relationTo: PayloadLockedDocument_User_RelationTo
@@ -5404,6 +5747,7 @@ enum PayloadLockedDocument_document_Relation_RelationTo {
   cyclical_relationship
   media
   sort
+  nested_relations
 }
 
 input PayloadLockedDocument_globalSlug_operator {
@@ -5637,7 +5981,7 @@ type PayloadLockedDocumentsDeleteDocAccess {
 
 type PayloadPreference {
   id: Int!
-  user(locale: LocaleInputType, fallbackLocale: FallbackLocaleInputType): PayloadPreference_User_Relationship!
+  user(locale: LocaleInputType, fallbackLocale: FallbackLocaleInputType): PayloadPreference_User_Relationship
   key: String
   value: JSON
   updatedAt: DateTime
@@ -5934,6 +6278,7 @@ type Access {
   cyclical_relationship: cyclical_relationshipAccess
   media: mediaAccess
   sort: sortAccess
+  nested_relations: nested_relationsAccess
   payload_kv: payload_kvAccess
   payload_locked_documents: payload_locked_documentsAccess
   payload_preferences: payload_preferencesAccess
@@ -8318,6 +8663,209 @@ type SortDeleteAccess {
   where: JSONObject
 }
 
+type nested_relationsAccess {
+  fields: NestedRelationsFields
+  create: NestedRelationsCreateAccess
+  read: NestedRelationsReadAccess
+  update: NestedRelationsUpdateAccess
+  delete: NestedRelationsDeleteAccess
+}
+
+type NestedRelationsFields {
+  topLevelRelation: NestedRelationsFields_topLevelRelation
+  array: NestedRelationsFields_array
+  blocks: NestedRelationsFields_blocks
+  updatedAt: NestedRelationsFields_updatedAt
+  createdAt: NestedRelationsFields_createdAt
+}
+
+type NestedRelationsFields_topLevelRelation {
+  create: NestedRelationsFields_topLevelRelation_Create
+  read: NestedRelationsFields_topLevelRelation_Read
+  update: NestedRelationsFields_topLevelRelation_Update
+  delete: NestedRelationsFields_topLevelRelation_Delete
+}
+
+type NestedRelationsFields_topLevelRelation_Create {
+  permission: Boolean!
+}
+
+type NestedRelationsFields_topLevelRelation_Read {
+  permission: Boolean!
+}
+
+type NestedRelationsFields_topLevelRelation_Update {
+  permission: Boolean!
+}
+
+type NestedRelationsFields_topLevelRelation_Delete {
+  permission: Boolean!
+}
+
+type NestedRelationsFields_array {
+  create: NestedRelationsFields_array_Create
+  read: NestedRelationsFields_array_Read
+  update: NestedRelationsFields_array_Update
+  delete: NestedRelationsFields_array_Delete
+  fields: NestedRelationsFields_array_Fields
+}
+
+type NestedRelationsFields_array_Create {
+  permission: Boolean!
+}
+
+type NestedRelationsFields_array_Read {
+  permission: Boolean!
+}
+
+type NestedRelationsFields_array_Update {
+  permission: Boolean!
+}
+
+type NestedRelationsFields_array_Delete {
+  permission: Boolean!
+}
+
+type NestedRelationsFields_array_Fields {
+  link: NestedRelationsFields_array_link
+  id: NestedRelationsFields_array_id
+}
+
+type NestedRelationsFields_array_link {
+  create: NestedRelationsFields_array_link_Create
+  read: NestedRelationsFields_array_link_Read
+  update: NestedRelationsFields_array_link_Update
+  delete: NestedRelationsFields_array_link_Delete
+}
+
+type NestedRelationsFields_array_link_Create {
+  permission: Boolean!
+}
+
+type NestedRelationsFields_array_link_Read {
+  permission: Boolean!
+}
+
+type NestedRelationsFields_array_link_Update {
+  permission: Boolean!
+}
+
+type NestedRelationsFields_array_link_Delete {
+  permission: Boolean!
+}
+
+type NestedRelationsFields_array_id {
+  create: NestedRelationsFields_array_id_Create
+  read: NestedRelationsFields_array_id_Read
+  update: NestedRelationsFields_array_id_Update
+  delete: NestedRelationsFields_array_id_Delete
+}
+
+type NestedRelationsFields_array_id_Create {
+  permission: Boolean!
+}
+
+type NestedRelationsFields_array_id_Read {
+  permission: Boolean!
+}
+
+type NestedRelationsFields_array_id_Update {
+  permission: Boolean!
+}
+
+type NestedRelationsFields_array_id_Delete {
+  permission: Boolean!
+}
+
+type NestedRelationsFields_blocks {
+  create: NestedRelationsFields_blocks_Create
+  read: NestedRelationsFields_blocks_Read
+  update: NestedRelationsFields_blocks_Update
+  delete: NestedRelationsFields_blocks_Delete
+}
+
+type NestedRelationsFields_blocks_Create {
+  permission: Boolean!
+}
+
+type NestedRelationsFields_blocks_Read {
+  permission: Boolean!
+}
+
+type NestedRelationsFields_blocks_Update {
+  permission: Boolean!
+}
+
+type NestedRelationsFields_blocks_Delete {
+  permission: Boolean!
+}
+
+type NestedRelationsFields_updatedAt {
+  create: NestedRelationsFields_updatedAt_Create
+  read: NestedRelationsFields_updatedAt_Read
+  update: NestedRelationsFields_updatedAt_Update
+  delete: NestedRelationsFields_updatedAt_Delete
+}
+
+type NestedRelationsFields_updatedAt_Create {
+  permission: Boolean!
+}
+
+type NestedRelationsFields_updatedAt_Read {
+  permission: Boolean!
+}
+
+type NestedRelationsFields_updatedAt_Update {
+  permission: Boolean!
+}
+
+type NestedRelationsFields_updatedAt_Delete {
+  permission: Boolean!
+}
+
+type NestedRelationsFields_createdAt {
+  create: NestedRelationsFields_createdAt_Create
+  read: NestedRelationsFields_createdAt_Read
+  update: NestedRelationsFields_createdAt_Update
+  delete: NestedRelationsFields_createdAt_Delete
+}
+
+type NestedRelationsFields_createdAt_Create {
+  permission: Boolean!
+}
+
+type NestedRelationsFields_createdAt_Read {
+  permission: Boolean!
+}
+
+type NestedRelationsFields_createdAt_Update {
+  permission: Boolean!
+}
+
+type NestedRelationsFields_createdAt_Delete {
+  permission: Boolean!
+}
+
+type NestedRelationsCreateAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type NestedRelationsReadAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type NestedRelationsUpdateAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type NestedRelationsDeleteAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
 type payload_kvAccess {
   fields: PayloadKvFields
   create: PayloadKvCreateAccess
@@ -8711,7 +9259,7 @@ type Mutation {
   logoutUser(allSessions: Boolean): String
   unlockUser(email: String!): Boolean!
   loginUser(email: String!, password: String): usersLoginResult
-  forgotPasswordUser(disableEmail: Boolean, expiration: Int, email: String!): Boolean!
+  forgotPasswordUser(email: String!): Boolean!
   resetPasswordUser(password: String, token: String): usersResetPassword
   verifyEmailUser(token: String): Boolean
   createPoint(data: mutationPointInput!, draft: Boolean, locale: LocaleInputType): Point
@@ -8765,6 +9313,10 @@ type Mutation {
   updateSort(id: Int!, autosave: Boolean, data: mutationSortUpdateInput!, draft: Boolean, locale: LocaleInputType, trash: Boolean): Sort
   deleteSort(id: Int!, trash: Boolean): Sort
   duplicateSort(id: Int!, data: mutationSortInput!): Sort
+  createNestedRelation(data: mutationNestedRelationInput!, draft: Boolean, locale: LocaleInputType): NestedRelation
+  updateNestedRelation(id: Int!, autosave: Boolean, data: mutationNestedRelationUpdateInput!, draft: Boolean, locale: LocaleInputType, trash: Boolean): NestedRelation
+  deleteNestedRelation(id: Int!, trash: Boolean): NestedRelation
+  duplicateNestedRelation(id: Int!, data: mutationNestedRelationInput!): NestedRelation
   createPayloadKv(data: mutationPayloadKvInput!, draft: Boolean, locale: LocaleInputType): PayloadKv
   updatePayloadKv(id: Int!, autosave: Boolean, data: mutationPayloadKvUpdateInput!, draft: Boolean, locale: LocaleInputType, trash: Boolean): PayloadKv
   deletePayloadKv(id: Int!, trash: Boolean): PayloadKv
@@ -9173,6 +9725,32 @@ input mutationSortUpdateInput {
   createdAt: String
 }
 
+input mutationNestedRelationInput {
+  topLevelRelation: Int
+  array: [mutationNestedRelation_ArrayInput]
+  blocks: JSON
+  updatedAt: String
+  createdAt: String
+}
+
+input mutationNestedRelation_ArrayInput {
+  link: Int
+  id: String
+}
+
+input mutationNestedRelationUpdateInput {
+  topLevelRelation: Int
+  array: [mutationNestedRelationUpdate_ArrayInput]
+  blocks: JSON
+  updatedAt: String
+  createdAt: String
+}
+
+input mutationNestedRelationUpdate_ArrayInput {
+  link: Int
+  id: String
+}
+
 input mutationPayloadKvInput {
   key: String!
   data: JSON!
@@ -9210,6 +9788,7 @@ enum PayloadLockedDocument_DocumentRelationshipInputRelationTo {
   cyclical_relationship
   media
   sort
+  nested_relations
 }
 
 input PayloadLockedDocument_UserRelationshipInput {
@@ -9248,6 +9827,7 @@ enum PayloadLockedDocumentUpdate_DocumentRelationshipInputRelationTo {
   cyclical_relationship
   media
   sort
+  nested_relations
 }
 
 input PayloadLockedDocumentUpdate_UserRelationshipInput {


### PR DESCRIPTION
### What?

Fixes GraphQL `select` projection so that a relationship's sub-selection is kept in
three cases where it was previously dropped:

- the relationship field is **aliased** in the query;
- the relationship is nested inside an **array** or a **block** (its GraphQL field name
  already matches the data name);
- the relationship is inside a **block** rendered as a union type.

Two small changes in `@payloadcms/graphql`:

- `schema/fieldToSchemaMap.ts` — `formattedNameResolver` now always attaches
  `extensions.field`, not only when the formatted name differs.
- `utilities/select.ts` — `resolveSelect` resolves the leaf field by
  `info.fieldName` (never the alias) and pushes the block slug onto the traversal
  path to match the tree produced by `buildSelectTree`.

### Why?

`resolveSelect` turns a GraphQL selection set into a `select` projection passed to the
DB adapter. It relied on `path.key` (the response key, i.e. the alias when aliased) and
on `extensions.field` being present on every field. Neither holds for aliased fields nor
for sub-fields whose name is already camelCase (arrays/blocks). When the lookup fails
the projection for the nested relationship is lost, and on the SQL adapters the
relationship comes back id-only / `null`, silently dropping the queried sub-fields.

### How?

- Always attach `extensions.field` in `formattedNameResolver`; keep the custom
  `resolve` only when the formatted name differs.
- In `resolveSelect`, for the field being resolved (`path === info.path`) use
  `info.fieldName` instead of `path.key`, and unshift `pathType.extensions.blockSlug`
  when the current type is a block, mirroring `buildSelectTree`.

Covered by a new integration test in `test/collections-graphql` asserting that the
sub-selection is returned for an aliased top-level relationship and for relationships
nested in an array and a block. Verified locally against `sqlite` (fails without the
fix, passes with it); the full `collections-graphql` and `select` int suites stay green.
I could not run the `mongodb`/`postgres` int suites locally (no Docker) — relying on CI
for those adapters.

### Known limitation

An aliased *container* field (an aliased `array`/`block`/`group` that itself contains a
relationship, e.g. `myArr: array { link { ... } }`) is not covered: `resolveSelect`
recovers the real field name from `info.fieldName` only for the leaf being resolved,
whereas `path.key` for ancestor nodes only ever holds the alias (graphql-js does not
retain the real name for ancestors in `info.path`). This was already the behavior before
this PR and is out of scope here; aliasing the relationship field itself is fixed.

Fixes #18141
