### PR TITLE
fix(ui): autosave fires a second PATCH when virtual fields change in the save response

### DIFF
--- a/packages/payload/src/admin/forms/Form.ts
+++ b/packages/payload/src/admin/forms/Form.ts
@@ -71,6 +71,12 @@ export type FieldState = {
    */
   isModified?: boolean
   /**
+   * Set to `true` for fields configured with `virtual: true` or `virtual: '<path>'`.
+   * Their values are not persisted and are recomputed on every read, so consumers must not
+   * treat a change in their value as a user edit. See `Autosave` for an example.
+   */
+  isVirtual?: boolean
+  /**
    * The path of the field when its custom components were last rendered.
    * This is used to denote if a field has been rendered, and if so,
    * what path it was rendered under last.

--- a/packages/ui/src/elements/Autosave/index.tsx
+++ b/packages/ui/src/elements/Autosave/index.tsx
@@ -1,5 +1,5 @@
 'use client'
-import type { ClientCollectionConfig, ClientGlobalConfig } from 'payload'
+import type { ClientCollectionConfig, ClientGlobalConfig, Data, FormState } from 'payload'
 
 import { dequal } from 'dequal/lite'
 import {
@@ -33,6 +33,40 @@ import './index.css'
 const baseClass = 'autosave'
 // The minimum time the saving state should be shown
 const minimumAnimationTime = 1000
+
+/**
+ * Reduces form state to only the values that can represent a user edit, so that autosave can tell
+ * a real change apart from one the server made to its own response.
+ *
+ * Excludes `updatedAt` and virtual fields (including anything nested beneath one). The server
+ * recomputes both on every autosave and merges them back into form state. Comparing them would
+ * make each autosave response look like a new change and schedule another, redundant autosave.
+ */
+const reduceFieldsToComparableValues = (formState: FormState): Data => {
+  const virtualPathPrefixes: string[] = []
+
+  for (const [path, field] of Object.entries(formState)) {
+    if (field.isVirtual) {
+      virtualPathPrefixes.push(`${path}.`)
+    }
+  }
+
+  const comparableState: FormState = {}
+
+  for (const [path, field] of Object.entries(formState)) {
+    if (path === 'updatedAt' || field.isVirtual) {
+      continue
+    }
+
+    if (virtualPathPrefixes.some((prefix) => path.startsWith(prefix))) {
+      continue
+    }
+
+    comparableState[path] = field
+  }
+
+  return reduceFieldsToValues(comparableState)
+}
 
 export type Props = {
   collection?: ClientCollectionConfig
@@ -188,7 +222,7 @@ export const Autosave: React.FC<Props> = ({ id, collection, global: globalDoc })
   })
 
   const didMount = useRef(false)
