### PR TITLE
docs: adds first batch of v4 ui component docs

### DIFF
--- a/docs/ui-components/animate-height.mdx
+++ b/docs/ui-components/animate-height.mdx
@@ -1,0 +1,43 @@
+---
+title: AnimateHeight
+label: Animate Height
+order: 20
+desc: Animate content between collapsed and expanded heights with Payload's AnimateHeight component.
+keywords: ui, component, animate height, collapse, expand, transition
+---
+
+The `AnimateHeight` component animates its children between a collapsed height and their natural height. It is useful when building disclosure controls and expandable regions.
+
+## Import
+
+Inside a Payload Admin Panel Custom Component:
+
+```tsx
+import { AnimateHeight } from '@payloadcms/ui'
+```
+
+You can also import the component directly:
+
+```tsx
+import { AnimateHeight } from '@payloadcms/ui/elements/AnimateHeight'
+```
+
+## Interactive example
+
+<ComponentPreview component="AnimateHeight" example="interactive" />
+
+The control that changes `height` remains your responsibility. Give that control an accessible label and expose its expanded state with `aria-expanded` when it controls a disclosure region.
+
+## Common props
+
+These are the props most commonly used with this component. See its exported types in `@payloadcms/ui` for the complete list.
+
+| Prop          | Type               | Default | Description                                     |
+| ------------- | ------------------ | ------- | ----------------------------------------------- |
+| `children` \* | `ReactNode`        | —       | Content whose height is animated.               |
+| `height`      | `number \| 'auto'` | —       | Target height. Use `0` to collapse the content. |
+| `duration`    | `number`           | `300`   | Animation duration in milliseconds.             |
+| `id`          | `string`           | —       | Sets the wrapper element ID.                    |
+| `className`   | `string`           | —       | Adds a class to the wrapper element.            |
+
+_\* An asterisk denotes that a prop is required._

--- a/docs/ui-components/animate-height.mdx
+++ b/docs/ui-components/animate-height.mdx
@@ -32,12 +32,12 @@ The control that changes `height` remains your responsibility. Give that control
 
 These are the props most commonly used with this component. See its exported types in `@payloadcms/ui` for the complete list.
 
-| Prop          | Type               | Default | Description                                     |
-| ------------- | ------------------ | ------- | ----------------------------------------------- |
-| `children` \* | `ReactNode`        | —       | Content whose height is animated.               |
-| `height`      | `number \| 'auto'` | —       | Target height. Use `0` to collapse the content. |
-| `duration`    | `number`           | `300`   | Animation duration in milliseconds.             |
-| `id`          | `string`           | —       | Sets the wrapper element ID.                    |
-| `className`   | `string`           | —       | Adds a class to the wrapper element.            |
+| Prop          | Type          | Default | Description                                  |
+| ------------- | ------------- | ------- | -------------------------------------------- |
+| `children` \* | `ReactNode`   | —       | Content whose height is animated.            |
+| `height`      | `0 \| 'auto'` | —       | Uses `0` to collapse and `'auto'` to expand. |
+| `duration`    | `number`      | `300`   | Animation duration in milliseconds.          |
+| `id`          | `string`      | —       | Sets the wrapper element ID.                 |
+| `className`   | `string`      | —       | Adds a class to the wrapper element.         |
 
 _\* An asterisk denotes that a prop is required._

--- a/docs/ui-components/banner.mdx
+++ b/docs/ui-components/banner.mdx
@@ -1,0 +1,54 @@
+---
+title: Banner
+label: Banner
+order: 30
+desc: Display contextual information and status messages with Payload's Banner component.
+keywords: ui, component, banner, notice, status, message
+---
+
+The `Banner` component displays a short message that needs more emphasis than surrounding content. Use its type to communicate the purpose of the message.
+
+## Import
+
+Inside a Payload Admin Panel Custom Component:
+
+```tsx
+import { Banner } from '@payloadcms/ui'
+```
+
+You can also import the component directly:
+
+```tsx
+import { Banner } from '@payloadcms/ui/elements/Banner'
+```
+
+## Basic usage
+
+<ComponentPreview component="Banner" example="basic" />
+
+## Types
+
+Use `brand` for product context, `success` to confirm an action, `warning` to flag a risk, and `danger` when something failed. Use the default type for neutral messages.
+
+<ComponentPreview component="Banner" example="variants" />
+
+Keep banner copy concise and include the next action when the user must resolve something.
+
+## Accessibility
+
+- Use text that communicates the message without relying on color alone.
+- Include an icon only when it reinforces the meaning of the message.
+- Keep actionable banners keyboard accessible and give their action a clear purpose.
+
+## Common props
+
+These are the props most commonly used with this component. See its exported types in `@payloadcms/ui` for the complete list.
+
+| Prop        | Type                                                         | Default     | Description                                 |
+| ----------- | ------------------------------------------------------------ | ----------- | ------------------------------------------- |
+| `children`  | `ReactNode`                                                  | —           | Message displayed inside the banner.        |
+| `type`      | `'default' \| 'brand' \| 'success' \| 'warning' \| 'danger'` | `'default'` | Sets the message style.                     |
+| `icon`      | `ReactNode`                                                  | —           | Displays an icon beside the message.        |
+| `alignIcon` | `'left' \| 'right'`                                          | `'left'`    | Positions the icon.                         |
+| `onClick`   | `(event: MouseEvent) => void`                                | —           | Makes the banner actionable.                |
+| `to`        | `string`                                                     | —           | Makes the banner navigate to the given URL. |

