### PR TITLE
fix(richtext-lexical): run beforeValidate hooks for nested fields

### DIFF
--- a/packages/richtext-lexical/src/hooks.ts
+++ b/packages/richtext-lexical/src/hooks.ts
@@ -550,7 +550,10 @@ export const getLexicalHooks: (args: {
         /**
          * Now that the maps for all hooks are set up, we can run the validate hook
          */
-        if (!editorConfig.features.nodeHooks?.beforeValidate?.size) {
+        if (
+          !editorConfig.features.nodeHooks?.beforeValidate?.size &&
+          !editorConfig.features.getSubFields?.size
+        ) {
           return value
         }
         const nodeIDMap: {
@@ -564,7 +567,7 @@ export const getLexicalHooks: (args: {
 
         // eslint-disable-next-line prefer-const
         for (let [id, node] of Object.entries(nodeIDMap)) {
-          const beforeValidateHooks = editorConfig.features.nodeHooks.beforeValidate
+          const beforeValidateHooks = editorConfig.features.nodeHooks?.beforeValidate
           const beforeValidateHooksForNode = beforeValidateHooks?.get(node.type)
           if (beforeValidateHooksForNode) {
             for (const hook of beforeValidateHooksForNode) {

--- a/test/lexical/collections/Lexical/blocks.ts
+++ b/test/lexical/collections/Lexical/blocks.ts
@@ -139,6 +139,7 @@ export const AsyncHooksBlock: Block = {
             return value?.toUpperCase()
           },
         ],
+        beforeValidate: [({ value }) => value?.trim()],
       },
     },
     {

--- a/test/lexical/lexical.int.spec.ts
+++ b/test/lexical/lexical.int.spec.ts
@@ -669,6 +669,44 @@ test.suite({ config: './config.ts' })('Lexical', () => {
   })
 
   test.describe('Hooks', () => {
+    test('should run beforeValidate hooks for fields inside lexical blocks', async ({
+      payload,
+    }) => {
+      const lexicalDocument = await payload.create({
+        collection: lexicalFieldsSlug,
+        data: {
+          lexicalWithBlocks: {
+            root: {
+              type: 'root',
+              children: [
+                {
+                  type: 'block',
+                  fields: {
+                    id: 'nested-before-validate-block',
+                    blockName: '',
+                    blockType: 'asyncHooksBlock',
+                    test1: ' nested hook value ',
+                  },
+                  format: '',
+                  version: 2,
+                },
+              ],
+              direction: null,
+              format: '',
+              indent: 0,
+              version: 1,
+            },
+          },
+          title: 'Nested beforeValidate hook',
+        },
+        depth: 0,
+      })
+
+      const lexicalBlock = lexicalDocument.lexicalWithBlocks.root.children[0] as SerializedBlockNode
+
+      expect((lexicalBlock.fields as { test1: string }).test1).toBe('NESTED HOOK VALUE')
+    })
+
     test('ensure hook within number field within lexical block runs', async ({ payload }) => {
       const lexicalDocEN = await payload.create({
         collection: 'lexical-localized-fields',


### PR DESCRIPTION
### What?

Runs beforeValidate hooks for fields nested within Lexical Blocks, Link, and Upload features.

### Why?

The rich text beforeValidate hook returned before it traversed feature subfields when no node-level beforeValidate hooks existed.

Fixes #17950

### How?

- Continue processing when the editor configuration contains feature subfields.
- Use the existing field traversal to run nested hooks.
- Add integration coverage for a nested field in a Lexical block.

Written with AI