### PR TITLE
fix(ui): stop forwarding react-select aria-hidden onto focusable select indicators

### DIFF
--- a/packages/ui/src/elements/ReactSelect/ClearIndicator/index.tsx
+++ b/packages/ui/src/elements/ReactSelect/ClearIndicator/index.tsx
@@ -21,6 +21,9 @@ export const ClearIndicator: React.FC<ClearIndicatorProps<OptionType, true>> = (
       className={baseClass}
       ref={ref}
       {...restInnerProps}
+      // react-select marks indicators aria-hidden, but this control is focusable,
+      // so forwarding that attribute would hide it from assistive tech
+      aria-hidden={undefined}
       onKeyDown={(e) => {
         if (e.key === 'Enter') {
           clearValue()

--- a/packages/ui/src/elements/ReactSelect/DropdownIndicator/index.spec.ts
+++ b/packages/ui/src/elements/ReactSelect/DropdownIndicator/index.spec.ts
@@ -1,0 +1,40 @@
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../../providers/Translation/index.js', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+import { ClearIndicator } from '../ClearIndicator/index.js'
+import { DropdownIndicator } from './index.js'
+
+const indicatorInnerProps = {
+  'aria-hidden': 'true',
+  onMouseDown: () => {},
+  onTouchEnd: () => {},
+}
+
+describe('DropdownIndicator', () => {
+  it('does not forward react-select aria-hidden onto the focusable button', () => {
+    const html = renderToStaticMarkup(
+      createElement(DropdownIndicator, {
+        innerProps: indicatorInnerProps,
+      } as unknown as Parameters<typeof DropdownIndicator>[0]),
+    )
+    expect(html).not.toContain('aria-hidden')
+    expect(html).toContain('aria-label="general:open"')
+  })
+})
+
+describe('ClearIndicator', () => {
+  it('does not forward react-select aria-hidden onto the focusable control', () => {
+    const html = renderToStaticMarkup(
+      createElement(ClearIndicator, {
+        clearValue: () => {},
+        innerProps: indicatorInnerProps,
+      } as unknown as Parameters<typeof ClearIndicator>[0]),
+    )
+    expect(html).not.toContain('aria-hidden')
+  })
+})

--- a/packages/ui/src/elements/ReactSelect/DropdownIndicator/index.tsx
+++ b/packages/ui/src/elements/ReactSelect/DropdownIndicator/index.tsx
@@ -27,6 +27,9 @@ export const DropdownIndicator: React.FC<
       className={baseClass}
       ref={ref}
       {...restInnerProps}
+      // react-select marks indicators aria-hidden, but this button is focusable
+      // and named, so forwarding that attribute would hide it from assistive tech
+      aria-hidden={undefined}
       onKeyDown={(e) => {
         if (e.key === 'Enter') {
           e.key = ' '


### PR DESCRIPTION
Fixes #18139.

## What
Every ReactSelect dropdown/clear indicator rendered as a focusable control carrying aria-hidden true, so keyboard and screen-reader users could land on controls hidden from the accessibility tree (axe aria-hidden-focus).

## Why
react-select injects aria-hidden true into indicator innerProps. Payload custom DropdownIndicator and ClearIndicator spread those props onto a focusable button/div. The controls are interactive and (for the dropdown) already named, so hiding them is wrong.

## Root cause
packages/ui custom indicators forwarded restInnerProps verbatim, including react-select aria-hidden.

## Fix
Override aria-hidden with undefined after the spread in both indicators, keeping all other innerProps (mouse/touch handlers) and the existing accessible name intact.

## Tests
- New: packages/ui/src/elements/ReactSelect/DropdownIndicator/index.spec.ts renders both indicators to static markup with react-select innerProps and asserts no aria-hidden is emitted (plus the dropdown keeps its aria-label). Both assertions fail on unpatched main and pass with the fix.
- vitest run --project unit on the spec: 2 passed.
- eslint clean; prettier clean.