--- a/docs/ui-components/button.mdx
+++ b/docs/ui-components/button.mdx
@@ -1,0 +1,73 @@
+---
+title: Button
+label: Button
+order: 40
+desc: Use Payload's Button component for actions and navigation in Admin Panel Custom Components.
+keywords: ui, component, button, action, link, loading, disabled
+---
+
+The `Button` component lets a user perform an action or navigate to another location. Use its style to communicate the importance and consequence of the action.
+
+## Import
+
+Inside a Payload Admin Panel Custom Component:
+
+```tsx
+import { Button } from '@payloadcms/ui'
+```
+
+You can also import the component directly:
+
+```tsx
+import { Button } from '@payloadcms/ui/elements/Button'
+```
+
+## Basic usage
+
+Use a primary button for the main action in a section or view.
+
+<ComponentPreview component="Button" example="primary" />
+
+## Styles
+
+Use `secondary` for supporting actions. Use `destructive` when an action is destructive or difficult to reverse. The `dashed`, `ghost`, and `pill` variants provide lower-emphasis treatments for controls that need them.
+
+<ComponentPreview component="Button" example="styles" />
+
+Avoid placing multiple primary buttons next to one another. When actions have equal emphasis, use secondary buttons instead.
+
+## Disabled state
+
+Use `disabled` when an action is temporarily unavailable. When possible, explain what the user must do before the action becomes available.
+
+<ComponentPreview component="Button" example="disabled" />
+
+## Sizes
+
+Buttons support `medium` and `large` sizes. Use `medium` unless the surrounding interface establishes the larger size.
+
+<ComponentPreview component="Button" example="sizes" />
+
+## Accessibility
+
+- Use a short, action-oriented label that describes what happens next.
+- Provide `aria-label` when an icon-only button has no visible label.
+- Do not rely on color alone to explain a destructive or disabled action.
+- Use `type="submit"` only when the button submits its containing form.
+- Use a link-style button for navigation rather than handling navigation in `onClick`.
+
+## Common props
+
+These are the props most commonly used with this component. See its exported types in `@payloadcms/ui` for the complete list.
+
+| Prop          | Type                                                                         | Default     | Description                                                   |
+| ------------- | ---------------------------------------------------------------------------- | ----------- | ------------------------------------------------------------- |
+| `buttonStyle` | `'primary' \| 'secondary' \| 'destructive' \| 'dashed' \| 'ghost' \| 'pill'` | `'primary'` | Sets the visual emphasis.                                     |
+| `children`    | `ReactNode`                                                                  | —           | Visible button content.                                       |
+| `disabled`    | `boolean`                                                                    | `false`     | Prevents interaction.                                         |
+| `loading`     | `boolean`                                                                    | `false`     | Shows a spinner, hides the content, and prevents interaction. |
+| `margin`      | `boolean`                                                                    | `true`      | Applies the default outer margin.                             |
+| `round`       | `boolean`                                                                    | `false`     | Gives an icon button equal width and height.                  |
+| `selected`    | `boolean`                                                                    | `false`     | Applies the active treatment to supported variants.           |
+| `size`        | `'medium' \| 'large'`                                                        | `'medium'`  | Sets the button height and spacing.                           |
+| `type`        | `'button' \| 'submit'`                                                       | `'button'`  | Sets the native button type.                                  |

--- a/docs/ui-components/card.mdx
+++ b/docs/ui-components/card.mdx
@@ -1,0 +1,50 @@
+---
+title: Card
+label: Card
+order: 50
+desc: Group a title and related actions with Payload's Card component.
+keywords: ui, component, card, action, navigation
+---
+
+The `Card` component groups a title with optional actions. It can also make the entire surface interactive.
+
+## Import
+
+Inside a Payload Admin Panel Custom Component:
+
+```tsx
+import { Card } from '@payloadcms/ui'
+```
+
+You can also import the component directly:
+
+```tsx
+import { Card } from '@payloadcms/ui/elements/Card'
+```
+
+## Basic usage
+
+<ComponentPreview component="Card" example="basic" />
+
+## Actions
+
+Use the `actions` prop for controls that act on the card without activating the full card surface.
+
+<ComponentPreview component="Card" example="actions" />
+
+When using `href` or `onClick`, provide `buttonAriaLabel` so the full-card control has an accessible name. Give controls passed to `actions` their own accessible names.
+
+## Common props
+
+These are the props most commonly used with this component. See its exported types in `@payloadcms/ui` for the complete list.
+
+| Prop              | Type          | Default | Description                                     |
+| ----------------- | ------------- | ------- | ----------------------------------------------- |
+| `title` \*        | `string`      | —       | Visible card title.                             |
+| `titleAs`         | `ElementType` | `'div'` | Sets the element used for the title.            |
+| `actions`         | `ReactNode`   | —       | Displays controls on the trailing edge.         |
+| `href`            | `string`      | —       | Makes the full card navigate to the given path. |
+| `onClick`         | `() => void`  | —       | Makes the full card perform an action.          |
+| `buttonAriaLabel` | `string`      | —       | Labels the full-card interactive control.       |
+
+_\* An asterisk denotes that a prop is required._

--- a/docs/ui-components/collapsible.mdx
+++ b/docs/ui-components/collapsible.mdx
@@ -1,0 +1,54 @@
+---
+title: Collapsible
+label: Collapsible
+order: 70
+desc: Show and hide a section of content with Payload's Collapsible component.
+keywords: ui, component, collapsible, disclosure, accordion
+---
+
+The `Collapsible` component groups content beneath a header that can be expanded or collapsed. It manages its own state by default and can also be controlled by a parent component.
+
+## Import
+
+Inside a Payload Admin Panel Custom Component:
+
+```tsx
+import { Collapsible } from '@payloadcms/ui'
+```
+
+You can also import the component directly:
+
+```tsx
+import { Collapsible } from '@payloadcms/ui/elements/Collapsible'
+```
+
+## Basic usage
+
+<ComponentPreview component="Collapsible" example="basic" />
+
+Use a concise header that describes the hidden content. The entire header is used as the toggle target unless `disableHeaderToggle` is enabled.
+
+## Error state
+
+<ComponentPreview component="Collapsible" example="error" />
+
+Use the `error` style when the section contains invalid fields that require attention.
+
+## Common props
+
+These are the props most commonly used with this component. See its exported types in `@payloadcms/ui` for the complete list.
+
+| Prop                     | Type                                            | Default     | Description                                            |
+| ------------------------ | ----------------------------------------------- | ----------- | ------------------------------------------------------ |
+| `children` \*            | `ReactNode`                                     | —           | Content displayed inside the collapsible section.      |
+| `header`                 | `ReactNode`                                     | —           | Content displayed in the section header.               |
+| `actions`                | `ReactNode`                                     | —           | Displays controls on the trailing edge of the header.  |
+| `collapsibleStyle`       | `'default' \| 'error'`                          | `'default'` | Sets the visual state.                                 |
+| `initCollapsed`          | `boolean`                                       | `false`     | Sets the initial uncontrolled state.                   |
+| `isCollapsed`            | `boolean`                                       | —           | Controls the collapsed state from a parent component.  |
+| `onToggle`               | `(collapsed: boolean) => Promise<void> \| void` | —           | Runs when the section is toggled.                      |
+| `disableHeaderToggle`    | `boolean`                                       | `false`     | Prevents the header from toggling the section.         |
+| `disableToggleIndicator` | `boolean`                                       | `false`     | Hides the trailing chevron.                            |
+| `AfterCollapsible`       | `ReactNode`                                     | —           | Renders content after the collapsible content wrapper. |
+
+_\* An asterisk denotes that a prop is required._