-  const previousDebouncedData = useRef(reduceFieldsToValues(debouncedFormState))
+  const previousDebouncedData = useRef(reduceFieldsToComparableValues(debouncedFormState))
 
   // When debounced fields change, autosave
   useEffect(() => {
@@ -202,12 +236,10 @@ export const Autosave: React.FC<Props> = ({ id, collection, global: globalDoc })
 
     /**
      * Ensure autosave only runs if the form data changes, not every time the entire form state changes
-     * Remove `updatedAt` from comparison as it changes on every autosave interval.
      */
-    const { updatedAt: _, ...formData } = reduceFieldsToValues(debouncedFormState)
-    const { updatedAt: __, ...prevFormData } = previousDebouncedData.current
+    const formData = reduceFieldsToComparableValues(debouncedFormState)
 
-    if (dequal(formData, prevFormData)) {
+    if (dequal(formData, previousDebouncedData.current)) {
       return
     }
 

--- a/packages/ui/src/forms/Form/index.tsx
+++ b/packages/ui/src/forms/Form/index.tsx
@@ -154,10 +154,12 @@ export const Form: React.FC<FormProps> = (props) => {
 
   /**
    * Intercept the `setModified` method to track whether the event happened during background processing.
+   * Only becoming modified counts - clearing `modified` during a background process is never itself
+   * a modification, and flagging it would leave the form permanently dirty after an autosave.
    * See the `modifiedWhileProcessingRef` ref for more details.
    */
   const setModified = useCallback((modified: boolean) => {
-    if (backgroundProcessingRef.current) {
+    if (modified && backgroundProcessingRef.current) {
       modifiedWhileProcessingRef.current = true
     }
 

--- a/packages/ui/src/forms/fieldSchemasToFormState/addFieldStatePromise.ts
+++ b/packages/ui/src/forms/fieldSchemasToFormState/addFieldStatePromise.ts
@@ -182,6 +182,11 @@ export const addFieldStatePromise = async (args: AddFieldStatePromiseArgs): Prom
   }
 
   // Append only if true to avoid sending '$undefined' through the network
+  if ('virtual' in field && field.virtual) {
+    fieldState.isVirtual = true
+  }
+
+  // Append only if true to avoid sending '$undefined' through the network
   if (includeSchema) {
     fieldState.fieldSchema = field
   }

--- a/test/versions/collections/AutosaveWithVirtual.ts
+++ b/test/versions/collections/AutosaveWithVirtual.ts
@@ -1,0 +1,56 @@
+import type { CollectionConfig, Field, FieldHook } from 'payload'
+
+import { autosaveWithVirtualSlug } from '../slugs.js'
+
+const deriveFromTitle: FieldHook = ({ siblingData }) => {
+  const { title } = siblingData
+
+  return typeof title === 'string' && title ? `derived:${title}` : ''
+}
+
+const virtualDerivedTitle: Field = {
+  name: 'titleDerived',
+  type: 'text',
+  admin: {
+    readOnly: true,
+  },
+  hooks: {
+    afterRead: [deriveFromTitle],
+  },
+  virtual: true,
+}
+
+const AutosaveWithVirtual: CollectionConfig = {
+  slug: autosaveWithVirtualSlug,
+  admin: {
+    useAsTitle: 'title',
+  },
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+      required: true,
+    },
+    virtualDerivedTitle,
+    {
+      name: 'array',
+      type: 'array',
+      fields: [
+        {
+          name: 'title',
+          type: 'text',
+        },
+        virtualDerivedTitle,
+      ],
+    },
+  ],
+  versions: {
+    drafts: {
+      autosave: {
+        interval: 100,
+      },
+    },
+  },
+}
+
+export default AutosaveWithVirtual

--- a/test/versions/config.ts
+++ b/test/versions/config.ts
@@ -8,6 +8,7 @@ import AutosavePosts from './collections/Autosave.js'
 import AutosaveWithDraftButtonPosts from './collections/AutosaveWithDraftButton.js'
 import AutosaveWithDraftValidate from './collections/AutosaveWithDraftValidate.js'
 import AutosaveWithMultiSelectPosts from './collections/AutosaveWithMultiSelect.js'
+import AutosaveWithVirtual from './collections/AutosaveWithVirtual.js'
 import CustomIDs from './collections/CustomIDs.js'
 import { Diff } from './collections/Diff/index.js'
 import DisablePublish from './collections/DisablePublish.js'
@@ -58,6 +59,7 @@ export default buildConfigWithDefaults({
       Posts,
       AutosavePosts,
       AutosaveWithDraftButtonPosts,
+      AutosaveWithVirtual,
       AutosaveWithMultiSelectPosts,
       NestedArraySelect,
       AutosaveWithDraftValidate,

--- a/test/versions/e2e.spec.ts
+++ b/test/versions/e2e.spec.ts
@@ -65,6 +65,7 @@ import {
   autosaveWithDraftButtonGlobal,
   autosaveWithDraftButtonSlug,
   autosaveWithDraftValidateSlug,
+  autosaveWithVirtualSlug,
   customIDSlug,
   diffCollectionSlug,
   disablePublishGlobalSlug,
@@ -104,6 +105,7 @@ describe('Versions', () => {
   let autosaveURL: AdminUrlUtil
   let autosaveWithDraftButtonURL: AdminUrlUtil
   let autosaveWithDraftValidateURL: AdminUrlUtil
+  let autosaveWithVirtualURL: AdminUrlUtil
   let draftWithValidateURL: AdminUrlUtil
   let draftWithChangeHookURL: AdminUrlUtil
   let disablePublishURL: AdminUrlUtil
@@ -146,6 +148,7 @@ describe('Versions', () => {
       autosaveURL = new AdminUrlUtil(serverURL, autosaveCollectionSlug)
       autosaveWithDraftButtonURL = new AdminUrlUtil(serverURL, autosaveWithDraftButtonSlug)
       autosaveWithDraftValidateURL = new AdminUrlUtil(serverURL, autosaveWithDraftValidateSlug)
+      autosaveWithVirtualURL = new AdminUrlUtil(serverURL, autosaveWithVirtualSlug)
       disablePublishURL = new AdminUrlUtil(serverURL, disablePublishSlug)
       customIDURL = new AdminUrlUtil(serverURL, customIDSlug)
       postURL = new AdminUrlUtil(serverURL, postCollectionSlug)
@@ -543,6 +546,103 @@ describe('Versions', () => {
       // Ensure that the value in context remains consistent across saves
       await expect(page.locator('#custom-field-label')).toHaveText(
         `Value in DocumentInfoContext: ${postID}`,
+      )
+    })
+
+    test('collection - autosave - should not re-autosave when virtual fields change in the response', async () => {
+      // Virtual fields are recomputed by `afterRead` on every autosave response and merged back
+      // into form state. They must not be mistaken for user edits and trigger another autosave.
+      const { id: docID } = await payload.create({
+        collection: autosaveWithVirtualSlug,
+        data: {
+          array: [{ title: 'array title' }],
+          title: 'title',
+        },
+      })
+
+      await page.goto(autosaveWithVirtualURL.edit(docID))
+
+      await expect(page.locator('#field-titleDerived')).toHaveValue('derived:title')
+
+      const autosaveRequestURL = formatAdminURL({
+        apiRoute: '/api',
+        path: `/${autosaveWithVirtualSlug}/${docID}?autosave=true&depth=0&draft=true&fallback-locale=null&locale=en`,
+        serverURL,
+      })
+
+      // The double autosave only surfaces on the second edit, once the virtual value from the
+      // previous response has been merged into form state
+      await assertNetworkRequests(
+        page,
+        autosaveRequestURL,
+        async () => {
+          await page.locator('#field-title').fill('first change')
+        },
+        {
+          allowedNumberOfRequests: 1,
+        },
+      )
+
+      await expect(page.locator('#field-titleDerived')).toHaveValue('derived:first change')
+
+      await assertNetworkRequests(
+        page,
+        autosaveRequestURL,
+        async () => {
+          await page.locator('#field-title').fill('second change')
+        },
+        {
+          allowedNumberOfRequests: 1,
+        },
+      )
+
+      await expect(page.locator('#field-titleDerived')).toHaveValue('derived:second change')
+    })
+
+    test('collection - autosave - should not re-autosave when nested virtual fields change in the response', async () => {
+      const { id: docID } = await payload.create({
+        collection: autosaveWithVirtualSlug,
+        data: {
+          array: [{ title: 'array title' }],
+          title: 'title',
+        },
+      })
+
+      await page.goto(autosaveWithVirtualURL.edit(docID))
+
+      const nestedTitle = page.locator('#field-array__0__title')
+      await expect(nestedTitle).toHaveValue('array title')
+
+      const autosaveRequestURL = formatAdminURL({
+        apiRoute: '/api',
+        path: `/${autosaveWithVirtualSlug}/${docID}?autosave=true&depth=0&draft=true&fallback-locale=null&locale=en`,
+        serverURL,
+      })
+
+      await assertNetworkRequests(
+        page,
+        autosaveRequestURL,
+        async () => {
+          await nestedTitle.fill('first change')
+        },
+        {
+          allowedNumberOfRequests: 1,
+        },
+      )
+
+      await assertNetworkRequests(
+        page,
+        autosaveRequestURL,
+        async () => {
+          await nestedTitle.fill('second change')
+        },
+        {
+          allowedNumberOfRequests: 1,
+        },
+      )
+
+      await expect(page.locator('#field-array__0__titleDerived')).toHaveValue(
+        'derived:second change',
       )
     })
 

--- a/test/versions/payload-types.ts
+++ b/test/versions/payload-types.ts
@@ -62,30 +62,32 @@ export type SupportedTimezones =
   | 'Pacific/Fiji';
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "LexicalNodes_E98BC274".
+ * via the `definition` "LexicalNodes_50E6ADE0".
  */
-export type LexicalNodes_E98BC274 =
+export type LexicalNodes_50E6ADE0 =
   | SerializedTextNode
   | SerializedTabNode
   | SerializedLineBreakNode
-  | SerializedParagraphNode<LexicalNodes_E98BC274>
+  | SerializedParagraphNode<LexicalNodes_50E6ADE0>
   | SerializedBlockNode<MyBlock>
-  | SerializedHeadingNode<LexicalNodes_E98BC274>
+  | SerializedHeadingNode<LexicalNodes_50E6ADE0>
   | SerializedUploadNode<'draft-with-upload'>
   | SerializedUploadNode<'draft-with-upload-cloud-storage'>
   | SerializedUploadNode<'media', LexicalUploadFields_1AB4670B>
   | SerializedUploadNode<'media2'>
-  | SerializedQuoteNode<LexicalNodes_E98BC274>
-  | SerializedListNode<LexicalNodes_E98BC274>
-  | SerializedListItemNode<LexicalNodes_E98BC274>
-  | SerializedAutoLinkNode<LexicalNodes_E98BC274, LexicalLinkFields_0A7E9EC0>
-  | SerializedLinkNode<LexicalNodes_E98BC274, LexicalLinkFields_0A7E9EC0>
+  | SerializedQuoteNode<LexicalNodes_50E6ADE0>
+  | SerializedListNode<LexicalNodes_50E6ADE0>
+  | SerializedListItemNode<LexicalNodes_50E6ADE0>
+  | SerializedAutoLinkNode<LexicalNodes_50E6ADE0, LexicalLinkFields_0A7E9EC0>
+  | SerializedLinkNode<LexicalNodes_50E6ADE0, LexicalLinkFields_0A7E9EC0>
   | SerializedRelationshipNode<
       | 'disable-publish'
       | 'posts'
       | 'autosave-posts'
       | 'autosave-with-draft-button-posts'
+      | 'autosave-with-virtual-posts'
       | 'autosave-multi-select-posts'
+      | 'nested-array-select'
       | 'autosave-with-validate-posts'
       | 'draft-posts'
       | 'drafts-no-read-versions'
@@ -117,7 +119,9 @@ export interface Config {
     posts: Post;
     'autosave-posts': AutosavePost;
     'autosave-with-draft-button-posts': AutosaveWithDraftButtonPost;
+    'autosave-with-virtual-posts': AutosaveWithVirtualPost;
     'autosave-multi-select-posts': AutosaveMultiSelectPost;
+    'nested-array-select': NestedArraySelect;
     'autosave-with-validate-posts': AutosaveWithValidatePost;
     'draft-posts': DraftPost;
     'drafts-no-read-versions': DraftsNoReadVersion;
@@ -148,7 +152,9 @@ export interface Config {
     posts: PostsSelect<false> | PostsSelect<true>;
     'autosave-posts': AutosavePostsSelect<false> | AutosavePostsSelect<true>;
     'autosave-with-draft-button-posts': AutosaveWithDraftButtonPostsSelect<false> | AutosaveWithDraftButtonPostsSelect<true>;
+    'autosave-with-virtual-posts': AutosaveWithVirtualPostsSelect<false> | AutosaveWithVirtualPostsSelect<true>;
     'autosave-multi-select-posts': AutosaveMultiSelectPostsSelect<false> | AutosaveMultiSelectPostsSelect<true>;
+    'nested-array-select': NestedArraySelectSelect<false> | NestedArraySelectSelect<true>;
     'autosave-with-validate-posts': AutosaveWithValidatePostsSelect<false> | AutosaveWithValidatePostsSelect<true>;
     'draft-posts': DraftPostsSelect<false> | DraftPostsSelect<true>;
     'drafts-no-read-versions': DraftsNoReadVersionsSelect<false> | DraftsNoReadVersionsSelect<true>;
@@ -187,6 +193,7 @@ export interface Config {
     'max-versions': MaxVersion;
     'draft-unlimited-global': DraftUnlimitedGlobal;
     'simple-draft-global': SimpleDraftGlobal;
+    'payload-jobs-stats': PayloadJobsStat;
   };
   globalsSelect: {
     'autosave-global': AutosaveGlobalSelect<false> | AutosaveGlobalSelect<true>;
@@ -198,6 +205,7 @@ export interface Config {
     'max-versions': MaxVersionsSelect<false> | MaxVersionsSelect<true>;
     'draft-unlimited-global': DraftUnlimitedGlobalSelect<false> | DraftUnlimitedGlobalSelect<true>;
     'simple-draft-global': SimpleDraftGlobalSelect<false> | SimpleDraftGlobalSelect<true>;
+    'payload-jobs-stats': PayloadJobsStatsSelect<false> | PayloadJobsStatsSelect<true>;
   };
   locale: 'en' | 'es' | 'de';
   widgets: {
@@ -267,7 +275,7 @@ export interface AutosavePost {
   title: string;
   relationship?: (string | null) | Post;
   computedTitle?: string | null;
-  richText?: LexicalRichText<LexicalNodes_E98BC274> | null;
+  richText?: LexicalRichText<LexicalNodes_50E6ADE0> | null;
   json?:
     | {
         [k: string]: unknown;
@@ -341,12 +349,52 @@ export interface AutosaveWithDraftButtonPost {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "autosave-with-virtual-posts".
+ */
+export interface AutosaveWithVirtualPost {
+  id: string;
+  title: string;
+  titleDerived?: string | null;
+  array?:
+    | {
+        title?: string | null;
+        titleDerived?: string | null;
+        id?: string | null;
+      }[]
+    | null;
+  updatedAt: string;
+  createdAt: string;
+  _status?: ('draft' | 'published') | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "autosave-multi-select-posts".
  */
 export interface AutosaveMultiSelectPost {
   id: string;
   title: string;
   tag?: ('blog' | 'essay' | 'portfolio')[] | null;
+  updatedAt: string;
+  createdAt: string;
+  _status?: ('draft' | 'published') | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "nested-array-select".
+ */
+export interface NestedArraySelect {
+  id: string;
+  outer?:
+    | {
+        inner?:
+          | {
+              days?: ('monday' | 'tuesday' | 'wednesday')[] | null;
+              id?: string | null;
+            }[]
+          | null;
+        id?: string | null;
+      }[]
+    | null;
   updatedAt: string;
   createdAt: string;
   _status?: ('draft' | 'published') | null;
@@ -566,8 +614,8 @@ export interface Diff {
       )[]
     | null;
   zeroDepthRelationship?: (string | null) | User;
-  richtext?: LexicalRichText<LexicalNodes_E98BC274> | null;
-  richtextWithCustomDiff?: LexicalRichText<LexicalNodes_E98BC274> | null;
+  richtext?: LexicalRichText<LexicalNodes_50E6ADE0> | null;
+  richtextWithCustomDiff?: LexicalRichText<LexicalNodes_50E6ADE0> | null;
   textInRow?: string | null;
   textCannotRead?: string | null;
   select?: ('option1' | 'option2') | null;
@@ -808,6 +856,15 @@ export interface PayloadJob {
     | number
     | boolean
     | null;
+  meta?:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
   completedAt?: string | null;
   totalTried?: number | null;
   /**
@@ -835,7 +892,7 @@ export interface PayloadJob {
         completedAt: string;
         taskSlug: 'inline' | 'schedulePublish';
         taskID: string;
-        input?:
+        input:
           | {
               [k: string]: unknown;
             }
@@ -863,13 +920,22 @@ export interface PayloadJob {
           | number
           | boolean
           | null;
+        parent?: {
+          taskSlug?: ('inline' | 'schedulePublish') | null;
+          taskID?: string | null;
+        };
         id?: string | null;
       }[]
     | null;
   taskSlug?: ('inline' | 'schedulePublish') | null;
   queue?: string | null;
   waitUntil?: string | null;
-  processing?: boolean | null;
+  processingUntil?: string | null;
+  processingToken?: string | null;
+  /**
+   * Used for concurrency control. Jobs with the same key are subject to exclusive/supersedes rules.
+   */
+  concurrencyKey?: string | null;
   updatedAt: string;
   createdAt: string;
 }
@@ -897,8 +963,16 @@ export interface PayloadLockedDocument {
         value: string | AutosaveWithDraftButtonPost;
       } | null)
     | ({
+        relationTo: 'autosave-with-virtual-posts';
+        value: string | AutosaveWithVirtualPost;
+      } | null)
+    | ({
         relationTo: 'autosave-multi-select-posts';
         value: string | AutosaveMultiSelectPost;
+      } | null)
+    | ({
+        relationTo: 'nested-array-select';
+        value: string | NestedArraySelect;
       } | null)
     | ({
         relationTo: 'autosave-with-validate-posts';
@@ -1068,11 +1142,49 @@ export interface AutosaveWithDraftButtonPostsSelect<T extends boolean = true> {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "autosave-with-virtual-posts_select".
+ */
+export interface AutosaveWithVirtualPostsSelect<T extends boolean = true> {
+  title?: T;
+  titleDerived?: T;
+  array?:
+    | T
+    | {
+        title?: T;
+        titleDerived?: T;
+        id?: T;
+      };
+  updatedAt?: T;
+  createdAt?: T;
+  _status?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "autosave-multi-select-posts_select".
  */
 export interface AutosaveMultiSelectPostsSelect<T extends boolean = true> {
   title?: T;
   tag?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  _status?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "nested-array-select_select".
+ */
+export interface NestedArraySelectSelect<T extends boolean = true> {
+  outer?:
+    | T
+    | {
+        inner?:
+          | T
+          | {
+              days?: T;
+              id?: T;
+            };
+        id?: T;
+      };
   updatedAt?: T;
   createdAt?: T;
   _status?: T;
@@ -1476,6 +1588,7 @@ export interface UsersSelect<T extends boolean = true> {
 export interface PayloadJobsSelect<T extends boolean = true> {
   input?: T;
   taskStatus?: T;
+  meta?: T;
   completedAt?: T;
   totalTried?: T;
   hasError?: T;
@@ -1491,12 +1604,20 @@ export interface PayloadJobsSelect<T extends boolean = true> {
         output?: T;
         state?: T;
         error?: T;
+        parent?:
+          | T
+          | {
+              taskSlug?: T;
+              taskID?: T;
+            };
         id?: T;
       };
   taskSlug?: T;
   queue?: T;
   waitUntil?: T;
-  processing?: T;
+  processingUntil?: T;
+  processingToken?: T;
+  concurrencyKey?: T;
   updatedAt?: T;
   createdAt?: T;
 }
@@ -1634,6 +1755,24 @@ export interface SimpleDraftGlobal {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "payload-jobs-stats".
+ */
+export interface PayloadJobsStat {
+  id: string;
+  stats?:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
+  updatedAt?: string | null;
+  createdAt?: string | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "autosave-global_select".
  */
 export interface AutosaveGlobalSelect<T extends boolean = true> {
@@ -1734,6 +1873,16 @@ export interface SimpleDraftGlobalSelect<T extends boolean = true> {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "payload-jobs-stats_select".
+ */
+export interface PayloadJobsStatsSelect<T extends boolean = true> {
+  stats?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  globalType?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "collections_widget".
  */
 export interface CollectionsWidget {
@@ -1754,7 +1903,9 @@ export interface CollectionQueryWidget {
       | 'posts'
       | 'autosave-posts'
       | 'autosave-with-draft-button-posts'
+      | 'autosave-with-virtual-posts'
       | 'autosave-multi-select-posts'
+      | 'nested-array-select'
       | 'autosave-with-validate-posts'
       | 'draft-posts'
       | 'drafts-no-read-versions'
@@ -1800,7 +1951,9 @@ export interface ActivityWidget {
           | 'posts'
           | 'autosave-posts'
           | 'autosave-with-draft-button-posts'
+          | 'autosave-with-virtual-posts'
           | 'autosave-multi-select-posts'
+          | 'nested-array-select'
           | 'autosave-with-validate-posts'
           | 'draft-posts'
           | 'drafts-no-read-versions'

--- a/test/versions/slugs.ts
+++ b/test/versions/slugs.ts
@@ -7,6 +7,8 @@ export const autosaveWithDraftButtonSlug = 'autosave-with-draft-button-posts'
 
 export const autosaveWithDraftValidateSlug = 'autosave-with-validate-posts'
 
+export const autosaveWithVirtualSlug = 'autosave-with-virtual-posts'
+
 export const customIDSlug = 'custom-ids'
 
 export const draftCollectionSlug = 'draft-posts'
@@ -38,6 +40,7 @@ export const textCollectionSlug = 'text'
 export const collectionSlugs = [
   autosaveCollectionSlug,
   autosaveWithMultiSelectCollectionSlug,
+  autosaveWithVirtualSlug,
   nestedArraySelectCollectionSlug,
   draftCollectionSlug,
   draftWithChangeHookCollectionSlug,


### PR DESCRIPTION
### What?

With **drafts + autosave** enabled, a single user edit could produce **two `PATCH` requests**. The second one is not a user edit — it is driven by the first response re-populating `virtual: true` fields.

Autosave already special-cased `updatedAt` for this class of problem, but did not account for virtual fields.


### Why?

1. User edits `title` → autosave `PATCH`
2. The update runs, then `afterRead` runs on the same request and computes `titleDerived`
3. The `200` body contains the new virtual value
4. `acceptValues` merges it into form state (there is no separate `GET`)
5. Autosave's `dequal` comparison — which only excluded `updatedAt` — sees `titleDerived` change and submits again

Consumers that record document history see two entries for one change.

There is a second defect that is what actually let the request out. `handleAutosave` gates on `modified`, and `submit` clears it once the request resolves:

```ts
if (!modifiedWhileProcessingRef.current) {
  setModified(false)
} else {
  modifiedWhileProcessingRef.current = false
}
```

That internal `setModified(false)` runs while `backgroundProcessingRef.current` is still `true` (`afterProcess` has not fired yet), so the `setModified` interceptor recorded it as "modified while processing" and the **next** autosave skipped its reset instead of clearing the flag. `modified` therefore stayed `true` after every other autosave — which matches the reported "first edit gives 1 `PATCH`, the second gives 2", and also leaves the form permanently dirty for that cycle.

### How?

- Added `isVirtual` to `FieldState`, set in `addFieldStatePromise` for both `virtual: true` and `virtual: '<path>'`. Carrying the flag in form state means nesting, blocks, and tabs are covered without re-deriving schema paths on the client — `clientFieldSchemaMap` is not available to client components.
- `reduceFieldsToComparableValues` in `Autosave` strips `updatedAt`, virtual fields, and anything nested beneath a virtual field before the `dequal` comparison.
- The `setModified` interceptor now only flags when `modified` is becoming `true`. Clearing `modified` during a background process is never itself a modification.

I did not add an `ignoreFields` / `ignoreVirtual` autosave option. That is a new public config surface needing sanitization and docs, and it only helps values computed in `afterRead` that are *not* marked virtual — happy to do it separately if maintainers want it.

### Tests

New `test/versions/collections/AutosaveWithVirtual.ts` fixture with a top-level and an in-array virtual field, plus two e2e tests asserting one `PATCH` per edit. Both fail with 2 requests before the fix and pass after.

Regression checks against the same commit without these changes:

- `versions` e2e — identical 20 failures before and after (pre-existing locally)
- `locked-documents` e2e — identical 15 failures before and after, including both `stale data across multiple save cycles` tests, which I checked specifically since they are `modified`-sensitive
- `pnpm test:unit` (2274 passed), `pnpm test:int versions` (111 passed), `build:core`, lint, and `tsc` over `test/` all clean

One note: `with autosave - does not override local changes to form state after autosave runs` failed in one of two full-suite runs on this branch. It passes 3/3 in isolation and 2/2 when its whole describe block runs, and it polls for the transient "Saving…" indicator, so I read it as ordering flake rather than a regression.

`test/versions/payload-types.ts` has churn beyond the new collection (`nested-array-select`, `payload-jobs-stats`, a lexical hash) because the committed file was already stale — that is just what `dev:generate-types versions` emits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
