### PR TITLE
fix(plugin-multi-tenant): await async validate override on tenant field (#18163)

### DIFF
--- a/packages/plugin-multi-tenant/src/fields/tenantField/index.ts
+++ b/packages/plugin-multi-tenant/src/fields/tenantField/index.ts
@@ -9,9 +9,9 @@ import { getUserTenantIDs } from '../../utilities/getUserTenantIDs.js'
 
 const fieldValidation =
   (validateFunction?: RelationshipFieldValidation): RelationshipFieldValidation =>
-  (value, options) => {
+  async (value, options) => {
     if (validateFunction) {
-      const result = validateFunction(value, options)
+      const result = await validateFunction(value, options)
       if (result !== true) {
         return result
       }

--- a/packages/plugin-multi-tenant/src/index.spec.ts
+++ b/packages/plugin-multi-tenant/src/index.spec.ts
@@ -58,4 +58,79 @@ describe('multiTenantPlugin', () => {
     expect(tenantsField?.access?.create).toBe(createAccess)
     expect(tenantsField?.access?.update).toBe(updateAccess)
   })
+
+  it('awaits async validate override and preserves required check on empty value', async () => {
+    let customValidatorCalled = false
+    const plugin = multiTenantPlugin({
+      collections: {
+        pages: {},
+      },
+      tenantField: {
+        validate: async (value) => {
+          customValidatorCalled = true
+          await Promise.resolve()
+          return true
+        },
+      },
+    })
+    const config = await plugin({
+      collections: [
+        { slug: 'users', auth: true, fields: [] },
+        { slug: 'tenants', fields: [] },
+        { slug: 'pages', fields: [] },
+      ],
+    } as Config)
+
+    const pagesCollection = config.collections?.find(({ slug }) => slug === 'pages')
+    const tenantField = pagesCollection?.fields.find(
+      (field) => 'name' in field && field.name === 'tenant',
+    ) as { validate?: (value: unknown, options: unknown) => Promise<string | true> | string | true }
+
+    expect(tenantField).toBeDefined()
+    expect(tenantField.validate).toBeDefined()
+
+    const mockOptions = {
+      hasMany: false,
+      req: {
+        t: (key: string) => `translated:${key}`,
+      },
+    }
+
+    // 1. When value is missing (null / undefined), required check must fail even though async validate resolved true
+    customValidatorCalled = false
+    const missingValueResult = await tenantField.validate?.(null, mockOptions)
+    expect(customValidatorCalled).toBe(true)
+    expect(missingValueResult).toBe('translated:validation:required')
+
+    // 2. When value is present, async validate resolves true and check passes
+    customValidatorCalled = false
+    const validValueResult = await tenantField.validate?.('tenant-1', mockOptions)
+    expect(customValidatorCalled).toBe(true)
+    expect(validValueResult).toBe(true)
+
+    // 3. When custom async validate returns an error string, that error is returned
+    const pluginWithError = multiTenantPlugin({
+      collections: { pages: {} },
+      tenantField: {
+        validate: async () => {
+          await Promise.resolve()
+          return 'custom-validation-failed'
+        },
+      },
+    })
+    const configWithError = await pluginWithError({
+      collections: [
+        { slug: 'users', auth: true, fields: [] },
+        { slug: 'tenants', fields: [] },
+        { slug: 'pages', fields: [] },
+      ],
+    } as Config)
+    const pagesWithError = configWithError.collections?.find(({ slug }) => slug === 'pages')
+    const tenantFieldWithError = pagesWithError?.fields.find(
+      (field) => 'name' in field && field.name === 'tenant',
+    ) as { validate?: (value: unknown, options: unknown) => Promise<string | true> | string | true }
+
+    const errorResult = await tenantFieldWithError.validate?.('tenant-1', mockOptions)
+    expect(errorResult).toBe('custom-validation-failed')
+  })
 })


### PR DESCRIPTION
Resolves #18163
/claim #18163

### Summary of Problem
In `@payloadcms/plugin-multi-tenant`, `fieldValidation` wraps the tenant field's `validate` function to enforce that the tenant field remains required:

```ts
const fieldValidation =
  (validateFunction?: RelationshipFieldValidation): RelationshipFieldValidation =>
  (value, options) => {
    if (validateFunction) {
      const result = validateFunction(value, options)
      if (result !== true) {
        return result
      }
    }
    ...
```

When a custom `validate` function is async (e.g. performing asynchronous tenant membership verification), `validateFunction(value, options)` returns a Promise. Because `[object Promise] !== true`, `fieldValidation` immediately returned the Promise without awaiting it. As a result, the required validation checks following the custom validator never executed once the Promise resolved, allowing documents with missing/empty tenant values to bypass validation and hit database constraints (or persist with `tenant: null`).

### Solution
1. Changed `fieldValidation`'s returned inner validator to be `async (value, options) => { ... }`.
2. Awaited `validateFunction(value, options)` so that synchronous and asynchronous validation results are resolved to boolean or string error messages.
3. Ensured that when the custom validator passes (`result === true`), the required check continues to execute on empty values.
4. Added comprehensive unit tests in `packages/plugin-multi-tenant/src/index.spec.ts` covering:
   - Async validate resolving to `true` with missing value -> triggers required error
   - Async validate resolving to `true` with valid value -> passes
   - Async validate resolving to custom error string -> returns error

### Settlement & Verification
- Unit test suite: 100% PASS (6/6 tests passing in `packages/plugin-multi-tenant`)
- Typecheck & build: `pnpm --filter @payloadcms/plugin-multi-tenant build` PASS
- Base L2 Sovereign Wallet: `0x46D5318E4397cFcBED06a235c1604E473682Ea1F`