--- a/docs/ui-components/copy-to-clipboard.mdx
+++ b/docs/ui-components/copy-to-clipboard.mdx
@@ -1,0 +1,45 @@
+---
+title: CopyToClipboard
+label: CopyToClipboard
+order: 80
+desc: Copy a string to the clipboard with Payload's CopyToClipboard component.
+keywords: ui, component, clipboard, copy, tooltip
+---
+
+The `CopyToClipboard` component renders a compact copy control with tooltip feedback. Use it beside values such as IDs, URLs, and API keys.
+
+## Import
+
+Inside a Payload Admin Panel Custom Component:
+
+```tsx
+import { CopyToClipboard } from '@payloadcms/ui'
+```
+
+You can also import the component directly:
+
+```tsx
+import { CopyToClipboard } from '@payloadcms/ui/elements/CopyToClipboard'
+```
+
+## Basic usage
+
+<ComponentPreview component="CopyToClipboard" example="basic" />
+
+The control is not rendered when `value` is empty. Provide surrounding text so users understand what will be copied.
+
+## Accessibility
+
+- Place the control beside a visible representation of the value being copied.
+- Use concise tooltip messages that identify the action and confirm success.
+- Do not place sensitive values in the clipboard without an explicit user action.
+
+## Common props
+
+These are the props most commonly used with this component. See its exported types in `@payloadcms/ui` for the complete list.
+
+| Prop             | Type     | Default                | Description                               |
+| ---------------- | -------- | ---------------------- | ----------------------------------------- |
+| `value`          | `string` | —                      | Value written to the clipboard.           |
+| `defaultMessage` | `string` | Localized copy label   | Tooltip shown before the value is copied. |
+| `successMessage` | `string` | Localized copied label | Tooltip shown after a successful copy.    |

--- a/docs/ui-components/date-picker.mdx
+++ b/docs/ui-components/date-picker.mdx
@@ -1,0 +1,65 @@
+---
+title: DatePicker
+label: DatePicker
+order: 90
+desc: Select dates and times with Payload's DatePicker component.
+keywords: ui, component, date, time, calendar, picker
+---
+
+The `DatePicker` component wraps `react-datepicker` with Payload's styles, localization, and date and time display options.
+
+## Import
+
+Inside a Payload Admin Panel Custom Component:
+
+```tsx
+import { DatePicker } from '@payloadcms/ui'
+```
+
+## Basic usage
+
+<ComponentPreview component="DatePicker" example="basic" />
+
+Pair the picker with a visible label. `id` is applied to the picker's wrapper element, not to the underlying input, so pass the input ID through `overrides` and point the label's `htmlFor` at that value:
+
+```tsx
+<label htmlFor="publish-date-input">Publish date</label>
+<DatePicker
+  onChange={setValue}
+  overrides={{ id: 'publish-date-input' }}
+  value={value}
+/>
+```
+
+The Admin Panel supplies the translation context that DatePicker uses for its calendar labels.
+
+## Picker appearances
+
+Use `pickerAppearance` to choose between a date, date and time, day, month, or time input. Payload selects a matching display format when `displayFormat` is not provided.
+
+| Appearance   | Input                  |
+| ------------ | ---------------------- |
+| `default`    | Calendar date          |
+| `dayAndTime` | Calendar date and time |
+| `dayOnly`    | Day and month          |
+| `monthOnly`  | Month                  |
+| `timeOnly`   | Time                   |
+
+## Common props
+
+These are the props most commonly used with this component. See its exported types in `@payloadcms/ui` for the complete list.
+
+| Prop               | Type                                                                  | Default     | Description                                      |
+| ------------------ | --------------------------------------------------------------------- | ----------- | ------------------------------------------------ |
+| `id`               | `string`                                                              | —           | Sets the ID of the picker's wrapper element.     |
+| `value`            | `Date \| string`                                                      | —           | Selected date or date string.                    |
+| `onChange`         | `(value: Date) => void`                                               | —           | Runs when the selected value changes.            |
+| `placeholder`      | `string`                                                              | —           | Displays text when no value is selected.         |
+| `pickerAppearance` | `'default' \| 'dayAndTime' \| 'dayOnly' \| 'monthOnly' \| 'timeOnly'` | `'default'` | Selects the date and time controls shown.        |
+| `displayFormat`    | `string`                                                              | Automatic   | Overrides the date-fns display format.           |
+| `minDate`          | `Date`                                                                | —           | Sets the earliest selectable date.               |
+| `maxDate`          | `Date`                                                                | —           | Sets the latest selectable date.                 |
+| `monthsToShow`     | `1 \| 2`                                                              | `1`         | Sets the number of visible calendar months.      |
+| `timeIntervals`    | `number`                                                              | `30`        | Sets the number of minutes between time options. |
+| `readOnly`         | `boolean`                                                             | `false`     | Prevents the value from being changed.           |
+| `overrides`        | `ReactDatePickerProps`                                                | —           | Passes supported options to `react-datepicker`.  |

