### PR TITLE
test: add type-safe admin page models

### DIFF
--- a/docs/superpowers/plans/2026-09-08-type-safe-admin-page-model.md
+++ b/docs/superpowers/plans/2026-09-08-type-safe-admin-page-model.md
@@ -1,0 +1,479 @@
+# Type-safe Admin Page Model Implementation Plan
+
+**Written with AI**
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a schema-generated, type-safe Playwright Admin page model and migrate the Text field E2E suite to it.
+
+**Architecture:** A focused generator converts selected collections from `SanitizedConfig` into a standalone literal `adminPageModel` module for the fields suite. A shared runtime factory maps that descriptor to root-scoped collection and field models while TypeScript mapped types provide completion and field-specific actions.
+
+**Tech Stack:** TypeScript 6, Playwright 1.59.1, TSTyche 7.2.1, Vitest 4.1.6, Payload test configuration and generated types.
+
+**Spec:** `docs/superpowers/specs/2026-09-08-type-safe-admin-page-model-design.md`
+
+## Global Constraints
+
+- Work only in `/Users/ppopus/projects/payload/core-codex/.worktrees/type-safe-admin-page-model` on `codex/type-safe-admin-page-model`.
+- Write and run each failing test before its implementation.
+- Keep code and documentation in US English.
+- Do not hide or replace Playwright errors.
+- Do not import full Payload server or React configuration into Playwright workers.
+- Keep the utility in `test/__helpers/e2e/adminPageModel/`.
+- Do not add a public Payload configuration option in this pull request.
+- Include `Written with AI` in team-facing documents and pull request text.
+- Do not commit, push, or open the pull request until the user gives a separate explicit instruction.
+
+## Current Status
+
+- Tasks 1-6 are implemented and covered by focused tests.
+- The generated descriptor, public type tests, runtime tests, Text migration, nested array/block test, and relationship drawer test are complete.
+- Final static checks and repeat verification are complete.
+- The complete SQLite Text run has 19 passes, 1 skip, and 1 existing `hasMany not_in` filter failure.
+- The focused relationship drawer run passes.
+- The branch is intentionally uncommitted until the user approves the commit and pull request actions.
+
+---
+
+### Task 1: Generate a serializable Admin page-model descriptor
+
+**Files:**
+
+- Create: `test/__helpers/e2e/adminPageModel/types.ts`
+- Create: `test/__helpers/e2e/adminPageModel/generate.ts`
+- Create: `test/__helpers/e2e/adminPageModel/generate.int.spec.ts`
+- Create: `test/fields/generateAdminPageModel.ts`
+- Create: `test/fields/admin-page-model.generated.ts`
+
+**Interfaces:**
+
+- Produces: `createAdminPageModelSource(config, { collections })` and the descriptor types `AdminPageModelDescriptor`, `AdminCollectionDescriptor`, and `AdminFieldDescriptor`.
+- Produces: generated `adminPageModel` for `array-fields`, `relationship-fields`, and `text-fields`.
+
+- [x] **Step 1: Write the failing descriptor-generation tests**
+
+Create a small evaluated-config fixture with scalar text, `hasMany` text, unnamed row fields, named group fields, arrays, blocks, and relationships. Assert literal output values rather than using the generator to build the expected result.
+
+```ts
+test('generates nested field and relationship metadata', () => {
+  const descriptor = createAdminPageModelDescriptor(config, {
+    collections: ['articles'],
+  })
+
+  expect(descriptor.collections.articles.fields).toEqual({
+    title: { hasMany: false, path: 'title', type: 'text' },
+    items: {
+      fields: {
+        labels: { hasMany: true, path: 'items.labels', type: 'text' },
+      },
+      path: 'items',
+      type: 'array',
+    },
+  })
+})
+```
+
+- [x] **Step 2: Run the test and verify the missing export fails**
+
+Run: `pnpm exec vitest run --project int test/__helpers/e2e/adminPageModel/generate.int.spec.ts`
+
+Expected: FAIL because `createAdminPageModelDescriptor` does not exist.
+
+- [x] **Step 3: Implement recursive descriptor and module generation**
+
+Implement field traversal with schema paths. Flatten unnamed layout fields, preserve named group and tab paths, preserve block slugs and labels, and emit relationship targets as string arrays. Runtime models will add array and block indexes to create instance paths.
+
+```ts
+export const createAdminPageModelSource = (
+  config: SanitizedConfig,
+  options: Options,
+): string => {
+  const descriptor = createAdminPageModelDescriptor(config, options)
+  return `export const adminPageModel = ${JSON.stringify(descriptor, null, 2)} as const\n`
+}
+```
+
+- [x] **Step 4: Run the generator tests and verify they pass**
+
+Run: `pnpm exec vitest run --project int test/__helpers/e2e/adminPageModel/generate.int.spec.ts`
+
+Expected: PASS.
+
+- [x] **Step 5: Add and run the fields-suite generator**
+
+Add `test/fields/generateAdminPageModel.ts`, then run:
+
+`pnpm runts ./test/fields/generateAdminPageModel.ts`
+
+Expected: `test/fields/admin-page-model.generated.ts` exports `adminPageModel` with `array-fields`, `relationship-fields`, and `text-fields`.
+
+- [x] **Step 6: Prepare the descriptor generator checkpoint**
+
+The files are ready for review. Commit them only after explicit user approval.
+
+### Task 2: Define and verify the type-safe public API
+
+**Files:**
+
+- Create: `test/__helpers/e2e/adminPageModel/modelTypes.ts`
+- Create: `test/__helpers/e2e/adminPageModel/types.spec.ts`
+- Create: `test/__helpers/e2e/adminPageModel/index.ts`
+
+**Interfaces:**
+
+- Consumes: `AdminPageModelDescriptor` and generated `adminPageModel`.
+- Produces: `PayloadAdmin<Model>`, `PayloadCollection<Model, Slug>`, `FieldsModel<Fields>`, `TextFieldModel`, `HasManyTextFieldModel`, `ArrayFieldModel`, `BlockFieldModel`, and `RelationshipFieldModel`.
+
+- [x] **Step 1: Write failing TSTyche tests for collection and field completion**
+
+```ts
+declare const admin: PayloadAdmin<typeof adminPageModel>
+
+const textFields = admin.collection('text-fields')
+expect(textFields.fields.text).type.toBeAssignableTo<TextFieldModel>()
+expect(textFields.fields.hasMany).type.toBeAssignableTo<HasManyTextFieldModel>()
+expect(textFields.fields).type.not.toHaveProperty('disableListColumnText')
+expect(admin.collection).type.not.toBeCallableWith('missing-collection')
+```
+
+- [x] **Step 2: Write failing TSTyche tests for arrays, blocks, and drawers**
+
+```ts
+expect(textFields.fields.array.addRow()).type.toBe<
+  Promise<ArrayRowModel<unknown>>
+>()
+expect(textFields.fields.blocks.addBlock('blockWithText')).type.toBe<
+  Promise<BlockRowModel<unknown>>
+>()
+
+const relationships = admin.collection('relationship-fields')
+expect(
+  relationships.fields.relationship.createInDrawer('text-fields'),
+).type.toBe<Promise<PayloadCollection<typeof adminPageModel, 'text-fields'>>>()
+expect(
+  relationships.fields.relationship.createInDrawer,
+).type.not.toBeCallableWith('users')
+```
+
+- [x] **Step 3: Run TSTyche and verify the missing types fail**
+
+Run: `pnpm exec tstyche adminPageModel --root .`
+
+Expected: FAIL because the public mapped types do not exist.
+
+- [x] **Step 4: Implement the minimum mapped types**
+
+Map descriptor discriminants to field model interfaces. Use the descriptor's literal collection keys, field keys, block keys, and relationship targets. Keep unsupported fields on a base locator model without high-level actions.
+
+- [x] **Step 5: Run TSTyche and verify the API tests pass**
+
+Run: `pnpm exec tstyche adminPageModel --root .`
+
+Expected: PASS.
+
+- [x] **Step 6: Prepare the type API checkpoint**
+
+The files are ready for review. Commit them only after explicit user approval.
+
+### Task 3: Build selector, navigation, and text field models
+
+**Files:**
+
+- Create: `test/__helpers/e2e/adminPageModel/selectors.ts`
+- Create: `test/__helpers/e2e/adminPageModel/createPayloadAdmin.ts`
+- Create: `test/__helpers/e2e/adminPageModel/collection.ts`
+- Create: `test/__helpers/e2e/adminPageModel/fields/base.ts`
+- Create: `test/__helpers/e2e/adminPageModel/fields/text.ts`
+- Create: `test/__helpers/e2e/adminPageModel/runtime.int.spec.ts`
+
+**Interfaces:**
+
+- Consumes: mapped model types from Task 2.
+- Produces: `createPayloadAdmin({ model, page, routes, serverURL })`.
+- Produces: scalar text methods `fill`, `getValue`, and `expectValue` and `hasMany` methods `addValue`, `expectValues`, and `value(index)`.
+
+- [x] **Step 1: Write failing URL and selector tests**
+
+Assert hand-written expected strings for collection URLs, nested paths, scalar inputs, `hasMany` controls, headings, and cells.
+
+```ts
+expect(selectors.textInput('array.0.texts')).toBe('#field-array__0__texts')
+expect(selectors.listHeading('i18nText')).toBe('#heading-i18nText')
+expect(selectors.listCell('i18nText', 0)).toBe('.row-1 .cell-i18nText')
+```
+
+- [x] **Step 2: Run runtime tests and verify missing implementations fail**
+
+Run: `pnpm exec vitest run --project int test/__helpers/e2e/adminPageModel/runtime.int.spec.ts`
+
+Expected: FAIL because the selector and model functions do not exist.
+
+- [x] **Step 3: Implement selector builders and collection navigation**
+
+Use `formatAdminURL` for collection URLs. Scope all field locators through the collection model's root locator. Expose `wrapper`, `input`, `selectors`, `inputID`, `heading`, and `cell(index)`.
+
+- [x] **Step 4: Implement text actions without wrapping Playwright failures**
+
+`fill()` must call `input.fill(value)` directly. `getValue()` must call `input.inputValue()`. `expectValue()` must call Playwright's `expect(input, context).toHaveValue(value)`.
+
+- [x] **Step 5: Run runtime and TSTyche tests**
+
+Run:
+
+```bash
+pnpm exec vitest run --project int test/__helpers/e2e/adminPageModel/runtime.int.spec.ts
+pnpm exec tstyche adminPageModel --root .
+```
+
+Expected: PASS.
+
+- [x] **Step 6: Prepare the navigation and text-model checkpoint**
+
+The files are ready for review. Commit them only after explicit user approval.
+
+### Task 4: Add row, block, and error-context behavior
+
+**Files:**
+
+- Create: `test/__helpers/e2e/adminPageModel/errors.ts`
+- Create: `test/__helpers/e2e/adminPageModel/fields/array.ts`
+- Create: `test/__helpers/e2e/adminPageModel/fields/blocks.ts`
+- Modify: `test/__helpers/e2e/adminPageModel/runtime.int.spec.ts`
+- Modify: `test/fields/collections/Text/e2e.spec.ts`
+
+**Interfaces:**
+
+- Produces: `array.row(index)`, `array.addRow()`, `blocks.block(index, slug)`, and `blocks.addBlock(slug)`.
+- Produces: `formatLocatorContext` for Playwright custom assertion messages.
+
+- [x] **Step 1: Write failing runtime tests for row and block context text**
+
+Use literal expected messages and cover zero rows, one row, five rows, and a mismatched block slug.
+
+- [x] **Step 2: Write a failing Playwright test that checks the full row error**
+
+On the Text create page, call `await textFields.fields.array.row(5)`, catch the error, and assert that it contains the standard Playwright locator assertion output plus:
+
+```text
+Could not resolve row 5 for "array".
+Available rows: 0
+Collection: text-fields
+```
+
+- [x] **Step 3: Run the focused Playwright test and verify the context is absent**
+
+Run: `PORT=3010 pnpm test:e2e fields__collections__Text --workers=1 --grep "reports an out-of-range array row"`
+
+Expected: FAIL because `row()` and its context do not exist.
+
+- [x] **Step 4: Implement asynchronous row and block lookup**
+
+Count current rows, then use a Playwright locator assertion with the formatted context. `addRow()` and `addBlock()` must record the old count, perform the UI action, assert the new count, and return the newly added typed row or block.
+
+- [x] **Step 5: Run focused runtime, type, and Playwright tests**
+
+Run:
+
+```bash
+pnpm exec vitest run --project int test/__helpers/e2e/adminPageModel/runtime.int.spec.ts
+pnpm exec tstyche adminPageModel --root .
+PORT=3010 pnpm test:e2e fields__collections__Text --workers=1 --grep "reports an out-of-range array row"
+```
+
+Expected: PASS.
+
+- [x] **Step 6: Prepare the row, block, and error-handling checkpoint**
+
+The files are ready for review. Commit them only after explicit user approval.
+
+### Task 5: Add relationship drawer scoping
+
+**Files:**
+
+- Create: `test/__helpers/e2e/adminPageModel/fields/relationship.ts`
+- Modify: `test/__helpers/e2e/adminPageModel/createPayloadAdmin.ts`
+- Modify: `test/__helpers/e2e/adminPageModel/collection.ts`
+- Modify: `test/__helpers/e2e/adminPageModel/runtime.int.spec.ts`
+- Modify: `test/fields/collections/Relationship/e2e.spec.ts`
+
+**Interfaces:**
+
+- Produces: `relationship.createInDrawer(targetSlug)` returning a collection model scoped to the new document drawer.
+- Produces: drawer collection methods `save()` and `close()`.
+
+- [x] **Step 1: Write failing selector and scope tests**
+
+Assert that a drawer collection model creates every field locator from the provided drawer root, not from `page`.
+
+- [x] **Step 2: Write the failing relationship drawer E2E test**
+
+Extend the existing inline relationship creation test. Create a `text-fields` document in its drawer, add a Text array row and `blockWithText` block, fill their nested `texts` fields, save and close the drawer, then save the relationship document.
+
+- [x] **Step 3: Run the focused drawer test and verify the method is missing**
+
+Run: `PORT=3011 pnpm test:e2e fields__collections__Relationship --workers=1 --grep "creates nested text data in a relationship drawer"`
+
+Expected: FAIL because `createInDrawer()` is not implemented.
+
+- [x] **Step 4: Implement typed drawer creation and root scoping**
+
+Use the relationship descriptor's `relationTo` list to select the target. Wait for the top document drawer, construct the returned collection model with that drawer as its root, and implement drawer-local save and close actions.
+
+- [x] **Step 5: Run focused runtime, type, and drawer tests**
+
+Run:
+
+```bash
+pnpm exec vitest run --project int test/__helpers/e2e/adminPageModel/runtime.int.spec.ts
+pnpm exec tstyche adminPageModel --root .
+PORT=3011 pnpm test:e2e fields__collections__Relationship --workers=1 --grep "creates nested text data in a relationship drawer"
+```
+
+Expected: PASS.
+
+- [x] **Step 6: Prepare the drawer-support checkpoint**
+
+The files are ready for review. Commit them only after explicit user approval.
+
+### Task 6: Migrate the complete Text E2E suite
+
+**Files:**
+
+- Modify: `test/fields/collections/Text/e2e.spec.ts`
+
+**Interfaces:**
+
+- Consumes: the generated `adminPageModel` and shared `createPayloadAdmin` factory.
+- Removes: Text-suite dependency on `AdminUrlUtil` and raw selectors for generated fields.
+
+- [x] **Step 1: Add `admin` and `textFields` setup in `beforeAll`**
+
+Create the collection model after `page` and `serverURL` are initialized. Keep the existing shared page lifecycle.
+
+- [x] **Step 2: Migrate create, list, heading, cell, label, description, and input access**
+
+Replace field selectors with generated handles. Keep raw selectors only for controls that are not schema fields.
+
+- [x] **Step 3: Run the non-filter Text tests**
+
+Run: `PORT=3010 pnpm test:e2e fields__collections__Text --workers=1 --grep-invert "collection list view"`
+
+Expected: all enabled non-filter tests pass except any recorded baseline environment failure that still occurs before migrated assertions.
+
+- [x] **Step 4: Migrate scalar and `hasMany` text actions**
+
+Use `fill`, `expectValue`, `addValue`, `value(index)`, and `expectValues`. Preserve the existing user behavior assertions.
+
+- [x] **Step 5: Delete the stale `disableListColumnText` test**
+
+The generated descriptor intentionally does not expose that removed field. Delete the test rather than adding a field that commit `270ac10fb4a3fb763f16f6cc0a96046ef95cf4f7` removed during list-view test consolidation.
+
+- [x] **Step 6: Run the complete Text suite and compare it with baseline**
+
+Run: `PORT=3010 pnpm test:e2e fields__collections__Text --workers=1`
+
+Expected: no new failure compared with the recorded 12-pass, 1-skip, 7-failure baseline. If the Mongoose warning does not occur, all remaining enabled tests pass.
+
+- [x] **Step 7: Prepare the Text-migration checkpoint**
+
+The files are ready for review. Commit them only after explicit user approval.
+
+### Task 7: Final verification and pull request preparation
+
+**Files:**
+
+- Modify: `docs/superpowers/specs/2026-09-08-type-safe-admin-page-model-design.md` only if implementation decisions changed.
+- Verify: `test/fields/admin-page-model.generated.ts` is current and stable.
+
+**Interfaces:**
+
+- Verifies all interfaces from Tasks 1-6.
+
+- [x] **Step 1: Regenerate the fields suite types and check for stable output**
+
+Run `pnpm runts ./test/fields/generateAdminPageModel.ts` twice and compare the generated file after each run.
+
+Expected: generation succeeds and produces identical output on the second run.
+
+- [x] **Step 2: Run focused type and runtime tests**
+
+Run:
+
+```bash
+pnpm exec tstyche adminPageModel --root .
+pnpm exec vitest run --project int test/__helpers/e2e/adminPageModel/generate.int.spec.ts test/__helpers/e2e/adminPageModel/runtime.int.spec.ts
+```
+
+Expected: PASS.
+
+- [x] **Step 3: Run the Text and drawer E2E coverage**
+
+Run:
+
+```bash
+PORT=3010 pnpm test:e2e fields__collections__Text --workers=1
+PORT=3011 pnpm test:e2e fields__collections__Relationship --workers=1 --grep "creates nested text data in a relationship drawer"
+```
+
+Result: the drawer test passes. The Text suite has 19 passes, 1 skip, and the existing SQLite `hasMany not_in` filter failure. No page-model test fails.
+
+- [x] **Step 4: Run formatting, lint, and targeted TypeScript checks**
+
+Run:
+
+```bash
+pnpm exec prettier --check test/__helpers/e2e/adminPageModel test/fields/generateAdminPageModel.ts test/fields/admin-page-model.generated.ts test/fields/adminPageModel.int.spec.ts test/fields/collections/Text/e2e.spec.ts test/fields/collections/Relationship/e2e.spec.ts docs/superpowers
+pnpm exec eslint test/__helpers/e2e/adminPageModel test/fields/generateAdminPageModel.ts test/fields/adminPageModel.int.spec.ts
+pnpm exec tsc --noEmit --project test/tsconfig.json --pretty false
+```
+
+Result: formatting, focused lint, TSTyche, and all changed-file TypeScript diagnostics pass. The full test TypeScript project still reports unrelated cross-suite configuration errors.
+
+- [x] **Step 5: Review the branch diff and source state**
+
+Run:
+
+```bash
+git diff --check
+git status --short
+git diff --stat origin/main...HEAD
+git log --oneline origin/main..HEAD
+```
+
+Expected: only planned files are present and no internal research-source file is staged.
+
+- [ ] **Step 6: Prepare and open the draft pull request after approval**
+
+Write a raw Markdown description with the visible label `Written with AI`. Summarize the generated descriptor, typed models, error guarantees, Text migration, drawer example, baseline failure, and verification commands. After explicit user approval, commit, push the branch, and create the draft pull request.
+
+### Task 8: Add an independent list-document helper
+
+**Files:**
+
+- Create: `test/__helpers/e2e/openListDocument.ts`
+- Modify: `test/fields/collections/Text/e2e.spec.ts`
+- Modify: `docs/superpowers/specs/2026-09-08-type-safe-admin-page-model-design.md`
+
+**Interfaces:**
+
+- `openListDocument({ page })` opens the first document on the current collection list.
+- `openListDocument({ index, page })` opens the document at a zero-based row index.
+- `document(id).goto()` remains unchanged for direct navigation by ID.
+
+- [x] **Step 1: Add Playwright coverage and confirm that it fails before implementation**
+
+Add Text-suite coverage for the default first row, an explicit index, and an out-of-range index. Run the focused tests and confirm that they fail because `openListDocument` does not exist.
+
+- [x] **Step 2: Implement the helper**
+
+Select standard collection-list rows and their `.cell--linked` document links. Use Playwright assertions with added context. Do not catch or replace Playwright errors.
+
+- [x] **Step 3: Run the focused Playwright tests**
+
+Run: `PAYLOAD_DATABASE=sqlite SQLITE_URL=file:./payload.db PORT=3116 pnpm test:e2e fields__collections__Text --workers=1 --grep "list document"`
+
+Result: 2 passed.
+
+- [x] **Step 4: Run final formatting, lint, type, and diff checks**
+
+Result: focused Prettier, ESLint, standalone TypeScript, TSTyche, and `git diff --check` all pass.

