### PR TITLE
fix(ui): stop hiding the ReactSelect dropdown indicator from assistive tech

### DIFF
--- a/packages/ui/src/elements/ReactSelect/DropdownIndicator/index.tsx
+++ b/packages/ui/src/elements/ReactSelect/DropdownIndicator/index.tsx
@@ -16,7 +16,10 @@ export const DropdownIndicator: React.FC<
   } & DropdownIndicatorProps<OptionType, true>
 > = (props) => {
   const {
-    innerProps: { ref, ...restInnerProps },
+    // react-select marks its indicators `aria-hidden`, which is correct for the
+    // non-focusable `div` it renders by default but not for this focusable button -
+    // spreading it would hide a keyboard-reachable control from the accessibility tree.
+    innerProps: { 'aria-hidden': _ariaHidden, ref, ...restInnerProps },
   } = props
 
   const { t } = useTranslation()


### PR DESCRIPTION
## What

`ReactSelect`'s `DropdownIndicator` renders a `<button>` and spreads react-select's `innerProps` onto it. react-select supplies `'aria-hidden': 'true'` in those props, so the attribute lands on a focusable button — and, because the spread comes after it, also overrides the `aria-label` set two lines above.

This PR drops `aria-hidden` from the spread. Everything else in `innerProps` (`onMouseDown`, `onTouchEnd`) is still forwarded, so mouse and touch behaviour is untouched.

## Why

axe flags this as `aria-hidden-focus` (serious): the element genuinely takes keyboard focus while being hidden from the accessibility tree, so a keyboard or screen-reader user lands on a control that does not exist as far as assistive tech is concerned.

The attribution in the issue was offered as a hypothesis; it is confirmed. react-select 5.9.0 (`Select.js`, `renderDropdownIndicator`) builds the props as:

```js
var innerProps = {
  onMouseDown: this.onDropdownIndicatorMouseDown,
  onTouchEnd: this.onDropdownIndicatorTouchEnd,
  'aria-hidden': 'true'
};
```

`aria-hidden` is correct for react-select's own default indicator, which is a non-focusable `div`. It stops being correct the moment those props are spread onto a `<button>`.

I removed the attribute rather than making the button unfocusable, because the control is a real, working one and not decoration: it has an `aria-label`, and pressing <kbd>Space</kbd> on it opens the menu (verified below). Hiding a functional control from assistive tech is the actual defect; the button only needed to stop claiming it was hidden. `MultiValueRemove` in this same directory already follows this shape — it picks the `innerProps` it wants instead of spreading them, so `aria-hidden` never reaches its button.

## How to test

`pnpm dev fields-relationship`, then open `/admin/collections/fields-relationship/create` and, in the console:

```js
const b = document.querySelector('#field-relationshipHasMany button.dropdown-indicator')
b.getAttribute('aria-hidden')          // null (was "true")
b.focus(); document.activeElement === b // true
```

Measured before and after on the same running dev server, scanning `#field-relationshipHasMany` with `@axe-core/playwright` restricted to `aria-hidden-focus`:

| | `aria-hidden` | accessible name | focusable | `aria-hidden-focus` violations |
|---|---|---|---|---|
| before | `"true"` | none (suppressed) | yes | **1** |
| after | absent | `Open` | yes | **0** |

No behavioural regression — on the patched build, clicking the indicator still opens the menu (10 options in that field), <kbd>Space</kbd> on the focused indicator still opens it, and the combobox input still opens on <kbd>ArrowDown</kbd>.

Also run: `pnpm test:unit` (2320 passed, 4 skipped, 0 failed), `tsc --noEmit` on `packages/ui` (clean), eslint and prettier on the changed file (clean).

I did not add a test — `test/a11y/e2e.spec.ts` is currently `test.describe.skip`, so a case added there would not run. Happy to add one if you would like it in place for when that suite is re-enabled.

## Notes for reviewers

Two adjacent spots have the same shape and are deliberately left alone here, since fixing them means deciding on accessible names and so overlaps #18140:

- `ReactSelect/ClearIndicator` — a `div` with `role="button"` and `tabIndex={0}` receiving the same spread, and no label.
- `TimezonePicker`'s local `SmallDropdownIndicator` / `SmallClearIndicator` — private copies of the same pattern; the dropdown one has no `aria-label` at all.

Separately, the `onKeyDown` handler here does `e.key = ' '` to remap <kbd>Enter</kbd> onto <kbd>Space</kbd>. Reassigning `key` on a React synthetic event has no effect, so <kbd>Enter</kbd> on the indicator does nothing today. Pre-existing and untouched by this PR, but now more visible with the control exposed to screen readers.

Closes #18139