--- a/docs/ui-components/error-pill.mdx
+++ b/docs/ui-components/error-pill.mdx
@@ -1,0 +1,43 @@
+---
+title: ErrorPill
+label: ErrorPill
+order: 110
+desc: Display a compact validation error count with Payload's ErrorPill component.
+keywords: ui, component, error, validation, count, pill
+---
+
+The `ErrorPill` component displays the number of validation errors associated with a field or group of fields. It returns `null` when the count is zero.
+
+## Import
+
+Inside a Payload Admin Panel Custom Component:
+
+```tsx
+import { ErrorPill, useTranslation } from '@payloadcms/ui'
+```
+
+You can also import the component directly:
+
+```tsx
+import { ErrorPill } from '@payloadcms/ui/elements/ErrorPill'
+import { useTranslation } from '@payloadcms/ui/providers/Translation'
+```
+
+## Counts
+
+<ComponentPreview component="ErrorPill" example="counts" />
+
+Pass the `i18n` object from `useTranslation`. Add `withMessage` when the count needs a localized “error” or “errors” label.
+
+## Common props
+
+These are the props most commonly used with this component. See its exported types in `@payloadcms/ui` for the complete list.
+
+| Prop          | Type         | Default | Description                                      |
+| ------------- | ------------ | ------- | ------------------------------------------------ |
+| `count` \*    | `number`     | —       | Number of errors. Renders nothing when set to 0. |
+| `i18n` \*     | `I18nClient` | —       | Supplies localized error labels.                 |
+| `withMessage` | `boolean`    | `false` | Displays “error” or “errors” after the count.    |
+| `className`   | `string`     | —       | Adds a custom class to the element.              |
+
+_\* An asterisk denotes that a prop is required._

--- a/docs/ui-components/gutter.mdx
+++ b/docs/ui-components/gutter.mdx
@@ -1,0 +1,44 @@
+---
+title: Gutter
+label: Gutter
+order: 120
+desc: Align content to Payload's horizontal Admin Panel gutters.
+keywords: ui, component, gutter, layout, spacing
+---
+
+The `Gutter` component applies the standard horizontal spacing used by Payload views. Use it to align custom view content with the surrounding Admin Panel.
+
+## Import
+
+Inside a Payload Admin Panel Custom Component:
+
+```tsx
+import { Gutter } from '@payloadcms/ui'
+```
+
+You can also import the component directly:
+
+```tsx
+import { Gutter } from '@payloadcms/ui/elements/Gutter'
+```
+
+## Basic usage
+
+<ComponentPreview component="Gutter" example="basic" />
+
+Left and right padding are enabled by default. Negative gutters let a child extend through spacing already applied by a parent layout.
+
+## Common props
+
+These are the props most commonly used with this component. See its exported types in `@payloadcms/ui` for the complete list.
+
+| Prop            | Type        | Default | Description                           |
+| --------------- | ----------- | ------- | ------------------------------------- |
+| `children` \*   | `ReactNode` | —       | Content positioned within the gutter. |
+| `left`          | `boolean`   | `true`  | Applies the standard left padding.    |
+| `right`         | `boolean`   | `true`  | Applies the standard right padding.   |
+| `negativeLeft`  | `boolean`   | `false` | Applies a negative left margin.       |
+| `negativeRight` | `boolean`   | `false` | Applies a negative right margin.      |
+| `className`     | `string`    | —       | Adds a custom class to the wrapper.   |
+
+_\* An asterisk denotes that a prop is required._

--- a/docs/ui-components/link.mdx
+++ b/docs/ui-components/link.mdx
@@ -1,0 +1,47 @@
+---
+title: Link
+label: Link
+order: 140
+desc: Navigate within the Payload Admin Panel using Payload's router-aware Link component.
+keywords: ui, component, link, navigation, router
+---
+
+The `Link` component uses Payload's router adapter and route-transition state. Use it for links between Admin Panel routes.
+
+## Import
+
+Inside a Payload Admin Panel Custom Component:
+
+```tsx
+import { Link } from '@payloadcms/ui'
+```
+
+You can also import the component directly:
+
+```tsx
+import { Link } from '@payloadcms/ui/elements/Link'
+```
+
+## Basic usage
+
+<ComponentPreview component="Link" example="basic" />
+
+`Link` supplies navigation behavior but does not add visual styling. Pass a `className` when the link needs its own visual treatment.
+
+The Admin Panel supplies the router and route-transition contexts used by the component.
+
+## Common props
+
+These are the props most commonly used with this component. See its exported types in `@payloadcms/ui` for the complete list.
+
+| Prop             | Type                | Default | Description                                                |
+| ---------------- | ------------------- | ------- | ---------------------------------------------------------- |
+| `href` \*        | `string`            | —       | Destination passed to Payload's router adapter.            |
+| `replace`        | `boolean`           | `false` | Replaces the current history entry instead of adding one.  |
+| `scroll`         | `boolean`           | `true`  | Controls whether navigation scrolls to the new page.       |
+| `prefetch`       | `boolean`           | —       | Controls route prefetching when the adapter supports it.   |
+| `preventDefault` | `boolean`           | `true`  | Lets Payload manage navigation and route-transition state. |
+| `forceReload`    | `boolean`           | `false` | Uses a hard browser navigation instead of client routing.  |
+| `onClick`        | `MouseEventHandler` | —       | Runs before navigation begins.                             |
+
+_\* An asterisk denotes that a prop is required._