--- a/docs/superpowers/specs/2026-09-08-type-safe-admin-page-model-design.md
+++ b/docs/superpowers/specs/2026-09-08-type-safe-admin-page-model-design.md
@@ -1,0 +1,262 @@
+# Type-safe Admin Page Model Design
+
+**Written with AI**
+
+## Goal
+
+Create a shared Playwright utility that derives collection, field, nested row, block, and relationship drawer types from Payload's evaluated configuration. Use the Text field E2E suite as the first full migration.
+
+## Scope
+
+The first pull request will:
+
+- Generate an Admin page-model descriptor in a separate TypeScript module from the evaluated test configuration.
+- Generate descriptors for `text-fields`, `relationship-fields`, and the polymorphic relationship target `array-fields` in the fields test suite.
+- Add the utility in `test/__helpers/e2e/adminPageModel/`.
+- Add TSTyche tests for the public type surface.
+- Add focused runtime and Playwright tests for selectors, row and block lookup, value assertions, and error output.
+- Migrate the Text E2E suite from `AdminUrlUtil` and raw field selectors.
+- Add one relationship drawer test that edits Text data inside an array and a block.
+- Remove the stale Text-suite test for `disableListColumnText`, which is absent from the Text schema.
+
+It will not add a public Payload configuration option or migrate other suites.
+
+## Generated descriptor
+
+`createAdminPageModelSource` will receive the evaluated `SanitizedConfig` and return a standalone module that exports a plain `adminPageModel` constant. Keeping the descriptor separate from `payload-types.ts` prevents an Admin test helper change from rewriting unrelated generated database types.
+
+The fields suite will generate the module explicitly:
+
+```ts
+const sanitizedConfig = await config
+
+const source = createAdminPageModelSource(sanitizedConfig, {
+  collections: ['array-fields', 'relationship-fields', 'text-fields'],
+})
+
+await writeFile(
+  'admin-page-model.generated.ts',
+  await format(source, prettierOptions),
+)
+```
+
+The generated value will contain only serializable test metadata:
+
+```ts
+export const adminPageModel = {
+  collections: {
+    'text-fields': {
+      fields: {
+        text: { hasMany: false, path: 'text', type: 'text' },
+        array: {
+          fields: {
+            texts: { hasMany: true, path: 'array.texts', type: 'text' },
+          },
+          path: 'array',
+          type: 'array',
+        },
+        blocks: {
+          blocks: {
+            blockWithText: {
+              fields: {
+                texts: { hasMany: true, path: 'blocks.texts', type: 'text' },
+              },
+              label: 'Block With Text',
+              slug: 'blockWithText',
+            },
+          },
+          path: 'blocks',
+          type: 'blocks',
+        },
+      },
+      slug: 'text-fields',
+    },
+  },
+} as const
+```
+
+Unnamed rows, tabs, and collapsible fields will expose their named children at the parent level. Named groups and tabs will retain their data-path segment. Unsupported field types will retain their type, path, and relationship targets so the model can provide locators without claiming unsupported high-level actions.
+
+## Public API
+
+Suite setup will create the Admin model once after the shared page is initialized:
+
+```ts
+let admin: PayloadAdmin<typeof adminPageModel>
+let textFields: PayloadCollection<typeof adminPageModel, 'text-fields'>
+
+beforeAll(async ({ browser }, testInfo) => {
+  ;({ payload, serverURL } = await initPayloadE2ENoConfig<Config>({ dirname }))
+  const context = await browser.newContext()
+  ;({ page } = await initPage({ context, serverURL }))
+
+  admin = createPayloadAdmin({ model: adminPageModel, page, serverURL })
+  textFields = admin.collection('text-fields')
+})
+```
+
+The collection object will replace `AdminUrlUtil` for normal collection navigation:
+
+```ts
+await textFields.create.goto()
+await textFields.list.goto()
+await textFields.document(documentID).goto()
+```
+
+Opening a document from the current list will remain an independent helper. It will use a zero-based index and default to the first row:
+
+```ts
+await textFields.list.goto()
+await openListDocument({ page })
+
+await textFields.list.goto()
+await openListDocument({ index: 2, page })
+```
+
+This helper will not replace `document(id).goto()`. Direct navigation by ID remains on the collection model.
+
+Text fields will expose typed actions, assertions, and raw access:
+
+```ts
+await textFields.fields.text.fill('Example')
+await textFields.fields.text.expectValue('Example')
+const value = await textFields.fields.text.getValue()
+
+textFields.fields.text.wrapper
+textFields.fields.text.input
+textFields.fields.text.selectors.wrapper
+textFields.fields.text.selectors.input
+textFields.fields.text.inputID
+```
+
+`wrapper` and `input` are Playwright `Locator` objects. `selectors` contains the exact selector strings used to create them. `inputID` is present only when the field adapter can guarantee a stable ID. Custom controls will not claim a stable input ID.
+
+List-view access will remain close to Playwright:
+
+```ts
+await expect(textFields.fields.text.cell(0)).toHaveText('Example')
+await expect(textFields.fields.text.heading).toBeVisible()
+```
+
+## Arrays and blocks
+
+Lookup functions are asynchronous because selecting an item is also an assertion that it exists:
+
+```ts
+const existingRow = await textFields.fields.array.row(0)
+const newRow = await textFields.fields.array.addRow()
+
+await newRow.fields.texts.addValue('Array value')
+await newRow.fields.texts.expectValues(['Array value'])
+```
+
+Blocks use the block slug as a type discriminator:
+
+```ts
+const existingBlock = await textFields.fields.blocks.block(0, 'blockWithText')
+const newBlock = await textFields.fields.blocks.addBlock('blockWithText')
+
+await newBlock.fields.texts.addValue('Block value')
+```
+
+`block(index, slug)` will first assert that the index exists, then assert that the rendered block matches the requested slug. It will return a model whose fields are limited to that block type.
+
+## Relationship drawers and modal scope
+
+A schema-backed drawer returns a collection model scoped to the drawer root. All child selectors start from that root, so a field behind the drawer cannot match a field inside it.
+
+```ts
+const relationshipFields = admin.collection('relationship-fields')
+const textDrawer =
+  await relationshipFields.fields.relationship.createInDrawer('text-fields')
+
+await textDrawer.fields.text.fill('Drawer document')
+await textDrawer.save()
+await textDrawer.close()
+```
+
+For a single-target relationship, the target slug argument is optional and inferred. For a polymorphic relationship, TypeScript requires one of the configured `relationTo` slugs.
+
+General modals that do not render a Payload document are outside the generated field model. They can receive small hand-written models later.
+
+## Error contract
+
+The utility must not replace useful Playwright errors.
+
+- Direct actions such as `fill()` and `click()` will not catch errors. The original Playwright error will propagate.
+- `save()` will observe matching failed API responses instead of waiting only for successful responses. The following Playwright assertion remains responsible for reporting the visible result.
+- `row()`, `block()`, and `value()` will use Playwright assertions with custom messages. The normal expected value, received value, locator, call log, and stack will remain in the error.
+- `openListDocument()` will use the same pattern when the requested list row does not exist. Its context will include the current URL, requested index, available row count, and valid index range.
+- The custom message will add the collection slug, field path, scope, selector, requested index, available count, and valid index range.
+- If counting or locating fails before the custom assertion, the original error will propagate without wrapping.
+
+An out-of-range row error will include information equivalent to:
+
+```text
+Could not resolve row 5 for "array".
+Collection: text-fields
+Scope: document drawer
+Field path: array
+Available rows: 5
+Valid indexes: 0-4
+```
+
+Tests will catch the failure and verify that both the additional context and Playwright's standard assertion details are present.
+
+## Selector contract
+
+The first migration will adapt the selectors already used by the fields suite:
+
+- Scalar text input: `#field-${instancePath}`.
+- Text `hasMany` control: `.field-${instancePath}`.
+- Array and blocks wrapper: `#field-${instancePath}`.
+- Array row: the direct `.array-field__row` descendants of the array wrapper.
+- Block row: the direct `.blocks-field__row` descendants of the blocks wrapper.
+- List heading: `#heading-${schemaPath}`.
+- List cell: `.row-${oneBasedRow} .cell-${schemaPath}`.
+
+Paths will replace dots with double underscores where the current Admin UI does so. Each field model will expose its wrapper and input selectors as strings and locators.
+
+The migration will record controls for which a stable wrapper cannot be derived. A later change can add `data-payload-field-path` and `data-payload-field-schema-path` to field wrappers. That DOM change is not part of this pull request.
+
+## Test strategy
+
+TSTyche tests will prove:
+
+- Collection slug completion and rejection of unknown slugs.
+- Field property completion and rejection of removed fields.
+- Scalar and `hasMany` text actions.
+- Nested array row fields.
+- Block slug narrowing.
+- Relationship target narrowing and drawer return types.
+- Optional input IDs on controls without a guaranteed ID.
+
+Focused runtime tests will prove descriptor generation, selector construction, path handling, URL construction, and custom error context.
+
+Playwright tests in the fields suite will prove:
+
+- `openListDocument()` opens the first document by default and supports an explicit zero-based index.
+- An out-of-range list-document lookup retains Playwright's assertion details and adds the available row count and valid index range.
+- Original Playwright assertion details remain present after a failed row lookup.
+- The extra row count and field context are present.
+- `addRow()` returns the new row.
+- `addBlock()` returns the selected block.
+- A Text document can be edited through a relationship drawer with array and block values.
+
+The unchanged baseline on 8 September 2026 produced 12 passes, 1 skip, and 7 failures. The first failure was an existing Mongoose deprecation warning treated as a browser console error; later filter tests ended early. Final verification will report this baseline separately from failures introduced by the branch.
+
+## Research basis
+
+This design follows the current guidance from the primary project documentation:
+
+- [Playwright page object models](https://playwright.dev/docs/pom) recommend a higher-level application API that keeps selectors in one place.
+- [Playwright locators](https://playwright.dev/docs/locators) resolve the current DOM element for every action and support narrowing from an existing locator. This supports live row models and drawer-root scoping.
+- [Playwright assertions](https://playwright.dev/docs/test-assertions) support custom messages while retaining auto-retrying locator assertions and their normal call logs.
+- [TypeScript mapped types](https://www.typescriptlang.org/docs/handbook/2/mapped-types.html), [`keyof`](https://www.typescriptlang.org/docs/handbook/2/keyof-types.html), and [`const` assertions](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html#const-assertions) provide the literal collection, field, block, and relationship target keys used for completion and rejection tests.
+- [Payload configuration](https://payloadcms.com/docs/configuration/overview) defines `SanitizedConfig` as the fully evaluated configuration, while the [field overview](https://payloadcms.com/docs/fields/overview) explains that fields define both stored document structure and generated Admin UI. The generator therefore reads the evaluated field configuration instead of database result types.
+
+Playwright recommends user-facing locators or explicit test contracts over DOM-dependent CSS. This first migration must use existing field path classes and IDs because they are the Admin UI contract already available from the schema. A later Admin UI change can add dedicated field-path test attributes without changing the page-model API.
+
+## Migration result
+
+The Text E2E suite will keep one `textFields` model created in `beforeAll`. Tests will use collection navigation and generated field handles. Raw locators will remain only for UI that is not represented by the Payload field schema, such as the custom schema-path component, bulk-edit controls, and list-filter controls.

--- a/test/__helpers/e2e/adminPageModel/collection.ts
+++ b/test/__helpers/e2e/adminPageModel/collection.ts
@@ -1,0 +1,195 @@
+import type { Page } from '@playwright/test'
+import type { Config } from 'payload'
+
+import { expect } from '@playwright/test'
+import { formatAdminURL } from 'payload/shared'
+
+import type { LocatorRoot } from './fields/base.js'
+import type { PayloadCollection } from './modelTypes.js'
+import type {
+  FieldsModelContext,
+  RuntimeAdminPageModel,
+  RuntimeCollectionDescriptor,
+  RuntimeFieldDescriptor,
+  RuntimeFieldsDescriptor,
+} from './runtimeTypes.js'
+
+import { createArrayFieldModel } from './fields/array.js'
+import { createBaseFieldModel } from './fields/base.js'
+import { createBlocksFieldModel } from './fields/blocks.js'
+import { createRelationshipFieldModel } from './fields/relationship.js'
+import { createHasManyTextFieldModel, createTextFieldModel } from './fields/text.js'
+import { selectors } from './selectors.js'
+
+type CreateCollectionModelArgs = {
+  descriptor: RuntimeCollectionDescriptor
+  model: RuntimeAdminPageModel
+  page: Page
+  root: LocatorRoot
+  routes?: Pick<NonNullable<Config['routes']>, 'admin'>
+  scope?: string
+  serverURL: string
+}
+
+const createFieldsModel = (
+  fields: RuntimeFieldsDescriptor,
+  context: FieldsModelContext,
+): Record<string, unknown> => {
+  return Object.fromEntries(
+    Object.entries(fields).map(([fieldName, descriptor]) => {
+      const { instanceParentPath, schemaParentPath } = context
+      const pathSuffix = schemaParentPath
+        ? descriptor.path.slice(schemaParentPath.length + 1)
+        : descriptor.path
+      const instancePath = instanceParentPath
+        ? `${instanceParentPath}.${pathSuffix}`
+        : descriptor.path
+      const args = {
+        collectionSlug: context.collectionSlug,
+        instancePath,
+        root: context.root,
+        schemaPath: descriptor.path,
+        scope: context.scope,
+      }
+
+      if (descriptor.type === 'text') {
+        return [
+          fieldName,
+          descriptor.hasMany ? createHasManyTextFieldModel(args) : createTextFieldModel(args),
+        ]
+      }
+
+      if (descriptor.type === 'array' && descriptor.fields) {
+        return [
+          fieldName,
+          createArrayFieldModel({
+            ...context,
+            createFieldsModel,
+            descriptor: descriptor as {
+              fields: RuntimeFieldsDescriptor
+            } & RuntimeFieldDescriptor,
+            instancePath,
+          }),
+        ]
+      }
+
+      if (descriptor.type === 'blocks' && descriptor.blocks) {
+        return [
+          fieldName,
+          createBlocksFieldModel({
+            ...context,
+            createFieldsModel,
+            descriptor: descriptor as {
+              blocks: NonNullable<RuntimeFieldDescriptor['blocks']>
+            } & RuntimeFieldDescriptor,
+            instancePath,
+          }),
+        ]
+      }
+
+      if (descriptor.type === 'relationship' && descriptor.relationTo) {
+        return [
+          fieldName,
+          createRelationshipFieldModel({
+            ...context,
+            createCollectionModel: (targetDescriptor, drawerRoot) =>
+              createCollectionModel({
+                descriptor: targetDescriptor,
+                model: context.model,
+                page: context.page,
+                root: drawerRoot,
+                routes: context.routes,
+                scope: 'document drawer',
+                serverURL: context.serverURL,
+              }),
+            descriptor: descriptor as {
+              relationTo: readonly string[]
+            } & RuntimeFieldDescriptor,
+            instancePath,
+            model: context.model,
+          }),
+        ]
+      }
+
+      if (descriptor.type === 'group' && descriptor.fields) {
+        const wrapperSelector = selectors.fieldWrapper(instancePath)
+        return [
+          fieldName,
+          {
+            ...createBaseFieldModel({ ...args, wrapperSelector }),
+            fields: createFieldsModel(descriptor.fields, {
+              ...context,
+              instanceParentPath: instancePath,
+              schemaParentPath: descriptor.path,
+            }),
+          },
+        ]
+      }
+
+      const wrapperSelector = selectors.fieldWrapper(instancePath)
+      return [fieldName, createBaseFieldModel({ ...args, wrapperSelector })]
+    }),
+  )
+}
+
+const createNavigationTarget = (page: Page, url: string) => ({
+  goto: async () => {
+    await page.goto(url)
+  },
+  url,
+})
+
+export const createCollectionModel = <
+  Model extends CreateCollectionModelArgs['model'],
+  Slug extends Extract<keyof Model['collections'], string>,
+>({
+  descriptor,
+  model,
+  page,
+  root,
+  routes,
+  scope,
+  serverURL,
+}: {
+  descriptor: Model['collections'][Slug]
+  model: Model
+} & CreateCollectionModelArgs): PayloadCollection<Model, Slug> => {
+  const listURL = formatAdminURL({
+    adminRoute: routes?.admin ?? '/admin',
+    path: `/collections/${descriptor.slug}`,
+    serverURL,
+  })
+
+  return {
+    slug: descriptor.slug as Slug,
+    close: () => root.locator('.drawer__close').click(),
+    create: createNavigationTarget(page, `${listURL}/create`),
+    document: (id) => createNavigationTarget(page, `${listURL}/${encodeURIComponent(String(id))}`),
+    fields: createFieldsModel(descriptor.fields, {
+      collectionSlug: descriptor.slug,
+      model,
+      page,
+      root,
+      routes,
+      scope: scope ?? 'document page',
+      serverURL,
+    }),
+    list: createNavigationTarget(page, listURL),
+    save: async () => {
+      const collectionAPIPath = `/api/${descriptor.slug}`
+      const saveResponse = page.waitForResponse((response) => {
+        const method = response.request().method()
+        const pathname = new URL(response.url()).pathname
+
+        return (
+          (method === 'POST' || method === 'PATCH') &&
+          (pathname === collectionAPIPath || pathname.startsWith(`${collectionAPIPath}/`))
+        )
+      })
+
+      await root.locator('#action-save').click()
+      await saveResponse
+      await expect(page.locator('.payload-toast-container')).toContainText('successfully')
+    },
+  } as PayloadCollection<Model, Slug>
+}

--- a/test/__helpers/e2e/adminPageModel/createPayloadAdmin.ts
+++ b/test/__helpers/e2e/adminPageModel/createPayloadAdmin.ts
@@ -1,0 +1,40 @@
+import type { Page } from '@playwright/test'
+import type { Config } from 'payload'
+
+import type { PayloadAdmin } from './modelTypes.js'
+import type { RuntimeAdminPageModel } from './runtimeTypes.js'
+
+import { createCollectionModel } from './collection.js'
+
+export type CreatePayloadAdminArgs<Model extends RuntimeAdminPageModel> = {
+  model: Model
+  page: Page
+  routes?: Pick<NonNullable<Config['routes']>, 'admin'>
+  serverURL: string
+}
+
+export const createPayloadAdmin = <Model extends RuntimeAdminPageModel>({
+  model,
+  page,
+  routes,
+  serverURL,
+}: CreatePayloadAdminArgs<Model>): PayloadAdmin<Model> => {
+  return {
+    collection: (slug) => {
+      const descriptor = model.collections[slug]
+
+      if (!descriptor) {
+        throw new Error(`Cannot create an Admin page model for unknown collection "${slug}".`)
+      }
+
+      return createCollectionModel<Model, typeof slug>({
+        descriptor: descriptor as Model['collections'][typeof slug],
+        model,
+        page,
+        root: page,
+        routes,
+        serverURL,
+      })
+    },
+  }
+}

--- a/test/__helpers/e2e/adminPageModel/errors.ts
+++ b/test/__helpers/e2e/adminPageModel/errors.ts
@@ -1,0 +1,54 @@
+export type IndexedLocatorContext = {
+  availableCount: number
+  collectionSlug: string
+  fieldPath: string
+  index: number
+  itemName: 'block' | 'row' | 'value'
+  scope: string
+  selector: string
+}
+
+const pluralize = (itemName: IndexedLocatorContext['itemName']): string => {
+  return itemName === 'row' ? 'rows' : `${itemName}s`
+}
+
+export const formatIndexedLocatorContext = ({
+  availableCount,
+  collectionSlug,
+  fieldPath,
+  index,
+  itemName,
+  scope,
+  selector,
+}: IndexedLocatorContext): string => {
+  const validIndexes = availableCount === 0 ? 'none' : `0-${availableCount - 1}`
+
+  return [
+    `Could not resolve ${itemName} ${index} for "${fieldPath}".`,
+    `Collection: ${collectionSlug}`,
+    `Scope: ${scope}`,
+    `Field path: ${fieldPath}`,
+    `Selector: ${selector}`,
+    `Requested index: ${index}`,
+    `Available ${pluralize(itemName)}: ${availableCount}`,
+    `Valid indexes: ${validIndexes}`,
+  ].join('\n')
+}
+
+export const formatBlockTypeContext = ({
+  slug,
+  collectionSlug,
+  fieldPath,
+  index,
+  scope,
+  selector,
+}: { slug: string } & Omit<IndexedLocatorContext, 'availableCount' | 'itemName'>): string => {
+  return [
+    `Could not resolve block type "${slug}" at index ${index} for "${fieldPath}".`,
+    `Collection: ${collectionSlug}`,
+    `Scope: ${scope}`,
+    `Field path: ${fieldPath}`,
+    `Selector: ${selector}`,
+    `Requested block type: ${slug}`,
+  ].join('\n')
+}

--- a/test/__helpers/e2e/adminPageModel/fields/array.ts
+++ b/test/__helpers/e2e/adminPageModel/fields/array.ts
@@ -1,0 +1,92 @@
+import { expect } from '@playwright/test'
+
+import type { ArrayFieldModel } from '../modelTypes.js'
+import type {
+  CreateFieldsModel,
+  FieldsModelContext,
+  RuntimeFieldDescriptor,
+  RuntimeFieldsDescriptor,
+} from '../runtimeTypes.js'
+
+import { formatIndexedLocatorContext } from '../errors.js'
+import { selectors } from '../selectors.js'
+import { createBaseFieldModel } from './base.js'
+
+type CreateArrayFieldModelArgs = {
+  createFieldsModel: CreateFieldsModel
+  descriptor: {
+    fields: RuntimeFieldsDescriptor
+  } & RuntimeFieldDescriptor
+  instancePath: string
+} & FieldsModelContext
+
+export const createArrayFieldModel = ({
+  collectionSlug,
+  createFieldsModel,
+  descriptor,
+  instancePath,
+  model,
+  page,
+  root,
+  routes,
+  scope,
+  serverURL,
+}: CreateArrayFieldModelArgs): ArrayFieldModel<RuntimeFieldsDescriptor> => {
+  const rowsSelector = selectors.arrayRows(instancePath)
+  const rows = root.locator(rowsSelector)
+  const baseField = createBaseFieldModel({
+    instancePath,
+    root,
+    schemaPath: descriptor.path,
+    wrapperSelector: selectors.fieldWrapper(instancePath),
+  })
+
+  const row = async (index: number) => {
+    const availableCount = await rows.count()
+    const rowLocator = rows.nth(index >= 0 ? index : availableCount)
+
+    await expect(
+      rowLocator,
+      formatIndexedLocatorContext({
+        availableCount,
+        collectionSlug,
+        fieldPath: descriptor.path,
+        index,
+        itemName: 'row',
+        scope,
+        selector: rowsSelector,
+      }),
+    ).toHaveCount(1)
+
+    return {
+      fields: createFieldsModel(descriptor.fields, {
+        collectionSlug,
+        instanceParentPath: `${instancePath}.${index}`,
+        model,
+        page,
+        root: rowLocator,
+        routes,
+        schemaParentPath: descriptor.path,
+        scope,
+        serverURL,
+      }),
+      wrapper: rowLocator,
+    }
+  }
+
+  return {
+    ...baseField,
+    addRow: async () => {
+      const previousCount = await rows.count()
+
+      await root.locator(selectors.arrayAddRow(instancePath)).click()
+      await expect(
+        rows,
+        `Expected addRow() to add one row to "${descriptor.path}" in collection "${collectionSlug}".`,
+      ).toHaveCount(previousCount + 1)
+
+      return row(previousCount)
+    },
+    row,
+  } as ArrayFieldModel<RuntimeFieldsDescriptor>
+}

--- a/test/__helpers/e2e/adminPageModel/fields/base.ts
+++ b/test/__helpers/e2e/adminPageModel/fields/base.ts
@@ -1,0 +1,29 @@
+import type { Locator, Page } from '@playwright/test'
+
+import type { BaseFieldModel } from '../modelTypes.js'
+
+import { selectors } from '../selectors.js'
+
+export type LocatorRoot = Pick<Locator, 'locator'> | Pick<Page, 'locator'>
+
+export type CreateBaseFieldModelArgs = {
+  instancePath: string
+  root: LocatorRoot
+  schemaPath: string
+  wrapperSelector: string
+}
+
+export const createBaseFieldModel = ({
+  root,
+  schemaPath,
+  wrapperSelector,
+}: CreateBaseFieldModelArgs): BaseFieldModel => {
+  return {
+    cell: (rowIndex) => root.locator(selectors.listCell(schemaPath, rowIndex)),
+    heading: root.locator(selectors.listHeading(schemaPath)),
+    selectors: {
+      wrapper: wrapperSelector,
+    },
+    wrapper: root.locator(wrapperSelector),
+  }
+}

--- a/test/__helpers/e2e/adminPageModel/fields/blocks.ts
+++ b/test/__helpers/e2e/adminPageModel/fields/blocks.ts
@@ -1,0 +1,129 @@
+import { expect } from '@playwright/test'
+
+import type { BlocksFieldModel } from '../modelTypes.js'
+import type {
+  CreateFieldsModel,
+  FieldsModelContext,
+  RuntimeBlockDescriptor,
+  RuntimeFieldDescriptor,
+} from '../runtimeTypes.js'
+
+import { formatBlockTypeContext, formatIndexedLocatorContext } from '../errors.js'
+import { selectors } from '../selectors.js'
+import { createBaseFieldModel } from './base.js'
+
+type CreateBlocksFieldModelArgs = {
+  createFieldsModel: CreateFieldsModel
+  descriptor: {
+    blocks: Readonly<Record<string, RuntimeBlockDescriptor>>
+  } & RuntimeFieldDescriptor
+  instancePath: string
+} & FieldsModelContext
+
+export const createBlocksFieldModel = ({
+  collectionSlug,
+  createFieldsModel,
+  descriptor,
+  instancePath,
+  model,
+  page,
+  root,
+  routes,
+  scope,
+  serverURL,
+}: CreateBlocksFieldModelArgs): BlocksFieldModel<
+  Readonly<Record<string, RuntimeBlockDescriptor>>
+> => {
+  const rowsSelector = selectors.blockRows(instancePath)
+  const rows = root.locator(rowsSelector)
+  const baseField = createBaseFieldModel({
+    instancePath,
+    root,
+    schemaPath: descriptor.path,
+    wrapperSelector: selectors.fieldWrapper(instancePath),
+  })
+  const getBlockDescriptor = (slug: string): RuntimeBlockDescriptor => {
+    const blockDescriptor = descriptor.blocks[slug]
+
+    if (!blockDescriptor) {
+      throw new Error(
+        `Block "${slug}" is not present in the generated model for "${descriptor.path}".`,
+      )
+    }
+
+    return blockDescriptor
+  }
+
+  const block = async (index: number, slug: string) => {
+    const availableCount = await rows.count()
+    const rowLocator = rows.nth(index >= 0 ? index : availableCount)
+
+    await expect(
+      rowLocator,
+      formatIndexedLocatorContext({
+        availableCount,
+        collectionSlug,
+        fieldPath: descriptor.path,
+        index,
+        itemName: 'block',
+        scope,
+        selector: rowsSelector,
+      }),
+    ).toHaveCount(1)
+
+    const blockTypeSelector = selectors.blockTypePill(slug)
+
+    await expect(
+      rowLocator.locator(blockTypeSelector),
+      formatBlockTypeContext({
+        slug,
+        collectionSlug,
+        fieldPath: descriptor.path,
+        index,
+        scope,
+        selector: blockTypeSelector,
+      }),
+    ).toHaveCount(1)
+
+    const blockDescriptor = getBlockDescriptor(slug)
+
+    return {
+      slug,
+      fields: createFieldsModel(blockDescriptor.fields, {
+        collectionSlug,
+        instanceParentPath: `${instancePath}.${index}`,
+        model,
+        page,
+        root: rowLocator,
+        routes,
+        schemaParentPath: descriptor.path,
+        scope,
+        serverURL,
+      }),
+      wrapper: rowLocator,
+    }
+  }
+
+  return {
+    ...baseField,
+    addBlock: async (slug) => {
+      const previousCount = await rows.count()
+      const blockDescriptor = getBlockDescriptor(slug)
+
+      await root.locator(selectors.blockDrawerToggler(instancePath)).click()
+
+      const blocksDrawer = page.locator(selectors.blocksDrawer).last()
+      await expect(blocksDrawer).toBeVisible()
+      await blocksDrawer
+        .locator('button.thumbnail-card', { hasText: blockDescriptor.label })
+        .dblclick()
+      await expect(
+        rows,
+        `Expected addBlock("${slug}") to add one block to "${descriptor.path}" in collection "${collectionSlug}".`,
+      ).toHaveCount(previousCount + 1)
+
+      return block(previousCount, slug)
+    },
+    block,
+  } as BlocksFieldModel<Readonly<Record<string, RuntimeBlockDescriptor>>>
+}

--- a/test/__helpers/e2e/adminPageModel/fields/relationship.ts
+++ b/test/__helpers/e2e/adminPageModel/fields/relationship.ts
@@ -1,0 +1,88 @@
+import type { Locator } from '@playwright/test'
+
+import { expect } from '@playwright/test'
+
+import type { RelationshipFieldModel } from '../modelTypes.js'
+import type {
+  FieldsModelContext,
+  RuntimeAdminPageModel,
+  RuntimeCollectionDescriptor,
+  RuntimeFieldDescriptor,
+} from '../runtimeTypes.js'
+
+import { selectors } from '../selectors.js'
+import { createBaseFieldModel } from './base.js'
+
+type CreateRelationshipFieldModelArgs = {
+  createCollectionModel: (descriptor: RuntimeCollectionDescriptor, root: Locator) => unknown
+  descriptor: {
+    relationTo: readonly string[]
+  } & RuntimeFieldDescriptor
+  instancePath: string
+  model: RuntimeAdminPageModel
+} & FieldsModelContext
+
+export const createRelationshipFieldModel = ({
+  createCollectionModel,
+  descriptor,
+  instancePath,
+  model,
+  page,
+  root,
+}: CreateRelationshipFieldModelArgs): RelationshipFieldModel<
+  RuntimeAdminPageModel,
+  RuntimeFieldDescriptor
+> => {
+  const wrapperSelector = selectors.fieldWrapper(instancePath)
+  const baseField = createBaseFieldModel({
+    instancePath,
+    root,
+    schemaPath: descriptor.path,
+    wrapperSelector,
+  })
+
+  return {
+    ...baseField,
+    createInDrawer: async (targetSlug?: string) => {
+      const resolvedTargetSlug = targetSlug ?? descriptor.relationTo[0]
+
+      if (!resolvedTargetSlug || !descriptor.relationTo.includes(resolvedTargetSlug)) {
+        throw new Error(
+          `Cannot create relationship target "${String(resolvedTargetSlug)}" from field "${descriptor.path}". Valid targets: ${descriptor.relationTo.join(', ')}.`,
+        )
+      }
+
+      const targetDescriptor = model.collections[resolvedTargetSlug]
+
+      if (!targetDescriptor) {
+        throw new Error(
+          `Cannot create a typed drawer for "${resolvedTargetSlug}" because it is absent from the generated Admin page model.`,
+        )
+      }
+
+      const addButton = root.locator(selectors.relationshipAddButton(instancePath))
+      await expect(
+        addButton,
+        `Expected relationship field "${descriptor.path}" to provide an add-new button.`,
+      ).toBeVisible()
+      await addButton.click()
+
+      if (descriptor.relationTo.length > 1) {
+        const targetButton = page.locator(selectors.relationshipTarget(resolvedTargetSlug))
+        await expect(
+          targetButton,
+          `Expected relationship field "${descriptor.path}" to offer target "${resolvedTargetSlug}".`,
+        ).toBeVisible()
+        await targetButton.click()
+      }
+
+      const drawer = page.locator(selectors.documentDrawer(resolvedTargetSlug)).last()
+      await expect(
+        drawer,
+        `Expected a document drawer for collection "${resolvedTargetSlug}" to open from relationship field "${descriptor.path}".`,
+      ).toBeVisible()
+
+      return createCollectionModel(targetDescriptor, drawer)
+    },
+  } as RelationshipFieldModel<RuntimeAdminPageModel, RuntimeFieldDescriptor>
+}

--- a/test/__helpers/e2e/adminPageModel/fields/text.ts
+++ b/test/__helpers/e2e/adminPageModel/fields/text.ts
@@ -1,0 +1,124 @@
+import { expect } from '@playwright/test'
+
+import type { HasManyTextFieldModel, TextFieldModel } from '../modelTypes.js'
+import type { CreateBaseFieldModelArgs } from './base.js'
+
+import { formatIndexedLocatorContext } from '../errors.js'
+import { selectors } from '../selectors.js'
+import { createBaseFieldModel } from './base.js'
+
+type CreateTextFieldModelArgs = {
+  collectionSlug: string
+  scope: string
+} & Omit<CreateBaseFieldModelArgs, 'wrapperSelector'>
+
+export const createTextFieldModel = ({
+  instancePath,
+  root,
+  schemaPath,
+  scope,
+}: CreateTextFieldModelArgs): TextFieldModel => {
+  const inputSelector = selectors.textInput(instancePath)
+  const wrapperSelector = selectors.textFieldWrapper(instancePath)
+  const baseField = createBaseFieldModel({
+    instancePath,
+    root,
+    schemaPath,
+    wrapperSelector,
+  })
+  const input = root.locator(inputSelector)
+
+  return {
+    ...baseField,
+    expectValue: async (value) => {
+      await expect(
+        input,
+        `Expected text field "${schemaPath}" at "${instancePath}" in ${scope} to have the requested value.`,
+      ).toHaveValue(value)
+    },
+    fill: (value) => input.fill(value),
+    getValue: () => input.inputValue(),
+    input,
+    inputID: selectors.textInputID(instancePath),
+    selectors: {
+      input: inputSelector,
+      wrapper: wrapperSelector,
+    },
+  }
+}
+
+export const createHasManyTextFieldModel = ({
+  collectionSlug,
+  instancePath,
+  root,
+  schemaPath,
+  scope,
+}: CreateTextFieldModelArgs): HasManyTextFieldModel => {
+  const wrapperSelector = selectors.hasManyTextControl(instancePath)
+  const inputSelector = selectors.hasManyTextInput(instancePath)
+  const baseField = createBaseFieldModel({
+    instancePath,
+    root,
+    schemaPath,
+    wrapperSelector,
+  })
+  const input = root.locator(inputSelector)
+  const valueLocators = baseField.wrapper.locator('.multi-value-label__text')
+
+  return {
+    ...baseField,
+    addValue: async (value) => {
+      const previousCount = await valueLocators.count()
+
+      await input.fill(value)
+      await input.press('Enter')
+      await expect(
+        valueLocators,
+        `Expected addValue() to add one value to "${schemaPath}" in collection "${collectionSlug}".`,
+      ).toHaveCount(previousCount + 1)
+      await expect(valueLocators.nth(previousCount)).toHaveText(value)
+    },
+    expectValues: async (values) => {
+      await expect(
+        valueLocators,
+        `Expected text field "${schemaPath}" at "${instancePath}" to have the requested values.`,
+      ).toHaveText([...values])
+    },
+    input,
+    selectors: {
+      input: inputSelector,
+      wrapper: wrapperSelector,
+    },
+    value: async (index) => {
+      const availableCount = await valueLocators.count()
+      const valueSelector = `${wrapperSelector} .multi-value-label__text`
+      const wrapper = valueLocators.nth(index >= 0 ? index : availableCount)
+
+      await expect(
+        wrapper,
+        formatIndexedLocatorContext({
+          availableCount,
+          collectionSlug,
+          fieldPath: schemaPath,
+          index,
+          itemName: 'value',
+          scope,
+          selector: valueSelector,
+        }),
+      ).toHaveCount(1)
+
+      return {
+        expectValue: async (value) => {
+          await expect(wrapper).toHaveText(value)
+        },
+        fill: async (value) => {
+          await wrapper.click()
+          await wrapper.fill(value)
+          await wrapper.press('Enter')
+        },
+        getValue: () => wrapper.innerText(),
+        wrapper,
+      }
+    },
+  }
+}

--- a/test/__helpers/e2e/adminPageModel/generate.int.spec.ts
+++ b/test/__helpers/e2e/adminPageModel/generate.int.spec.ts
@@ -1,0 +1,280 @@
+import type { SanitizedConfig } from 'payload'
+
+import { describe, expect, it } from 'vitest'
+
+import { createAdminPageModelDescriptor, createAdminPageModelSource } from './generate.js'
+
+const config = {
+  blocks: [
+    {
+      slug: 'reusableQuote',
+      fields: [
+        {
+          name: 'citation',
+          type: 'text',
+        },
+      ],
+      labels: {
+        plural: 'Reusable Quotes',
+        singular: 'Reusable Quote',
+      },
+    },
+  ],
+  collections: [
+    {
+      slug: 'articles',
+      fields: [
+        {
+          name: 'title',
+          type: 'text',
+          admin: {
+            disabled: true,
+          },
+          required: true,
+        },
+        {
+          name: 'tags',
+          type: 'text',
+          hasMany: true,
+        },
+        {
+          type: 'row',
+          fields: [
+            {
+              name: 'summary',
+              type: 'text',
+            },
+          ],
+        },
+        {
+          type: 'collapsible',
+          fields: [
+            {
+              name: 'collapsibleText',
+              type: 'text',
+            },
+          ],
+          label: 'Collapsible',
+        },
+        {
+          type: 'tabs',
+          tabs: [
+            {
+              fields: [
+                {
+                  name: 'tabText',
+                  type: 'text',
+                },
+              ],
+              label: 'Unnamed Tab',
+            },
+            {
+              name: 'namedTab',
+              fields: [
+                {
+                  name: 'nestedText',
+                  type: 'text',
+                },
+              ],
+              label: 'Named Tab',
+            },
+          ],
+        },
+        {
+          name: 'meta',
+          type: 'group',
+          fields: [
+            {
+              name: 'description',
+              type: 'text',
+            },
+          ],
+        },
+        {
+          name: 'items',
+          type: 'array',
+          fields: [
+            {
+              name: 'labels',
+              type: 'text',
+              hasMany: true,
+            },
+          ],
+        },
+        {
+          name: 'content',
+          type: 'blocks',
+          blocks: [
+            {
+              slug: 'quote',
+              fields: [
+                {
+                  name: 'quoteText',
+                  type: 'text',
+                },
+              ],
+              labels: {
+                plural: 'Quotes',
+                singular: 'Quote',
+              },
+            },
+          ],
+        },
+        {
+          name: 'reusableContent',
+          type: 'blocks',
+          blocks: ['reusableQuote'],
+        },
+        {
+          name: 'author',
+          type: 'relationship',
+          relationTo: ['users', 'guests'],
+        },
+      ],
+    },
+    {
+      slug: 'excluded',
+      fields: [],
+    },
+  ],
+} as unknown as SanitizedConfig
+
+describe('createAdminPageModelDescriptor', () => {
+  it('generates selected collections and nested field metadata', () => {
+    const descriptor = createAdminPageModelDescriptor(config, {
+      collections: ['articles'],
+    })
+
+    expect(descriptor).toEqual({
+      collections: {
+        articles: {
+          slug: 'articles',
+          fields: {
+            author: {
+              type: 'relationship',
+              hasMany: false,
+              path: 'author',
+              relationTo: ['users', 'guests'],
+            },
+            collapsibleText: {
+              type: 'text',
+              hasMany: false,
+              path: 'collapsibleText',
+            },
+            content: {
+              type: 'blocks',
+              blocks: {
+                quote: {
+                  slug: 'quote',
+                  fields: {
+                    quoteText: {
+                      type: 'text',
+                      hasMany: false,
+                      path: 'content.quoteText',
+                    },
+                  },
+                  label: 'Quote',
+                },
+              },
+              path: 'content',
+            },
+            items: {
+              type: 'array',
+              fields: {
+                labels: {
+                  type: 'text',
+                  hasMany: true,
+                  path: 'items.labels',
+                },
+              },
+              path: 'items',
+            },
+            meta: {
+              type: 'group',
+              fields: {
+                description: {
+                  type: 'text',
+                  hasMany: false,
+                  path: 'meta.description',
+                },
+              },
+              path: 'meta',
+            },
+            namedTab: {
+              type: 'group',
+              fields: {
+                nestedText: {
+                  type: 'text',
+                  hasMany: false,
+                  path: 'namedTab.nestedText',
+                },
+              },
+              path: 'namedTab',
+            },
+            reusableContent: {
+              type: 'blocks',
+              blocks: {
+                reusableQuote: {
+                  slug: 'reusableQuote',
+                  fields: {
+                    citation: {
+                      type: 'text',
+                      hasMany: false,
+                      path: 'reusableContent.citation',
+                    },
+                  },
+                  label: 'Reusable Quote',
+                },
+              },
+              path: 'reusableContent',
+            },
+            summary: {
+              type: 'text',
+              hasMany: false,
+              path: 'summary',
+            },
+            tabText: {
+              type: 'text',
+              hasMany: false,
+              path: 'tabText',
+            },
+            tags: {
+              type: 'text',
+              hasMany: true,
+              path: 'tags',
+            },
+            title: {
+              type: 'text',
+              admin: {
+                disabled: true,
+                hidden: false,
+                readOnly: false,
+              },
+              hasMany: false,
+              path: 'title',
+              required: true,
+            },
+          },
+        },
+      },
+    })
+  })
+
+  it('reports a requested collection that does not exist', () => {
+    expect(() =>
+      createAdminPageModelDescriptor(config, {
+        collections: ['missing'],
+      }),
+    ).toThrow('Cannot generate an Admin page model for unknown collection "missing".')
+  })
+})
+
+describe('createAdminPageModelSource', () => {
+  it('creates a standalone literal descriptor module', () => {
+    const result = createAdminPageModelSource(config, { collections: ['articles'] })
+
+    expect(result).toContain('export const adminPageModel = {')
+    expect(result).toContain('"articles": {')
+    expect(result).toContain('} as const')
+  })
+})

--- a/test/__helpers/e2e/adminPageModel/generate.ts
+++ b/test/__helpers/e2e/adminPageModel/generate.ts
@@ -1,0 +1,196 @@
+import type { Block, Field, SanitizedConfig } from 'payload'
+
+import type {
+  AdminBlockDescriptor,
+  AdminFieldDescriptor,
+  AdminFieldsDescriptor,
+  AdminPageModelDescriptor,
+  CreateAdminPageModelOptions,
+} from './types.js'
+
+type FieldWithName = {
+  name: string
+} & Field
+
+const joinPath = (parentPath: string, name: string): string => {
+  return parentPath ? `${parentPath}.${name}` : name
+}
+
+const hasName = (field: Field): field is FieldWithName => {
+  return 'name' in field && typeof field.name === 'string'
+}
+
+const getCommonFieldMetadata = (field: FieldWithName, path: string) => {
+  const fieldMetadata = field as {
+    admin?: { disabled?: boolean; hidden?: boolean; readOnly?: boolean }
+    hidden?: boolean
+    required?: boolean
+  }
+  const metadata: {
+    admin?: { disabled: boolean; hidden: boolean; readOnly: boolean }
+    hidden?: true
+    path: string
+    required?: true
+  } = { path }
+
+  if (fieldMetadata.required) {
+    metadata.required = true
+  }
+
+  if (fieldMetadata.hidden === true) {
+    metadata.hidden = true
+  }
+
+  if (
+    fieldMetadata.admin?.disabled ||
+    fieldMetadata.admin?.hidden ||
+    fieldMetadata.admin?.readOnly
+  ) {
+    metadata.admin = {
+      disabled: fieldMetadata.admin?.disabled === true,
+      hidden: fieldMetadata.admin?.hidden === true,
+      readOnly: fieldMetadata.admin?.readOnly === true,
+    }
+  }
+
+  return metadata
+}
+
+const getBlockLabel = (block: { labels?: { singular?: unknown }; slug: string }): string => {
+  return typeof block.labels?.singular === 'string' ? block.labels.singular : block.slug
+}
+
+const createFieldsDescriptor = (
+  fields: Field[],
+  blocksBySlug: Readonly<Record<string, Block>>,
+  parentPath = '',
+): AdminFieldsDescriptor => {
+  const descriptor: AdminFieldsDescriptor = {}
+
+  for (const field of fields) {
+    if (field.type === 'row' || field.type === 'collapsible') {
+      Object.assign(descriptor, createFieldsDescriptor(field.fields, blocksBySlug, parentPath))
+      continue
+    }
+
+    if (field.type === 'tabs') {
+      for (const tab of field.tabs) {
+        if ('name' in tab && typeof tab.name === 'string') {
+          const path = joinPath(parentPath, tab.name)
+          descriptor[tab.name] = {
+            type: 'group',
+            fields: createFieldsDescriptor(tab.fields, blocksBySlug, path),
+            path,
+          }
+        } else {
+          Object.assign(descriptor, createFieldsDescriptor(tab.fields, blocksBySlug, parentPath))
+        }
+      }
+      continue
+    }
+
+    if (!hasName(field)) {
+      continue
+    }
+
+    const path = joinPath(parentPath, field.name)
+    const commonMetadata = getCommonFieldMetadata(field, path)
+    let fieldDescriptor: AdminFieldDescriptor
+
+    if (field.type === 'text') {
+      fieldDescriptor = {
+        ...commonMetadata,
+        type: 'text',
+        hasMany: field.hasMany === true,
+      }
+    } else if (field.type === 'array') {
+      fieldDescriptor = {
+        ...commonMetadata,
+        type: 'array',
+        fields: createFieldsDescriptor(field.fields, blocksBySlug, path),
+      }
+    } else if (field.type === 'blocks') {
+      const blocks: Record<string, AdminBlockDescriptor> = {}
+
+      for (const block of field.blocks) {
+        const resolvedBlock = typeof block === 'string' ? blocksBySlug[block] : block
+
+        if (!resolvedBlock) {
+          continue
+        }
+
+        blocks[resolvedBlock.slug] = {
+          slug: resolvedBlock.slug,
+          fields: createFieldsDescriptor(resolvedBlock.fields, blocksBySlug, path),
+          label: getBlockLabel(resolvedBlock),
+        }
+      }
+
+      fieldDescriptor = {
+        ...commonMetadata,
+        type: 'blocks',
+        blocks,
+      }
+    } else if (field.type === 'group') {
+      fieldDescriptor = {
+        ...commonMetadata,
+        type: 'group',
+        fields: createFieldsDescriptor(field.fields, blocksBySlug, path),
+      }
+    } else if (field.type === 'relationship') {
+      fieldDescriptor = {
+        ...commonMetadata,
+        type: 'relationship',
+        hasMany: field.hasMany === true,
+        relationTo: Array.isArray(field.relationTo) ? field.relationTo : [field.relationTo],
+      }
+    } else {
+      fieldDescriptor = {
+        ...commonMetadata,
+        type: field.type,
+      }
+    }
+
+    descriptor[field.name] = fieldDescriptor
+  }
+
+  return descriptor
+}
+
+export const createAdminPageModelDescriptor = (
+  config: SanitizedConfig,
+  options: CreateAdminPageModelOptions,
+): AdminPageModelDescriptor => {
+  const blocksBySlug: Record<string, Block> = {}
+  const collections: AdminPageModelDescriptor['collections'] = {}
+
+  for (const block of config.blocks) {
+    blocksBySlug[block.slug] = block
+  }
+
+  for (const collectionSlug of options.collections) {
+    const collection = config.collections.find(({ slug }) => slug === collectionSlug)
+
+    if (!collection) {
+      throw new Error(
+        `Cannot generate an Admin page model for unknown collection "${collectionSlug}".`,
+      )
+    }
+
+    collections[collectionSlug] = {
+      slug: collection.slug,
+      fields: createFieldsDescriptor(collection.fields, blocksBySlug),
+    }
+  }
+
+  return { collections }
+}
+
+export const createAdminPageModelSource = (
+  config: SanitizedConfig,
+  options: CreateAdminPageModelOptions,
+): string => {
+  const descriptor = createAdminPageModelDescriptor(config, options)
+
+  return `export const adminPageModel = ${JSON.stringify(descriptor, null, 2)} as const\n`
+}

--- a/test/__helpers/e2e/adminPageModel/index.ts
+++ b/test/__helpers/e2e/adminPageModel/index.ts
@@ -1,0 +1,18 @@
+export { createPayloadAdmin } from './createPayloadAdmin.js'
+export { formatIndexedLocatorContext } from './errors.js'
+export type {
+  ArrayFieldModel,
+  ArrayRowModel,
+  BaseFieldModel,
+  BlockRowModel,
+  BlocksFieldModel,
+  FieldsModel,
+  GroupFieldModel,
+  HasManyTextFieldModel,
+  HasManyTextValueModel,
+  PayloadAdmin,
+  PayloadCollection,
+  RelationshipFieldModel,
+  TextFieldModel,
+} from './modelTypes.js'
+export { selectors } from './selectors.js'

--- a/test/__helpers/e2e/adminPageModel/modelTypes.ts
+++ b/test/__helpers/e2e/adminPageModel/modelTypes.ts
@@ -1,0 +1,192 @@
+import type { Locator } from '@playwright/test'
+
+type AdminFieldDescriptorLike = {
+  readonly path: string
+  readonly type: string
+}
+
+type AdminFieldsDescriptorLike = Readonly<Record<string, AdminFieldDescriptorLike>>
+
+type AdminCollectionDescriptorLike = {
+  readonly fields: AdminFieldsDescriptorLike
+  readonly slug: string
+}
+
+type AdminPageModelLike = {
+  readonly collections: Readonly<Record<string, AdminCollectionDescriptorLike>>
+}
+
+type CollectionSlug<Model extends AdminPageModelLike> = Extract<keyof Model['collections'], string>
+
+type FieldSelectors = {
+  readonly wrapper: string
+}
+
+export type BaseFieldModel = {
+  readonly cell: (rowIndex: number) => Locator
+  readonly heading: Locator
+  readonly selectors: FieldSelectors
+  readonly wrapper: Locator
+}
+
+export type TextFieldModel = {
+  readonly expectValue: (value: string) => Promise<void>
+  readonly fill: (value: string) => Promise<void>
+  readonly getValue: () => Promise<string>
+  readonly input: Locator
+  readonly inputID: string
+  readonly selectors: {
+    readonly input: string
+  } & FieldSelectors
+} & BaseFieldModel
+
+export type HasManyTextValueModel = {
+  readonly expectValue: (value: string) => Promise<void>
+  readonly fill: (value: string) => Promise<void>
+  readonly getValue: () => Promise<string>
+  readonly wrapper: Locator
+}
+
+export type HasManyTextFieldModel = {
+  readonly addValue: (value: string) => Promise<void>
+  readonly expectValues: (values: readonly string[]) => Promise<void>
+  readonly input: Locator
+  readonly selectors: {
+    readonly input: string
+  } & FieldSelectors
+  readonly value: (index: number) => Promise<HasManyTextValueModel>
+} & BaseFieldModel
+
+export type ArrayRowModel<
+  Fields extends AdminFieldsDescriptorLike,
+  Model extends AdminPageModelLike = AdminPageModelLike,
+> = {
+  readonly fields: FieldsModel<Fields, Model>
+  readonly wrapper: Locator
+}
+
+export type ArrayFieldModel<
+  Fields extends AdminFieldsDescriptorLike,
+  Model extends AdminPageModelLike = AdminPageModelLike,
+> = {
+  readonly addRow: () => Promise<ArrayRowModel<Fields, Model>>
+  readonly row: (index: number) => Promise<ArrayRowModel<Fields, Model>>
+} & BaseFieldModel
+
+type AdminBlockDescriptorLike = {
+  readonly fields: AdminFieldsDescriptorLike
+  readonly slug: string
+}
+
+export type BlockRowModel<
+  Block extends AdminBlockDescriptorLike,
+  Model extends AdminPageModelLike = AdminPageModelLike,
+> = {
+  readonly fields: FieldsModel<Block['fields'], Model>
+  readonly slug: Block['slug']
+  readonly wrapper: Locator
+}
+
+export type BlocksFieldModel<
+  Blocks extends Readonly<Record<string, AdminBlockDescriptorLike>>,
+  Model extends AdminPageModelLike = AdminPageModelLike,
+> = {
+  readonly addBlock: <Slug extends Extract<keyof Blocks, string>>(
+    slug: Slug,
+  ) => Promise<BlockRowModel<Blocks[Slug], Model>>
+  readonly block: <Slug extends Extract<keyof Blocks, string>>(
+    index: number,
+    slug: Slug,
+  ) => Promise<BlockRowModel<Blocks[Slug], Model>>
+} & BaseFieldModel
+
+export type GroupFieldModel<
+  Fields extends AdminFieldsDescriptorLike,
+  Model extends AdminPageModelLike = AdminPageModelLike,
+> = {
+  readonly fields: FieldsModel<Fields, Model>
+} & BaseFieldModel
+
+type RelationshipTarget<Model extends AdminPageModelLike, Descriptor> = Descriptor extends {
+  readonly relationTo: readonly (infer Target extends string)[]
+}
+  ? Extract<Target, CollectionSlug<Model>>
+  : never
+
+type RelationshipDrawerArguments<Descriptor, TargetSlug extends string> = Descriptor extends {
+  readonly relationTo: readonly [string]
+}
+  ? [targetSlug?: TargetSlug]
+  : [targetSlug: TargetSlug]
+
+export type RelationshipFieldModel<Model extends AdminPageModelLike, Descriptor> = {
+  readonly createInDrawer: <
+    TargetSlug extends RelationshipTarget<Model, Descriptor> = RelationshipTarget<
+      Model,
+      Descriptor
+    >,
+  >(
+    ...args: RelationshipDrawerArguments<Descriptor, TargetSlug>
+  ) => Promise<PayloadCollection<Model, TargetSlug>>
+} & BaseFieldModel
+
+type FieldModel<Model extends AdminPageModelLike, Descriptor> = Descriptor extends {
+  readonly hasMany: true
+  readonly type: 'text'
+}
+  ? HasManyTextFieldModel
+  : Descriptor extends { readonly type: 'text' }
+    ? TextFieldModel
+    : Descriptor extends {
+          readonly fields: infer Fields extends AdminFieldsDescriptorLike
+          readonly type: 'array'
+        }
+      ? ArrayFieldModel<Fields, Model>
+      : Descriptor extends {
+            readonly blocks: infer Blocks extends Readonly<Record<string, AdminBlockDescriptorLike>>
+            readonly type: 'blocks'
+          }
+        ? BlocksFieldModel<Blocks, Model>
+        : Descriptor extends {
+              readonly fields: infer Fields extends AdminFieldsDescriptorLike
+              readonly type: 'group'
+            }
+          ? GroupFieldModel<Fields, Model>
+          : Descriptor extends { readonly type: 'relationship' }
+            ? RelationshipFieldModel<Model, Descriptor>
+            : BaseFieldModel
+
+export type FieldsModel<
+  Fields extends AdminFieldsDescriptorLike,
+  Model extends AdminPageModelLike = AdminPageModelLike,
+> = {
+  readonly [FieldName in keyof Fields]: FieldModel<Model, Fields[FieldName]>
+}
+
+export type PayloadCollection<
+  Model extends AdminPageModelLike,
+  Slug extends CollectionSlug<Model>,
+> = {
+  readonly close: () => Promise<void>
+  readonly create: {
+    readonly goto: () => Promise<void>
+    readonly url: string
+  }
+  readonly document: (id: number | string) => {
+    readonly goto: () => Promise<void>
+    readonly url: string
+  }
+  readonly fields: FieldsModel<Model['collections'][Slug]['fields'], Model>
+  readonly list: {
+    readonly goto: () => Promise<void>
+    readonly url: string
+  }
+  readonly save: () => Promise<void>
+  readonly slug: Slug
+}
+
+export type PayloadAdmin<Model extends AdminPageModelLike> = {
+  readonly collection: <Slug extends CollectionSlug<Model>>(
+    slug: Slug,
+  ) => PayloadCollection<Model, Slug>
+}

--- a/test/__helpers/e2e/adminPageModel/runtime.int.spec.ts
+++ b/test/__helpers/e2e/adminPageModel/runtime.int.spec.ts
@@ -1,0 +1,279 @@
+import type { Locator, Page, Response } from '@playwright/test'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import { adminPageModel } from '../../../fields/admin-page-model.generated.js'
+import { formatBlockTypeContext } from './errors.js'
+import { createPayloadAdmin, formatIndexedLocatorContext, selectors } from './index.js'
+
+const createLocator = (): Locator => {
+  return {
+    click: vi.fn(),
+    fill: vi.fn(),
+    innerText: vi.fn().mockResolvedValue('current value'),
+    inputValue: vi.fn().mockResolvedValue('current value'),
+    locator: vi.fn(() => createLocator()),
+    nth: vi.fn(() => createLocator()),
+    press: vi.fn(),
+  } as unknown as Locator
+}
+
+describe('Admin page model selectors', () => {
+  it('creates selectors for scalar and multi-value text controls', () => {
+    expect(selectors.textInput('array.0.texts')).toBe('#field-array__0__texts')
+    expect(selectors.textFieldWrapper('array.0.texts')).toBe(
+      '.field-type.text:has(#field-array__0__texts)',
+    )
+    expect(selectors.hasManyTextControl('array.0.texts')).toBe('.field-array__0__texts')
+    expect(selectors.hasManyTextInput('array.0.texts')).toBe('.field-array__0__texts input')
+  })
+
+  it('creates zero-based list selectors with escaped schema paths', () => {
+    expect(selectors.listHeading('group.value')).toBe('#heading-group__value')
+    expect(selectors.listCell('group.value', 0)).toBe('.row-1 .cell-group__value')
+    expect(selectors.listCell('group.value', 3)).toBe('.row-4 .cell-group__value')
+  })
+
+  it('creates direct array and block selectors', () => {
+    expect(selectors.arrayRows('content.items')).toBe(
+      '#field-content__items > .array-field__draggable-rows > div > .array-field__row',
+    )
+    expect(selectors.arrayAddRow('content.items')).toBe(
+      '#field-content__items > .array-field__add-row',
+    )
+    expect(selectors.blockRows('content.blocks')).toBe(
+      '#field-content__blocks > .blocks-field__rows > div > .blocks-field__row',
+    )
+    expect(selectors.blockDrawerToggler('content.blocks')).toBe(
+      '#field-content__blocks > .blocks-field__drawer-toggler',
+    )
+    expect(selectors.blockTypePill('quote')).toBe('.blocks-field__block-pill-quote')
+  })
+
+  it('creates relationship and document drawer selectors', () => {
+    expect(selectors.relationshipAddButton('items.0.author')).toBe(
+      '#field-items__0__author .relationship-add-new__add-button',
+    )
+    expect(selectors.relationshipTarget('text-fields')).toBe(
+      '.popup__content .relationship-add-new__relation-button--text-fields',
+    )
+    expect(selectors.documentDrawer('text-fields')).toBe('[id^=doc-drawer_text-fields_]')
+  })
+})
+
+describe('formatIndexedLocatorContext', () => {
+  it('reports an empty row collection', () => {
+    expect(
+      formatIndexedLocatorContext({
+        availableCount: 0,
+        collectionSlug: 'text-fields',
+        fieldPath: 'array',
+        index: 5,
+        itemName: 'row',
+        scope: 'document page',
+        selector: '#field-array .array-field__row',
+      }),
+    ).toBe(`Could not resolve row 5 for "array".
+Collection: text-fields
+Scope: document page
+Field path: array
+Selector: #field-array .array-field__row
+Requested index: 5
+Available rows: 0
+Valid indexes: none`)
+  })
+
+  it('reports the valid range for a non-empty block collection', () => {
+    expect(
+      formatIndexedLocatorContext({
+        availableCount: 5,
+        collectionSlug: 'pages',
+        fieldPath: 'layout',
+        index: 7,
+        itemName: 'block',
+        scope: 'document drawer',
+        selector: '#field-layout .blocks-field__row',
+      }),
+    ).toContain(`Could not resolve block 7 for "layout".
+Collection: pages
+Scope: document drawer
+Field path: layout
+Selector: #field-layout .blocks-field__row
+Requested index: 7
+Available blocks: 5
+Valid indexes: 0-4`)
+  })
+
+  it('reports the only valid index when one value exists', () => {
+    expect(
+      formatIndexedLocatorContext({
+        availableCount: 1,
+        collectionSlug: 'text-fields',
+        fieldPath: 'hasMany',
+        index: 1,
+        itemName: 'value',
+        scope: 'document page',
+        selector: '.field-hasMany .multi-value-label__text',
+      }),
+    ).toContain(`Available values: 1
+Valid indexes: 0-0`)
+  })
+
+  it('reports the requested block type and location', () => {
+    expect(
+      formatBlockTypeContext({
+        slug: 'quote',
+        collectionSlug: 'text-fields',
+        fieldPath: 'blocks',
+        index: 0,
+        scope: 'document drawer',
+        selector: '.blocks-field__block-pill-quote',
+      }),
+    ).toBe(`Could not resolve block type "quote" at index 0 for "blocks".
+Collection: text-fields
+Scope: document drawer
+Field path: blocks
+Selector: .blocks-field__block-pill-quote
+Requested block type: quote`)
+  })
+})
+
+describe('createPayloadAdmin', () => {
+  it('provides collection URLs and navigation', async () => {
+    const goto = vi.fn().mockResolvedValue(null)
+    const page = {
+      goto,
+      locator: vi.fn().mockReturnValue(createLocator()),
+    } as unknown as Page
+    const admin = createPayloadAdmin({
+      model: adminPageModel,
+      page,
+      routes: { admin: '/control' },
+      serverURL: 'https://example.com',
+    })
+    const textFields = admin.collection('text-fields')
+
+    expect(textFields.list.url).toBe('https://example.com/control/collections/text-fields')
+    expect(textFields.create.url).toBe('https://example.com/control/collections/text-fields/create')
+    expect(textFields.document('document-id').url).toBe(
+      'https://example.com/control/collections/text-fields/document-id',
+    )
+
+    await textFields.create.goto()
+    await textFields.list.goto()
+    await textFields.document('document-id').goto()
+
+    expect(goto).toHaveBeenNthCalledWith(
+      1,
+      'https://example.com/control/collections/text-fields/create',
+    )
+    expect(goto).toHaveBeenNthCalledWith(2, 'https://example.com/control/collections/text-fields')
+    expect(goto).toHaveBeenNthCalledWith(
+      3,
+      'https://example.com/control/collections/text-fields/document-id',
+    )
+  })
+
+  it('uses generated scalar text selectors and direct locator actions', async () => {
+    const fill = vi.fn()
+    const inputValue = vi.fn().mockResolvedValue('current value')
+    const textInput = {
+      ...createLocator(),
+      fill,
+      inputValue,
+    } as unknown as Locator
+    const root = {
+      goto: vi.fn(),
+      locator: vi.fn((selector: string) => {
+        if (selector === '#field-text') {
+          return textInput
+        }
+
+        return createLocator()
+      }),
+    } as unknown as Page
+    const textField = createPayloadAdmin({
+      model: adminPageModel,
+      page: root,
+      serverURL: 'https://example.com',
+    }).collection('text-fields').fields.text
+
+    expect(textField.inputID).toBe('field-text')
+    expect(textField.selectors).toEqual({
+      input: '#field-text',
+      wrapper: '.field-type.text:has(#field-text)',
+    })
+
+    await textField.fill('next value')
+    await expect(textField.getValue()).resolves.toBe('current value')
+
+    expect(fill).toHaveBeenCalledExactlyOnceWith('next value')
+    expect(inputValue).toHaveBeenCalledOnce()
+  })
+
+  it('does not catch or replace a locator fill error', async () => {
+    const playwrightError = new Error('Playwright fill failed')
+    const fill = vi.fn().mockRejectedValue(playwrightError)
+    const textInput = {
+      ...createLocator(),
+      fill,
+    } as unknown as Locator
+    const page = {
+      goto: vi.fn(),
+      locator: vi.fn((selector: string) => {
+        if (selector === '#field-text') {
+          return textInput
+        }
+
+        return createLocator()
+      }),
+    } as unknown as Page
+    const textField = createPayloadAdmin({
+      model: adminPageModel,
+      page,
+      serverURL: 'https://example.com',
+    }).collection('text-fields').fields.text
+
+    await expect(textField.fill('next value')).rejects.toBe(playwrightError)
+  })
+
+  it('observes failed save responses without matching a similar collection slug', async () => {
+    let responsePredicate: ((response: Response) => boolean | Promise<boolean>) | undefined
+    const saveClickError = new Error('Playwright save click failed')
+    const saveButton = {
+      ...createLocator(),
+      click: vi.fn().mockRejectedValue(saveClickError),
+    } as unknown as Locator
+    const waitForResponse = vi.fn(
+      (predicate: (response: Response) => boolean | Promise<boolean>): Promise<Response> => {
+        responsePredicate = predicate
+        return new Promise(() => undefined)
+      },
+    )
+    const page = {
+      goto: vi.fn(),
+      locator: vi.fn((selector: string) => {
+        return selector === '#action-save' ? saveButton : createLocator()
+      }),
+      waitForResponse,
+    } as unknown as Page
+    const textFields = createPayloadAdmin({
+      model: adminPageModel,
+      page,
+      serverURL: 'https://example.com',
+    }).collection('text-fields')
+    const response = (method: string, pathname: string, ok: boolean) =>
+      ({
+        ok: () => ok,
+        request: () => ({ method: () => method }),
+        url: () => `https://example.com${pathname}`,
+      }) as Response
+
+    await expect(textFields.save()).rejects.toBe(saveClickError)
+    expect(responsePredicate).toBeTypeOf('function')
+    expect(await responsePredicate?.(response('POST', '/api/text-fields', false))).toBe(true)
+    expect(await responsePredicate?.(response('PATCH', '/api/text-fields/123', false))).toBe(true)
+    expect(await responsePredicate?.(response('POST', '/api/text-fields-other', true))).toBe(false)
+    expect(await responsePredicate?.(response('GET', '/api/text-fields', true))).toBe(false)
+  })
+})

--- a/test/__helpers/e2e/adminPageModel/runtimeTypes.ts
+++ b/test/__helpers/e2e/adminPageModel/runtimeTypes.ts
@@ -1,0 +1,48 @@
+import type { Page } from '@playwright/test'
+
+import type { LocatorRoot } from './fields/base.js'
+
+export type RuntimeBlockDescriptor = {
+  readonly fields: RuntimeFieldsDescriptor
+  readonly label: string
+  readonly slug: string
+}
+
+export type RuntimeFieldDescriptor = {
+  readonly blocks?: Readonly<Record<string, RuntimeBlockDescriptor>>
+  readonly fields?: RuntimeFieldsDescriptor
+  readonly hasMany?: boolean
+  readonly path: string
+  readonly relationTo?: readonly string[]
+  readonly type: string
+}
+
+export type RuntimeFieldsDescriptor = Readonly<Record<string, RuntimeFieldDescriptor>>
+
+export type RuntimeCollectionDescriptor = {
+  readonly fields: RuntimeFieldsDescriptor
+  readonly slug: string
+}
+
+export type RuntimeAdminPageModel = {
+  readonly collections: Readonly<Record<string, RuntimeCollectionDescriptor>>
+}
+
+export type FieldsModelContext = {
+  collectionSlug: string
+  instanceParentPath?: string
+  model: RuntimeAdminPageModel
+  page: Page
+  root: LocatorRoot
+  routes?: {
+    admin?: string
+  }
+  schemaParentPath?: string
+  scope: string
+  serverURL: string
+}
+
+export type CreateFieldsModel = (
+  fields: RuntimeFieldsDescriptor,
+  context: FieldsModelContext,
+) => Record<string, unknown>

--- a/test/__helpers/e2e/adminPageModel/selectors.ts
+++ b/test/__helpers/e2e/adminPageModel/selectors.ts
@@ -1,0 +1,53 @@
+const formatFieldPath = (path: string): string => path.replaceAll('.', '__')
+
+export const selectors = {
+  arrayAddRow: (instancePath: string): string => {
+    return `${selectors.fieldWrapper(instancePath)} > .array-field__add-row`
+  },
+  arrayRows: (instancePath: string): string => {
+    return `${selectors.fieldWrapper(instancePath)} > .array-field__draggable-rows > div > .array-field__row`
+  },
+  blockDrawerToggler: (instancePath: string): string => {
+    return `${selectors.fieldWrapper(instancePath)} > .blocks-field__drawer-toggler`
+  },
+  blockRows: (instancePath: string): string => {
+    return `${selectors.fieldWrapper(instancePath)} > .blocks-field__rows > div > .blocks-field__row`
+  },
+  blocksDrawer: '[id^=drawer_][id*=_blocks-drawer-]',
+  blockTypePill: (slug: string): string => {
+    return `.blocks-field__block-pill-${slug}`
+  },
+  documentDrawer: (collectionSlug: string): string => {
+    return `[id^=doc-drawer_${collectionSlug}_]`
+  },
+  fieldWrapper: (instancePath: string): string => {
+    return `#field-${formatFieldPath(instancePath)}`
+  },
+  hasManyTextControl: (instancePath: string): string => {
+    return `.field-${formatFieldPath(instancePath)}`
+  },
+  hasManyTextInput: (instancePath: string): string => {
+    return `${selectors.hasManyTextControl(instancePath)} input`
+  },
+  listCell: (schemaPath: string, rowIndex: number): string => {
+    return `.row-${rowIndex + 1} .cell-${formatFieldPath(schemaPath)}`
+  },
+  listHeading: (schemaPath: string): string => {
+    return `#heading-${formatFieldPath(schemaPath)}`
+  },
+  relationshipAddButton: (instancePath: string): string => {
+    return `${selectors.fieldWrapper(instancePath)} .relationship-add-new__add-button`
+  },
+  relationshipTarget: (collectionSlug: string): string => {
+    return `.popup__content .relationship-add-new__relation-button--${collectionSlug}`
+  },
+  textFieldWrapper: (instancePath: string): string => {
+    return `.field-type.text:has(${selectors.textInput(instancePath)})`
+  },
+  textInput: (instancePath: string): string => {
+    return `#${selectors.textInputID(instancePath)}`
+  },
+  textInputID: (instancePath: string): string => {
+    return `field-${formatFieldPath(instancePath)}`
+  },
+}

--- a/test/__helpers/e2e/adminPageModel/types.spec.ts
+++ b/test/__helpers/e2e/adminPageModel/types.spec.ts
@@ -1,0 +1,108 @@
+import type { Locator } from '@playwright/test'
+
+import { describe, expect, test } from 'tstyche'
+
+import type { adminPageModel } from '../../../fields/admin-page-model.generated.js'
+import type {
+  ArrayRowModel,
+  BlockRowModel,
+  HasManyTextFieldModel,
+  HasManyTextValueModel,
+  PayloadAdmin,
+  PayloadCollection,
+  TextFieldModel,
+} from './index.js'
+
+type FieldsAdminPageModel = typeof adminPageModel
+
+declare const admin: PayloadAdmin<FieldsAdminPageModel>
+
+describe('PayloadAdmin', () => {
+  test('limits collections and fields to the generated descriptor', () => {
+    const textFields = admin.collection('text-fields')
+
+    expect(textFields).type.toBe<PayloadCollection<FieldsAdminPageModel, 'text-fields'>>()
+    expect(textFields.fields.text).type.toBe<TextFieldModel>()
+    expect(textFields.fields.hasMany).type.toBe<HasManyTextFieldModel>()
+    expect(textFields.fields).type.not.toHaveProperty('disableListColumnText')
+    expect(admin.collection).type.not.toBeCallableWith('missing-collection')
+  })
+
+  test('provides raw selectors and high-level scalar text actions', () => {
+    const field = admin.collection('text-fields').fields.text
+
+    expect(field.wrapper).type.toBe<Locator>()
+    expect(field.input).type.toBe<Locator>()
+    expect(field.inputID).type.toBe<string>()
+    expect(field.selectors.wrapper).type.toBe<string>()
+    expect(field.selectors.input).type.toBe<string>()
+    expect(field.fill).type.toBeCallableWith('value')
+    expect(field.getValue()).type.toBe<Promise<string>>()
+    expect(field.expectValue).type.toBeCallableWith('value')
+    expect(field.heading).type.toBe<Locator>()
+    expect(field.cell(0)).type.toBe<Locator>()
+  })
+
+  test('provides multi-value text actions without claiming a stable input ID', () => {
+    const field = admin.collection('text-fields').fields.hasMany
+
+    expect(field).type.not.toHaveProperty('inputID')
+    expect(field.addValue).type.toBeCallableWith('first')
+    expect(field.expectValues).type.toBeCallableWith(['first', 'second'])
+    expect(field.value(0)).type.toBe<Promise<HasManyTextValueModel>>()
+  })
+
+  test('narrows nested array and block fields', async () => {
+    const textFields = admin.collection('text-fields')
+    const arrayRow = await textFields.fields.array.row(0)
+    const addedArrayRow = await textFields.fields.array.addRow()
+    const blockRow = await textFields.fields.blocks.block(0, 'blockWithText')
+    const addedBlockRow = await textFields.fields.blocks.addBlock('blockWithText')
+
+    expect(arrayRow).type.toBe<
+      ArrayRowModel<
+        FieldsAdminPageModel['collections']['text-fields']['fields']['array']['fields'],
+        FieldsAdminPageModel
+      >
+    >()
+    expect(addedArrayRow.fields.texts).type.toBe<HasManyTextFieldModel>()
+    expect(blockRow).type.toBe<
+      BlockRowModel<
+        FieldsAdminPageModel['collections']['text-fields']['fields']['blocks']['blocks']['blockWithText'],
+        FieldsAdminPageModel
+      >
+    >()
+    expect(addedBlockRow.fields.texts).type.toBe<HasManyTextFieldModel>()
+    expect(textFields.fields.blocks.block).type.not.toBeCallableWith(0, 'missing-block')
+    expect(textFields.fields.blocks.addBlock).type.not.toBeCallableWith('missing-block')
+  })
+
+  test('narrows relationship drawer targets', () => {
+    const relationships = admin.collection('relationship-fields')
+
+    expect(relationships.fields.relationship.createInDrawer('text-fields')).type.toBe<
+      Promise<PayloadCollection<FieldsAdminPageModel, 'text-fields'>>
+    >()
+    expect(relationships.fields.relationship.createInDrawer('array-fields')).type.toBe<
+      Promise<PayloadCollection<FieldsAdminPageModel, 'array-fields'>>
+    >()
+    expect(relationships.fields.relationship.createInDrawer).type.not.toBeCallableWith('users')
+    expect(relationships.fields.relationship.createInDrawer).type.not.toBeCallableWith()
+
+    expect(relationships.fields.relationshipDrawer.createInDrawer()).type.toBe<
+      Promise<PayloadCollection<FieldsAdminPageModel, 'text-fields'>>
+    >()
+    expect(relationships.fields.relationshipDrawer.createInDrawer).type.not.toBeCallableWith(
+      'array-fields',
+    )
+  })
+
+  test('preserves the generated model for relationships nested in arrays', async () => {
+    const relationships = admin.collection('relationship-fields')
+    const arrayRow = await relationships.fields.array.row(0)
+
+    expect(arrayRow.fields.relationship.createInDrawer()).type.toBe<
+      Promise<PayloadCollection<FieldsAdminPageModel, 'text-fields'>>
+    >()
+  })
+})

--- a/test/__helpers/e2e/adminPageModel/types.ts
+++ b/test/__helpers/e2e/adminPageModel/types.ts
@@ -1,0 +1,72 @@
+export type AdminFieldState = {
+  disabled: boolean
+  hidden: boolean
+  readOnly: boolean
+}
+
+export type AdminFieldDescriptorBase = {
+  admin?: AdminFieldState
+  hidden?: true
+  path: string
+  required?: true
+  type: string
+}
+
+export type AdminTextFieldDescriptor = {
+  hasMany: boolean
+  type: 'text'
+} & AdminFieldDescriptorBase
+
+export type AdminArrayFieldDescriptor = {
+  fields: AdminFieldsDescriptor
+  type: 'array'
+} & AdminFieldDescriptorBase
+
+export type AdminBlockDescriptor = {
+  fields: AdminFieldsDescriptor
+  label: string
+  slug: string
+}
+
+export type AdminBlocksFieldDescriptor = {
+  blocks: Record<string, AdminBlockDescriptor>
+  type: 'blocks'
+} & AdminFieldDescriptorBase
+
+export type AdminGroupFieldDescriptor = {
+  fields: AdminFieldsDescriptor
+  type: 'group'
+} & AdminFieldDescriptorBase
+
+export type AdminRelationshipFieldDescriptor = {
+  hasMany: boolean
+  relationTo: string[]
+  type: 'relationship'
+} & AdminFieldDescriptorBase
+
+export type AdminUnsupportedFieldDescriptor = {
+  type: Exclude<string, 'array' | 'blocks' | 'group' | 'relationship' | 'text'>
+} & AdminFieldDescriptorBase
+
+export type AdminFieldDescriptor =
+  | AdminArrayFieldDescriptor
+  | AdminBlocksFieldDescriptor
+  | AdminGroupFieldDescriptor
+  | AdminRelationshipFieldDescriptor
+  | AdminTextFieldDescriptor
+  | AdminUnsupportedFieldDescriptor
+
+export type AdminFieldsDescriptor = Record<string, AdminFieldDescriptor>
+
+export type AdminCollectionDescriptor = {
+  fields: AdminFieldsDescriptor
+  slug: string
+}
+
+export type AdminPageModelDescriptor = {
+  collections: Record<string, AdminCollectionDescriptor>
+}
+
+export type CreateAdminPageModelOptions = {
+  collections: readonly string[]
+}

--- a/test/__helpers/e2e/openListDocument.ts
+++ b/test/__helpers/e2e/openListDocument.ts
@@ -1,0 +1,68 @@
+import type { Page } from '@playwright/test'
+
+import { expect } from '@playwright/test'
+
+const listRowsSelector = '.collection-list table > tbody > tr'
+const linkedDocumentSelector = '.cell--linked a'
+
+export type OpenListDocumentArgs = {
+  index?: number
+  page: Page
+}
+
+const formatListDocumentContext = ({
+  availableCount,
+  index,
+  page,
+}: {
+  availableCount: number
+  index: number
+  page: Page
+}): string => {
+  const validIndexes = availableCount === 0 ? 'none' : `0-${availableCount - 1}`
+
+  return [
+    `Could not open list document at index ${index}.`,
+    `Current URL: ${page.url()}`,
+    `List row selector: ${listRowsSelector}`,
+    `Requested index: ${index}`,
+    `Available rows: ${availableCount}`,
+    `Valid indexes: ${validIndexes}`,
+  ].join('\n')
+}
+
+export const openListDocument = async ({
+  index = 0,
+  page,
+}: OpenListDocumentArgs): Promise<void> => {
+  const rows = page.locator(listRowsSelector)
+  const availableCount = await rows.count()
+  const canSelectIndex = Number.isInteger(index) && index >= 0
+  const row = rows.nth(canSelectIndex ? index : availableCount)
+  const context = formatListDocumentContext({ availableCount, index, page })
+
+  await expect(row, context).toHaveCount(1)
+
+  const documentLink = row.locator(linkedDocumentSelector)
+  const availableLinkCount = await documentLink.count()
+
+  await expect(
+    documentLink,
+    [
+      context,
+      `Linked document selector: ${linkedDocumentSelector}`,
+      `Available linked document links in row: ${availableLinkCount}`,
+    ].join('\n'),
+  ).toHaveCount(1)
+
+  const href = await documentLink.getAttribute('href')
+
+  await expect(documentLink, context).toHaveAttribute('href', /.+/)
+
+  const destinationURL = new URL(href as string, page.url()).href
+
+  await documentLink.click()
+  await expect(page, `Expected list document ${index} to open ${destinationURL}.`).toHaveURL(
+    destinationURL,
+  )
+}

--- a/test/fields/admin-page-model.generated.ts
+++ b/test/fields/admin-page-model.generated.ts
@@ -1,0 +1,833 @@
+export const adminPageModel = {
+  collections: {
+    'array-fields': {
+      slug: 'array-fields',
+      fields: {
+        title: {
+          path: 'title',
+          type: 'text',
+          hasMany: false,
+        },
+        items: {
+          path: 'items',
+          required: true,
+          type: 'array',
+          fields: {
+            text: {
+              path: 'items.text',
+              required: true,
+              type: 'text',
+              hasMany: false,
+            },
+            anotherText: {
+              path: 'items.anotherText',
+              type: 'text',
+              hasMany: false,
+            },
+            uiField: {
+              path: 'items.uiField',
+              admin: {
+                disabled: false,
+                hidden: false,
+                readOnly: false,
+              },
+              type: 'ui',
+            },
+            localizedText: {
+              path: 'items.localizedText',
+              type: 'text',
+              hasMany: false,
+            },
+            richTextField: {
+              path: 'items.richTextField',
+              type: 'richText',
+            },
+            subArray: {
+              path: 'items.subArray',
+              type: 'array',
+              fields: {
+                text: {
+                  path: 'items.subArray.text',
+                  type: 'text',
+                  hasMany: false,
+                },
+                textTwo: {
+                  path: 'items.subArray.textTwo',
+                  required: true,
+                  type: 'text',
+                  hasMany: false,
+                },
+                textInRow: {
+                  path: 'items.subArray.textInRow',
+                  required: true,
+                  type: 'text',
+                  hasMany: false,
+                },
+                id: {
+                  path: 'items.subArray.id',
+                  admin: {
+                    disabled: false,
+                    hidden: true,
+                    readOnly: false,
+                  },
+                  type: 'text',
+                  hasMany: false,
+                },
+              },
+            },
+            id: {
+              path: 'items.id',
+              admin: {
+                disabled: false,
+                hidden: true,
+                readOnly: false,
+              },
+              type: 'text',
+              hasMany: false,
+            },
+          },
+        },
+        collapsedArray: {
+          path: 'collapsedArray',
+          type: 'array',
+          fields: {
+            text: {
+              path: 'collapsedArray.text',
+              required: true,
+              type: 'text',
+              hasMany: false,
+            },
+            id: {
+              path: 'collapsedArray.id',
+              admin: {
+                disabled: false,
+                hidden: true,
+                readOnly: false,
+              },
+              type: 'text',
+              hasMany: false,
+            },
+          },
+        },
+        localized: {
+          path: 'localized',
+          required: true,
+          type: 'array',
+          fields: {
+            text: {
+              path: 'localized.text',
+              required: true,
+              type: 'text',
+              hasMany: false,
+            },
+            id: {
+              path: 'localized.id',
+              admin: {
+                disabled: false,
+                hidden: true,
+                readOnly: false,
+              },
+              type: 'text',
+              hasMany: false,
+            },
+          },
+        },
+        readOnly: {
+          path: 'readOnly',
+          admin: {
+            disabled: false,
+            hidden: false,
+            readOnly: true,
+          },
+          type: 'array',
+          fields: {
+            text: {
+              path: 'readOnly.text',
+              type: 'text',
+              hasMany: false,
+            },
+            id: {
+              path: 'readOnly.id',
+              admin: {
+                disabled: false,
+                hidden: true,
+                readOnly: false,
+              },
+              type: 'text',
+              hasMany: false,
+            },
+          },
+        },
+        potentiallyEmptyArray: {
+          path: 'potentiallyEmptyArray',
+          type: 'array',
+          fields: {
+            text: {
+              path: 'potentiallyEmptyArray.text',
+              type: 'text',
+              hasMany: false,
+            },
+            group: {
+              path: 'potentiallyEmptyArray.group',
+              type: 'group',
+              fields: {
+                text: {
+                  path: 'potentiallyEmptyArray.group.text',
+                  type: 'text',
+                  hasMany: false,
+                },
+              },
+            },
+            array: {
+              path: 'potentiallyEmptyArray.array',
+              type: 'array',
+              fields: {
+                text: {
+                  path: 'potentiallyEmptyArray.array.text',
+                  type: 'text',
+                  hasMany: false,
+                },
+                id: {
+                  path: 'potentiallyEmptyArray.array.id',
+                  admin: {
+                    disabled: false,
+                    hidden: true,
+                    readOnly: false,
+                  },
+                  type: 'text',
+                  hasMany: false,
+                },
+              },
+            },
+            id: {
+              path: 'potentiallyEmptyArray.id',
+              admin: {
+                disabled: false,
+                hidden: true,
+                readOnly: false,
+              },
+              type: 'text',
+              hasMany: false,
+            },
+          },
+        },
+        rowLabelAsComponent: {
+          path: 'rowLabelAsComponent',
+          type: 'array',
+          fields: {
+            title: {
+              path: 'rowLabelAsComponent.title',
+              type: 'text',
+              hasMany: false,
+            },
+            id: {
+              path: 'rowLabelAsComponent.id',
+              admin: {
+                disabled: false,
+                hidden: true,
+                readOnly: false,
+              },
+              type: 'text',
+              hasMany: false,
+            },
+          },
+        },
+        arrayWithMinRows: {
+          path: 'arrayWithMinRows',
+          type: 'array',
+          fields: {
+            text: {
+              path: 'arrayWithMinRows.text',
+              type: 'text',
+              hasMany: false,
+            },
+            id: {
+              path: 'arrayWithMinRows.id',
+              admin: {
+                disabled: false,
+                hidden: true,
+                readOnly: false,
+              },
+              type: 'text',
+              hasMany: false,
+            },
+          },
+        },
+        disableSort: {
+          path: 'disableSort',
+          type: 'array',
+          fields: {
+            text: {
+              path: 'disableSort.text',
+              required: true,
+              type: 'text',
+              hasMany: false,
+            },
+            id: {
+              path: 'disableSort.id',
+              admin: {
+                disabled: false,
+                hidden: true,
+                readOnly: false,
+              },
+              type: 'text',
+              hasMany: false,
+            },
+          },
+        },
+        nestedArrayLocalized: {
+          path: 'nestedArrayLocalized',
+          type: 'array',
+          fields: {
+            array: {
+              path: 'nestedArrayLocalized.array',
+              type: 'array',
+              fields: {
+                text: {
+                  path: 'nestedArrayLocalized.array.text',
+                  type: 'text',
+                  hasMany: false,
+                },
+                id: {
+                  path: 'nestedArrayLocalized.array.id',
+                  admin: {
+                    disabled: false,
+                    hidden: true,
+                    readOnly: false,
+                  },
+                  type: 'text',
+                  hasMany: false,
+                },
+              },
+            },
+            id: {
+              path: 'nestedArrayLocalized.id',
+              admin: {
+                disabled: false,
+                hidden: true,
+                readOnly: false,
+              },
+              type: 'text',
+              hasMany: false,
+            },
+          },
+        },
+        externallyUpdatedArray: {
+          path: 'externallyUpdatedArray',
+          type: 'array',
+          fields: {
+            customTextField: {
+              path: 'externallyUpdatedArray.customTextField',
+              admin: {
+                disabled: false,
+                hidden: false,
+                readOnly: false,
+              },
+              type: 'ui',
+            },
+            id: {
+              path: 'externallyUpdatedArray.id',
+              admin: {
+                disabled: false,
+                hidden: true,
+                readOnly: false,
+              },
+              type: 'text',
+              hasMany: false,
+            },
+          },
+        },
+        customArrayField: {
+          path: 'customArrayField',
+          type: 'array',
+          fields: {
+            text: {
+              path: 'customArrayField.text',
+              type: 'text',
+              hasMany: false,
+            },
+            id: {
+              path: 'customArrayField.id',
+              admin: {
+                disabled: false,
+                hidden: true,
+                readOnly: false,
+              },
+              type: 'text',
+              hasMany: false,
+            },
+          },
+        },
+        ui: {
+          path: 'ui',
+          admin: {
+            disabled: false,
+            hidden: false,
+            readOnly: false,
+          },
+          type: 'ui',
+        },
+        arrayWithLabels: {
+          path: 'arrayWithLabels',
+          type: 'array',
+          fields: {
+            text: {
+              path: 'arrayWithLabels.text',
+              type: 'text',
+              hasMany: false,
+            },
+            id: {
+              path: 'arrayWithLabels.id',
+              admin: {
+                disabled: false,
+                hidden: true,
+                readOnly: false,
+              },
+              type: 'text',
+              hasMany: false,
+            },
+          },
+        },
+        arrayWithCustomID: {
+          path: 'arrayWithCustomID',
+          type: 'array',
+          fields: {
+            id: {
+              path: 'arrayWithCustomID.id',
+              admin: {
+                disabled: false,
+                hidden: false,
+                readOnly: false,
+              },
+              type: 'text',
+              hasMany: false,
+            },
+            text: {
+              path: 'arrayWithCustomID.text',
+              type: 'text',
+              hasMany: false,
+            },
+          },
+        },
+        getDataByPathTest: {
+          path: 'getDataByPathTest',
+          admin: {
+            disabled: false,
+            hidden: false,
+            readOnly: false,
+          },
+          type: 'ui',
+        },
+        updatedAt: {
+          path: 'updatedAt',
+          admin: {
+            disabled: false,
+            hidden: true,
+            readOnly: false,
+          },
+          type: 'date',
+        },
+        createdAt: {
+          path: 'createdAt',
+          admin: {
+            disabled: false,
+            hidden: true,
+            readOnly: false,
+          },
+          type: 'date',
+        },
+      },
+    },
+    'relationship-fields': {
+      slug: 'relationship-fields',
+      fields: {
+        text: {
+          path: 'text',
+          type: 'text',
+          hasMany: false,
+        },
+        relationship: {
+          path: 'relationship',
+          required: true,
+          type: 'relationship',
+          hasMany: false,
+          relationTo: ['text-fields', 'array-fields'],
+        },
+        relationHasManyPolymorphic: {
+          path: 'relationHasManyPolymorphic',
+          type: 'relationship',
+          hasMany: true,
+          relationTo: ['text-fields', 'array-fields'],
+        },
+        relationToSelf: {
+          path: 'relationToSelf',
+          type: 'relationship',
+          hasMany: false,
+          relationTo: ['relationship-fields'],
+        },
+        relationToSelfSelectOnly: {
+          path: 'relationToSelfSelectOnly',
+          type: 'relationship',
+          hasMany: false,
+          relationTo: ['relationship-fields'],
+        },
+        relationWithAllowCreateToFalse: {
+          path: 'relationWithAllowCreateToFalse',
+          type: 'relationship',
+          hasMany: false,
+          relationTo: ['users'],
+        },
+        relationWithAllowEditToFalse: {
+          path: 'relationWithAllowEditToFalse',
+          type: 'relationship',
+          hasMany: false,
+          relationTo: ['users'],
+        },
+        relationWithDynamicDefault: {
+          path: 'relationWithDynamicDefault',
+          type: 'relationship',
+          hasMany: false,
+          relationTo: ['users'],
+        },
+        relationHasManyWithDynamicDefault: {
+          path: 'relationHasManyWithDynamicDefault',
+          type: 'relationship',
+          hasMany: false,
+          relationTo: ['users'],
+        },
+        relationshipWithMin: {
+          path: 'relationshipWithMin',
+          type: 'relationship',
+          hasMany: true,
+          relationTo: ['text-fields'],
+        },
+        relationshipWithMax: {
+          path: 'relationshipWithMax',
+          type: 'relationship',
+          hasMany: true,
+          relationTo: ['text-fields'],
+        },
+        relationshipHasMany: {
+          path: 'relationshipHasMany',
+          type: 'relationship',
+          hasMany: true,
+          relationTo: ['text-fields'],
+        },
+        array: {
+          path: 'array',
+          type: 'array',
+          fields: {
+            relationship: {
+              path: 'array.relationship',
+              type: 'relationship',
+              hasMany: false,
+              relationTo: ['text-fields'],
+            },
+            id: {
+              path: 'array.id',
+              admin: {
+                disabled: false,
+                hidden: true,
+                readOnly: false,
+              },
+              type: 'text',
+              hasMany: false,
+            },
+          },
+        },
+        relationshipWithMinRows: {
+          path: 'relationshipWithMinRows',
+          type: 'relationship',
+          hasMany: true,
+          relationTo: ['text-fields'],
+        },
+        relationToRow: {
+          path: 'relationToRow',
+          type: 'relationship',
+          hasMany: false,
+          relationTo: ['row-fields'],
+        },
+        relationToRowMany: {
+          path: 'relationToRowMany',
+          type: 'relationship',
+          hasMany: true,
+          relationTo: ['row-fields'],
+        },
+        relationshipDrawer: {
+          path: 'relationshipDrawer',
+          type: 'relationship',
+          hasMany: false,
+          relationTo: ['text-fields'],
+        },
+        relationshipDrawerReadOnly: {
+          path: 'relationshipDrawerReadOnly',
+          admin: {
+            disabled: false,
+            hidden: false,
+            readOnly: true,
+          },
+          type: 'relationship',
+          hasMany: false,
+          relationTo: ['text-fields'],
+        },
+        polymorphicRelationshipDrawer: {
+          path: 'polymorphicRelationshipDrawer',
+          type: 'relationship',
+          hasMany: false,
+          relationTo: ['text-fields', 'array-fields'],
+        },
+        relationshipDrawerHasMany: {
+          path: 'relationshipDrawerHasMany',
+          type: 'relationship',
+          hasMany: true,
+          relationTo: ['text-fields'],
+        },
+        relationshipDrawerHasManyPolymorphic: {
+          path: 'relationshipDrawerHasManyPolymorphic',
+          type: 'relationship',
+          hasMany: true,
+          relationTo: ['text-fields', 'array-fields'],
+        },
+        relationshipDrawerWithAllowCreateFalse: {
+          path: 'relationshipDrawerWithAllowCreateFalse',
+          type: 'relationship',
+          hasMany: false,
+          relationTo: ['text-fields'],
+        },
+        relationshipDrawerWithFilterOptions: {
+          path: 'relationshipDrawerWithFilterOptions',
+          type: 'relationship',
+          hasMany: false,
+          relationTo: ['text-fields'],
+        },
+        updatedAt: {
+          path: 'updatedAt',
+          admin: {
+            disabled: false,
+            hidden: true,
+            readOnly: false,
+          },
+          type: 'date',
+        },
+        createdAt: {
+          path: 'createdAt',
+          admin: {
+            disabled: false,
+            hidden: true,
+            readOnly: false,
+          },
+          type: 'date',
+        },
+      },
+    },
+    'text-fields': {
+      slug: 'text-fields',
+      fields: {
+        text: {
+          path: 'text',
+          required: true,
+          type: 'text',
+          hasMany: false,
+        },
+        hiddenTextField: {
+          path: 'hiddenTextField',
+          hidden: true,
+          type: 'text',
+          hasMany: false,
+        },
+        adminHiddenTextField: {
+          path: 'adminHiddenTextField',
+          admin: {
+            disabled: false,
+            hidden: true,
+            readOnly: false,
+          },
+          type: 'text',
+          hasMany: false,
+        },
+        disabledTextField: {
+          path: 'disabledTextField',
+          admin: {
+            disabled: true,
+            hidden: false,
+            readOnly: false,
+          },
+          type: 'text',
+          hasMany: false,
+        },
+        localizedText: {
+          path: 'localizedText',
+          type: 'text',
+          hasMany: false,
+        },
+        localizedRequiredText: {
+          path: 'localizedRequiredText',
+          required: true,
+          type: 'text',
+          hasMany: false,
+        },
+        i18nText: {
+          path: 'i18nText',
+          type: 'text',
+          hasMany: false,
+        },
+        defaultString: {
+          path: 'defaultString',
+          type: 'text',
+          hasMany: false,
+        },
+        defaultEmptyString: {
+          path: 'defaultEmptyString',
+          type: 'text',
+          hasMany: false,
+        },
+        defaultFunction: {
+          path: 'defaultFunction',
+          type: 'text',
+          hasMany: false,
+        },
+        defaultAsync: {
+          path: 'defaultAsync',
+          type: 'text',
+          hasMany: false,
+        },
+        overrideLength: {
+          path: 'overrideLength',
+          type: 'text',
+          hasMany: false,
+        },
+        fieldWithDefaultValue: {
+          path: 'fieldWithDefaultValue',
+          type: 'text',
+          hasMany: false,
+        },
+        dependentOnFieldWithDefaultValue: {
+          path: 'dependentOnFieldWithDefaultValue',
+          type: 'text',
+          hasMany: false,
+        },
+        hasMany: {
+          path: 'hasMany',
+          type: 'text',
+          hasMany: true,
+        },
+        hasManySecond: {
+          path: 'hasManySecond',
+          type: 'text',
+          hasMany: true,
+        },
+        readOnlyHasMany: {
+          path: 'readOnlyHasMany',
+          admin: {
+            disabled: false,
+            hidden: false,
+            readOnly: true,
+          },
+          type: 'text',
+          hasMany: true,
+        },
+        validatesHasMany: {
+          path: 'validatesHasMany',
+          type: 'text',
+          hasMany: true,
+        },
+        localizedHasMany: {
+          path: 'localizedHasMany',
+          type: 'text',
+          hasMany: true,
+        },
+        withMinRows: {
+          path: 'withMinRows',
+          type: 'text',
+          hasMany: true,
+        },
+        withMaxRows: {
+          path: 'withMaxRows',
+          type: 'text',
+          hasMany: true,
+        },
+        defaultValueFromReq: {
+          path: 'defaultValueFromReq',
+          type: 'text',
+          hasMany: false,
+        },
+        array: {
+          path: 'array',
+          type: 'array',
+          fields: {
+            texts: {
+              path: 'array.texts',
+              type: 'text',
+              hasMany: true,
+            },
+            id: {
+              path: 'array.id',
+              admin: {
+                disabled: false,
+                hidden: true,
+                readOnly: false,
+              },
+              type: 'text',
+              hasMany: false,
+            },
+          },
+        },
+        blocks: {
+          path: 'blocks',
+          type: 'blocks',
+          blocks: {
+            blockWithText: {
+              slug: 'blockWithText',
+              fields: {
+                texts: {
+                  path: 'blocks.texts',
+                  type: 'text',
+                  hasMany: true,
+                },
+                id: {
+                  path: 'blocks.id',
+                  admin: {
+                    disabled: false,
+                    hidden: true,
+                    readOnly: false,
+                  },
+                  type: 'text',
+                  hasMany: false,
+                },
+                blockName: {
+                  path: 'blocks.blockName',
+                  admin: {
+                    disabled: true,
+                    hidden: false,
+                    readOnly: false,
+                  },
+                  type: 'text',
+                  hasMany: false,
+                },
+              },
+              label: 'Block With Text',
+            },
+          },
+        },
+        updatedAt: {
+          path: 'updatedAt',
+          admin: {
+            disabled: false,
+            hidden: true,
+            readOnly: false,
+          },
+          type: 'date',
+        },
+        createdAt: {
+          path: 'createdAt',
+          admin: {
+            disabled: false,
+            hidden: true,
+            readOnly: false,
+          },
+          type: 'date',
+        },
+      },
+    },
+  },
+} as const

--- a/test/fields/adminPageModel.int.spec.ts
+++ b/test/fields/adminPageModel.int.spec.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+
+import { createAdminPageModelDescriptor } from '../__helpers/e2e/adminPageModel/generate.js'
+import { adminPageModel } from './admin-page-model.generated.js'
+import config from './config.js'
+
+describe('fields Admin page model', () => {
+  it('matches the current evaluated configuration', async () => {
+    const sanitizedConfig = await config
+    const currentDescriptor = createAdminPageModelDescriptor(sanitizedConfig, {
+      collections: ['array-fields', 'relationship-fields', 'text-fields'],
+    })
+
+    expect(adminPageModel).toEqual(currentDescriptor)
+  })
+})

--- a/test/fields/collections/Relationship/e2e.spec.ts
+++ b/test/fields/collections/Relationship/e2e.spec.ts
@@ -5,9 +5,11 @@ import path from 'path'
 import { wait } from 'payload/shared'
 import { fileURLToPath } from 'url'
 
+import type { PayloadCollection } from '../../../__helpers/e2e/adminPageModel/index.js'
 import type { PayloadTestSDK } from '../../../__helpers/shared/sdk/index.js'
 import type { Config, RelationshipField, TextField } from '../../payload-types.js'
 
+import { createPayloadAdmin } from '../../../__helpers/e2e/adminPageModel/index.js'
 import { checkFocusIndicators } from '../../../__helpers/e2e/checkFocusIndicators.js'
 import { openCreateDocDrawer } from '../../../__helpers/e2e/fields/relationship/openCreateDocDrawer.js'
 import { addListFilter, openListFilters } from '../../../__helpers/e2e/filters/index.js'
@@ -32,6 +34,7 @@ import { initPayloadE2ENoConfig } from '../../../__helpers/shared/initPayloadE2E
 import { ensureCompilationIsDone } from '../../../__setup/e2e/ensureCompilationIsDone.js'
 import { initPage } from '../../../__setup/e2e/initPage.js'
 import { POLL_TOPASS_TIMEOUT, TEST_TIMEOUT_LONG } from '../../../playwright.config.js'
+import { adminPageModel } from '../../admin-page-model.generated.js'
 import { relationshipFieldsSlug, textFieldsSlug } from '../../slugs.js'
 
 const filename = fileURLToPath(import.meta.url)
@@ -42,6 +45,7 @@ const { beforeAll, beforeEach, describe } = test
 
 let payload: PayloadTestSDK<Config>
 let page: Page
+let relationshipFields: PayloadCollection<typeof adminPageModel, 'relationship-fields'>
 let serverURL: string
 // If we want to make this run in parallel: test.describe.configure({ mode: 'parallel' })
 
@@ -54,6 +58,9 @@ describe('relationship', () => {
 
     const context = await browser.newContext()
     ;({ page } = await initPage({ context, serverURL }))
+    relationshipFields = createPayloadAdmin({ model: adminPageModel, page, serverURL }).collection(
+      'relationship-fields',
+    )
   })
   beforeEach(async () => {
     await reInitializeDB({
@@ -96,6 +103,42 @@ describe('relationship', () => {
     ).toContainText(textValue)
     await page.locator('#action-save').click()
     await expect(page.locator('.payload-toast-container')).toContainText('successfully')
+  })
+
+  test('should create nested text data in a relationship drawer', async () => {
+    await relationshipFields.create.goto()
+
+    const textDrawer = await relationshipFields.fields.relationship.createInDrawer('text-fields')
+    await textDrawer.fields.text.fill('Drawer nested text')
+    await textDrawer.fields.text.expectValue('Drawer nested text')
+
+    const arrayRow = await textDrawer.fields.array.addRow()
+    await arrayRow.fields.texts.addValue('Drawer array text')
+
+    const blockRow = await textDrawer.fields.blocks.addBlock('blockWithText')
+    await blockRow.fields.texts.addValue('Drawer block text')
+
+    await textDrawer.save()
+    await textDrawer.close()
+
+    await expect(
+      relationshipFields.fields.relationship.wrapper.locator('.relationship--single-value__text'),
+    ).toContainText('Drawer nested text')
+
+    await relationshipFields.save()
+
+    const result = await payload.find({
+      collection: textFieldsSlug,
+      where: {
+        text: {
+          equals: 'Drawer nested text',
+        },
+      },
+    })
+    const textDocument = result.docs[0]
+
+    expect(textDocument?.array?.[0]?.texts).toEqual(['Drawer array text'])
+    expect(textDocument?.blocks?.[0]?.texts).toEqual(['Drawer block text'])
   })
 
   test('should save correct relationTo when creating doc in second collection (bug #14728)', async () => {

--- a/test/fields/collections/Text/e2e.spec.ts
+++ b/test/fields/collections/Text/e2e.spec.ts
@@ -5,10 +5,10 @@ import path from 'path'
 import { wait } from 'payload/shared'
 import { fileURLToPath } from 'url'
 
-import type { PayloadTestSDK } from '../../../__helpers/shared/sdk/index.js'
-import type { GeneratedTypes } from '../../../__helpers/shared/sdk/types.js'
-import type { Config } from '../../payload-types.js'
+import type { PayloadCollection } from '../../../__helpers/e2e/adminPageModel/index.js'
+import type { Config, TextField } from '../../payload-types.js'
 
+import { createPayloadAdmin } from '../../../__helpers/e2e/adminPageModel/index.js'
 import {
   getColumnSelectorItem,
   openListColumns,
@@ -16,15 +16,15 @@ import {
 } from '../../../__helpers/e2e/columns/index.js'
 import { addListFilter } from '../../../__helpers/e2e/filters/index.js'
 import { exactText, saveDocAndAssert, selectTableRow } from '../../../__helpers/e2e/helpers.js'
-import { upsertPreferences } from '../../../__helpers/e2e/preferences.js'
+import { openListDocument } from '../../../__helpers/e2e/openListDocument.js'
 import { runAxeScan } from '../../../__helpers/e2e/runAxeScan.js'
-import { AdminUrlUtil } from '../../../__helpers/shared/adminUrlUtil.js'
 import { reInitializeDB } from '../../../__helpers/shared/clearAndSeed/reInitializeDB.js'
 import { initPayloadE2ENoConfig } from '../../../__helpers/shared/initPayloadE2ENoConfig.js'
 import { RESTClient } from '../../../__helpers/shared/rest.js'
 import { ensureCompilationIsDone } from '../../../__setup/e2e/ensureCompilationIsDone.js'
 import { initPage } from '../../../__setup/e2e/initPage.js'
 import { TEST_TIMEOUT_LONG } from '../../../playwright.config.js'
+import { adminPageModel } from '../../admin-page-model.generated.js'
 import { textFieldsSlug } from '../../slugs.js'
 import { textDoc } from './shared.js'
 
@@ -34,24 +34,25 @@ const dirname = path.resolve(currentFolder, '../../')
 
 const { beforeAll, beforeEach, describe } = test
 
-let payload: PayloadTestSDK<Config>
 let client: RESTClient
 let page: Page
 let serverURL: string
+let textFields: PayloadCollection<typeof adminPageModel, 'text-fields'>
 // If we want to make this run in parallel: test.describe.configure({ mode: 'parallel' })
-let url: AdminUrlUtil
 
 describe('Text', () => {
   beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(TEST_TIMEOUT_LONG)
-    ;({ payload, serverURL } = await initPayloadE2ENoConfig<Config>({
+    ;({ serverURL } = await initPayloadE2ENoConfig<Config>({
       dirname,
       // prebuild,
     }))
-    url = new AdminUrlUtil(serverURL, textFieldsSlug)
 
     const context = await browser.newContext()
     ;({ page } = await initPage({ context, serverURL }))
+    textFields = createPayloadAdmin({ model: adminPageModel, page, serverURL }).collection(
+      'text-fields',
+    )
   })
   beforeEach(async () => {
     await reInitializeDB({
@@ -69,11 +70,11 @@ describe('Text', () => {
 
   describe('hidden and disabled fields', () => {
     test('should not render top-level hidden fields in the UI', async () => {
-      await page.goto(url.create)
-      await expect(page.locator('#field-hiddenTextField')).toBeHidden()
-      await page.goto(url.list)
-      await expect(page.locator('.cell-hiddenTextField')).toBeHidden()
-      await expect(page.locator('#heading-hiddenTextField')).toBeHidden()
+      await textFields.create.goto()
+      await expect(textFields.fields.hiddenTextField.input).toBeHidden()
+      await textFields.list.goto()
+      await expect(textFields.fields.hiddenTextField.cell(0)).toBeHidden()
+      await expect(textFields.fields.hiddenTextField.heading).toBeHidden()
 
       const { columnContainer } = await openListColumns(page, {})
 
@@ -93,11 +94,11 @@ describe('Text', () => {
     })
 
     test('should not show disabled fields in the UI', async () => {
-      await page.goto(url.create)
-      await expect(page.locator('#field-disabledTextField')).toHaveCount(0)
-      await page.goto(url.list)
-      await expect(page.locator('.cell-disabledTextField')).toBeHidden()
-      await expect(page.locator('#heading-disabledTextField')).toBeHidden()
+      await textFields.create.goto()
+      await expect(textFields.fields.disabledTextField.input).toHaveCount(0)
+      await textFields.list.goto()
+      await expect(textFields.fields.disabledTextField.cell(0)).toBeHidden()
+      await expect(textFields.fields.disabledTextField.heading).toBeHidden()
 
       const { columnContainer } = await openListColumns(page, {})
 
@@ -119,11 +120,11 @@ describe('Text', () => {
     })
 
     test('should render hidden input for admin.hidden fields', async () => {
-      await page.goto(url.create)
-      await expect(page.locator('#field-adminHiddenTextField')).toHaveAttribute('type', 'hidden')
-      await page.goto(url.list)
-      await expect(page.locator('.cell-adminHiddenTextField').first()).toBeVisible()
-      await expect(page.locator('#heading-adminHiddenTextField')).toBeVisible()
+      await textFields.create.goto()
+      await expect(textFields.fields.adminHiddenTextField.input).toHaveAttribute('type', 'hidden')
+      await textFields.list.goto()
+      await expect(textFields.fields.adminHiddenTextField.cell(0).first()).toBeVisible()
+      await expect(textFields.fields.adminHiddenTextField.heading).toBeVisible()
 
       const { columnContainer } = await openListColumns(page, {})
 
@@ -143,45 +144,119 @@ describe('Text', () => {
     })
 
     test('hidden and disabled fields should not break subsequent field paths', async () => {
-      await page.goto(url.create)
+      await textFields.create.goto()
       await expect(page.locator('#custom-field-schema-path')).toHaveText('text-fields._index-4')
     })
   })
 
   test('should display field in list view', async () => {
-    await page.goto(url.list)
-    const textCell = page.locator('.row-1 .cell-text')
-    await expect(textCell).toHaveText(textDoc.text)
+    await textFields.list.goto()
+    await expect(textFields.fields.text.cell(0)).toHaveText(textDoc.text)
   })
 
-  test('should respect admin.disableListColumn despite preferences', async () => {
-    await upsertPreferences<Config, GeneratedTypes<any>>({
-      key: 'text-fields-list',
-      payload,
-      user: client.user,
-      value: {
-        columns: [
-          {
-            accessor: 'disableListColumnText',
-            active: true,
-          },
-        ],
-      },
+  test('should open the first list document by default and accept an index', async () => {
+    await textFields.list.goto()
+
+    const rows = page.locator('table > tbody > tr')
+    const firstDocumentID = await rows.nth(0).getAttribute('data-id')
+    const secondDocumentID = await rows.nth(1).getAttribute('data-id')
+
+    if (firstDocumentID === null || secondDocumentID === null) {
+      throw new Error('Expected both list rows to include a document ID.')
+    }
+
+    await openListDocument({ page })
+    await expect(page).toHaveURL(textFields.document(firstDocumentID).url)
+
+    await textFields.list.goto()
+    await openListDocument({ index: 1, page })
+    await expect(page).toHaveURL(textFields.document(secondDocumentID).url)
+  })
+
+  test('should report context for an out-of-range list document', async () => {
+    await textFields.list.goto()
+
+    let listDocumentError: unknown
+
+    try {
+      await openListDocument({ index: 5, page })
+    } catch (error) {
+      listDocumentError = error
+    }
+
+    expect(listDocumentError).toBeInstanceOf(Error)
+
+    const message = (listDocumentError as Error).message
+
+    expect(message).toContain('toHaveCount')
+    expect(message).toContain('Locator:')
+    expect(message).toContain('Expected:')
+    expect(message).toContain('Received:')
+    expect(message).toContain('Call log:')
+    expect(message).toContain('Could not open list document at index 5.')
+    expect(message).toContain('Available rows: 2')
+    expect(message).toContain('Valid indexes: 0-1')
+  })
+
+  test('should report context for an out-of-range array row', async () => {
+    await textFields.create.goto()
+
+    let rowError: unknown
+
+    try {
+      await textFields.fields.array.row(5)
+    } catch (error) {
+      rowError = error
+    }
+
+    expect(rowError).toBeInstanceOf(Error)
+
+    const message = (rowError as Error).message
+
+    expect(message).toContain('toHaveCount')
+    expect(message).toContain('Locator:')
+    expect(message).toContain('Expected:')
+    expect(message).toContain('Received:')
+    expect(message).toContain('Call log:')
+    expect(message).toContain('Could not resolve row 5 for "array".')
+    expect(message).toContain('Collection: text-fields')
+    expect(message).toContain('Scope: document page')
+    expect(message).toContain('Field path: array')
+    expect(message).toContain('Available rows: 0')
+    expect(message).toContain('Valid indexes: none')
+  })
+
+  test('should edit nested text values in an array and block', async () => {
+    await textFields.create.goto()
+    await textFields.fields.text.fill('Nested text document')
+    await textFields.fields.text.expectValue('Nested text document')
+
+    const arrayRow = await textFields.fields.array.addRow()
+    await arrayRow.fields.texts.addValue('Array text')
+
+    const blockRow = await textFields.fields.blocks.addBlock('blockWithText')
+    await blockRow.fields.texts.addValue('Block text')
+
+    await saveDocAndAssert(page)
+
+    const documentID = page.url().split('/').at(-1)
+    if (!documentID) {
+      throw new Error('Expected the saved document URL to include a document ID.')
+    }
+
+    const { doc } = await client.findByID<TextField>({
+      id: documentID,
+      slug: textFieldsSlug,
+      auth: true,
     })
 
-    await page.goto(url.list)
-    await openListColumns(page, {})
-    await expect(
-      getColumnSelectorItem({ container: page, label: 'Disable List Column Text' }),
-    ).toBeHidden()
-
-    await expect(page.locator('#heading-disableListColumnText')).toBeHidden()
-    await expect(page.locator('table .row-1 .cell-disableListColumnText')).toBeHidden()
+    expect(doc.array?.[0]?.texts).toEqual(['Array text'])
+    expect(doc.blocks?.[0]?.texts).toEqual(['Block text'])
   })
 
   test('should display i18n label in cells when missing field data', async () => {
-    await page.goto(url.list)
-    await page.waitForURL(new RegExp(`${url.list}.*\\?.*`))
+    await textFields.list.goto()
+    await page.waitForURL(new RegExp(`${textFields.list.url}.*\\?.*`))
 
     await toggleColumn(page, {
       columnLabel: 'Text en',
@@ -189,89 +264,72 @@ describe('Text', () => {
       targetState: 'on',
     })
 
-    const textCell = page.locator('.row-1 .cell-i18nText')
-
-    await expect(textCell).toHaveText('<No Text en>')
+    await expect(textFields.fields.i18nText.cell(0)).toHaveText('<No Text en>')
   })
 
   test('should show i18n label', async () => {
-    await page.goto(url.create)
+    await textFields.create.goto()
 
-    await expect(page.locator('label[for="field-i18nText"]')).toHaveText('Text en')
+    await expect(
+      textFields.fields.i18nText.wrapper.locator(
+        `label[for="${textFields.fields.i18nText.inputID}"]`,
+      ),
+    ).toHaveText('Text en')
   })
 
   test('should show i18n placeholder', async () => {
-    await page.goto(url.create)
-    await expect(page.locator('#field-i18nText')).toHaveAttribute('placeholder', 'en placeholder')
+    await textFields.create.goto()
+    await expect(textFields.fields.i18nText.input).toHaveAttribute('placeholder', 'en placeholder')
   })
 
   test('should show i18n descriptions', async () => {
-    await page.goto(url.create)
-    const description = page.locator('.field-description-i18nText')
-    await expect(description).toHaveText('en description')
+    await textFields.create.goto()
+    await expect(textFields.fields.i18nText.wrapper.locator('.field-description')).toHaveText(
+      'en description',
+    )
   })
 
   test('should create hasMany with multiple texts', async () => {
     const input = 'five'
     const furtherInput = 'six'
 
-    await page.goto(url.create)
-    const requiredField = page.locator('#field-text')
-    const field = page.locator('.field-hasMany')
-
-    await requiredField.fill(String(input))
-    await field.click()
-    await page.keyboard.type(input)
-    await page.keyboard.press('Enter')
-    await page.keyboard.type(furtherInput)
-    await page.keyboard.press('Enter')
+    await textFields.create.goto()
+    await textFields.fields.text.fill(input)
+    await textFields.fields.hasMany.addValue(input)
+    await textFields.fields.hasMany.addValue(furtherInput)
     await saveDocAndAssert(page)
-    await expect(field.locator('.rs__value-container')).toContainText(input)
-    await expect(field.locator('.rs__value-container')).toContainText(furtherInput)
+    await textFields.fields.hasMany.expectValues([input, furtherInput])
   })
 
   test('should allow editing hasMany text field values by clicking', async () => {
     const originalText = 'original'
     const newText = 'new'
 
-    await page.goto(url.create)
+    await textFields.create.goto()
+    await textFields.fields.text.fill(originalText)
+    await textFields.fields.hasMany.addValue(originalText)
 
-    // fill required field
-    const requiredField = page.locator('#field-text')
-    await requiredField.fill(String(originalText))
-
-    const field = page.locator('.field-hasMany')
-
-    // Add initial value
-    await field.click()
-    await page.keyboard.type(originalText)
-    await page.keyboard.press('Enter')
-
-    // Click to edit existing value
-    const value = field.locator('.multi-value-label__text')
-    await value.click()
-    await value.dblclick()
-    await page.keyboard.type(newText)
-    await page.keyboard.press('Enter')
+    const value = await textFields.fields.hasMany.value(0)
+    await value.fill(newText)
 
     await saveDocAndAssert(page)
-    await expect(field.locator('.rs__value-container')).toContainText(`${newText}`)
+    await textFields.fields.hasMany.expectValues([newText])
   })
 
   test('should not allow editing hasMany text field values when disabled', async () => {
-    await page.goto(url.create)
-    const field = page.locator('.field-readOnlyHasMany')
+    await textFields.create.goto()
+    const field = textFields.fields.readOnlyHasMany
+    const value = await field.value(0)
 
     // Try to click to edit
-    const value = field.locator('.multi-value-label__text')
-    await value.click({ force: true })
+    await value.wrapper.click({ force: true })
 
     // Verify it does not become editable
-    await expect(field.locator('.multi-value-label__text')).not.toHaveClass(/.*--editable/)
+    await expect(value.wrapper).not.toHaveClass(/.*--editable/)
   })
 
   test('should filter Text field hasMany: false in the collection list view - in', async () => {
-    await page.goto(url.list)
+    await textFields.list.goto()
     await expect(page.locator('table >> tbody >> tr')).toHaveCount(2)
 
     await addListFilter({
@@ -286,7 +344,7 @@ describe('Text', () => {
   })
 
   test('should filter Text field hasMany: false in the collection list view - is not in', async () => {
-    await page.goto(url.list)
+    await textFields.list.goto()
     await expect(page.locator('table >> tbody >> tr')).toHaveCount(2)
 
     await addListFilter({
@@ -301,7 +359,7 @@ describe('Text', () => {
   })
 
   test('should filter Text field hasMany: true in the collection list view - in', async () => {
-    await page.goto(url.list)
+    await textFields.list.goto()
     await expect(page.locator('table >> tbody >> tr')).toHaveCount(2)
 
     await addListFilter({
@@ -316,7 +374,7 @@ describe('Text', () => {
   })
 
   test('should filter Text field hasMany: true in the collection list view - is not in', async () => {
-    await page.goto(url.list)
+    await textFields.list.goto()
     await expect(page.locator('table >> tbody >> tr')).toHaveCount(2)
 
     await addListFilter({
@@ -331,7 +389,7 @@ describe('Text', () => {
   })
 
   test('should filter Text field hasMany: true in the collection list view - contains single value', async () => {
-    await page.goto(url.list)
+    await textFields.list.goto()
     await expect(page.locator('table >> tbody >> tr')).toHaveCount(2)
 
     await addListFilter({
@@ -346,7 +404,7 @@ describe('Text', () => {
   })
 
   test('should filter Text field hasMany: true in the collection list view - contains multiple values', async () => {
-    await page.goto(url.list)
+    await textFields.list.goto()
     await expect(page.locator('table >> tbody >> tr')).toHaveCount(2)
 
     // Add filter with first value
@@ -369,8 +427,8 @@ describe('Text', () => {
 
   describe.skip('A11y', () => {
     test.fixme('Edit view should have no accessibility violations', async ({}, testInfo) => {
-      await page.goto(url.create)
-      await page.locator('#field-text').waitFor()
+      await textFields.create.goto()
+      await textFields.fields.text.input.waitFor()
 
       const scanResults = await runAxeScan({
         exclude: ['[id*="react-select-"]'], // ignore react-select elements here

--- a/test/fields/generateAdminPageModel.ts
+++ b/test/fields/generateAdminPageModel.ts
@@ -1,0 +1,27 @@
+import { writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { format, resolveConfig } from 'prettier'
+
+import { createAdminPageModelSource } from '../__helpers/e2e/adminPageModel/generate.js'
+import config from './config.js'
+
+const filename = fileURLToPath(import.meta.url)
+const dirname = path.dirname(filename)
+const outputFile = path.resolve(dirname, 'admin-page-model.generated.ts')
+const sanitizedConfig = await config
+const prettierConfig = await resolveConfig(outputFile)
+
+const source = await format(
+  createAdminPageModelSource(sanitizedConfig, {
+    collections: ['array-fields', 'relationship-fields', 'text-fields'],
+  }),
+  {
+    ...prettierConfig,
+    filepath: outputFile,
+  },
+)
+
+await writeFile(outputFile, source)
+
+process.stdout.write(`Admin page model written to ${outputFile}\n`)


### PR DESCRIPTION
This PR adds a type-safe Playwright page model for Payload Admin E2E tests.

### What?

The fields test suite can now generate a page-model descriptor from its evaluated Payload configuration. Tests receive collection, field, array, block, and relationship target suggestions from TypeScript.

The Text suite uses the new model as the first migration. A relationship test also covers nested editing inside a document drawer.

### Why?

Field tests currently repeat selectors and manually connect them to Payload field paths. This makes deeply nested tests harder to read and permits invalid field and block names.

The page model keeps the schema relationship visible in test code. It also adds useful context to failed indexed lookups without replacing Playwright error details.

### How?

- Generate a serializable Admin page-model descriptor from `SanitizedConfig`.
- Map literal collection, field, block, and relationship names into typed Playwright helpers.
- Scope drawer models to their drawer root so nested selectors cannot match the parent document.
- Keep raw locators, selector strings, and stable input IDs available for lower-level assertions.
- Provide an independent `openListDocument()` helper with a zero-based index that defaults to the first row.

### Before

```ts
await page.goto(url.create)
await page.locator('#field-text').fill('Example')

await page.locator('#field-array > .array-field__add-row').click()
await page.locator('#field-array__0__texts input').fill('Array value')
```

### After

```ts
await textFields.create.goto()
await textFields.fields.text.fill('Example')

const row = await textFields.fields.array.addRow()
await row.fields.texts.addValue('Array value')
```

Direct document navigation remains unchanged:

```ts
await textFields.document(documentID).goto()
```

List navigation can open a displayed document without first reading its ID:

```ts
await textFields.list.goto()
await openListDocument({ page })
await openListDocument({ index: 2, page })
```

### Testing

- 16 runtime and generation tests passed.
- Six TSTyche tests passed with 32 assertions.
- Five focused Text E2E page-model tests passed after the final rebase.
- The nested relationship-drawer E2E test passed after the final rebase.
- Prettier and focused ESLint checks passed.
- Repeated generation produced identical output.

The full SQLite Text run reported the existing `hasMany not_in` filter failure. The expected row count is one, but SQLite returns two. This filter behaviour is outside this PR.

Written with AI
