### PR TITLE
fix(drizzle): skip omitted groups/tabs in include-mode select instead of joining everything inside

### DIFF
--- a/packages/drizzle/src/find/traverseFields.ts
+++ b/packages/drizzle/src/find/traverseFields.ts
@@ -404,7 +404,9 @@ export const traverseFields = ({
       case 'tab': {
         const fieldSelect = select?.[field.name]
 
-        if (fieldSelect === false) {
+        // An include-mode select that omits this group must skip it like the blocks branch does,
+        // otherwise it recurses with no select and joins every table inside the group.
+        if (fieldSelect === false || (select && selectMode === 'include' && !fieldSelect)) {
           break
         }
 

--- a/test/select/postgreslogs.int.spec.ts
+++ b/test/select/postgreslogs.int.spec.ts
@@ -134,6 +134,38 @@ test.suite({ config: './config.postgreslogs.ts', db: (adapter) => adapter.starts
           ],
         })
       })
+
+      // Regression: an include-mode select that omits the `version` group used to recurse into it
+      // with no select at all and join every block table (~220 joins on a 70-block-type collection).
+      test('ensure include-mode select that omits a group does not join the tables inside it', async ({
+        payload,
+      }) => {
+        const doc = await payload.create({
+          collection: 'versioned-posts',
+          data: { text: 'text', blocks: [{ blockType: 'test', text: 'block' }] },
+        })
+
+        const logs: string[] = []
+        const consoleSpy = vitest.spyOn(console, 'log').mockImplementation((...args) => {
+          logs.push(args.map(String).join(' '))
+        })
+
+        const { docs } = await payload.db.findVersions({
+          collection: 'versioned-posts',
+          select: { parent: true },
+          where: { parent: { equals: doc.id } },
+        })
+
+        consoleSpy.mockRestore()
+
+        expect(docs).toHaveLength(1)
+        expect(docs[0]?.parent).toEqual(doc.id)
+        expect(logs.length).toBeGreaterThan(0)
+        // The `version` group was not selected, so nothing inside it may be joined.
+        expect(logs.some((log) => log.includes('blocks_test'))).toBe(false)
+
+        await payload.delete({ collection: 'versioned-posts', id: doc.id })
+      })
     })
   },
 )


### PR DESCRIPTION
### What?

In `@payloadcms/drizzle` `find/traverseFields.ts`, the `group` / `tab` branch only skips a group when `select[field.name] === false`. With an include-mode `select` that simply omits the group, `fieldSelect` is `undefined`, the guard does not fire, and `traverseFields` recurses into the group with no `select` at all. Every relational field inside the group is then joined, including any `blocks` field, which joins every registered block table.

This PR adds the same guard the sibling `blocks` branch already has (`selectMode === 'include' && !fieldSelect`) and a regression test in `test/select/postgreslogs.int.spec.ts`.

### Why?

The admin list view's draft-status enrichment queries the versions collection with `select: { parent: true }`. The `version` group is omitted, so the query joins the whole version including `layout`. On a collection with ~70 block types that is a single statement joining ~220 tables (about 250 KB of SQL and about 2 s of planner time on Postgres 18) for a query that needs one column.

Measured on a real production dump: 2,139 ms and 246 KB of SQL before, 20 ms and under 1 KB after, identical rows returned.

### How?

```ts
case 'group':
case 'tab': {
  const fieldSelect = select?.[field.name]

  if (fieldSelect === false || (select && selectMode === 'include' && !fieldSelect)) {
    break
  }
```

The new test creates a `versioned-posts` doc with a block, runs `payload.db.findVersions({ select: { parent: true } })` with the Postgres logger on, and asserts the logged SQL never references the block table. Verified locally against Postgres 18: the test fails on `main` without the source change and passes with it; the rest of `test/select/int.spec.ts` (79 tests) stays green.

The same lines exist unchanged on `3.x`; the fix applies there as-is if you want a backport.