--- a/docs/ui-components/list-and-pagination-controls.mdx
+++ b/docs/ui-components/list-and-pagination-controls.mdx
@@ -1,0 +1,93 @@
+---
+title: List and Pagination Controls
+label: List and Pagination Controls
+order: 150
+desc: Add pagination, page-size, sorting, and selection controls to Payload Admin lists.
+keywords: ui, components, list, pagination, per page, sorting, selection
+---
+
+Payload's list controls support paginated data, page-size selection, sorting, and row selection. Use standalone controls for custom data views and provider-backed controls when extending an existing Admin list.
+
+## Import
+
+Inside a Payload Admin Panel Custom Component:
+
+```tsx
+import {
+  Pagination,
+  PerPage,
+  SelectAll,
+  SelectMany,
+  SelectRow,
+  SortColumn,
+  SortHeader,
+  SortRow,
+} from '@payloadcms/ui'
+```
+
+## Pagination
+
+<ComponentPreview component="ListAndPagination" example="pagination" />
+
+`Pagination` is controlled. It renders previous and next controls alongside an editable page input. Pass the current page metadata and update your query or local state from `onChange`.
+
+The input accepts a page between `1` and `totalPages`. Press <kbd>Enter</kbd> or move focus away to apply the value, and press <kbd>Escape</kbd> to restore the current page.
+
+## Page size
+
+`PerPage` displays a compact selector for the number of rows shown on each page.
+
+```tsx
+const [limit, setLimit] = useState(10)
+
+<PerPage handleChange={setLimit} limit={limit} limits={[10, 25, 50, 100]} />
+```
+
+Reset the current page when changing the limit if the new page size would make that page invalid.
+
+## Sorting
+
+- `SortColumn` renders ascending and descending controls for a named column.
+- `SortHeader` switches an orderable list to its configured order field.
+- `SortRow` renders the drag handle used by an actively orderable list.
+
+These controls read and update Payload's `ListQuery` context. Use them inside an Admin list or a custom view that provides the same list-query state.
+
+## Selection
+
+- `SelectAll` toggles selection for the current list.
+- `SelectRow` toggles one row and respects document locking.
+- `SelectMany` renders an action pill for the current selection.
+
+Selection controls require Payload's selection context. `SelectRow` also reads the authenticated user to determine whether a locked row can be selected.
+
+## Common props
+
+These are the props most commonly used. See the exported types in `@payloadcms/ui` for the complete list.
+
+### Pagination props
+
+| Prop          | Type                     | Default | Description                                     |
+| ------------- | ------------------------ | ------- | ----------------------------------------------- |
+| `page`        | `number`                 | `1`     | Sets the current page.                          |
+| `totalPages`  | `number`                 | `1`     | Sets the total page count.                      |
+| `hasNextPage` | `boolean`                | `false` | Enables the next-page control.                  |
+| `hasPrevPage` | `boolean`                | `false` | Enables the previous-page control.              |
+| `nextPage`    | `number`                 | —       | Sets the page selected by the next control.     |
+| `prevPage`    | `number`                 | —       | Sets the page selected by the previous control. |
+| `onChange`    | `(page: number) => void` | —       | Runs when the user selects a different page.    |
+
+### PerPage props
+
+| Prop           | Type                      | Default | Description                                      |
+| -------------- | ------------------------- | ------- | ------------------------------------------------ |
+| `limit` \*     | `number`                  | —       | Sets the selected page size.                     |
+| `limits` \*    | `number[]`                | —       | Sets the available page sizes.                   |
+| `defaultLimit` | `number`                  | `10`    | Provides a fallback when `limit` is not numeric. |
+| `handleChange` | `(limit: number) => void` | —       | Runs when the user chooses a new page size.      |
+
+_\* An asterisk denotes that a prop is required._
+
+## Internal list wrappers
+
+`PageControls` and `PageControlsComponent` are exported for Payload's own list views but are marked internal. For Custom Components, compose `Pagination` and `PerPage` unless you are intentionally extending Payload's existing list-query implementation.

--- a/docs/ui-components/motion-and-loading.mdx
+++ b/docs/ui-components/motion-and-loading.mdx
@@ -1,0 +1,88 @@
+---
+title: Motion and Loading
+label: Motion and Loading
+order: 170
+desc: Communicate loading and layout changes with Payload's motion and loading components.
+keywords: ui, components, loading, overlay, shimmer, progress, animation
+---
+
+Payload's loading components communicate that work is in progress, while its motion helpers make layout changes easier to follow.
+
+## Import
+
+Inside a Payload Admin Panel Custom Component:
+
+```tsx
+import {
+  AnimateHeight,
+  FormLoadingOverlayToggle,
+  LoadingOverlay,
+  LoadingOverlayToggle,
+  ProgressBar,
+  ShimmerEffect,
+  StaggeredShimmers,
+} from '@payloadcms/ui'
+```
+
+## Loading overlay
+
+<ComponentPreview component="MotionAndLoading" example="overlay" />
+
+`LoadingOverlay` renders a spinner and backdrop directly. Use `LoadingOverlayToggle` inside the Admin Panel to update Payload's shared loading overlay instead.
+
+`FormLoadingOverlayToggle` connects that shared overlay to a Payload form's loading and processing states. It must be rendered inside the Admin Panel's form and loading providers.
+
+## Staggered shimmers
+
+<ComponentPreview component="MotionAndLoading" example="staggered" />
+
+Use `ShimmerEffect` for one placeholder or `StaggeredShimmers` for a repeated set. Match their dimensions to the content they temporarily replace to reduce layout movement.
+
+## Route progress
+
+<ComponentPreview component="MotionAndLoading" example="progress" />
+
+`ProgressBar` displays progress for transitions started within `RouteTransitionProvider`. Payload's `Link` component starts this transition automatically. Use `startRouteTransition` from `useRouteTransition` when navigation begins from another control.
+
+The preview simulates a brief route transition so the delayed progress indicator remains visible long enough to inspect.
+
+## Other helpers
+
+- [`AnimateHeight`](./animate-height) animates a container when its content changes height.
+- [`ShimmerEffect`](./shimmer-effect) documents the single-placeholder API in more detail.
+
+## Common props
+
+These are the props most commonly used. See the exported types in `@payloadcms/ui` for the complete list.
+
+### LoadingOverlay
+
+| Prop                | Type      | Default   | Description                                      |
+| ------------------- | --------- | --------- | ------------------------------------------------ |
+| `show`              | `boolean` | `true`    | Selects the entering or exiting animation state. |
+| `animationDuration` | `string`  | `'500ms'` | Sets the CSS animation duration.                 |
+| `overlayType`       | `string`  | —         | Adds a type modifier to the overlay.             |
+
+### LoadingOverlayToggle
+
+| Prop      | Type                           | Default        | Description                                   |
+| --------- | ------------------------------ | -------------- | --------------------------------------------- |
+| `name` \* | `string`                       | —              | Identifies this source in the shared overlay. |
+| `show` \* | `boolean`                      | —              | Adds or removes this source's loading state.  |
+| `type`    | `'fullscreen' \| 'withoutNav'` | `'fullscreen'` | Selects the shared overlay layout.            |
+
+### StaggeredShimmers
+
+| Prop           | Type               | Default | Description                                      |
+| -------------- | ------------------ | ------- | ------------------------------------------------ |
+| `count` \*     | `number`           | —       | Sets the number of shimmer placeholders.         |
+| `height`       | `number \| string` | —       | Sets each placeholder's height.                  |
+| `width`        | `number \| string` | —       | Sets each placeholder's width.                   |
+| `renderDelay`  | `number`           | `500`   | Delays rendering to avoid flashing on fast work. |
+| `shimmerDelay` | `number \| string` | `25`    | Staggers the animation between placeholders.     |
+
+_\* An asterisk denotes that a prop is required._
+
+## Accessibility
+
+Loading visuals should accompany, not replace, meaningful status text. Prevent interaction when an action cannot safely continue, and keep the loading state visible only while work is actually pending.

