### PR TITLE
fix: keep concurrent login sessions from overwriting each other

### DIFF
--- a/packages/payload/src/auth/sessions.ts
+++ b/packages/payload/src/auth/sessions.ts
@@ -41,18 +41,17 @@ export const addSessionToUser = async ({
 
     const session = { id: sid, createdAt: now, expiresAt }
 
-    if (!user.sessions?.length) {
-      user.sessions = [session]
-    } else {
-      user.sessions = removeExpiredSessions(user.sessions)
-      user.sessions.push(session)
-    }
+    // Store the new session in memory to reflect it in the response, without
+    // writing the full sessions array back to the database. Concurrent logins
+    // each read the same sessions array, so writing it back would silently
+    // drop the sessions the other logins have added in the meantime.
+    user.sessions = [...removeExpiredSessions(user.sessions ?? []), session]
 
     await payload.db.updateOne({
       id: user.id,
       collection: collectionConfig.slug,
       data: {
-        ...user,
+        sessions: { $push: session },
         // Prevent updatedAt from being updated when only adding a session
         updatedAt: null,
       },

--- a/test/auth/int.spec.ts
+++ b/test/auth/int.spec.ts
@@ -2054,6 +2054,51 @@ test.suite({ config: './config.ts', resetBetweenTests: false })('Auth', () => {
       expect(user2.docs[0]?.sessions).toHaveLength(1)
     })
 
+    test('should keep all sessions when logging in concurrently', async ({ payload }) => {
+      const concurrentLogins = 8
+
+      const results = await Promise.allSettled(
+        Array.from({ length: concurrentLogins }, () =>
+          payload.login({
+            collection: slug,
+            data: {
+              email,
+              password,
+            },
+          }),
+        ),
+      )
+
+      const sids = []
+
+      for (const result of results) {
+        if (result.status === 'fulfilled') {
+          sids.push(jwtDecode<{ sid: string }>(String(result.value.token)).sid)
+        }
+      }
+
+      expect(sids.length).toBeGreaterThan(0)
+      expect(new Set(sids).size).toBe(sids.length)
+
+      const user = await payload.db.find<User>({
+        collection: slug,
+        where: {
+          email: {
+            equals: email,
+          },
+        },
+      })
+
+      const storedSessions = user.docs[0]?.sessions ?? []
+
+      for (const sid of sids) {
+        expect(
+          storedSessions.some(({ id }) => id === sid),
+          `session ${sid} was lost after concurrent logins`,
+        ).toBe(true)
+      }
+    })
+
     test('should not update updatedAt when creating a session', async ({ payload }) => {
       // Create a user
       const testUser = await payload.create({


### PR DESCRIPTION
### What?

`addSessionToUser` now appends the new session with an atomic `$push` instead of rewriting the full user document.

### Why?

Fixes #18132. The same race is described in #16027. Concurrent logins read the same sessions array and overwrite each other's sessions. The user who loses the race holds a JWT whose `sid` is no longer stored, so every subsequent request is silently anonymous: `JWTAuthentication` finds no matching session and returns `{ user: null }` with no error and nothing logged. This is reproducible on all database adapters (8 concurrent logins lose sessions, matching the numbers reported in the issue).

### How?

`loginOperation` reads the full user document before the session is added, then `addSessionToUser` writes that whole document (including the sessions array read earlier) back with `updateOne`. Under concurrency the last writer wins and drops the sessions of every other concurrent login. On MongoDB the overlapping whole-document writes additionally make concurrent login transactions abort with `WriteConflict`, while on the relational adapters the logins succeed but silently lose each other's sessions.

The fix appends atomically with `sessions: { $push: session }`, using the same atomic push primitive the queues feature already relies on (`packages/payload/src/queues/errors/handleTaskError.ts`). Concurrent logins no longer read or rewrite each other's sessions. `updatedAt` is still passed as `null` so adding a session does not bump the document timestamp, and the in-memory `user.sessions` still filters expired sessions for the login response.

Note: `removeExpiredSessions` now only affects the login response, no longer the persisted array. Auth already rejects expired sessions by JWT `exp` rather than `expiresAt`, and `refresh` still removes expired sessions on refresh. Trimming the array when it grows unbounded is a separate design question raised in the issue; this PR keeps scope to the race.

The same read-modify-write exists on the `3.x` branch (`3.88.x`), where the issue was reported, with a slightly different `data: user` shape. Happy to open a `3.x` PR with the same fix and test if that is preferred.

### Relation to open PRs

- #17135 addresses the same race by re-reading sessions inside the transaction before writing the full array back. The re-read shrinks the window but the whole-array write remains, so a login committing between another login's re-read and its write still gets overwritten. The atomic push removes the read entirely, so there is no window left.
- #17596 narrows login's write to `sessions` + `updatedAt` (and fixes drizzle `undefined` semantics for it) and explicitly leaves the concurrent-array case open: "those operations still use read-modify-write and need an atomic, cross-adapter design". This PR is that atomic primitive for the append path, and it composes with the narrow-write direction: the write is now a single field append with no user snapshot.

Both prior PRs informed this one; credit to @codewithsupra and @OtacilioN for the analysis in them.

### Test

New regression test `should keep all sessions when logging in concurrently` in `test/auth/int.spec.ts`: 8 concurrent logins, then every token that was issued must have its `sid` present in the stored sessions. The test fails on `main` (issued sessions are silently lost) and passes with this fix on both `sqlite` and `mongodb`.

Verified locally:
- `pnpm run test:int auth` full suite on `sqlite`: 98/98 green
- `pnpm run test:int auth` full suite on `mongodb`: 98/98 green
- `pnpm --filter payload run lint`: no new warnings
