### PR TITLE
fix(plugin-seo): keep sidebar fields out of the generated tabbedUI Content tab

### DIFF
--- a/packages/plugin-seo/src/index.spec.ts
+++ b/packages/plugin-seo/src/index.spec.ts
@@ -1,0 +1,56 @@
+import type { Config, Field } from 'payload'
+
+import { describe, expect, it } from 'vitest'
+
+import { seoPlugin } from './index.js'
+
+const runTabbedUI = (fields: Field[]) => {
+  const plugin = seoPlugin({ collections: ['posts'], tabbedUI: true })
+  const result = plugin({
+    collections: [
+      {
+        fields,
+        slug: 'posts',
+      },
+    ],
+  } as unknown as Config)
+  return result.collections?.[0]?.fields ?? []
+}
+
+const contentTabFields = (fields: Field[]): Field[] => {
+  const tabs = fields.find((field) => field.type === 'tabs')
+  if (tabs?.type !== 'tabs' || !Array.isArray(tabs.tabs)) {
+    return []
+  }
+  const contentTab = tabs.tabs.find((tab) => tab.label === 'Content')
+  return contentTab && 'fields' in contentTab ? (contentTab.fields as Field[]) : []
+}
+
+describe('seoPlugin tabbedUI sidebar fields', () => {
+  it('keeps admin.position sidebar fields at the top level instead of the Content tab', () => {
+    const fields = runTabbedUI([
+      { name: 'title', type: 'text' },
+      { admin: { position: 'sidebar' }, name: 'status', type: 'text' },
+    ])
+
+    const topLevelNames = fields
+      .filter((field) => 'name' in field)
+      .map((field) => (field as { name: string }).name)
+    expect(topLevelNames).toContain('status')
+
+    const contentNames = contentTabFields(fields)
+      .filter((field) => 'name' in field)
+      .map((field) => (field as { name: string }).name)
+    expect(contentNames).toContain('title')
+    expect(contentNames).not.toContain('status')
+  })
+
+  it('leaves collections without sidebar fields unchanged', () => {
+    const fields = runTabbedUI([{ name: 'title', type: 'text' }])
+
+    const contentNames = contentTabFields(fields)
+      .filter((field) => 'name' in field)
+      .map((field) => (field as { name: string }).name)
+    expect(contentNames).toContain('title')
+  })
+})

--- a/packages/plugin-seo/src/index.ts
+++ b/packages/plugin-seo/src/index.ts
@@ -1,7 +1,7 @@
 import type { Config, Field, GroupField, TabsField } from 'payload'
 
 import { definePlugin } from 'payload'
-import { deepMergeSimple } from 'payload/shared'
+import { deepMergeSimple, fieldIsSidebar } from 'payload/shared'
 
 import type {
   GenerateDescription,
@@ -81,6 +81,15 @@ export const seoPlugin = definePlugin<SEOPluginConfig>({
                 collection.fields?.find((field) => 'name' in field && field.name === 'email')
               const hasOnlyEmailField = collection.fields?.length === 1 && emailField
 
+              // keep sidebar-positioned fields at the top level so the document
+              // view still renders its two-column layout instead of moving them
+              // into the generated Content tab where core sidebar detection
+              // cannot see them
+              const sidebarFields =
+                collection.fields?.filter((field) => fieldIsSidebar(field)) ?? []
+              const nonSidebarFields =
+                collection.fields?.filter((field) => !fieldIsSidebar(field)) ?? []
+
               const seoTabs: TabsField[] = hasOnlyEmailField
                 ? [
                     {
@@ -98,6 +107,7 @@ export const seoPlugin = definePlugin<SEOPluginConfig>({
                       type: 'tabs',
                       tabs: [
                         // append a new tab onto the end of the tabs array, if there is one at the first index
+                        // append a new tab onto the end of the tabs array, if there is one at the first index
                         // if needed, create a new `Content` tab in the first index for this collection's base fields
                         ...(collection?.fields?.[0]?.type === 'tabs' &&
                         collection?.fields?.[0]?.tabs
@@ -106,10 +116,10 @@ export const seoPlugin = definePlugin<SEOPluginConfig>({
                               {
                                 fields: [
                                   ...(emailField
-                                    ? collection.fields.filter(
+                                    ? nonSidebarFields.filter(
                                         (field) => 'name' in field && field.name !== 'email',
                                       )
-                                    : collection.fields),
+                                    : nonSidebarFields),
                                 ],
                                 label: collection?.labels?.singular || 'Content',
                               },
@@ -126,8 +136,11 @@ export const seoPlugin = definePlugin<SEOPluginConfig>({
                 ...collection,
                 fields: [
                   ...(emailField ? [emailField] : []),
+                  ...sidebarFields,
                   ...seoTabs,
-                  ...(collection?.fields?.[0]?.type === 'tabs' ? collection.fields.slice(1) : []),
+                  ...(collection?.fields?.[0]?.type === 'tabs'
+                    ? collection.fields.slice(1).filter((field) => !fieldIsSidebar(field))
+                    : []),
                 ],
               }
             }


### PR DESCRIPTION
Fixes #18138.

## What
With seoPlugin tabbedUI enabled, a collection containing admin.position sidebar fields lost its two-column edit layout: the sidebar field was moved inside the generated Content tab and rendered full-width.

## Why
Core sidebar detection only inspects top-level fields, so anything nested in tabs is invisible to it. The tabbedUI branch copied every field into the Content tab (with only the auth email carved out).

## Root cause
packages/plugin-seo/src/index.ts built the Content tab from all collection fields without excluding sidebar-positioned ones.

## Fix
Partition fields with the canonical fieldIsSidebar predicate (from payload/shared): sidebar fields stay top-level next to the email field, everything else goes into the Content tab as before. The existing-tabs tail is filtered the same way to avoid duplicates.

## Tests
- New: packages/plugin-seo/src/index.spec.ts (sidebar field stays top-level and out of the Content tab; no-sidebar collections unchanged). The sidebar case fails on unpatched main and passes with the fix.
- vitest run --project unit packages/plugin-seo/src/index.spec.ts: 2 passed.
- eslint clean on index.ts; prettier clean on both files.