--- a/docs/ui-components/overview.mdx
+++ b/docs/ui-components/overview.mdx
@@ -1,0 +1,147 @@
+---
+title: UI Components
+label: Overview
+order: 10
+desc: Use the React components that power the Payload Admin Panel in your own Custom Components.
+keywords: ui, components, react, admin panel, custom components, payload ui
+---
+
+The `@payloadcms/ui` package contains the React components used throughout the Payload Admin Panel. You can use these components to build Custom Components that match the surrounding Admin Panel interface and behavior.
+
+Each component guide includes working examples for the selected version of Payload, common props, accessibility guidance, and any providers or setup the component requires.
+
+## Components
+
+<CardGroup variant="compact">
+  <Card
+    title="AnimateHeight"
+    description="Animate a container as its content changes height."
+    link="./animate-height"
+  />
+  <Card
+    title="Banner"
+    description="Display contextual notices, warnings, and errors."
+    link="./banner"
+  />
+  <Card
+    title="Button"
+    description="Trigger actions with Payload's standard button styles."
+    link="./button"
+  />
+  <Card
+    title="Card"
+    description="Present a title with optional actions or full-surface interaction."
+    link="./card"
+  />
+  <Card
+    title="Collapsible"
+    description="Show and hide a section beneath a collapsible header."
+    link="./collapsible"
+  />
+  <Card
+    title="CopyToClipboard"
+    description="Copy text to the clipboard with built-in feedback."
+    link="./copy-to-clipboard"
+  />
+  <Card
+    title="DatePicker"
+    description="Select dates and times with Payload's styled calendar control."
+    link="./date-picker"
+  />
+  <Card
+    title="ErrorPill"
+    description="Display a compact, localized validation error count."
+    link="./error-pill"
+  />
+  <Card
+    title="Gutter"
+    description="Align content with the Admin Panel's responsive gutters."
+    link="./gutter"
+  />
+  <Card
+    title="Link"
+    description="Navigate between Admin routes through Payload's router adapter."
+    link="./link"
+  />
+  <Card
+    title="List and Pagination Controls"
+    description="Navigate paginated data and compose common Admin list controls."
+    link="./list-and-pagination-controls"
+  />
+  <Card
+    title="Motion and Loading"
+    description="Communicate loading and route transitions with Payload's motion helpers."
+    link="./motion-and-loading"
+  />
+  <Card
+    title="Pill"
+    description="Display compact metadata, categories, and statuses."
+    link="./pill"
+  />
+  <Card
+    title="PillSelector"
+    description="Select, deselect, and optionally reorder compact options."
+    link="./pill-selector"
+  />
+  <Card
+    title="ReactSelect"
+    description="Select one or more options with Payload's react-select adapter."
+    link="./react-select"
+  />
+  <Card
+    title="ShimmerEffect"
+    description="Show a loading placeholder while content resolves."
+    link="./shimmer-effect"
+  />
+</CardGroup>
+
+<Banner type="warning">
+  UI component APIs can change between major versions of Payload. Use the
+  version selector to view examples that match the version installed in your
+  project.
+</Banner>
+
+## Using UI components
+
+Inside a Payload Admin Panel Custom Component, import components from `@payloadcms/ui`:
+
+```tsx
+'use client'
+
+import { Button } from '@payloadcms/ui'
+
+export function SaveButton() {
+  return <Button>Save changes</Button>
+}
+```
+
+Some components depend on context provided by the Admin Panel. Each guide calls out those requirements when a component cannot be rendered independently.
+
+## Customizing components
+
+The Design tab in each component example provides CSS you can use as a starting point. Add those overrides to the stylesheet loaded by your Admin Panel.
+
+<CodeTabs>
+```css label="Next.js"
+/* app/(payload)/custom.css */
+@layer payload {
+  .btn--style-primary {
+    --color-bg-brand: #6d5dfc;
+  }
+}
+```
+
+```css label="TanStack Start"
+/* src/payload.css */
+@import '@payloadcms/ui/css/app.css';
+
+@layer payload {
+  .btn--style-primary {
+    --color-bg-brand: #6d5dfc;
+  }
+}
+```
+
+</CodeTabs>
+
+Both frameworks use the same Payload selectors and design tokens. Only the stylesheet entry point differs.

