### PR TITLE
fix(ui): update version state only after successful submissions

### DIFF
--- a/packages/ui/src/elements/PublishButton/index.tsx
+++ b/packages/ui/src/elements/PublishButton/index.tsx
@@ -185,7 +185,7 @@ export function PublishButton({
       },
     })
 
-    if (result) {
+    if (result && result.res.ok) {
       setUnpublishedVersionCount(0)
       setMostRecentVersionIsAutosaved(false)
       setHasPublishedDoc(true)
@@ -234,7 +234,7 @@ export function PublishButton({
         },
       })
 
-      if (result) {
+      if (result && result.res.ok) {
         setUnpublishedVersionCount(0)
         setMostRecentVersionIsAutosaved(false)
         setHasPublishedDoc(true)

--- a/packages/ui/src/elements/SaveDraftButton/index.tsx
+++ b/packages/ui/src/elements/SaveDraftButton/index.tsx
@@ -63,7 +63,7 @@ export function SaveDraftButton(props: SaveDraftButtonClientProps) {
       })
     }
 
-    await submit({
+    const result = await submit({
       action,
       method,
       overrides: {
@@ -71,6 +71,10 @@ export function SaveDraftButton(props: SaveDraftButtonClientProps) {
       },
       skipValidation: true,
     })
+
+    if (!result || !result.res.ok) {
+      return
+    }
 
     setUnpublishedVersionCount((count) => count + 1)
   }, [submit, collectionSlug, globalSlug, api, locale, id, disabled, setUnpublishedVersionCount])


### PR DESCRIPTION
### What?

SaveDraftButton and both PublishButton paths now update version and
publication state only after `Form.submit` returns a successful response.

### Why?

A failed save or publish currently updates the UI as if it had succeeded.
`Form.submit` returns nothing for handled JSON and network errors, but a
non-JSON HTTP error (for example a plain-text 503) returns a truthy result with
`res.ok === false`. Save Draft then increments the unpublished version count,
and Publish resets it and marks the document Published.

Before and after on 3.89.0, same failed request (HTTP 503):

**Save Draft, before**

![Save Draft before: status flips to Changed after a failed save](https://raw.githubusercontent.com/alvisk/payload/pr-18164-assets/save-draft-before.png)

**Save Draft, after**

![Save Draft after: status stays Published after a failed save](https://raw.githubusercontent.com/alvisk/payload/pr-18164-assets/save-draft-after.png)

**Publish, before**

![Publish before: draft shows as Published after a failed publish](https://raw.githubusercontent.com/alvisk/payload/pr-18164-assets/publish-before.png)

**Publish, after**

![Publish after: status stays Draft after a failed publish](https://raw.githubusercontent.com/alvisk/payload/pr-18164-assets/publish-after.png)

### How?

Guard the state updates with `result.res.ok`, matching
[Autosave's existing check](https://github.com/payloadcms/payload/blob/479458d8e03cb60aa505378d086c2e66f16ccdfc/packages/ui/src/elements/Autosave/index.tsx#L149-L169)
on the same counter. Form's error handling and retry behaviour are unchanged.

Related: #13664 / #13673 added PublishButton's truthiness check. #17517 (a
failed publish still clears the modified flag) is not changed here.