--- a/docs/ui-components/pill-selector.mdx
+++ b/docs/ui-components/pill-selector.mdx
@@ -1,0 +1,60 @@
+---
+title: PillSelector
+label: Pill Selector
+order: 200
+desc: Let users select one or more compact options with Payload's PillSelector component.
+keywords: ui, component, pill selector, filter, selection
+---
+
+The `PillSelector` component displays a wrapping list of options that can be selected, deselected, and optionally reordered.
+
+## Import
+
+Inside a Payload Admin Panel Custom Component:
+
+```tsx
+import { PillSelector } from '@payloadcms/ui'
+```
+
+You can also import the component directly:
+
+```tsx
+import { PillSelector } from '@payloadcms/ui/elements/PillSelector'
+```
+
+## Interactive example
+
+<ComponentPreview component="PillSelector" example="interactive" />
+
+The component does not manage selection state. Update the `pills` array in `onClick` and pass the new array back to the component.
+
+## Pill shape
+
+Each item in `pills` accepts:
+
+| Property      | Type        | Description                                  |
+| ------------- | ----------- | -------------------------------------------- |
+| `name` \*     | `string`    | Stable value and default visible label.      |
+| `selected` \* | `boolean`   | Whether the option is currently selected.    |
+| `Label`       | `ReactNode` | Replaces the visible label.                  |
+| `key`         | `string`    | Overrides the React key used for the option. |
+
+_\* An asterisk denotes that a property is required._
+
+## Accessibility
+
+- Give each option a short, unique `name`; Payload uses it as the Chip's accessible label.
+- Do not communicate selection by color alone. Selected items replace the plus icon with a remove icon.
+- When enabling reordering, provide another way to understand or change the order when drag-and-drop is unavailable.
+
+## Common props
+
+These are the props most commonly used with this component. See its exported types in `@payloadcms/ui` for the complete list.
+
+| Prop        | Type                                                      | Default | Description                                |
+| ----------- | --------------------------------------------------------- | ------- | ------------------------------------------ |
+| `pills` \*  | `SelectablePill[]`                                        | —       | Options displayed by the selector.         |
+| `onClick`   | `({ pill }) => Promise<void> \| void`                     | —       | Called when an option is activated.        |
+| `draggable` | `{ onDragEnd: ({ moveFromIndex, moveToIndex }) => void }` | —       | Enables reordering and handles the result. |
+
+_\* An asterisk denotes that a prop is required._

--- a/docs/ui-components/pill.mdx
+++ b/docs/ui-components/pill.mdx
@@ -1,0 +1,57 @@
+---
+title: Pill
+label: Pill
+order: 190
+desc: Display compact statuses and categories with Payload's Pill component.
+keywords: ui, component, pill, status, category, tag
+---
+
+The `Pill` component displays compact metadata, a category, or a status. Keep its label short so it remains easy to scan.
+
+## Import
+
+Inside a Payload Admin Panel Custom Component:
+
+```tsx
+import { Pill } from '@payloadcms/ui'
+```
+
+You can also import the component directly:
+
+```tsx
+import { Pill } from '@payloadcms/ui/elements/Pill'
+```
+
+## Styles
+
+<ComponentPreview component="Pill" example="styles" />
+
+Use semantic styles only when the label represents that state. For example, use `error` for a failed state rather than decoration.
+
+## Shape
+
+<ComponentPreview component="Pill" example="shapes" />
+
+Pills use Payload's standard small corner radius by default. Add `rounded` when the label should use the larger rounded corner treatment.
+
+## Sizes
+
+<ComponentPreview component="Pill" example="sizes" />
+
+## Accessibility
+
+- Keep labels concise and ensure their meaning does not depend on color alone.
+- Treat a Pill as presentational metadata. Use a Button or Link when the user needs to perform an action.
+- Provide an accessible label when an icon communicates information that is not present in the visible text.
+
+## Common props
+
+These are the props most commonly used with this component. See its exported types in `@payloadcms/ui` for the complete list.
+
+| Prop        | Type                                                                                                  | Default    | Description                          |
+| ----------- | ----------------------------------------------------------------------------------------------------- | ---------- | ------------------------------------ |
+| `children`  | `ReactNode`                                                                                           | —          | Visible pill content.                |
+| `pillStyle` | `'light' \| 'light-gray' \| 'dark' \| 'white' \| 'always-white' \| 'success' \| 'warning' \| 'error'` | `'light'`  | Sets the visual style.               |
+| `size`      | `'small' \| 'medium'`                                                                                 | `'medium'` | Sets the pill height and spacing.    |
+| `rounded`   | `boolean`                                                                                             | `false`    | Uses a larger rounded corner radius. |
+| `icon`      | `ReactNode`                                                                                           | —          | Displays an icon beside the label.   |

--- a/docs/ui-components/react-select.mdx
+++ b/docs/ui-components/react-select.mdx
@@ -1,0 +1,64 @@
+---
+title: ReactSelect
+label: ReactSelect
+order: 220
+desc: Select one or more options with Payload's ReactSelect component.
+keywords: ui, component, select, dropdown, option, form
+---
+
+The `ReactSelect` component adapts `react-select` to Payload's styles and interaction patterns. It is also exported as `Select`.
+
+## Import
+
+Inside a Payload Admin Panel Custom Component:
+
+```tsx
+import { ReactSelect } from '@payloadcms/ui'
+```
+
+You can also import the component directly:
+
+```tsx
+import { ReactSelect } from '@payloadcms/ui/elements/ReactSelect'
+```
+
+## Basic usage
+
+<ComponentPreview component="ReactSelect" example="basic" />
+
+Store the selected option object rather than only its value. Use `isMulti` when users can select more than one option.
+
+By default, the options menu is rendered in a portal so it can escape drawers and other containers without being clipped.
+
+## Multiple values
+
+<ComponentPreview component="ReactSelect" example="multiple" />
+
+Enable `isMulti` to store an array of selected options. Add `isSortable` when users should also be able to reorder those values by dragging them.
+
+## Accessibility
+
+- Add `aria-label` or associate the select with a visible field label when its purpose is not clear from nearby text.
+- Keep option labels unique and concise.
+- Preserve keyboard search and selection behavior when supplying custom `components`.
+
+## Common props
+
+These are the props most commonly used with this component. See its exported types in `@payloadcms/ui` for the complete list.
+
+| Prop           | Type                                  | Default   | Description                                        |
+| -------------- | ------------------------------------- | --------- | -------------------------------------------------- |
+| `options` \*   | `Option[] \| OptionGroup[]`           | —         | Options displayed in the menu.                     |
+| `value`        | `Option \| Option[]`                  | —         | Selected option or options.                        |
+| `onChange`     | `(value: Option \| Option[]) => void` | —         | Runs when the selection changes.                   |
+| `placeholder`  | `string \| LabelFunction`             | Localized | Sets the empty-state label.                        |
+| `isMulti`      | `boolean`                             | `false`   | Allows multiple selected values.                   |
+| `isSortable`   | `boolean`                             | `false`   | Allows selected multi-value items to be reordered. |
+| `isClearable`  | `boolean`                             | `true`    | Displays a control for clearing the value.         |
+| `isSearchable` | `boolean`                             | `true`    | Allows options to be filtered by typing.           |
+| `isCreatable`  | `boolean`                             | `false`   | Allows users to create values not in `options`.    |
+| `disabled`     | `boolean`                             | `false`   | Prevents interaction.                              |
+| `isLoading`    | `boolean`                             | `false`   | Displays the loading state.                        |
+| `showError`    | `boolean`                             | `false`   | Applies the validation error style.                |
+
+_\* An asterisk denotes that a prop is required._

--- a/docs/ui-components/react-select.mdx
+++ b/docs/ui-components/react-select.mdx
@@ -46,19 +46,19 @@ Enable `isMulti` to store an array of selected options. Add `isSortable` when us
 
 These are the props most commonly used with this component. See its exported types in `@payloadcms/ui` for the complete list.
 
-| Prop           | Type                                  | Default   | Description                                        |
-| -------------- | ------------------------------------- | --------- | -------------------------------------------------- |
-| `options` \*   | `Option[] \| OptionGroup[]`           | —         | Options displayed in the menu.                     |
-| `value`        | `Option \| Option[]`                  | —         | Selected option or options.                        |
-| `onChange`     | `(value: Option \| Option[]) => void` | —         | Runs when the selection changes.                   |
-| `placeholder`  | `string \| LabelFunction`             | Localized | Sets the empty-state label.                        |
-| `isMulti`      | `boolean`                             | `false`   | Allows multiple selected values.                   |
-| `isSortable`   | `boolean`                             | `false`   | Allows selected multi-value items to be reordered. |
-| `isClearable`  | `boolean`                             | `true`    | Displays a control for clearing the value.         |
-| `isSearchable` | `boolean`                             | `true`    | Allows options to be filtered by typing.           |
-| `isCreatable`  | `boolean`                             | `false`   | Allows users to create values not in `options`.    |
-| `disabled`     | `boolean`                             | `false`   | Prevents interaction.                              |
-| `isLoading`    | `boolean`                             | `false`   | Displays the loading state.                        |
-| `showError`    | `boolean`                             | `false`   | Applies the validation error style.                |
+| Prop           | Type                                          | Default   | Description                                        |
+| -------------- | --------------------------------------------- | --------- | -------------------------------------------------- |
+| `options` \*   | `Option[] \| OptionGroup[]`                   | —         | Options displayed in the menu.                     |
+| `value`        | `Option \| Option[]`                          | —         | Selected option or options.                        |
+| `onChange`     | `(value: Option \| Option[] \| null) => void` | —         | Runs when the selection changes or is cleared.     |
+| `placeholder`  | `string \| LabelFunction`                     | Localized | Sets the empty-state label.                        |
+| `isMulti`      | `boolean`                                     | `false`   | Allows multiple selected values.                   |
+| `isSortable`   | `boolean`                                     | `false`   | Allows selected multi-value items to be reordered. |
+| `isClearable`  | `boolean`                                     | `true`    | Displays a control for clearing the value.         |
+| `isSearchable` | `boolean`                                     | `true`    | Allows options to be filtered by typing.           |
+| `isCreatable`  | `boolean`                                     | `false`   | Allows users to create values not in `options`.    |
+| `disabled`     | `boolean`                                     | `false`   | Prevents interaction.                              |
+| `isLoading`    | `boolean`                                     | `false`   | Displays the loading state.                        |
+| `showError`    | `boolean`                                     | `false`   | Applies the validation error style.                |
 
 _\* An asterisk denotes that a prop is required._

--- a/docs/ui-components/shimmer-effect.mdx
+++ b/docs/ui-components/shimmer-effect.mdx
@@ -1,0 +1,53 @@
+---
+title: ShimmerEffect
+label: Shimmer Effect
+order: 240
+desc: Represent loading content with Payload's ShimmerEffect component.
+keywords: ui, component, shimmer, skeleton, loading
+---
+
+The `ShimmerEffect` component provides a visual placeholder while content is loading. Match its dimensions to the content that will replace it to reduce layout shift.
+
+## Import
+
+Inside a Payload Admin Panel Custom Component:
+
+```tsx
+import { ShimmerEffect } from '@payloadcms/ui'
+```
+
+You can also import the component directly:
+
+```tsx
+import { ShimmerEffect } from '@payloadcms/ui/elements/ShimmerEffect'
+```
+
+## Basic usage
+
+<ComponentPreview component="ShimmerEffect" example="basic" />
+
+## Composing a skeleton
+
+Combine multiple shimmer elements to approximate the final layout.
+
+<ComponentPreview component="ShimmerEffect" example="shapes" />
+
+Loading indicators should not replace an accessible loading label or status when users need to know that work is in progress.
+
+## Accessibility
+
+- Keep the loading announcement outside the decorative shimmer element.
+- Avoid changing the placeholder dimensions when the final content loads.
+- Respect the surrounding interface's reduced-motion behavior.
+
+## Common props
+
+These are the props most commonly used with this component. See its exported types in `@payloadcms/ui` for the complete list.
+
+| Prop                  | Type               | Default  | Description                                         |
+| --------------------- | ------------------ | -------- | --------------------------------------------------- |
+| `height`              | `number \| string` | `'60px'` | Sets the placeholder height.                        |
+| `width`               | `number \| string` | `'100%'` | Sets the placeholder width.                         |
+| `animationDelay`      | `string`           | `'0ms'`  | Delays the shimmer animation.                       |
+| `transparent`         | `boolean`          | `false`  | Allows the underlying background to remain visible. |
+| `disableInlineStyles` | `boolean`          | `false`  | Leaves dimensions to a custom class or stylesheet.  |


### PR DESCRIPTION
adds the first release of `@payloadcms/ui `component documentation, focused on common, visually useful components and working Payload v4 examples (on website repo)
